### PR TITLE
Issue#387 - Validate parent hash

### DIFF
--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -218,6 +218,9 @@ def validate_header(header: Header, parent_header: Header) -> None:
         parent_header.difficulty,
     )
 
+    block_parent_hash = crypto.keccak256(rlp.encode(parent_header))
+
+    ensure(header.parent_hash == block_parent_hash)
     ensure(header.difficulty == block_difficulty)
     ensure(header.number == parent_header.number + 1)
     ensure(check_gas_limit(header.gas_limit, parent_header.gas_limit))

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -188,6 +188,9 @@ def validate_header(header: Header, parent_header: Header) -> None:
         parent_header.difficulty,
     )
 
+    block_parent_hash = crypto.keccak256(rlp.encode(parent_header))
+
+    ensure(header.parent_hash == block_parent_hash)
     ensure(header.difficulty == block_difficulty)
     ensure(header.number == parent_header.number + 1)
     ensure(check_gas_limit(header.gas_limit, parent_header.gas_limit))


### PR DESCRIPTION
### What was wrong?
The spec doesn't ensure that the parent_hash of the current block matches the hash of the previous block.

Related to Issue #387 

### How was it fixed?
Added an additional check in the validate_header function to ensure that the `parent hash` calculated from the parent header matches the `parent hash` specified in the block header.

The issue was opened only for the Frontier fork. However, I noticed that the issue was opened before the spec for Homestead was added. I believe this is relevant to Homestead as well and have therefore updated the corresponding function in both places.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/01/A364%2C_Lone_Pine_Koala_Sanctuary%2C_Queensland%2C_Australia%2C_koala%2C_2007.png)
