### PR TITLE
[Proposal] Raise exception Halt for normal halting of the EVM

### DIFF
--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -73,7 +73,6 @@ class Evm:
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]
     refund_counter: U256
-    running: bool
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]

--- a/src/ethereum/frontier/vm/error.py
+++ b/src/ethereum/frontier/vm/error.py
@@ -63,3 +63,11 @@ class StackDepthLimitError(Exception):
     """
 
     pass
+
+
+class Halt(Exception):
+    """
+    Raised when an opcode halts vm execution.
+    """
+
+    pass

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -13,7 +13,7 @@ Implementations of the EVM control flow instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.vm.error import InvalidJumpDestError
+from ethereum.frontier.vm.error import Halt, InvalidJumpDestError
 from ethereum.frontier.vm.gas import (
     GAS_BASE,
     GAS_HIGH,
@@ -35,7 +35,7 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.running = False
+    raise Halt("STOP")
 
 
 def jump(evm: Evm) -> None:

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Uint
+from ethereum.frontier.vm.error import Halt
 
 from ...state import get_account, increment_nonce, set_account_balance
 from ...utils.address import compute_contract_address, to_address
@@ -115,7 +116,7 @@ def return_(evm: Evm) -> None:
         evm.memory, memory_start_position, memory_size
     )
     # HALT the execution
-    evm.running = False
+    raise Halt("Return")
 
 
 def call(evm: Evm) -> None:
@@ -311,4 +312,4 @@ def selfdestruct(evm: Evm) -> None:
     evm.accounts_to_delete.add(originator)
 
     # HALT the execution
-    evm.running = False
+    raise Halt("SELFDESTRUCT")

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -22,6 +22,7 @@ from ethereum.frontier.state import (
 )
 from ethereum.frontier.vm import Message
 from ethereum.frontier.vm.error import (
+    Halt,
     InvalidJumpDestError,
     InvalidOpcode,
     OutOfGasError,
@@ -169,7 +170,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         valid_jump_destinations=valid_jump_destinations,
         logs=(),
         refund_counter=U256(0),
-        running=True,
         message=message,
         output=b"",
         accounts_to_delete=set(),
@@ -181,7 +181,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
-        while evm.running and evm.pc < len(evm.code):
+        while evm.pc < len(evm.code):
             try:
                 op = Ops(evm.code[evm.pc])
             except ValueError:
@@ -207,5 +207,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         ValueError,
     ):
         evm.has_erred = True
+    except Halt:
+        pass
     finally:
         return evm


### PR DESCRIPTION
### What was wrong?
The Yellow paper defines two types of Halting: Normal and exceptional.
Currently, we raise exceptions for exceptional halting. eg. `OutOfGasError`.
However, we use a flag to halt normal execution. `evm.running = False`.
Why not raise an exception for normal halting as well and handle it gracefully in the interpreter?
This way the code will be consistent. 

### How was it fixed?
 I have added a new exception `Halt` that is raised whenever an opcode halts VM execution. 

PS: This is more of a proposal. If other devs don't like it then I'm fine with closing it. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-003.jpg)

Pic credits: [abduzeedo.com](https://abduzeedo.com/node/74367)
