### PR TITLE
[Bug Fix] Charge transaction gas fee before executing the transaction

### DIFF
--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -236,6 +236,7 @@ def test_precompiles(test_file: str) -> None:
         "suicideOrigin_d0g0v0.json",
         "suicideSendEtherPostDeath_d0g0v0.json",
         "suicideSendEtherToMe_d0g0v0.json",
+        "callerAccountBalance_d0g0v0.json",
     ],
 )
 def test_system_operations(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?

A failing test for the `BALANCE` opcode helped me identify a bug in our implementation. Here's what is happening:
1. We subtract the transaction gas fee from the sender after the transaction is executed.
2. `BALANCE` opcode in this case will push the sender's balance before charging the tx gas fee to the stack.

The correct behaviour is to first subtract the tx gas_fee before executing the tx and then refund the gas if needed at the end. 

### How was it fixed?
Charged transaction gas fee before executing the transaction

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/34096/blue-tit-bird-cute-nature.jpg?auto=compress&cs=tinysrgb&dpr=2&w=500)

Pic credits: [www.pexels.com](https://www.pexels.com/search/cute%20animals/)