### PR TITLE
Only store most recent 255 blocks in the Blockchain object

### DIFF
--- a/tests/frontier/vm/vm_test_helpers.py
+++ b/tests/frontier/vm/vm_test_helpers.py
@@ -6,7 +6,7 @@ from ethereum.base_types import U256, Uint
 from ethereum.crypto import keccak256
 from ethereum.frontier import rlp
 from ethereum.frontier.eth_types import Account, Address
-from ethereum.frontier.spec import BlockChain, get_recent_block_hashes
+from ethereum.frontier.spec import BlockChain, get_last_256_block_hashes
 from ethereum.frontier.state import (
     State,
     close_state,
@@ -106,7 +106,7 @@ def json_to_env(json_data: Any) -> Environment:
     return Environment(
         caller=hex_to_address(json_data["exec"]["caller"]),
         origin=hex_to_address(json_data["exec"]["origin"]),
-        block_hashes=get_recent_block_hashes(chain, Uint(256)),
+        block_hashes=get_last_256_block_hashes(chain),
         coinbase=hex_to_address(json_data["env"]["currentCoinbase"]),
         number=hex_to_uint(json_data["env"]["currentNumber"]),
         gas_limit=hex_to_uint(json_data["env"]["currentGasLimit"]),


### PR DESCRIPTION
This patch makes the spec forget blocks older than 255 blocks ago. This is all that is required in order to implement the EVM. This saves about 5GB of memory usage by the end of Frontier.

I experimented with the `deque` object for this, but the complexity it introduced wasn't worth it.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/50862bw8g8u71.jpg)
