### PR TITLE
fixed a bug in the BLOCKHASH opcode

### DIFF
--- a/src/ethereum/frontier/vm/instructions/block.py
+++ b/src/ethereum/frontier/vm/instructions/block.py
@@ -46,7 +46,7 @@ def block_hash(evm: Evm) -> None:
         # or if the block's age is more than 256.
         hash = b"\x00"
     else:
-        hash = evm.env.block_hashes[256 - (evm.env.number - block_number)]
+        hash = evm.env.block_hashes[evm.env.number - block_number - 1]
 
     push(evm.stack, U256.from_be_bytes(hash))
 


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/execution-specs/blob/296d030880570aacb061c21e9e689d2e5be13cfd/src/ethereum/frontier/vm/instructions/block.py#L49
In the code above, `256 - (evm.env.number - block_number)` should be `evm.env.number - block_number - 1`.

This bug was caught by some homestead tests.

I verified my thoughts by checking  a few implementations:
- [rust-evm](https://github.com/rust-blockchain/evm/blob/8b1875c83105f47b74d3d7be7302f942e92eb374/src/backend/memory.rs#L97)
- [py-evm](https://github.com/ethereum/py-evm/blob/21759ee681315f7099b14893b6ac6d1a5e659bc0/eth/vm/state.py#L229)


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1578956919791-af7615c94b90?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=739&q=80)
Pic credits: [unsplash.com](https://unsplash.com/photos/JDzoTGfoogA)
