### PR TITLE
Hex encode block numbers for RPC requests

### DIFF
--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -317,7 +317,7 @@ class Sync:
                         "jsonrpc": "2.0",
                         "id": hex(block_number * 20 + i),
                         "method": "eth_getUncleByBlockNumberAndIndex",
-                        "params": [block_number, hex(i)],
+                        "params": [hex(block_number), hex(i)],
                     }
                 )
 
@@ -391,7 +391,7 @@ class Sync:
                     "jsonrpc": "2.0",
                     "id": hex(number),
                     "method": "eth_getBlockByNumber",
-                    "params": [number, True],
+                    "params": [hex(number), True],
                 }
             )
 


### PR DESCRIPTION
fixes #380

### What was wrong?

RPC requests were not being encoded correctly

### How was it fixed?

Applied hex encoding to the block number parameter


#### Cute Animal Picture

![78f17654b0a80c34aba2bfa173cc5e4e](https://user-images.githubusercontent.com/824194/138323723-eff9a97f-201b-44ea-be68-71fd51346d05.jpg)
