### PR TITLE
[Bug Fix] gas_left should be zero whenever there's exceptional halting

### DIFF
--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -186,9 +186,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
             if op not in PC_CHANGING_OPS:
                 evm.pc += 1
 
-    except OutOfGasError:
-        evm.gas_left = U256(0)
-        evm.has_erred = True
     except (
         OutOfGasError,
         InvalidOpcode,
@@ -196,6 +193,10 @@ def execute_code(message: Message, env: Environment) -> Evm:
         StackOverflowError,
         StackUnderflowError,
         StackDepthLimitError,
+    ):
+        evm.gas_left = U256(0)
+        evm.has_erred = True
+    except (
         AssertionError,
         ValueError,
     ):

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -40,11 +40,9 @@ def test_add() -> None:
     [
         f"Opcodes_TransactionInit_d{i}g0v0.json"
         for i in range(128)
-        if i not in [33, 37, 38, 124, 125, 126, 127]
+        if i not in [33, 127]
         # NOTE:
         # - Test 33, 127 has no tests for Frontier
-        # - test 37, 38 124, 125, 126 have invalid opcodes
-        # that need to be handled gracefully
     ],
 )
 def test_transaction_init(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?
There are some tests that have invalid opcodes that were failing. Upon investigating I figured out whenever there's exceptional halting in the EVM, `gas_left` needs to be set to zero. 

### How was it fixed?
- set `gas_left` to zero whenever there's exceptional halting. 
- Also, uncommented some tests with invalid opcodes. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://c4.wallpaperflare.com/wallpaper/479/73/137/cuttest-bunny-ever-wallpaper-preview.jpg)

Pic credits: [wallpaperflare.com](https://www.wallpaperflare.com/cuttest-bunny-ever-rabbit-baby-pretty-cute-animals-wallpaper-tvxbm)
