### PR TITLE
[Bug Fix][Call Family Opcodes]Subtract memory related gas costs before subtracting message call related gas costs

### DIFF
--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -160,15 +160,6 @@ def call(evm: Evm) -> None:
     memory_output_start_position = Uint(pop(evm.stack))
     memory_output_size = pop(evm.stack)
 
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
@@ -182,6 +173,15 @@ def call(evm: Evm) -> None:
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
+
+    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
+    message_call_gas_fee = u256_safe_add(
+        gas,
+        calculate_message_call_gas_stipend(value),
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -251,15 +251,6 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
@@ -273,6 +264,15 @@ def callcode(evm: Evm) -> None:
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
+
+    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
+    message_call_gas_fee = u256_safe_add(
+        gas,
+        calculate_message_call_gas_stipend(value),
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -162,15 +162,6 @@ def call(evm: Evm) -> None:
     memory_output_start_position = Uint(pop(evm.stack))
     memory_output_size = pop(evm.stack)
 
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
@@ -184,6 +175,15 @@ def call(evm: Evm) -> None:
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
+
+    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
+    message_call_gas_fee = u256_safe_add(
+        gas,
+        calculate_message_call_gas_stipend(value),
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -254,15 +254,6 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
@@ -276,6 +267,15 @@ def callcode(evm: Evm) -> None:
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
+
+    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
+    message_call_gas_fee = u256_safe_add(
+        gas,
+        calculate_message_call_gas_stipend(value),
+        exception_type=OutOfGasError,
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -376,11 +376,6 @@ def delegatecall(evm: Evm) -> None:
     value = evm.message.value
     to = evm.message.current_target
 
-    call_gas_fee = GAS_CALL + gas
-    message_call_gas_fee = gas
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
@@ -394,6 +389,10 @@ def delegatecall(evm: Evm) -> None:
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
+
+    call_gas_fee = GAS_CALL + gas
+    message_call_gas_fee = gas
+    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
 
     evm.pc += 1
 


### PR DESCRIPTION
### What was wrong?

Some tests from the Tangerine Whistle hard fork caught a bug in the call family implementation. Here's what's happening:
- Currently, the call family opcodes subtract message-call related gas costs before subtracting memory-related gas charges.
- However, this sequence of steps causes consensus failure in tangerine whistle. Message-call related gas costs in Tangerine whistle are dependent on the amount of `gas_left` and hence the order in which the gas is subtracted matters. 

### How was it fixed?

Subtracted memory-related gas costs before subtracting message-call related gas costs.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2019/11/18/00/38/dog-4633734_1280.jpg)
Pic credits: [pixabay.com](https://pixabay.com/photos/dog-puppy-animal-4633734/)