### PR TITLE
Fixed a bug in the dup opcode

### DIFF
--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -93,7 +93,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
         If `evm.gas_left` is less than `3`.
     """
     evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack))
+    ensure(item_number < len(evm.stack), exception_class=StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)


### PR DESCRIPTION
### What was wrong?

We need to raise `StackUnderflowError` whenever the DUP opcode tries to pop more items than currently present in the stack. This bug was caught by the homestead tests. 


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/media/FEVa_kAWYAEPnTY?format=jpg&name=small)

Pic credits: [animalplctures](https://mobile.twitter.com/animalplctures)
