### PR TITLE
[BugFix]Handle collision of addresses and OutofGasError while setting code during contract creation 

### DIFF
--- a/src/ethereum/frontier/state.py
+++ b/src/ethereum/frontier/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum.base_types import U256, Bytes, modify
+from ethereum.base_types import U256, Bytes, Uint, modify
 
 from .eth_types import EMPTY_ACCOUNT, Account, Address, Root
 from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
@@ -291,6 +291,27 @@ def account_exists(state: State, address: Address) -> bool:
         True if account exists in the state trie, False otherwise
     """
     return get_account_optional(state, address) is not None
+
+
+def account_has_code_or_nonce(state: State, address: Address) -> bool:
+    """
+    Checks if an account has non zero nonce or non empty code
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    has_code_or_nonce : `bool`
+        True if if an account has non zero nonce or non empty code,
+        False otherwise.
+    """
+    account = get_account(state, address)
+    return account.nonce != Uint(0) or account.code != b""
 
 
 def modify_state(

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Uint
+from ethereum.frontier.state import account_has_code_or_nonce
 from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
@@ -76,6 +77,10 @@ def create(evm: Evm) -> None:
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
     )
+    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
+    if is_collision:
+        push(evm.stack, U256(0))
+        return
 
     gas_left = evm.gas_left
     evm.gas_left = subtract_gas(evm.gas_left, gas_left)

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -116,8 +116,12 @@ def process_create_message(message: Message, env: Environment) -> Evm:
     contract_code = evm.output
     if contract_code:
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
-        evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
-        set_code(env.state, message.current_target, contract_code)
+        try:
+            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+        except OutOfGasError:
+            evm.output = b""
+        else:
+            set_code(env.state, message.current_target, contract_code)
     return evm
 
 

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -249,6 +249,7 @@ def test_system_operations(test_file: str) -> None:
         "CREATE_ContractRETURNBigOffset_d0g0v0.json",
         "CREATE_ContractRETURNBigOffset_d1g0v0.json",
         "CREATE_ContractRETURNBigOffset_d2g0v0.json",
+        "CREATE_ContractRETURNBigOffset_d3g0v0.json",
         "CREATE_ContractSSTOREDuringInit_d0g0v0.json",
         "CREATE_ContractSuicideDuringInit_ThenStoreThenReturn_d0g0v0.json",
         "CREATE_ContractSuicideDuringInit_WithValueToItself_d0g0v0.json",
@@ -274,8 +275,6 @@ def test_system_operations(test_file: str) -> None:
         "TransactionCollisionToEmptyButNonce_d0g0v1.json",
         "TransactionCollisionToEmpty_d0g0v0.json",
         "TransactionCollisionToEmpty_d0g0v1.json",
-        # FIXME: The test below results in gas overflow
-        # "CREATE_ContractRETURNBigOffset_d3g0v0.json",
         # Note: All other tests from stCreateTest that aren't listed
         # here don't have tests for Frontier.
     ],

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -36,6 +36,12 @@ run_system_operations_test = partial(
     "GeneralStateTests/stSystemOperationsTest/",
 )
 
+run_create_test = partial(
+    run_frontier_blockchain_st_tests,
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    "GeneralStateTests/stCreateTest/",
+)
+
 
 def test_add() -> None:
     run_example_test("add11_d0g0v0.json")
@@ -234,3 +240,45 @@ def test_precompiles(test_file: str) -> None:
 )
 def test_system_operations(test_file: str) -> None:
     run_system_operations_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "CREATE_AcreateB_BSuicide_BStore_d0g0v0.json",
+        "CREATE_ContractRETURNBigOffset_d0g0v0.json",
+        "CREATE_ContractRETURNBigOffset_d1g0v0.json",
+        "CREATE_ContractRETURNBigOffset_d2g0v0.json",
+        "CREATE_ContractSSTOREDuringInit_d0g0v0.json",
+        "CREATE_ContractSuicideDuringInit_ThenStoreThenReturn_d0g0v0.json",
+        "CREATE_ContractSuicideDuringInit_WithValueToItself_d0g0v0.json",
+        "CREATE_ContractSuicideDuringInit_WithValue_d0g0v0.json",
+        "CREATE_ContractSuicideDuringInit_d0g0v0.json",
+        "CREATE_EContractCreateEContractInInit_Tr_d0g0v0.json",
+        "CREATE_EContractCreateNEContractInInitOOG_Tr_d0g0v0.json",
+        "CREATE_EContractCreateNEContractInInit_Tr_d0g0v0.json",
+        "CREATE_EContract_ThenCALLToNonExistentAcc_d0g0v0.json",
+        "CREATE_EmptyContractAndCallIt_0wei_d0g0v0.json",
+        "CREATE_EmptyContractAndCallIt_1wei_d0g0v0.json",
+        "CREATE_EmptyContractWithBalance_d0g0v0.json",
+        "CREATE_EmptyContractWithStorageAndCallIt_0wei_d0g0v0.json",
+        "CREATE_EmptyContractWithStorageAndCallIt_1wei_d0g0v0.json",
+        "CREATE_EmptyContractWithStorage_d0g0v0.json",
+        "CREATE_EmptyContract_d0g0v0.json",
+        "CREATE_empty000CreateinInitCode_Transaction_d0g0v0.json",
+        "CreateCollisionToEmpty_d0g0v0.json",
+        "CreateCollisionToEmpty_d0g0v1.json",
+        "TransactionCollisionToEmptyButCode_d0g0v0.json",
+        "TransactionCollisionToEmptyButCode_d0g0v1.json",
+        "TransactionCollisionToEmptyButNonce_d0g0v0.json",
+        "TransactionCollisionToEmptyButNonce_d0g0v1.json",
+        "TransactionCollisionToEmpty_d0g0v0.json",
+        "TransactionCollisionToEmpty_d0g0v1.json",
+        # FIXME: The test below results in gas overflow
+        # "CREATE_ContractRETURNBigOffset_d3g0v0.json",
+        # Note: All other tests from stCreateTest that aren't listed
+        # here don't have tests for Frontier.
+    ],
+)
+def test_create(test_file: str) -> None:
+    run_create_test(test_file)

--- a/tests/frontier/vm/vm_test_helpers.py
+++ b/tests/frontier/vm/vm_test_helpers.py
@@ -38,16 +38,17 @@ def run_test(test_dir: str, test_file: str) -> None:
         env=env,
     )
 
-    evm = process_message_call(
-        message=message,
-        env=env,
-    )
+    (
+        gas_left,
+        refund_counter,
+        logs,
+        accounts_to_delete,
+        has_erred,
+    ) = process_message_call(message=message, env=env)
 
     if test_data["has_post_state"]:
-        assert evm.gas_left == test_data["expected_gas_left"]
-        assert (
-            keccak256(rlp.encode(evm.logs)) == test_data["expected_logs_hash"]
-        )
+        assert gas_left == test_data["expected_gas_left"]
+        assert keccak256(rlp.encode(logs)) == test_data["expected_logs_hash"]
         # We are checking only the storage here and not the whole state, as the
         # balances in the testcases don't change even though some value is
         # transferred along with code invocation. But our evm execution transfers
@@ -55,9 +56,9 @@ def run_test(test_dir: str, test_file: str) -> None:
         for addr in test_data["expected_post_state"]._storage_tries:
             assert storage_root(
                 test_data["expected_post_state"], addr
-            ) == storage_root(evm.env.state, addr)
+            ) == storage_root(env.state, addr)
     else:
-        assert evm.has_erred is True
+        assert has_erred is True
 
 
 def load_test(test_dir: str, test_file: str) -> Any:


### PR DESCRIPTION
### What was wrong?

Tried to pass tests from `stCreateTest` and found the following problems:
- Collision of Address isn't currently handled
- OutOfGasError raised while setting code during contract creation isn't handled correctly.

### How was it fixed?
Fixed the two problems discussed above in separate commits as described below:
- Handled collision of address during contract creation.  b10bbf1
- Handled `OutOfGasError` raised while setting code during contract creation.  8266384

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/39317/chihuahua-dog-puppy-cute-39317.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=500)

Pic credits: [pexels.com](https://www.pexels.com/search/cute%20animals/)