### PR TITLE
Add semantic diffs between hardforks to the docs.

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -28,4 +28,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
-          folder: .tox/docs_out
+          folder: .tox/docs/stage1_out

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ pip-delete-this-directory.txt
 /doc/_autosummary
 
 .coverage
+
+/doc/diffs

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -45,3 +45,24 @@ dl.field-list > dt {
     content: '\A';
     white-space: pre;
 }
+
+*[class*="change-"] + *[class*="change-"] {
+    margin-left: 0.1em;
+}
+
+.change-added, .change-removed, .change-replacement, .change-replaced {
+    padding: 0.2em;
+    border: 1px solid;
+    border-left: none;
+    border-right: none;
+}
+
+.change-added, .change-replacement {
+    background: rgba(0, 255, 0, 0.2);
+    border-color: green;
+}
+
+.change-removed, .change-replaced {
+    background: rgba(255, 0, 0, 0.2);
+    border-color: red;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,6 +32,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'autoapi.extension',
     'undocinclude.extension',
+    'picklebuilder.picklebuilder',
 ]
 
 autoapi_type = 'python'
@@ -41,10 +42,35 @@ autoapi_template_dir = '_templates/autoapi'
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# The default language to highlight source code in.
+highlight_language = 'python3'
+
+# A boolean that decides whether module names are prepended to all object
+# names (for object types where a "module" of some kind is defined), e.g.
+# for py:function directives.
+add_module_names = False
+
+# This value controls how to represent typehints (PEP 484.)
+autodoc_typehints = 'signature'
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+if tags.has('stage0'):
+    root_doc = 'stage0'
+    exclude_patterns.append('index.rst')
+    exclude_patterns.append('diffs/**')
+
+    # Avoid generating nodes that'll always differ between hard forks to reduce
+    # noise in the diffs.
+    autodoc_typehints = 'none'
+elif tags.has('stage1'):
+    root_doc = 'index'
+    exclude_patterns.append('stage0.rst')
+else:
+    raise Exception("Pass either `-t stage0` or `-t stage1` to sphinx-build")
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -59,12 +85,9 @@ html_theme = 'alabaster'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-autodoc_typehints = "signature"
-
 html_css_files = [
     'css/custom.css',
 ]
-
 
 def skip_max_value(app, what, name, obj, skip, options):
     """

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,15 +1,8 @@
-Ethereum Specification
-======================
+.. include:: stage0.rst
 
 .. toctree::
-   :maxdepth: 4
-   :caption: Contents:
+   :caption: Comparisons:
+   :maxdepth: 2
+   :hidden:
 
-   autoapi/index
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   diffs/index

--- a/doc/stage0.rst
+++ b/doc/stage0.rst
@@ -1,0 +1,15 @@
+Ethereum Specification
+======================
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+   autoapi/index
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ ethereum =
 console_scripts =
     ethereum-spec-lint = ethereum_spec_tools.lint:main
     ethereum-spec-sync = ethereum_spec_tools.sync:main
+    ethereum-spec-diff = ethereum_spec_tools.diff:main
 
 [options.extras_require]
 test =
@@ -67,6 +68,8 @@ doc =
     sphinx-autoapi>=1.8.1,<2
     undocinclude>=0.2.0,<0.3
     sphinx==4.0.2
+    rstdiff>=0.5.0,<0.6
+    picklebuilder>=0.1.0,<0.2
 
 doc-autobuild =
     sphinx-autobuild==2021.3.14

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -68,7 +68,7 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `gas_left` is less than `amount`.
     """
     if gas_left < amount:

--- a/src/ethereum/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/frontier/vm/instructions/arithmetic.py
@@ -38,9 +38,9 @@ def add(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -66,9 +66,9 @@ def sub(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -94,9 +94,9 @@ def mul(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
@@ -122,9 +122,9 @@ def div(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
@@ -153,9 +153,9 @@ def sdiv(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
@@ -188,9 +188,9 @@ def mod(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
@@ -219,9 +219,9 @@ def smod(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
@@ -251,9 +251,9 @@ def addmod(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `3`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `8`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
@@ -284,9 +284,9 @@ def mulmod(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `3`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `8`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
@@ -317,7 +317,7 @@ def exp(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
     """
     base = Uint(pop(evm.stack))
@@ -351,9 +351,9 @@ def signextend(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `5`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)

--- a/src/ethereum/frontier/vm/instructions/bitwise.py
+++ b/src/ethereum/frontier/vm/instructions/bitwise.py
@@ -31,9 +31,9 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -56,9 +56,9 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -81,9 +81,9 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -106,9 +106,9 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -131,9 +131,9 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)

--- a/src/ethereum/frontier/vm/instructions/block.py
+++ b/src/ethereum/frontier/vm/instructions/block.py
@@ -31,9 +31,9 @@ def block_hash(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `20`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
@@ -68,9 +68,9 @@ def coinbase(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equal to `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -94,9 +94,9 @@ def timestamp(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equal to `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -119,9 +119,9 @@ def number(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equal to `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -144,9 +144,9 @@ def difficulty(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equal to `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -169,9 +169,9 @@ def gas_limit(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equal to `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)

--- a/src/ethereum/frontier/vm/instructions/comparison.py
+++ b/src/ethereum/frontier/vm/instructions/comparison.py
@@ -31,9 +31,9 @@ def less_than(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -58,9 +58,9 @@ def signed_less_than(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -86,9 +86,9 @@ def greater_than(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -113,9 +113,9 @@ def signed_greater_than(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -141,9 +141,9 @@ def equal(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -169,9 +169,9 @@ def is_zero(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -44,15 +44,15 @@ def jump(evm: Evm) -> None:
 
     Raises
     ------
-    InvalidJumpDestError
+    ethereum.frontier.vm.error.InvalidJumpDestError
         If the jump destination doesn't meet any of the following criteria:
             * The jump destination is less than the length of the code.
             * The jump destination should have the `JUMPDEST` opcode (0x5B).
             * The jump destination shouldn't be part of the data corresponding
             to `PUSH-N` opcodes.
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `8`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
@@ -77,15 +77,15 @@ def jumpi(evm: Evm) -> None:
 
     Raises
     ------
-    InvalidJumpDestError
+    ethereum.frontier.vm.error.InvalidJumpDestError
         If the jump destination doesn't meet any of the following criteria:
             * The jump destination is less than the length of the code.
             * The jump destination should have the `JUMPDEST` opcode (0x5B).
             * The jump destination shouldn't be part of the data corresponding
             to `PUSH-N` opcodes.
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `10`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
@@ -115,9 +115,9 @@ def pc(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is more than `1023`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -137,9 +137,9 @@ def gas_left(evm: Evm) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is more than `1023`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -160,7 +160,7 @@ def jumpdest(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `1`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -43,7 +43,7 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -63,9 +63,9 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `20`.
     """
     # TODO: There are no test cases against this function. Need to write
@@ -94,7 +94,7 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -114,7 +114,7 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -134,7 +134,7 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -155,9 +155,9 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -185,7 +185,7 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -208,7 +208,7 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `3`.
     """
     # Converting below to Uint as though the start indices may belong to U256,
@@ -260,7 +260,7 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -283,7 +283,7 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `3`.
     """
     # Converting below to Uint as though the start indices may belong to U256,
@@ -336,7 +336,7 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -356,9 +356,9 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `20`.
     """
     # TODO: There are no test cases against this function. Need to write
@@ -386,7 +386,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `4`.
     """
     # TODO: There are no test cases against this function. Need to write

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -43,7 +43,7 @@ def keccak(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
     """
     # Converting memory_start_index to Uint as memory_end_index can

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -46,7 +46,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2 + num_topics`.
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -39,9 +39,9 @@ def mstore(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
@@ -79,9 +79,9 @@ def mstore8(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
@@ -119,9 +119,9 @@ def mload(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
@@ -159,7 +159,7 @@ def msize(evm: Evm) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)

--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -33,9 +33,9 @@ def pop(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `2`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
@@ -59,9 +59,9 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is equals `1024`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -89,7 +89,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
@@ -120,7 +120,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
 
     Raises
     ------
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)

--- a/src/ethereum/frontier/vm/instructions/storage.py
+++ b/src/ethereum/frontier/vm/instructions/storage.py
@@ -36,9 +36,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `1`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `50`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
@@ -62,9 +62,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `len(stack)` is less than `2`.
-    OutOfGasError
+    ethereum.frontier.vm.error.OutOfGasError
         If `evm.gas_left` is less than `20000`.
     """
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/frontier/vm/stack.py
+++ b/src/ethereum/frontier/vm/stack.py
@@ -35,7 +35,7 @@ def pop(stack: List[U256]) -> U256:
 
     Raises
     ------
-    StackUnderflowError
+    ethereum.frontier.vm.error.StackUnderflowError
         If `stack` is empty.
     """
     if len(stack) == 0:
@@ -58,7 +58,7 @@ def push(stack: List[U256], value: U256) -> None:
 
     Raises
     ------
-    StackOverflowError
+    ethereum.frontier.vm.error.StackOverflowError
         If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:

--- a/src/ethereum_spec_tools/diff.py
+++ b/src/ethereum_spec_tools/diff.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+"""
+Generates diffs between Ethereum hardforks documentation.
+"""
+
+import os.path
+import pickle
+from typing import Iterator, List, TypeVar
+
+import rstdiff
+from docutils import SettingsSpec
+from docutils.utils import new_document, new_reporter
+
+from ethereum_spec_tools.forks import Hardfork
+
+T = TypeVar("T")
+
+
+def window(forks: List[T], window_size: int = 2) -> Iterator[List[T]]:
+    """
+    Group a list into overlapping chunks.
+    """
+    for i in range(len(forks) - window_size + 1):
+        yield forks[i : i + window_size]
+
+
+def find_pickles(path: str, fork: Hardfork) -> Iterator[str]:
+    """
+    Find files ending with :code:`.pickle`.
+    """
+    for directory, _, filenames in os.walk(path):
+        for filename in filenames:
+            if filename.endswith(".pickle"):
+                file_path = os.path.join(directory, filename)
+                file_path = file_path[len(path) + 1 :]
+                yield file_path
+
+
+def diff(
+    output_path: str, input_path: str, old: Hardfork, new: Hardfork
+) -> Iterator[str]:
+    """
+    Calculate the structured diff between two hardforks.
+    """
+    old_path = old.name.replace(".", os.sep)
+    old_path = os.path.join(input_path, old_path)
+
+    new_path = new.name.replace(".", os.sep)
+    new_path = os.path.join(input_path, new_path)
+
+    diff_path = old.name.split(".")[-1] + "_" + new.name.split(".")[-1]
+    diff_path = os.path.join(output_path, diff_path)
+
+    old_pickles = set(find_pickles(old_path, old))
+    new_pickles = set(find_pickles(new_path, new))
+
+    pickles = old_pickles | new_pickles
+
+    for count, pickle_path in enumerate(pickles, start=1):
+        old_pickle_path = os.path.join(old_path, pickle_path)
+        new_pickle_path = os.path.join(new_path, pickle_path)
+        diff_pickle_path = os.path.join(diff_path, pickle_path + "64")
+
+        diff_dir_path = os.path.dirname(diff_pickle_path)
+
+        os.makedirs(diff_dir_path, exist_ok=True)
+
+        try:
+            with open(old_pickle_path, "rb") as old_file:
+                old_doc = pickle.load(old_file)
+        except FileNotFoundError:
+            old_doc = new_document(old_pickle_path)
+            old_pickle_path = os.devnull
+
+        try:
+            with open(new_pickle_path, "rb") as new_file:
+                new_doc = pickle.load(new_file)
+        except FileNotFoundError:
+            new_doc = new_document(new_pickle_path)
+            new_pickle_path = os.devnull
+
+        print(
+            f"[{count}/{len(pickles)}] diff",
+            old_pickle_path[len(input_path) :],
+            "->",
+            new_pickle_path[len(input_path) :],
+        )
+
+        pub = rstdiff.processCommandLine()
+
+        pub.set_writer("picklebuilder.writers.pickle64")
+
+        settings_spec = SettingsSpec()
+        settings_spec.settings_spec = rstdiff.settings_spec
+        settings_spec.settings_defaults = rstdiff.settings_defaults
+        pub.process_command_line(
+            usage=rstdiff.usage,
+            description=rstdiff.description,
+            settings_spec=settings_spec,
+            config_section=rstdiff.config_section,
+        )
+        pub.set_destination(destination_path=diff_pickle_path)
+        pub.set_reader("standalone", None, "restructuredtext")
+        pub.settings.language_code = "en"  # TODO
+
+        old_doc.settings = pub.settings
+        old_doc.reporter = new_reporter("RSTDIFF", pub.settings)
+
+        new_doc.settings = pub.settings
+        new_doc.reporter = new_reporter("RSTDIFF", pub.settings)
+
+        rstdiff.Text2Words(old_doc).apply()
+        rstdiff.Text2Words(new_doc).apply()
+
+        try:
+            diff_doc = rstdiff.createDiff(pub, old_doc, new_doc)
+        except rstdiff.DocumentUnchanged:
+            continue
+
+        rstdiff.Words2Text(diff_doc).apply()
+        rstdiff.Generated2Inline(diff_doc).apply()
+
+        pub.writer.write(diff_doc, pub.destination)
+        pub.writer.assemble_parts()
+
+        yield os.path.abspath(diff_pickle_path)
+
+
+def main() -> None:
+    """
+    Compute structural diffs between hard forks.
+    """
+    import shutil
+    import sys
+
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    shutil.rmtree(output_path, ignore_errors=True)
+    os.makedirs(output_path)
+
+    forks = Hardfork.discover()
+
+    diffs = (diff(output_path, input_path, o, n) for o, n in window(forks))
+    paths = (item for inner in diffs for item in inner)
+    paths = (os.path.relpath(d, output_path) for d in paths)
+    paths = (os.path.splitext(d)[0] for d in paths)
+
+    index_path = os.path.join(output_path, "index.rst")
+
+    with open(index_path, "w") as f:
+        f.write("===========\n")
+        f.write("Comparisons\n")
+        f.write("===========\n\n")
+
+        f.write(".. toctree::\n")
+        f.write("   :maxdepth: 1\n\n")
+
+        for item in paths:
+            f.write(f"   {item}\n")

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,32 @@ commands =
 basepython = python3
 extras = doc
 commands =
-    sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
-    python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+    sphinx-build \
+        -t stage0 \
+        -d "{toxworkdir}/docs/stage0_doctree" \
+        doc \
+        "{toxworkdir}/docs/stage0_out" \
+        --color \
+        -W \
+        -brpickle \
+        {posargs}
+
+    ethereum-spec-diff \
+        "{toxworkdir}/docs/stage0_out/autoapi/" \
+        "doc/diffs" \
+        --compare-sections-normally
+
+    sphinx-build \
+        -t stage1 \
+        -d "{toxworkdir}/docs/stage1_doctree" \
+        doc \
+        "{toxworkdir}/docs/stage1_out" \
+        --color \
+        -W \
+        -bhtml \
+        {posargs}
+
+    python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs" / "stage1_out" / "index.html"))'
 
 [testenv:doc-autobuild]
 basepython = python3

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -274,3 +274,12 @@ noop
 0x0
 0x1
 0x2
+
+rstdiff
+docutils
+dirname
+Text2
+Words2
+Generated2
+devnull
+splitext


### PR DESCRIPTION
### What was wrong?

No easy way to see changes between hard forks.

### How was it fixed?

Using a modified version of `rstdiff` from the docutils package.

Won't really show much until a new hard fork is added, but I've done some limited testing with fake forks locally.

Couple known issues:

 - Links inside the diffed documents point to `.pickle` files instead of `.html`, which don't exist.
 - Very noisy diff since anywhere the module name appears, there's a change reported.
 - No quick navigation to the diffs.

Here's what an example change might look like so far: https://samwilsn.github.io/eth1.0-specs/diffs/frontier_banana/rlp/index.html

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/I5i30fp.jpeg)

@voith would you also mind taking a look?
