### PR TITLE
[Bug Fix] Make sure that the empty substate is set whenever there is exceptional halting

### DIFF
--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -201,6 +201,9 @@ def execute_code(message: Message, env: Environment) -> Evm:
         StackDepthLimitError,
     ):
         evm.gas_left = U256(0)
+        evm.logs = ()
+        evm.accounts_to_delete = set()
+        evm.refund_counter = U256(0)
         evm.has_erred = True
     except (
         AssertionError,

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -103,8 +103,7 @@ def test_transaction_init(test_file: str) -> None:
         "log3_logMemsizeTooHigh_d0g0v0.json",
         "log4_logMemStartTooHigh_d0g0v0.json",
         "log4_logMemsizeTooHigh_d0g0v0.json",
-        # FIXME: The receipt root doesn't match for the test below
-        # "logInOOG_Call_d0g0v0.json",
+        "logInOOG_Call_d0g0v0.json",
     ],
 )
 def test_log_operations(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?

depends on #342 

The yellow paper says that the empty substate needs to be set whenever there's exceptional halting as shown below:
![Screenshot 2021-09-15 at 6 50 29 PM](https://user-images.githubusercontent.com/8171193/133441108-bb273284-3452-44a2-9848-3c588a9b1af6.png)

The empty substate is defines as:
![Screenshot 2021-09-15 at 6 55 00 PM](https://user-images.githubusercontent.com/8171193/133441573-0eb58ce0-4da4-4325-bccf-9030cb25865a.png)

The literal translation of this in our codebase would be:
```python
evm.accounts_to_delete = set()
evm.logs = ()
evm.refund_counter = U256(0)
```
Our current implementation doesn't set to empty substate whenever there's exceptional halting. 

### How was it fixed?

set empty substate whenever there's exceptional halting.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.shopify.com/s/files/1/1057/6184/files/goats-enhanced-26656-1415220251-17_grande_2x.jpg?10091555796653403950)

Pic credits: [homeoanimal.com/](https://www.homeoanimal.com/blogs/blog-pet-health/worlds-cutest-baby-animals)
