### PR TITLE
[Bug Fix] subtract all remaining gas before checking for address collision in the CREATE opcode

### DIFF
--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -73,6 +73,10 @@ def create(evm: Evm) -> None:
     )
 
     increment_nonce(evm.env.state, evm.message.current_target)
+
+    create_message_gas = evm.gas_left
+    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
+
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
@@ -82,13 +86,10 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         return
 
-    gas_left = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, gas_left)
-
     child_message = Message(
         caller=evm.message.current_target,
         target=b"",
-        gas=gas_left,
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -237,6 +237,7 @@ def test_precompiles(test_file: str) -> None:
         "suicideSendEtherPostDeath_d0g0v0.json",
         "suicideSendEtherToMe_d0g0v0.json",
         "callerAccountBalance_d0g0v0.json",
+        "CreateHashCollision_d0g0v0.json",
     ],
 )
 def test_system_operations(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?

While trying to pass a test related to address collision I learned that all the remaining gas needs to be subtracted before checking address collision in the `CREATE` opcode. 


### How was it fixed?

subtracted all remaining gas before checking for address collision in the `CREATE` opcode


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/162140/duckling-birds-yellow-fluffy-162140.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=500)

Pic credits: [www.pexels.com](https://www.pexels.com/search/cute%20animals/)
