### PR TITLE
Quote globbing syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ tox
 The development tools can also be run outside of `tox`, and can automatically reformat the code:
 
 ```bash
-$ pip install -e .[doc,lint,test]   # Installs eth1spec, and development tools.
+$ pip install -e ".[doc,lint,test]" # Installs eth1spec, and development tools.
 $ isort src                         # Organizes imports.
 $ black src                         # Formats code.
 $ flake8                            # Reports style/spelling/documentation errors.


### PR DESCRIPTION
### What was wrong?

cf. https://github.com/ethereum/execution-specs/issues/326#issuecomment-914574299

### How was it fixed?

Editing the README to quote the globbing syntax.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/TM2dLX8.jpg)
