### PR TITLE
skip tests when the fixture has no tests for frontier

### DIFF
--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -28,4 +28,4 @@ def test_general_state_tests(test_file: str) -> None:
         run_general_state_tests(test_file)
     except KeyError:
         # KeyError is raised when a test_file has no tests for frontier
-        pass
+        raise pytest.skip(f"{test_file} has no tests for frontier")


### PR DESCRIPTION
### What was wrong?

Right now we get a false impression that 10k state tests are passing. In reality, there are several fixtures that have no tests for frontier. Such tests should be skipped so that we know the exact number of tests that are passing. 

### How was it fixed?
skipped tests when the fixture has no tests for frontier

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://tailandfur.com/wp-content/uploads/2014/09/beautiful-and-cute-animals-wallpaper-39-1024x576.jpg)

Pic credits: [https://tailandfur.com/](https://tailandfur.com/wp-content/uploads/2014/09/beautiful-and-cute-animals-wallpaper-39-1024x576.jpg)
