### PR TITLE
use safe arithmetic wherever gas calculations can cause U256 to overflow

### DIFF
--- a/src/ethereum/frontier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/identity.py
@@ -12,7 +12,9 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 from ethereum.base_types import Uint
+from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
 from ...vm.gas import GAS_IDENTITY, GAS_IDENTITY_WORD, subtract_gas
@@ -29,6 +31,15 @@ def identity(evm: Evm) -> None:
     """
     data = evm.message.data
     word_count = ceil32(Uint(len(data))) // 32
-    gas_fee = GAS_IDENTITY + word_count * GAS_IDENTITY_WORD
-    evm.gas_left = subtract_gas(evm.gas_left, gas_fee)
+    word_count_gas_cost = u256_safe_multiply(
+        word_count,
+        GAS_IDENTITY_WORD,
+        exception_type=OutOfGasError,
+    )
+    total_gas_cost = u256_safe_add(
+        GAS_IDENTITY,
+        word_count_gas_cost,
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
     evm.output = data

--- a/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
@@ -14,8 +14,10 @@ Implementation of the `RIPEMD160` precompiled contract.
 import hashlib
 
 from ethereum.base_types import Uint
+from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
 from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
@@ -32,8 +34,17 @@ def ripemd160(evm: Evm) -> None:
     """
     data = evm.message.data
     word_count = ceil32(Uint(len(data))) // 32
-    gas_fee = GAS_RIPEMD160 + word_count * GAS_RIPEMD160_WORD
-    evm.gas_left = subtract_gas(evm.gas_left, gas_fee)
+    word_count_gas_cost = u256_safe_multiply(
+        word_count,
+        GAS_RIPEMD160_WORD,
+        exception_type=OutOfGasError,
+    )
+    total_gas_cost = u256_safe_add(
+        GAS_RIPEMD160,
+        word_count_gas_cost,
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
@@ -14,7 +14,9 @@ Implementation of the `SHA256` precompiled contract.
 import hashlib
 
 from ethereum.base_types import Uint
+from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
 from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
@@ -31,6 +33,15 @@ def sha256(evm: Evm) -> None:
     """
     data = evm.message.data
     word_count = ceil32(Uint(len(data))) // 32
-    gas_fee = GAS_SHA256 + word_count * GAS_SHA256_WORD
-    evm.gas_left = subtract_gas(evm.gas_left, gas_fee)
+    word_count_gas_cost = u256_safe_multiply(
+        word_count,
+        GAS_SHA256_WORD,
+        exception_type=OutOfGasError,
+    )
+    total_gas_cost = u256_safe_add(
+        GAS_SHA256,
+        word_count_gas_cost,
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/utils/safe_arithmetic.py
+++ b/src/ethereum/utils/safe_arithmetic.py
@@ -11,13 +11,14 @@ Introduction
 
 Safe arithmetic utility functions for U256 integer type.
 """
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
-from ethereum.base_types import U256
+from ethereum.base_types import U256, Uint
 
 
 def u256_safe_add(
-    *numbers: U256, exception_type: Optional[Type[BaseException]] = None
+    *numbers: Union[U256, Uint],
+    exception_type: Optional[Type[BaseException]] = None
 ) -> U256:
     """
     Adds together the given sequence of numbers. If the total sum of the
@@ -54,7 +55,8 @@ def u256_safe_add(
 
 
 def u256_safe_multiply(
-    *numbers: U256, exception_type: Optional[Type[BaseException]] = None
+    *numbers: Union[U256, Uint],
+    exception_type: Optional[Type[BaseException]] = None
 ) -> U256:
     """
     Multiplies together the given sequence of numbers. If the net product of
@@ -85,7 +87,7 @@ def u256_safe_multiply(
     try:
         for number in numbers[1:]:
             result *= number
-        return result
+        return U256(result)
     except ValueError as e:
         if exception_type:
             raise exception_type from e


### PR DESCRIPTION
### What was wrong?

Related to Issue #342

#342 introduced safe arithmetic for handling gas calculations that could overflow U256. There are several more places where gas calculations can cause U256 to overflow.

### How was it fixed?
Used safe arithmetic wherever gas calculations can cause U256 to overflow.

### Note:
The Yellow paper says that the "data" size is unlimited:
<img width="480" alt="Screenshot 2021-09-16 at 3 23 58 PM" src="https://user-images.githubusercontent.com/8171193/133591688-8f5684bf-b6d9-4571-9b43-76f9e849a6a5.png">
There are some precompiles that calculate gas cost based on the input data size. This is the reason why `u256_safe_add` and  `u256_safe_multiply` have been modified to accept `Uint` as input.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/127027/pexels-photo-127027.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=500)

Pic credits: [pexels.com](https://www.pexels.com/search/cute%20animals/)
