### PR TITLE
Remove newline from description field in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = ethereum
-description = Ethereum specification, provided as a Python package for tooling
-    and testing
+description = Ethereum specification, provided as a Python package for tooling and testing
 long_description = file: README.md
 long_description_content_type = text/markdown
 version = 0.1.0


### PR DESCRIPTION
### What was wrong?

There is a newline in the description field in setup.cfg. This is [illegal](https://github.com/pypa/setuptools/issues/1390), but was only caught by python buildtools in [after a recent patch](https://github.com/pypa/setuptools/pull/2870).

### How was it fixed?

Removed the newline.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/xrcn64wcu8y71.jpg)
