### PR TITLE
Add Parent Hash Unit Test

### DIFF
--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import pytest
 
+from ethereum.utils.ensure import EnsureError
 from tests.frontier.blockchain_st_test_helpers import (
     run_frontier_blockchain_st_tests,
 )
@@ -29,3 +30,22 @@ def test_general_state_tests(test_file: str) -> None:
     except KeyError:
         # KeyError is raised when a test_file has no tests for frontier
         raise pytest.skip(f"{test_file} has no tests for frontier")
+
+
+# Test Invalid Block Headers
+run_invalid_header_test = partial(
+    run_frontier_blockchain_st_tests,
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_parent_hash",
+    [
+        "wrongParentHash.json",
+        "wrongParentHash.json",
+    ],
+)
+def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
+    with pytest.raises(EnsureError):
+        run_invalid_header_test(test_file_parent_hash)

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -43,7 +43,7 @@ run_invalid_header_test = partial(
     "test_file_parent_hash",
     [
         "wrongParentHash.json",
-        "wrongParentHash.json",
+        "wrongParentHash2.json",
     ],
 )
 def test_invalid_parent_hash(test_file_parent_hash: str) -> None:

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -128,7 +128,7 @@ run_invalid_header_test = partial(
     "test_file_parent_hash",
     [
         "wrongParentHash.json",
-        "wrongParentHash.json",
+        "wrongParentHash2.json",
     ],
 )
 def test_invalid_parent_hash(test_file_parent_hash: str) -> None:

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -4,6 +4,7 @@ from typing import Generator
 
 import pytest
 
+from ethereum.utils.ensure import EnsureError
 from tests.homestead.blockchain_st_test_helpers import (
     run_homestead_blockchain_st_tests,
 )
@@ -114,3 +115,22 @@ def test_general_state_tests(test_file: str) -> None:
     except KeyError:
         # KeyError is raised when a test_file has no tests for homestead
         raise pytest.skip(f"{test_file} has no tests for homestead")
+
+
+# Test Invalid Block Headers
+run_invalid_header_test = partial(
+    run_homestead_blockchain_st_tests,
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_parent_hash",
+    [
+        "wrongParentHash.json",
+        "wrongParentHash.json",
+    ],
+)
+def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
+    with pytest.raises(EnsureError):
+        run_invalid_header_test(test_file_parent_hash)


### PR DESCRIPTION
### What was wrong?
Test to validate the parent hash of a block was missing

Related to Issue #387 

### How was it fixed?
Added the unit tests for parent hash

