### PR TITLE
changed some absolute imports to relative imports

### DIFF
--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -17,19 +17,12 @@ from typing import List, Optional, Set, Tuple
 
 from ethereum.crypto import SECP256K1N
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.frontier.bloom import logs_bloom
-from ethereum.frontier.genesis import genesis_configuration
-from ethereum.frontier.state import (
-    destroy_account,
-    increment_nonce,
-    set_account_balance,
-)
-from ethereum.frontier.utils.message import prepare_message
 from ethereum.utils.ensure import ensure
 
 from .. import crypto
 from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint
 from . import rlp, vm
+from .bloom import logs_bloom
 from .eth_types import (
     TX_BASE_COST,
     TX_DATA_COST_PER_NON_ZERO,
@@ -44,8 +37,18 @@ from .eth_types import (
     Root,
     Transaction,
 )
-from .state import State, create_ether, get_account, state_root
+from .genesis import genesis_configuration
+from .state import (
+    State,
+    create_ether,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
 from .trie import Trie, root, trie_set
+from .utils.message import prepare_message
 from .vm.interpreter import process_message_call
 
 BLOCK_REWARD = U256(5 * 10 ** 18)

--- a/src/ethereum/frontier/utils/address.py
+++ b/src/ethereum/frontier/utils/address.py
@@ -15,8 +15,9 @@ from typing import Union
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto import keccak256
-from ethereum.frontier import rlp
-from ethereum.frontier.eth_types import Address
+
+from .. import rlp
+from ..eth_types import Address
 
 
 def to_address(data: Union[Uint, U256]) -> Address:

--- a/src/ethereum/frontier/utils/json.py
+++ b/src/ethereum/frontier/utils/json.py
@@ -14,12 +14,6 @@ Json specific utilities used in this frontier version of specification.
 from typing import Any, Dict, Tuple
 
 from ethereum.base_types import Bytes0
-from ethereum.frontier.eth_types import Block, Header, Transaction
-from ethereum.frontier.utils.hexadecimal import (
-    hex_to_address,
-    hex_to_bloom,
-    hex_to_root,
-)
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,
@@ -28,6 +22,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_u256,
     hex_to_uint,
 )
+
+from ..eth_types import Block, Header, Transaction
+from ..utils.hexadecimal import hex_to_address, hex_to_bloom, hex_to_root
 
 
 def json_to_transactions(json_data: Dict[Any, Any]) -> Tuple[Transaction, ...]:

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -12,11 +12,11 @@ Introduction
 EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.eth_types import Address
-from ethereum.frontier.state import State, account_exists
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ..eth_types import Address
+from ..state import State, account_exists
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -13,15 +13,9 @@ Implementations of the EVM control flow instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.vm.error import InvalidJumpDestError
-from ethereum.frontier.vm.gas import (
-    GAS_BASE,
-    GAS_HIGH,
-    GAS_JUMPDEST,
-    GAS_MID,
-    subtract_gas,
-)
 
+from ...vm.error import InvalidJumpDestError
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
 from .. import Evm
 from ..stack import pop, push
 

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -13,13 +13,13 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.state import get_account
-from ethereum.frontier.utils.address import to_address
-from ethereum.frontier.vm.error import OutOfGasError
-from ethereum.frontier.vm.memory import extend_memory, memory_write
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...state import get_account
+from ...utils.address import to_address
+from ...vm.error import OutOfGasError
+from ...vm.memory import extend_memory, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BASE,

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -14,10 +14,10 @@ Implementations of the EVM keccak instructions.
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto import keccak256
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import (
     GAS_KECCAK256,

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -14,10 +14,10 @@ Implementations of the EVM logging instructions.
 from functools import partial
 
 from ethereum.base_types import U256, Uint
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
+from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -12,9 +12,9 @@ Introduction
 Implementations of the EVM Memory instructions.
 """
 from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import (
     GAS_BASE,

--- a/src/ethereum/frontier/vm/instructions/storage.py
+++ b/src/ethereum/frontier/vm/instructions/storage.py
@@ -12,8 +12,7 @@ Introduction
 Implementations of the EVM storage related instructions.
 """
 
-from ethereum.frontier.state import get_storage, set_storage
-
+from ...state import get_storage, set_storage
 from .. import Evm
 from ..gas import (
     GAS_SLOAD,

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -12,12 +12,16 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.frontier.state import account_has_code_or_nonce
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
-from ...state import get_account, increment_nonce, set_account_balance
+from ...state import (
+    account_has_code_or_nonce,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+)
 from ...utils.address import compute_contract_address, to_address
+from ...vm.error import OutOfGasError
 from .. import Evm, Message
 from ..gas import (
     GAS_CREATE,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -14,8 +14,10 @@ A straightforward interpreter that executes EVM code.
 from typing import Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.frontier.eth_types import Address, Log
-from ethereum.frontier.state import (
+from ethereum.utils.ensure import EnsureError
+
+from ..eth_types import Address, Log
+from ..state import (
     account_has_code_or_nonce,
     begin_transaction,
     commit_transaction,
@@ -25,8 +27,8 @@ from ethereum.frontier.state import (
     set_code,
     touch_account,
 )
-from ethereum.frontier.vm import Message
-from ethereum.frontier.vm.error import (
+from ..vm import Message
+from ..vm.error import (
     InsufficientFunds,
     InvalidJumpDestError,
     InvalidOpcode,
@@ -35,16 +37,8 @@ from ethereum.frontier.vm.error import (
     StackOverflowError,
     StackUnderflowError,
 )
-from ethereum.frontier.vm.gas import (
-    GAS_CODE_DEPOSIT,
-    REFUND_SELF_DESTRUCT,
-    subtract_gas,
-)
-from ethereum.frontier.vm.precompiled_contracts.mapping import (
-    PRE_COMPILED_CONTRACTS,
-)
-from ethereum.utils.ensure import EnsureError
-
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_jump_destinations

--- a/src/ethereum/frontier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/identity.py
@@ -12,11 +12,11 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 from ethereum.base_types import Uint
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
+from ...vm.error import OutOfGasError
 from ...vm.gas import GAS_IDENTITY, GAS_IDENTITY_WORD, subtract_gas
 
 

--- a/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
@@ -13,8 +13,7 @@ Mapping of precompiled contracts their implementations.
 """
 from typing import Callable, Dict
 
-from ethereum.frontier.eth_types import Address
-
+from ...eth_types import Address
 from ...utils.hexadecimal import hex_to_address
 from .ecrecover import ecrecover
 from .identity import identity

--- a/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
@@ -14,12 +14,12 @@ Implementation of the `RIPEMD160` precompiled contract.
 import hashlib
 
 from ethereum.base_types import Uint
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
+from ...vm.error import OutOfGasError
 from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
 
 

--- a/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
@@ -14,11 +14,11 @@ Implementation of the `SHA256` precompiled contract.
 import hashlib
 
 from ethereum.base_types import Uint
-from ethereum.frontier.vm.error import OutOfGasError
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
+from ...vm.error import OutOfGasError
 from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
 
 

--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_block_operations.py
+++ b/tests/frontier/vm/test_block_operations.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_control_flow_operations.py
+++ b/tests/frontier/vm/test_control_flow_operations.py
@@ -1,5 +1,4 @@
 from functools import partial
-from typing import Any
 
 import pytest
 

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_keccak.py
+++ b/tests/frontier/vm/test_keccak.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_logging_operations.py
+++ b/tests/frontier/vm/test_logging_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_memory_operations.py
+++ b/tests/frontier/vm/test_memory_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_stack_operations.py
+++ b/tests/frontier/vm/test_stack_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_storage_operations.py
+++ b/tests/frontier/vm/test_storage_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,

--- a/tests/frontier/vm/test_system_operations.py
+++ b/tests/frontier/vm/test_system_operations.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from tests.frontier.vm.vm_test_helpers import run_test
+from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,


### PR DESCRIPTION
### What was wrong?

Currently, there are some frontier-specific imports that are absolute. This would require us to change these imports every time a hard fork is created.

### How was it fixed?

Made frontier-specific imports relative so that they work without any changes when a hard fork copy is created. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.parade.com/wp-content/uploads/2016/09/6650977359_69e091447f_b.jpg)

Pic credits: [parade.com/](https://www.parade.com/)
