### PR TITLE
Fix bug preventing storage changes being persisted in optimized state

### DIFF
--- a/src/ethereum_optimized/frontier/state_db.py
+++ b/src/ethereum_optimized/frontier/state_db.py
@@ -447,14 +447,14 @@ def _storage_root(state: State, internal_address: Bytes, cursor: Any) -> Root:
         clear_destroyed_account(state, internal_address)
     storage_prefix = internal_address + b"\x00"
     dirty_storage = state._dirty_storage[-1].pop(internal_address, {}).items()
-    for key, value in dirty_storage:
+    for internal_key, value in dirty_storage:
         if value is None:
             state._current_tx.delete(
-                b"\x01" + internal_address + b"\x00" + internal_address
+                b"\x01" + internal_address + b"\x00" + internal_key
             )
         else:
             state._current_tx.put(
-                b"\x01" + internal_address + b"\x00" + internal_address,
+                b"\x01" + internal_address + b"\x00" + internal_key,
                 rlp.encode(value),
             )
     root_node = walk(


### PR DESCRIPTION
### What was wrong?

Due to a typo, storage changes would be lost after calls to `state_root()`. This prevented syncing past block 50111, where the first non-zero storage read occurred. This did not affect the calculation of the state root itself, only storage reads.

### How was it fixed?

Fixed typo

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/e3mol6u2qhs71.jpg)
