### PR TITLE
Remove geth download from test suite and make it part of github workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,7 +18,12 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages
-        run: pip install tox
+        run: pip install tox requests
+      - name: Download Geth and add to $PATH
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          $GITHUB_WORKSPACE/scripts/download_geth_linux.py --dir $GITHUB_WORKSPACE/bin
+          echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Run Tox (PyPy)
         if: ${{ matrix.python == 'pypy-3.7' }}
         run: tox -e pypy3

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Running the tests necessary to merge into the repository requires:
 
  * Python 3.7.x (not 3.8 or later), and
  * [PyPy 7.3.x](https://www.pypy.org/).
+ * `geth` installed and present in `$PATH`
 
 These version ranges are necessary because, at the time of writing, PyPy is only compatible with Python 3.7.
 
@@ -86,7 +87,7 @@ $ isort src                         # Organizes imports.
 $ black src                         # Formats code.
 $ flake8                            # Reports style/spelling/documentation errors.
 $ mypy src                          # Verifies type annotations.
-$ pytest                            # Runs tests.
+$ pytest -n 4                       # Runs tests parallelly.
 $ pytest -m "not slow"              # Runs tests which execute quickly.
 ```
 

--- a/scripts/download_geth_linux.py
+++ b/scripts/download_geth_linux.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import shutil
+import tarfile
+
+import requests
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dir", help="Directory to which geth binary will be downloaded to"
+    )
+
+    return parser.parse_args()
+
+
+def download_geth_linux(dir: str) -> None:
+    geth_release_name = "geth-linux-amd64-1.10.8-26675454"
+    url = (
+        f"https://gethstore.blob.core.windows.net/builds/"
+        f"{geth_release_name}.tar.gz"
+    )
+    r = requests.get(url)
+
+    with open(f"{dir}/geth.tar.gz", "wb") as f:
+        f.write(r.content)
+
+    geth_tar = tarfile.open(f"{dir}/geth.tar.gz")
+    geth_tar.extractall(dir)
+
+    shutil.move(f"{dir}/{geth_release_name}/geth", dir)
+    shutil.rmtree(f"{dir}/{geth_release_name}", ignore_errors=True)
+    os.remove(f"{dir}/geth.tar.gz")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    download_geth_linux(args.dir)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ console_scripts =
 test =
     pytest>=6.2,<7
     pytest-cov>=2.12,<3
+    pytest-xdist>=2.3.0,<3
     requests
 
 lint =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*"
-    pytest --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*'
+    pytest --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' -n 4
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -20,7 +20,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest --ignore-glob='tests/fixtures/*'
+    pytest --ignore-glob='tests/fixtures/*' -n 4
     ethereum-spec-lint
 
 [testenv:doc]


### PR DESCRIPTION
### What's new?

- Geth download has been removed from the test suite execution and made a pre-requisite
- Added geth download to github workflows
- Parallellize test case execution

Closes #329

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1560114928-40f1f1eb26a0?ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Y3V0ZSUyMGFuaW1hbHxlbnwwfHwwfHw%3D&ixlib=rb-1.2.1&w=1000&q=80)
