### PR TITLE
Implement an optimized merkle trie

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ packages =
     ethereum/frontier/vm
     ethereum/frontier/vm/instructions
     ethereum/utils
+    ethereum_optimized/
 
 package_dir =
     =src

--- a/src/ethereum_optimized/__init__.py
+++ b/src/ethereum_optimized/__init__.py
@@ -25,9 +25,9 @@ optimized_state_patches = {
     "root": optimized_trie.root,
     "trie_get": optimized_trie.trie_get,
     "trie_set": optimized_trie.trie_set,
-    "State": optimized_state.State,  # type: ignore
-    "set_storage": optimized_state.set_storage,  # type: ignore
-    "get_storage": optimized_state.get_storage,  # type: ignore
+    "State": optimized_state.State,
+    "set_storage": optimized_state.set_storage,
+    "get_storage": optimized_state.get_storage,
 }
 
 

--- a/src/ethereum_optimized/__init__.py
+++ b/src/ethereum_optimized/__init__.py
@@ -1,0 +1,42 @@
+"""
+Optimized Implementations
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+This module contains alternative implementations of routines in the spec that
+have been optimized for speed rather than clarity.
+
+They can be monkey patched in during start up by calling the `monkey_patch_X()`
+functions.
+"""
+
+import ethereum.frontier.state as normal_state
+import ethereum_optimized.state as optimized_state
+import ethereum_optimized.trie as optimized_trie
+
+optimized_state_patches = {
+    "Trie": optimized_trie.Trie,
+    "root": optimized_trie.root,
+    "trie_get": optimized_trie.trie_get,
+    "trie_set": optimized_trie.trie_set,
+    "State": optimized_state.State,  # type: ignore
+    "set_storage": optimized_state.set_storage,  # type: ignore
+    "get_storage": optimized_state.get_storage,  # type: ignore
+}
+
+
+def monkey_patch_optimized_state() -> None:
+    """
+    Replace the state interface with one that supports high performance
+    updates.
+
+    This function must be called before the state interface imported anywhere.
+    """
+    for (name, value) in optimized_state_patches.items():
+        setattr(normal_state, name, value)

--- a/src/ethereum_optimized/state.py
+++ b/src/ethereum_optimized/state.py
@@ -1,4 +1,3 @@
-# type: ignore
 """
 Optimized State
 ^^^^^^^^^^^^^^^
@@ -15,8 +14,9 @@ This module contains functions can be monkey patched into
 """
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, cast
 
+import ethereum.frontier.state
 from ethereum.base_types import U256, Bytes
 from ethereum.frontier.eth_types import EMPTY_ACCOUNT, Account, Address
 from ethereum.frontier.state import state_root
@@ -35,13 +35,15 @@ class State:
     )
     _storage_tries: Dict[Address, Trie[U256]] = field(default_factory=dict)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """
         Test for equality by comparing state roots.
         """
         if type(self) != type(other):
             return NotImplemented
-        return state_root(self) == state_root(other)
+        return state_root(
+            cast(ethereum.frontier.state.State, self)
+        ) == state_root(cast(ethereum.frontier.state.State, other))
 
 
 def set_storage(

--- a/src/ethereum_optimized/state.py
+++ b/src/ethereum_optimized/state.py
@@ -1,0 +1,103 @@
+# type: ignore
+"""
+Optimized State
+^^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+This module contains functions can be monkey patched into
+`ethereum.frontier.state` to make it use the optimized trie.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from ethereum.base_types import U256, Bytes
+from ethereum.frontier.eth_types import EMPTY_ACCOUNT, Account, Address
+from ethereum.frontier.state import state_root
+
+from .trie import Trie, get_internal_key, trie_get, trie_set
+
+
+@dataclass
+class State:
+    """
+    Contains all information that is preserved between transactions.
+    """
+
+    _main_trie: Trie[Account] = field(
+        default_factory=lambda: Trie(secured=True, default=EMPTY_ACCOUNT)
+    )
+    _storage_tries: Dict[Address, Trie[U256]] = field(default_factory=dict)
+
+    def __eq__(self, other):
+        """
+        Test for equality by comparing state roots.
+        """
+        if type(self) != type(other):
+            return NotImplemented
+        return state_root(self) == state_root(other)
+
+
+def set_storage(
+    state: State, address: Address, key: Bytes, value: U256
+) -> None:
+    """
+    Set a value at a storage key on an account. Setting to `U256(0)` deletes
+    the key.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of the account.
+    key : `Bytes`
+        Key to set.
+    value : `U256`
+        Value to set at the key.
+    """
+    internal_address = get_internal_key(state._main_trie, address)
+    trie = state._storage_tries.get(internal_address)
+    if trie is None:
+        trie = Trie(secured=True, default=U256(0))
+        state._storage_tries[internal_address] = trie
+    trie_set(trie, key, value)
+    state._main_trie._dirty_set.add(internal_address)
+    if trie._data == {}:
+        del state._storage_tries[internal_address]
+
+
+def get_storage(state: State, address: Address, key: Bytes) -> U256:
+    """
+    Get a value at a storage key on an account. Returns `U256(0)` if the
+    storage key has not been set previously.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of the account.
+    key : `Bytes`
+        Key to lookup.
+
+    Returns
+    -------
+    value : `U256`
+        Value at the key.
+    """
+    internal_address = get_internal_key(state._main_trie, address)
+    trie = state._storage_tries.get(internal_address)
+    if trie is None:
+        return U256(0)
+
+    value = trie_get(trie, key)
+
+    assert isinstance(value, U256)
+    return value

--- a/src/ethereum_optimized/trie.py
+++ b/src/ethereum_optimized/trie.py
@@ -33,7 +33,7 @@ from ethereum.frontier.trie import (
 )
 
 
-@dataclass(eq=False)
+@dataclass
 class Trie(Generic[T]):
     """An optimized Trie implementation."""
 

--- a/src/ethereum_optimized/trie.py
+++ b/src/ethereum_optimized/trie.py
@@ -1,0 +1,332 @@
+"""
+Optimized Trie
+^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+This module contains an implementation of a merkle trie that supports efficient
+updates.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Generic, List, Set
+
+from ethereum import crypto
+from ethereum.base_types import Bytes
+from ethereum.frontier import rlp
+from ethereum.frontier.eth_types import Root
+from ethereum.frontier.trie import (
+    EMPTY_TRIE_ROOT,
+    BranchNode,
+    ExtensionNode,
+    InternalNode,
+    LeafNode,
+    T,
+    bytes_to_nibble_list,
+    common_prefix_length,
+    encode_internal_node,
+    encode_node,
+)
+
+
+@dataclass(eq=False)
+class Trie(Generic[T]):
+    """An optimized Trie implementation."""
+
+    secured: bool
+    default: T
+    _data: Dict[Bytes, T] = field(default_factory=dict)
+    _internal_nodes: Dict[Bytes, InternalNode] = field(default_factory=dict)
+    _dirty_set: Set[Bytes] = field(default_factory=set)
+    _root: Root = field(default=EMPTY_TRIE_ROOT)
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Test for equality by comparing roots.
+
+        This function does not work on tries that contain accounts.
+        """
+        if type(self) != type(other):
+            return NotImplemented
+        return root(self) == root(other)
+
+
+def get_internal_key(trie: Trie[T], key: Bytes) -> Bytes:
+    """
+    Convert a key to the form used internally inside the trie.
+    """
+    if trie.secured:
+        return bytes_to_nibble_list(crypto.keccak256(key))
+    else:
+        return bytes_to_nibble_list(key)
+
+
+def trie_get(trie: Trie, key: Bytes) -> T:
+    """
+    Gets an item from the Merkle Trie.
+    """
+    return trie._data.get(get_internal_key(trie, key), trie.default)
+
+
+def trie_set(trie: Trie[T], key: Bytes, value: T) -> None:
+    """
+    Stores an item in a Merkle Trie and adds `key` to `trie.dirty_set`.
+    """
+    nibble_list_key = get_internal_key(trie, key)
+    trie._dirty_set.add(nibble_list_key)
+    if value == trie.default:
+        if nibble_list_key in trie._data:
+            del trie._data[nibble_list_key]
+    else:
+        trie._data[nibble_list_key] = value
+
+
+def no_storage(x: Bytes) -> Bytes:
+    """
+    A stub to replace the `get_storage_root` argument in tries that don't
+    contain `Account` objects.
+    """
+    return None  # type: ignore
+
+
+def root(
+    trie: Trie,
+    get_storage_root: Callable[[Bytes], Bytes] = no_storage,
+) -> Root:
+    """
+    Calculate the root of the trie, by regenerating all internal nodes as
+    required by `trie.dirty_set`.
+    """
+    if trie._dirty_set == set():
+        return trie._root
+    walk(
+        trie,
+        b"",
+        list(sorted(trie._dirty_set, reverse=True)),
+        get_storage_root,
+    )
+    trie._dirty_set = set()
+    if b"" in trie._internal_nodes:
+        root = encode_internal_node(trie._internal_nodes[b""])
+        if isinstance(root, Bytes):
+            trie._root = root
+        else:
+            trie._root = crypto.keccak256(rlp.encode(root))
+    else:
+        trie._root = crypto.keccak256(rlp.encode(b""))
+    return trie._root
+
+
+def walk(
+    trie: Trie,
+    node_key: Bytes,
+    dirty_list: List[Bytes],
+    get_storage_root: Callable[[Bytes], Bytes],
+) -> None:
+    """
+    Visit the internal node at `node_key` and update it and all its subnodes as
+    required by possible changes to elements in `dirty_list`.
+    """
+    while dirty_list and dirty_list[-1].startswith(node_key):
+        current_node = trie._internal_nodes.get(node_key, None)
+        if current_node is None:
+            walk_empty(trie, node_key, dirty_list, get_storage_root)
+        elif isinstance(current_node, LeafNode):
+            walk_leaf(trie, node_key, dirty_list, get_storage_root)
+        elif isinstance(current_node, ExtensionNode):
+            walk_extension(trie, node_key, dirty_list, get_storage_root)
+        elif isinstance(current_node, BranchNode):
+            walk_branch(trie, node_key, dirty_list, get_storage_root)
+        else:
+            assert False  # Invalid internal node type
+
+
+def walk_empty(
+    trie: Trie,
+    node_key: Bytes,
+    dirty_list: List[Bytes],
+    get_storage_root: Callable[[Bytes], Bytes],
+) -> None:
+    """
+    Consume the last element of `dirty_list` and create a `LeafNode` pointing
+    to it at `node_key`.
+    """
+    assert trie._internal_nodes.get(node_key) is None
+    key = dirty_list.pop()
+    value = trie._data.get(key)
+    if value is not None:
+        trie._internal_nodes[node_key] = LeafNode(
+            key[len(node_key) :], encode_node(value, get_storage_root(key))
+        )
+
+
+def walk_leaf(
+    trie: Trie,
+    node_key: Bytes,
+    dirty_list: List[Bytes],
+    get_storage_root: Callable[[Bytes], Bytes],
+) -> None:
+    """
+    Consume the last element of `dirty_list` and update the `LeafNode` at
+    `node_key`, potentially turning it into `ExtensionNode` -> `BranchNode`
+    -> `LeafNode`.
+    """
+    leaf_node = trie._internal_nodes[node_key]
+    assert isinstance(leaf_node, LeafNode)
+    key = dirty_list[-1]
+    value = trie._data.get(key, None)
+    if key[len(node_key) :] == leaf_node.rest_of_key:
+        if value is None:
+            del trie._internal_nodes[node_key]
+        else:
+            trie._internal_nodes[node_key] = LeafNode(
+                leaf_node.rest_of_key,
+                encode_node(value, get_storage_root(key)),
+            )
+        dirty_list.pop()
+    else:
+        prefix_length = common_prefix_length(
+            leaf_node.rest_of_key, key[len(node_key) :]
+        )
+        prefix = leaf_node.rest_of_key[:prefix_length]
+        if len(leaf_node.rest_of_key) != prefix_length:
+            trie._internal_nodes[
+                node_key + leaf_node.rest_of_key[: prefix_length + 1]
+            ] = LeafNode(
+                leaf_node.rest_of_key[prefix_length + 1 :],
+                encode_node(
+                    leaf_node.value,
+                    get_storage_root(
+                        node_key + leaf_node.rest_of_key[: prefix_length + 1]
+                    ),
+                ),
+            )
+        walk_branch(trie, node_key + prefix, dirty_list, get_storage_root)
+        if prefix_length != 0:
+            make_extension_node(trie, node_key, node_key + prefix)
+
+
+def walk_extension(
+    trie: Trie,
+    node_key: Bytes,
+    dirty_list: List[Bytes],
+    get_storage_root: Callable[[Bytes], Bytes],
+) -> None:
+    """
+    Consume the last element of `dirty_list` and update the `ExtensionNode` at
+    `node_key`, potentially turning it into `ExtensionNode` -> `BranchNode`
+    -> `ExtensionNode`.
+    """
+    extension_node = trie._internal_nodes[node_key]
+    assert isinstance(extension_node, ExtensionNode)
+    key = dirty_list[-1]
+    if key[len(node_key) :].startswith(extension_node.key_segment):
+        walk(
+            trie,
+            node_key + extension_node.key_segment,
+            dirty_list,
+            get_storage_root,
+        )
+        make_extension_node(
+            trie, node_key, node_key + extension_node.key_segment
+        )
+        return
+    prefix_length = common_prefix_length(
+        extension_node.key_segment, key[len(node_key) :]
+    )
+    prefix = extension_node.key_segment[:prefix_length]
+    if prefix_length != len(extension_node.key_segment) - 1:
+        make_extension_node(
+            trie,
+            node_key + extension_node.key_segment[: prefix_length + 1],
+            node_key + extension_node.key_segment,
+        )
+    walk_branch(trie, node_key + prefix, dirty_list, get_storage_root)
+    if prefix_length != 0:
+        make_extension_node(trie, node_key, node_key + prefix)
+
+
+def walk_branch(
+    trie: Trie,
+    node_key: Bytes,
+    dirty_list: List[Bytes],
+    get_storage_root: Callable[[Bytes], Bytes],
+) -> None:
+    """
+    Make a `BranchNode` at `node_key` and consume all elements of `dirty_list`
+    that are under it.
+    """
+    if dirty_list[-1] == node_key:
+        dirty_list.pop()
+
+    subnodes = []
+    for i in range(16):
+        walk(trie, node_key + bytes([i]), dirty_list, get_storage_root)
+        subnodes.append(trie._internal_nodes.get(node_key + bytes([i]), None))
+
+    value_at_node = trie._data.get(node_key, None)
+    number_of_subnodes = 16 - subnodes.count(None)
+
+    if number_of_subnodes == 0:
+        if value_at_node is None:
+            if node_key in trie._internal_nodes:
+                del trie._internal_nodes[node_key]
+        else:
+            trie._internal_nodes[node_key] = LeafNode(
+                b"", encode_node(value_at_node, get_storage_root(node_key))
+            )
+    elif number_of_subnodes == 1 and value_at_node is None:
+        for i in range(16):
+            if subnodes[i] is not None:
+                subnode_index = i
+                break
+        make_extension_node(trie, node_key, node_key + bytes([subnode_index]))
+    else:
+        encoded_subnodes = [
+            encode_internal_node(subnode) for subnode in subnodes
+        ]
+        if value_at_node is None:
+            trie._internal_nodes[node_key] = BranchNode(encoded_subnodes, b"")
+        else:
+            trie._internal_nodes[node_key] = BranchNode(
+                encoded_subnodes, value_at_node
+            )
+
+
+def make_extension_node(
+    trie: Trie, node_key: Bytes, target_key: Bytes
+) -> None:
+    """
+    Make an extension node at `node_key` pointing at `target_key`. This
+    function will correctly replace `ExtensionNode -> LeafNode` with `LeafNode`
+    and `ExtensionNode -> ExtensionNode` with `ExtensionNode`.
+    """
+    assert node_key != target_key
+    target_node = trie._internal_nodes.get(target_key, None)
+    if target_node is None:
+        if (
+            node_key in trie._internal_nodes
+        ):  # This condition never fails, but is included for correctness
+            del trie._internal_nodes[node_key]
+    elif isinstance(target_node, LeafNode):
+        trie._internal_nodes[node_key] = LeafNode(
+            target_key[len(node_key) :] + target_node.rest_of_key,
+            target_node.value,
+        )
+        del trie._internal_nodes[target_key]
+    elif isinstance(target_node, ExtensionNode):
+        trie._internal_nodes[node_key] = ExtensionNode(
+            target_key[len(node_key) :] + target_node.key_segment,
+            target_node.subnode,
+        )
+        del trie._internal_nodes[target_key]
+    elif isinstance(target_node, BranchNode):
+        trie._internal_nodes[node_key] = ExtensionNode(
+            target_key[len(node_key) :], encode_internal_node(target_node)
+        )
+    else:
+        assert False  # Invalid internal node type

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -8,7 +8,7 @@ from ethereum.frontier import rlp
 from ethereum.frontier.eth_types import Account, Block, Header, Transaction
 from ethereum.frontier.rlp import rlp_hash
 from ethereum.frontier.spec import BlockChain, state_transition
-from ethereum.frontier.state import State, set_account, set_storage
+from ethereum.frontier.state import State, set_account, set_storage, state_root
 from ethereum.frontier.utils.hexadecimal import hex_to_address, hex_to_root
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,

--- a/tests/optimized/test_trie.py
+++ b/tests/optimized/test_trie.py
@@ -1,0 +1,45 @@
+from typing import List, Tuple
+
+import ethereum.frontier.trie as normal_trie
+import ethereum_optimized.trie as optimized_trie
+from ethereum.base_types import Bytes
+
+operations: List[List[Tuple[Bytes, Bytes]]] = [
+    [],  # Empty Trie
+    [(b"1234", b"foo")],  # Add a leaf
+    [(b"1234", b"bar")],  # Change the value of a leaf
+    [(b"1234", b"")],  # Delete a leaf
+    [(b"abcde", b"foo"), (b"abcdef", b"foo")],  # Make an extension node
+    [(b"abc", b"foo")],  # Split an extension node
+    [(b"abcde", b"")],  # Merge an extension and leaf
+    [(b"abcde1", b"foo"), (b"abcde2", b"")],  # Split a leaf node
+    [  # Delete all subnodes of an extension node but not the value at the node
+        (b"abcde1", b""),
+        (b"abcde2", b""),
+        (b"abcdef", b""),
+    ],
+    [(b"abcde", b"")],
+    [(b"abcde1", b"foo"), (b"abcde2", b"")],
+    [  # Delete all subnodes of an extension node and the value at the node
+        (b"abcde1", b""),
+        (b"abcde2", b""),
+        (b"abcde", b""),
+    ],
+    [(b"a", b"foo"), (b"aaa", b"foo"), (b"aaaa", b"foo")],
+    [(b"a", b""), (b"aa", b"foo")],
+    [(b"\x00\x00\x00\x00", b"foo"), (b"\x00\x00\x00\x01", b"foo")],
+    [(b"\x00\x00\x00\x10", b"foo")],
+    [(b"a", b"foo"), (b"b", b"foo"), (b"c", b"foo"), (b"d", b"foo")],
+]
+
+
+def test_trie() -> None:
+    trie_normal = normal_trie.Trie(False, b"")
+    trie_optimized = optimized_trie.Trie(False, b"")
+    for insert_list in operations:
+        for (key, value) in insert_list:
+            normal_trie.trie_set(trie_normal, key, value)
+            optimized_trie.trie_set(trie_optimized, key, value)
+        assert normal_trie.root(trie_normal) == optimized_trie.root(
+            trie_optimized
+        )


### PR DESCRIPTION
This pull requests adds the optimized Merkle Trie. This faster implementation can be used for the state interface by calling `ethereum.optimized.monkey_patch_optimized_state()` during startup.

There is currently one regression. Equality comparisons between optimized `Trie`/`State` objects do not work (you have to call `root`/`state_root`.

#### Testing

The code in `optimized/test_trie.py` achieves 100% branch coverage on the core logic (excluding a few impossible cases).

I have not added any other tests for the optimized logic. You can run the test suite using the optimized state implementation by adding
```python
import ethereum.optimized

ethereum.optimized.monkey_patch_optimized_state()
```
to `src/ethereum/__init__.py`.

#### Performance
These tests were done on a trie containing 1 million random keys using cpython.

Any operation on the unoptimized trie: 66s
Adding 60 keys on the optimized trie: 3.7ms (62μs per key)

It is unlikely that performance will be a problem on tries that fit in memory.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/w6i59wlueoq51.jpg)
