### PR TITLE
Increase Python's default recursion limit

### DIFF
--- a/src/ethereum/__init__.py
+++ b/src/ethereum/__init__.py
@@ -4,3 +4,10 @@ Ethereum Specification
 
 Core specifications for Ethereum clients.
 """
+import sys
+
+#
+#  Ensure we can reach 1024 frames of recursion
+#
+EVM_RECURSION_LIMIT = 1024 * 12
+sys.setrecursionlimit(max(EVM_RECURSION_LIMIT, sys.getrecursionlimit()))

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -169,6 +169,8 @@ def test_precompiles(test_file: str) -> None:
     "test_file",
     [
         "ABAcalls0_d0g0v0.json",
+        "ABAcalls1_d0g0v0.json",
+        "ABAcalls2_d0g0v0.json",
         "ABAcalls3_d0g0v0.json",
         "ABAcallsSuicide0_d0g0v0.json",
         "ABAcallsSuicide1_d0g0v0.json",

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -257,3 +257,6 @@ sqrt
 precompiled
 ripemd160
 ecrecover
+
+getrecursionlimit
+setrecursionlimit


### PR DESCRIPTION
### What was wrong?
closes #335

There are some tests that use `CALL` and `CALLCODE` to make recursive calls. This was exceeding python's default recursion limit and was causing some tests to fail. 

### How was it fixed?
Increased the recursion limit to `1024 * 12`. I found this number in [py-evm](https://github.com/ethereum/py-evm/blob/2da165f98cedf08d3a8d21ee92f9de82d0a1baa8/eth/__init__.py#L14-L15). I haven't calculated the limit myself. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pinclipart.com/picdir/big/127-1274260_medium-size-of-things-to-draw-about-drawing.png)

Picture credits: [pinclipart.com](https://www.pinclipart.com/maxpin/bhhTTR/)