### PR TITLE
Fix bugs in the state trie

### DIFF
--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -54,7 +54,13 @@ EMPTY_TRIE_ROOT = hex_to_bytes(
 
 Node = Union[Account, Bytes, Transaction, Receipt, Uint, U256, None]
 T = TypeVar(
-    "T", Account, Bytes, Optional[Transaction], Optional[Receipt], Uint, U256
+    "T",
+    Optional[Account],
+    Bytes,
+    Optional[Transaction],
+    Optional[Receipt],
+    Uint,
+    U256,
 )
 
 
@@ -141,10 +147,14 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     if isinstance(node, Account):
         assert storage_root is not None
         return rlp.encode_account(node, storage_root)
-    elif isinstance(node, (Transaction, Receipt)):
+    elif isinstance(node, (Transaction, Receipt, U256)):
         return rlp.encode(cast(rlp.RLP, node))
+    elif isinstance(node, Bytes):
+        return node
     else:
-        return cast(Bytes, node)
+        raise NotImplementedError(
+            f"encoding for {type(node)} is not currently implemented"
+        )
 
 
 @dataclass

--- a/src/ethereum_optimized/state.py
+++ b/src/ethereum_optimized/state.py
@@ -14,11 +14,11 @@ This module contains functions can be monkey patched into
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, cast
+from typing import Dict, Optional, cast
 
 import ethereum.frontier.state
 from ethereum.base_types import U256, Bytes
-from ethereum.frontier.eth_types import EMPTY_ACCOUNT, Account, Address
+from ethereum.frontier.eth_types import Account, Address
 from ethereum.frontier.state import state_root
 
 from .trie import Trie, get_internal_key, trie_get, trie_set
@@ -30,8 +30,8 @@ class State:
     Contains all information that is preserved between transactions.
     """
 
-    _main_trie: Trie[Account] = field(
-        default_factory=lambda: Trie(secured=True, default=EMPTY_ACCOUNT)
+    _main_trie: Trie[Optional[Account]] = field(
+        default_factory=lambda: Trie(secured=True, default=None)
     )
     _storage_tries: Dict[Address, Trie[U256]] = field(default_factory=dict)
 


### PR DESCRIPTION
### What was wrong?

The state trie incorrectly handling cases involving empty accounts and storage resulting in incorrect state roots. Most state roots involving storage will be wrong prior to this fix.

Code (mostly involving gas costs) that needs to know about the difference between `EMPTY_ACCOUNT` and a non-existent one will need to use the new function `get_account_optional()`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/un44882dvyj21.jpg)
