### PR TITLE
Fixed a bug in the selfdestruct refund logic

### DIFF
--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -12,7 +12,6 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.vm.gas import REFUND_SELF_DESTRUCT
 
 from ...state import get_account, increment_nonce, set_account_balance
 from ...utils.address import compute_contract_address, to_address
@@ -304,9 +303,6 @@ def selfdestruct(evm: Evm) -> None:
     # sending to beneficiary in case the contract named itself as the
     # beneficiary).
     set_account_balance(evm.env.state, originator, U256(0))
-
-    # gas refund
-    evm.refund_counter += REFUND_SELF_DESTRUCT
 
     # register account for deletion
     evm.accounts_to_delete.add(originator)

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -29,7 +29,11 @@ from ethereum.frontier.vm.error import (
     StackOverflowError,
     StackUnderflowError,
 )
-from ethereum.frontier.vm.gas import GAS_CODE_DEPOSIT, subtract_gas
+from ethereum.frontier.vm.gas import (
+    GAS_CODE_DEPOSIT,
+    REFUND_SELF_DESTRUCT,
+    subtract_gas,
+)
 from ethereum.frontier.vm.precompiled_contracts.mapping import (
     PRE_COMPILED_CONTRACTS,
 )
@@ -68,6 +72,8 @@ def process_message_call(message: Message, env: Environment) -> Evm:
         evm = process_create_message(message, env)
     else:
         evm = process_message(message, env)
+
+    evm.refund_counter += len(evm.accounts_to_delete) * REFUND_SELF_DESTRUCT
 
     return evm
 


### PR DESCRIPTION
### What was wrong?
The refund logic in `selfdestruct` was implemented incorrectly. The current implementation would refund gas every time an account was self-destructed in the same transaction. In fact, the implementation is clearly described in the YP as shown below:

<img width="745" alt="Screenshot 2021-09-13 at 5 34 06 PM" src="https://user-images.githubusercontent.com/8171193/133080426-1ef98c55-c6d2-4b40-baa8-068e37edc6cd.png">

The conversation held in [discord](https://discord.com/channels/595666850260713488/856943705209569291/885164284903063596) helped me identify this bug.

### How was it fixed?
<strike>Made sure that gas is only refunded once for the address being deleted in case `selfdestruct` is called multiple times for the address in the same transaction.</strike>

calculated gas refund for `selfdestruct` at the end of bytecode execution by multiplying the number of unique `accounts to delete` with the refund amount for `selfdestruct`.

PS: sadly, I haven't found any tests that check this logic. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://png.pngtree.com/png-clipart/20190705/original/pngtree-cute-rabbit-png-image_4358746.jpg)

Pic credits: [pngtree.com](https://pngtree.com/freepng/cute-rabbit_4358746.html)
