### PR TITLE
fixed log tests that were failing because gas calculations were resulting in U256 to overflow

### DIFF
--- a/src/ethereum/utils/safe_arithmetic.py
+++ b/src/ethereum/utils/safe_arithmetic.py
@@ -1,0 +1,93 @@
+"""
+Safe Arithmetic for U256 Integer Type
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Safe arithmetic utility functions for U256 integer type.
+"""
+from typing import Optional, Type
+
+from ethereum.base_types import U256
+
+
+def u256_safe_add(
+    *numbers: U256, exception_type: Optional[Type[BaseException]] = None
+) -> U256:
+    """
+    Adds together the given sequence of numbers. If the total sum of the
+    numbers exceeds `U256.MAX_VALUE` then an exception is raised.
+    If `exception_type` = None then the exception raised defaults to the one
+    raised by `U256` when `U256.value > U256.MAX_VALUE`
+    else `exception_type` is raised.
+
+    Parameters
+    ----------
+    numbers :
+        The sequence of numbers that need to be added together.
+
+    exception_type:
+        The exception that needs to be raised if the sum of the `numbers`
+        exceeds `U256.MAX_VALUE`.
+
+    Returns
+    -------
+    result : `ethereum.base_types.U256`
+        The sum of the given sequence of numbers if the total is less than
+        `U256.MAX_VALUE` else an exception is raised.
+        If `exception_type` = None then the exception raised defaults to the
+        one raised by `U256` when `U256.value > U256.MAX_VALUE`
+        else `exception_type` is raised.
+    """
+    try:
+        return U256(sum(numbers))
+    except ValueError as e:
+        if exception_type:
+            raise exception_type from e
+        else:
+            raise e
+
+
+def u256_safe_multiply(
+    *numbers: U256, exception_type: Optional[Type[BaseException]] = None
+) -> U256:
+    """
+    Multiplies together the given sequence of numbers. If the net product of
+    the numbers exceeds `U256.MAX_VALUE` then an exception is raised.
+    If `exception_type` = None then the exception raised defaults to the one
+    raised by `U256` when `U256.value > U256.MAX_VALUE` else
+    `exception_type` is raised.
+
+    Parameters
+    ----------
+    numbers :
+        The sequence of numbers that need to be multiplies together.
+
+    exception_type:
+        The exception that needs to be raised if the sum of the `numbers`
+        exceeds `U256.MAX_VALUE`.
+
+    Returns
+    -------
+    result : `ethereum.base_types.U256`
+        The multiplication product of the given sequence of numbers if the
+        net product  is less than `U256.MAX_VALUE` else an exception is raised.
+        If `exception_type` = None then the exception raised defaults to the
+        one raised by `U256` when `U256.value > U256.MAX_VALUE`
+        else `exception_type` is raised.
+    """
+    result = numbers[0]
+    try:
+        for number in numbers[1:]:
+            result *= number
+        return result
+    except ValueError as e:
+        if exception_type:
+            raise exception_type from e
+        else:
+            raise e

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -93,19 +93,18 @@ def test_transaction_init(test_file: str) -> None:
         "log4_nonEmptyMem_d0g0v0.json",
         "log4_nonEmptyMem_logMemSize1_d0g0v0.json",
         "log4_nonEmptyMem_logMemSize1_logMemStart31_d0g0v0.json",
-        # FIXME: The tests below are failing because gas calculation is causing
-        #  U256 to overflow. These tests are supposed to fail with OOG exception
-        #  "log0_logMemStartTooHigh_d0g0v0.json",
-        #  "log0_logMemsizeTooHigh_d0g0v0.json",
-        #  "log1_logMemStartTooHigh_d0g0v0.json",
-        #  "log1_logMemsizeTooHigh_d0g0v0.json",
-        #  "log2_logMemStartTooHigh_d0g0v0.json",
-        #  "log2_logMemsizeTooHigh_d0g0v0.json",
-        #  "log3_logMemStartTooHigh_d0g0v0.json",
-        #  "log3_logMemsizeTooHigh_d0g0v0.json",
-        #  "log4_logMemStartTooHigh_d0g0v0.json",
-        #  "log4_logMemsizeTooHigh_d0g0v0.json",
-        #  "logInOOG_Call_d0g0v0.json",
+        "log0_logMemStartTooHigh_d0g0v0.json",
+        "log0_logMemsizeTooHigh_d0g0v0.json",
+        "log1_logMemStartTooHigh_d0g0v0.json",
+        "log1_logMemsizeTooHigh_d0g0v0.json",
+        "log2_logMemStartTooHigh_d0g0v0.json",
+        "log2_logMemsizeTooHigh_d0g0v0.json",
+        "log3_logMemStartTooHigh_d0g0v0.json",
+        "log3_logMemsizeTooHigh_d0g0v0.json",
+        "log4_logMemStartTooHigh_d0g0v0.json",
+        "log4_logMemsizeTooHigh_d0g0v0.json",
+        # FIXME: The receipt root doesn't match for the test below
+        # "logInOOG_Call_d0g0v0.json",
     ],
 )
 def test_log_operations(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?

Some gas calculations were causing U256 to overflow.

### How was it fixed?
- Implemented `u256_safe_add` and `u256_safe_multiply` that add and multiuply respectively and raise `OutOfGasError` if the result exceeds `U256.MAX_VALUE`.
- Uncommented tests that were failing because of the above-mentioned error. 

### Note

I haven't applied the new safe arithmetic methods in other places where gas calculation could possibly overflow. I can do this in a separate PR. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.shopify.com/s/files/1/1057/6184/files/baby-rhyno_grande_2x.jpg?17358227885677525412)

Pic credits: [www.homeoanimal.com](https://www.homeoanimal.com/blogs/blog-pet-health/worlds-cutest-baby-animals)
