### PR TITLE
Uncomment tests that were dependent on the RETURN opcode. 

### DIFF
--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -48,8 +48,7 @@ def test_sub(test_file: str) -> None:
         "mul4.json",
         "mul5.json",
         "mul6.json",
-        # TODO: Uncomment mul7.json once RETURN is implemented
-        # "mul7.json",
+        "mul7.json",
     ],
 )
 def test_mul(test_file: str) -> None:
@@ -59,8 +58,7 @@ def test_mul(test_file: str) -> None:
 @pytest.mark.parametrize(
     "test_file",
     [
-        # TODO: Uncomment div1.json file once RETURN is implemented
-        # "div1.json",
+        "div1.json",
         "divBoostBug.json",
         "divByNonZero0.json",
         "divByNonZero1.json",
@@ -169,8 +167,7 @@ def test_addmod(test_file: str) -> None:
         "mulmod2_1.json",
         "mulmod3.json",
         "mulmod3_0.json",
-        # TODO: Test file 'mulmod4.json' after implementing RETURN opcode
-        # "mulmod4.json",
+        "mulmod4.json",
     ],
 )
 def test_mulmod(test_file: str) -> None:

--- a/tests/frontier/vm/test_control_flow_operations.py
+++ b/tests/frontier/vm/test_control_flow_operations.py
@@ -19,15 +19,14 @@ run_control_flow_ops_vm_test = partial(
         "jumpAfterStop.json",
         "jumpdestBigList.json",
         "jumpTo1InstructionafterJump.json",
-        # TODO: Run below test once RETURN is implemented
-        # "jumpDynamicJumpSameDest.json",
-        # "indirect_jump1.json",
-        # "indirect_jump2.json",
-        # "indirect_jump3.json",
-        # "DynamicJump_value1.json",
-        # "DynamicJump_value2.json",
-        # "DynamicJump_value3.json",
-        # "stackjump1.json",
+        "jumpDynamicJumpSameDest.json",
+        "indirect_jump1.json",
+        "indirect_jump2.json",
+        "indirect_jump3.json",
+        "DynamicJump_value1.json",
+        "DynamicJump_value2.json",
+        "DynamicJump_value3.json",
+        "stackjump1.json",
         "indirect_jump4.json",
         "JDfromStorageDynamicJump0_jumpdest0.json",
         "JDfromStorageDynamicJump0_jumpdest2.json",
@@ -153,8 +152,7 @@ def test_gas(test_file: str) -> None:
     [
         "for_loop1.json",
         "for_loop2.json",
-        # TODO: Run below test once RETURN opcode has been implemented.
-        # "loop_stacklimit_1020.json",
+        "loop_stacklimit_1020.json",
         "loop_stacklimit_1021.json",
     ],
 )
@@ -172,8 +170,7 @@ def test_when() -> None:
         "byte1.json",
         "calldatacopyMemExp.json",
         "codecopyMemExp.json",
-        # TODO: Run below test case once RETURN opcode has been implemented
-        # "deadCode_1.json",
+        "deadCode_1.json",
         "dupAt51becameMload.json",
         "swapAt52becameMstore.json",
         "log1MemExp.json",

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -70,9 +70,13 @@ def test_calldatasize(test_file: str) -> None:
         "calldatacopy_DataIndexTooHigh.json",
         "calldatacopy_DataIndexTooHigh2.json",
         "calldatacopy_sec.json",
-        "calldatacopyUnderFlow.json"
-        # TODO: Run the above test cases which end with `_return.json` once
-        # RETURN opcode is implemented.
+        "calldatacopyUnderFlow.json",
+        "calldatacopy0_return.json",
+        "calldatacopy1_return.json",
+        "calldatacopy2_return.json",
+        "calldatacopyZeroMemExpansion_return.json",
+        "calldatacopy_DataIndexTooHigh_return.json",
+        "calldatacopy_DataIndexTooHigh2_return.json",
     ],
 )
 def test_calldatacopy(test_file: str) -> None:

--- a/tests/frontier/vm/test_storage_operations.py
+++ b/tests/frontier/vm/test_storage_operations.py
@@ -16,9 +16,8 @@ run_storage_vm_test = partial(
         "sstore_load_0.json",
         "sstore_load_1.json",
         "sstore_load_2.json",
-        "sstore_underflow.json"
-        # TODO: Run below test once RETURN opcode has been implemented.
-        # "kv1.json",
+        "sstore_underflow.json",
+        "kv1.json",
     ],
 )
 def test_sstore_and_sload(test_file: str) -> None:

--- a/tests/frontier/vm/test_system_operations.py
+++ b/tests/frontier/vm/test_system_operations.py
@@ -29,3 +29,15 @@ def test_seldestruct(test_file: str) -> None:
 
 def test_seldestruct_vm_test() -> None:
     run_vm_test("suicide.json")
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "return0.json",
+        "return1.json",
+        "return2.json",
+    ],
+)
+def test_return(test_file: str) -> None:
+    run_system_vm_test(test_file)


### PR DESCRIPTION
### What was wrong?
There were several tests that were commented out because the `RETURN` opcode was not implemented. Now that the `RETURN` opcode has been [implemented](https://github.com/ethereum/execution-specs/pull/280), we can uncomment these tests. 

### How was it fixed?
1. Uncomment arithmetic operations tests: 9a7d31b
2. Uncommented control flow operation tests: d280e8e
3. Uncommented environmental operation tests: 83af1e1
4. Uncommented storage operation tests: 9f39f37
5. Added VM tests for the return opcode that I forgot to add in PR-280: 5da3c17


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://listproducer.com/wp-content/uploads/2014/10/cute.jpg)

Pic credits: [listproducer.com](https://listproducer.com/2014/10/cute-animals-can-help-increase-productivity/)