### PR TITLE
Add an optimized RLP implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,8 @@ doc-autobuild =
 optimized =
     lmdb>=1
     ethash==0.5.1a1
+    rusty-rlp; platform_python_implementation=="CPython"
+    rlp; platform_python_implementation=="PyPy"
 
 [flake8]
 dictionaries=en_US,python,technical

--- a/src/ethereum/frontier/eth_types.py
+++ b/src/ethereum/frontier/eth_types.py
@@ -71,7 +71,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=bytes(),
 )
 
 

--- a/src/ethereum/frontier/rlp.py
+++ b/src/ethereum/frontier/rlp.py
@@ -71,21 +71,21 @@ def encode(raw_data: RLP) -> Bytes:
     if isinstance(raw_data, (bytearray, bytes)):
         return encode_bytes(raw_data)
     elif isinstance(raw_data, (Uint, U256)):
-        return encode(raw_data.to_be_bytes())
+        return encode_bytes(raw_data.to_be_bytes())
     elif isinstance(raw_data, str):
         return encode_bytes(raw_data.encode())
     elif isinstance(raw_data, Sequence):
         return encode_sequence(cast(Sequence[RLP], raw_data))
     elif isinstance(raw_data, Block):
-        return encode_block(raw_data)
+        return encode(transcode_block(raw_data))
     elif isinstance(raw_data, Header):
-        return encode_header(raw_data)
+        return encode(transcode_header(raw_data))
     elif isinstance(raw_data, Transaction):
-        return encode_transaction(raw_data)
+        return encode(transcode_transaction(raw_data))
     elif isinstance(raw_data, Receipt):
-        return encode_receipt(raw_data)
+        return encode(transcode_receipt(raw_data))
     elif isinstance(raw_data, Log):
-        return encode_log(raw_data)
+        return encode(transcode_log(raw_data))
     else:
         raise TypeError(
             "RLP Encoding of type {} is not supported".format(type(raw_data))
@@ -393,41 +393,37 @@ def decode_item_length(encoded_data: Bytes) -> int:
 #
 
 
-def encode_block(raw_block_data: Block) -> Bytes:
+def transcode_block(raw_block_data: Block) -> RLP:
     """
     Encode `Block` dataclass
     """
-    return encode(
-        (
-            raw_block_data.header,
-            raw_block_data.transactions,
-            raw_block_data.ommers,
-        )
+    return (
+        raw_block_data.header,
+        raw_block_data.transactions,
+        raw_block_data.ommers,
     )
 
 
-def encode_header(raw_header_data: Header) -> Bytes:
+def transcode_header(raw_header_data: Header) -> RLP:
     """
     Encode `Header` dataclass
     """
-    return encode(
-        (
-            raw_header_data.parent_hash,
-            raw_header_data.ommers_hash,
-            raw_header_data.coinbase,
-            raw_header_data.state_root,
-            raw_header_data.transactions_root,
-            raw_header_data.receipt_root,
-            raw_header_data.bloom,
-            raw_header_data.difficulty,
-            raw_header_data.number,
-            raw_header_data.gas_limit,
-            raw_header_data.gas_used,
-            raw_header_data.timestamp,
-            raw_header_data.extra_data,
-            raw_header_data.mix_digest,
-            raw_header_data.nonce,
-        )
+    return (
+        raw_header_data.parent_hash,
+        raw_header_data.ommers_hash,
+        raw_header_data.coinbase,
+        raw_header_data.state_root,
+        raw_header_data.transactions_root,
+        raw_header_data.receipt_root,
+        raw_header_data.bloom,
+        raw_header_data.difficulty,
+        raw_header_data.number,
+        raw_header_data.gas_limit,
+        raw_header_data.gas_used,
+        raw_header_data.timestamp,
+        raw_header_data.extra_data,
+        raw_header_data.mix_digest,
+        raw_header_data.nonce,
     )
 
 
@@ -448,49 +444,43 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     )
 
 
-def encode_transaction(raw_tx_data: Transaction) -> Bytes:
+def transcode_transaction(raw_tx_data: Transaction) -> RLP:
     """
     Encode `Transaction` dataclass
     """
-    return encode(
-        (
-            raw_tx_data.nonce,
-            raw_tx_data.gas_price,
-            raw_tx_data.gas,
-            raw_tx_data.to,
-            raw_tx_data.value,
-            raw_tx_data.data,
-            raw_tx_data.v,
-            raw_tx_data.r,
-            raw_tx_data.s,
-        )
+    return (
+        raw_tx_data.nonce,
+        raw_tx_data.gas_price,
+        raw_tx_data.gas,
+        raw_tx_data.to,
+        raw_tx_data.value,
+        raw_tx_data.data,
+        raw_tx_data.v,
+        raw_tx_data.r,
+        raw_tx_data.s,
     )
 
 
-def encode_receipt(raw_receipt_data: Receipt) -> Bytes:
+def transcode_receipt(raw_receipt_data: Receipt) -> RLP:
     """
     Encode `Receipt` dataclass
     """
-    return encode(
-        (
-            raw_receipt_data.post_state,
-            raw_receipt_data.cumulative_gas_used,
-            raw_receipt_data.bloom,
-            raw_receipt_data.logs,
-        )
+    return (
+        raw_receipt_data.post_state,
+        raw_receipt_data.cumulative_gas_used,
+        raw_receipt_data.bloom,
+        raw_receipt_data.logs,
     )
 
 
-def encode_log(raw_log_data: Log) -> Bytes:
+def transcode_log(raw_log_data: Log) -> RLP:
     """
     Encode `Log` dataclass
     """
-    return encode(
-        (
-            raw_log_data.address,
-            raw_log_data.topics,
-            raw_log_data.data,
-        )
+    return (
+        raw_log_data.address,
+        raw_log_data.topics,
+        raw_log_data.data,
     )
 
 

--- a/src/ethereum_optimized/frontier/__init__.py
+++ b/src/ethereum_optimized/frontier/__init__.py
@@ -60,6 +60,20 @@ def monkey_patch_optimized_spec() -> None:
     slow_spec.validate_proof_of_work = fast_spec.validate_proof_of_work
 
 
+def monkey_patch_rlp() -> None:
+    """
+    Replace the rlp implementation with one that supports higher performance.
+
+    This function must be called before the rlp interface is imported anywhere.
+    """
+    import ethereum.frontier.rlp as slow_rlp
+
+    from . import rlp as fast_rlp
+
+    slow_rlp.encode = fast_rlp.encode
+    slow_rlp.decode = fast_rlp.decode
+
+
 def monkey_patch(state_path: Optional[str]) -> None:
     """
     Apply all monkey patches to swap in high performance implementations.
@@ -67,5 +81,6 @@ def monkey_patch(state_path: Optional[str]) -> None:
     This function must be called before any of the ethereum modules are
     imported anywhere.
     """
+    monkey_patch_rlp()
     monkey_patch_optimized_state_db(state_path)
     monkey_patch_optimized_spec()

--- a/src/ethereum_optimized/frontier/rlp.py
+++ b/src/ethereum_optimized/frontier/rlp.py
@@ -1,0 +1,83 @@
+"""
+Optimized RLP
+^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+This module contains functions can be monkey patched into
+`ethereum.frontier.rlp` to use alternate optimized implementations.
+"""
+
+from platform import python_implementation
+from typing import Sequence
+
+import ethereum.frontier.rlp as rlp
+from ethereum.base_types import U256, Bytes, Uint
+from ethereum.frontier.eth_types import (
+    Block,
+    Header,
+    Log,
+    Receipt,
+    Transaction,
+)
+
+if python_implementation() == "CPython":
+    from rusty_rlp import decode_raw, encode_raw
+elif python_implementation() == "PyPy":
+    from rlp.codec import decode_raw, encode_raw
+
+
+def encode(raw_data: rlp.RLP) -> Bytes:
+    """F"""
+    return encode_raw(transcode(raw_data))
+
+
+def decode(encoded_data: Bytes) -> rlp.RLP:
+    """F"""
+    return decode_raw(encoded_data, True, False)[0]
+
+
+def transcode(raw_data: rlp.RLP) -> rlp.RLP:
+    """
+    Encodes `raw_data` into a sequence of bytes using RLP.
+
+    Parameters
+    ----------
+    raw_data :
+        A `Bytes`, `Uint`, `Uint256` or sequence of `RLP` encodable
+        objects.
+
+    Returns
+    -------
+    encoded : `eth1spec.base_types.Bytes`
+        The RLP encoded bytes representing `raw_data`.
+    """
+    if isinstance(raw_data, bytes):
+        return raw_data
+    elif isinstance(raw_data, (Uint, U256)):
+        return raw_data.to_be_bytes()
+    elif isinstance(raw_data, str):
+        return raw_data.encode()
+    elif isinstance(raw_data, bytearray):
+        return bytes(raw_data)
+    elif isinstance(raw_data, Sequence):
+        return list(map(transcode, raw_data))
+    elif isinstance(raw_data, Block):
+        return transcode(rlp.transcode_block(raw_data))
+    elif isinstance(raw_data, Header):
+        return transcode(rlp.transcode_header(raw_data))
+    elif isinstance(raw_data, Transaction):
+        return transcode(rlp.transcode_transaction(raw_data))
+    elif isinstance(raw_data, Receipt):
+        return transcode(rlp.transcode_receipt(raw_data))
+    elif isinstance(raw_data, Log):
+        return transcode(rlp.transcode_log(raw_data))
+    else:
+        raise TypeError(
+            "RLP Encoding of type {} is not supported".format(type(raw_data))
+        )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -274,3 +274,6 @@ noop
 0x0
 0x1
 0x2
+
+transcode
+codec


### PR DESCRIPTION
### What was wrong?

RLP encoding/decoding was slow.

### How was it fixed?

Implemented an optimized version of RLP encoding/decoding. Under CPython, this uses the rust encoder/decoder provided by [rusty-rlp](https://github.com/cburgdorf/rusty-rlp). Under PyPy, we use the pure python implementation in [pyrlp](https://github.com/ethereum/pyrlp).

Although I did [get the rusty-rlp implementation to work](https://github.com/cburgdorf/rusty-rlp/pull/21) under PyPy, it is extremely slow due to [architectural differences](https://morepypy.blogspot.com/2018/09/inside-cpyext-why-emulating-cpython-c.html) between CPython and PyPy.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/hqjrxylc0xv71.jpg)
