### PR TITLE
Add README.md to mainnet-upgrades folder

### DIFF
--- a/network-upgrades/mainnet-upgrades/README.md
+++ b/network-upgrades/mainnet-upgrades/README.md
@@ -1,0 +1,22 @@
+# Mainnet Network Upgrades
+
+This folder provides the specifications for all the network upgrades of Ethereum 1.0 mainnet.
+
+
+| Upgrade name                                | Block number | Timestamp (UTC) |
+| ------------------------------------------- | ------------ | -------- |
+| Frontier                                    | 0            | Jul-30-2015 03:26:13 PM |
+| [Homestead](./homestead.md)                 | 1,150,000    | Mar-14-2016 06:49:53 PM |
+| [DAO Fork](./dao-fork.md)                   | 1,920,000    | Jul-20-2016 01:20:40 PM |
+| [Tangerine Whistle](./tangerine-whistle.md) | 2,463,000    | Oct-18-2016 01:19:31 PM |
+| [Spurious Dragon](./spurious-dragon.md)     | 2,675,000    | Nov-22-2016 04:15:44 PM |
+| [Byzantium](./byzantium.md)                 | 4,370,000    | Oct-16-2017 05:22:11 AM |
+| [Constantinople](./constantinople.md)       | 7,280,000    | Feb-28-2019 07:52:04 PM |
+| [Petersburg](./petersburg.md)               | 7,280,000    | Feb-28-2019 07:52:04 PM |
+| [Istanbul](./istanbul.md)                   | 9,069,000    | Dec-08-2019 12:25:09 AM |
+| [Muir Glacier](./muir-glacier.md)           | 9,200,000    | Jan-02-2020 08:30:49 AM |
+| [Berlin](./berlin.md)                       | 12,244,000   | Apr-15-2021 10:07:03 AM |
+| [London](./london.md)                       | 12,965,000   | Aug-05-2021 12:33:42 PM |
+| [Arrow Glacier](./arrow-glacier.md)         | 13,773,000   | Dec-09-2021 07:55:23 PM |
+| [The Merge](./merge.md)                     | TBA          | TBA |
+| [Shanghai](./shanghai.md)                   | TBA          | TBA |


### PR DESCRIPTION
### What was wrong?

I was missing a chronological list of all the network upgrades.

### How was it fixed?

I added a README with a table with links to all upgrades, ordered by block number.
Checked against [go-ethereum config](https://github.com/ethereum/go-ethereum/blob/bc6bf1e1937829b5d5b0d431a9333d47c3e08082/params/config.go#L58-L74) and https://ethereum.org/en/history.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://mirplaneta.ru/images/6/1071.jpg)
