### PR TITLE
Add a PREV_FORK variable to each fork use it in trie.py

### DIFF
--- a/src/ethereum/dao_fork/__init__.py
+++ b/src/ethereum/dao_fork/__init__.py
@@ -6,3 +6,4 @@ The third Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 1920000
+PREV_FORK = "homestead"

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -15,7 +15,9 @@ The state trie is the structure responsible for storing
 
 import copy
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import (
+    Any,
     Callable,
     Dict,
     Generic,
@@ -29,12 +31,12 @@ from typing import (
     cast,
 )
 
-import ethereum.homestead.trie
 from ethereum.utils.ensure import ensure
 from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import crypto, rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
+from . import PREV_FORK
 from .eth_types import (
     Account,
     Address,
@@ -151,11 +153,28 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
         return crypto.keccak256(encoded)
 
 
+if PREV_FORK is None:
+
+    def prev_fork_encode_node(
+        node: Node, storage_root: Optional[Bytes] = None
+    ) -> Bytes:
+        """
+        The `encode_node()` function from the previous fork.
+        """
+        raise NotImplementedError(
+            f"encoding for {type(node)} is not currently implemented"
+        )
+
+
+else:
+    prev_fork: Any
+    prev_fork = import_module(f"ethereum.{PREV_FORK}.trie")
+    prev_fork_encode_node = prev_fork
+
+
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None
@@ -165,7 +184,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     elif isinstance(node, Bytes):
         return node
     else:
-        return ethereum.homestead.trie.encode_node(node, storage_root)
+        return prev_fork_encode_node(node, storage_root)
 
 
 @dataclass

--- a/src/ethereum/frontier/__init__.py
+++ b/src/ethereum/frontier/__init__.py
@@ -6,3 +6,4 @@ The first Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 0
+PREV_FORK = None

--- a/src/ethereum/homestead/__init__.py
+++ b/src/ethereum/homestead/__init__.py
@@ -6,3 +6,4 @@ The second Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 1150000
+PREV_FORK = "frontier"

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -15,7 +15,9 @@ The state trie is the structure responsible for storing
 
 import copy
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import (
+    Any,
     Callable,
     Dict,
     Generic,
@@ -29,12 +31,12 @@ from typing import (
     cast,
 )
 
-import ethereum.frontier.trie
 from ethereum.utils.ensure import ensure
 from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import crypto, rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
+from . import PREV_FORK
 from .eth_types import (
     Account,
     Address,
@@ -151,11 +153,28 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
         return crypto.keccak256(encoded)
 
 
+if PREV_FORK is None:
+
+    def prev_fork_encode_node(
+        node: Node, storage_root: Optional[Bytes] = None
+    ) -> Bytes:
+        """
+        The `encode_node()` function from the previous fork.
+        """
+        raise NotImplementedError(
+            f"encoding for {type(node)} is not currently implemented"
+        )
+
+
+else:
+    prev_fork: Any
+    prev_fork = import_module(f"ethereum.{PREV_FORK}.trie")
+    prev_fork_encode_node = prev_fork
+
+
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None
@@ -165,7 +184,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     elif isinstance(node, Bytes):
         return node
     else:
-        return ethereum.frontier.trie.encode_node(node, storage_root)
+        return prev_fork_encode_node(node, storage_root)
 
 
 @dataclass

--- a/src/ethereum/tangerine_whistle/__init__.py
+++ b/src/ethereum/tangerine_whistle/__init__.py
@@ -6,3 +6,4 @@ The fourth Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 2463000
+PREV_FORK = "dao_fork"

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -15,7 +15,9 @@ The state trie is the structure responsible for storing
 
 import copy
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import (
+    Any,
     Callable,
     Dict,
     Generic,
@@ -29,12 +31,12 @@ from typing import (
     cast,
 )
 
-import ethereum.dao_fork.trie
 from ethereum.utils.ensure import ensure
 from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import crypto, rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
+from . import PREV_FORK
 from .eth_types import (
     Account,
     Address,
@@ -151,11 +153,28 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
         return crypto.keccak256(encoded)
 
 
+if PREV_FORK is None:
+
+    def prev_fork_encode_node(
+        node: Node, storage_root: Optional[Bytes] = None
+    ) -> Bytes:
+        """
+        The `encode_node()` function from the previous fork.
+        """
+        raise NotImplementedError(
+            f"encoding for {type(node)} is not currently implemented"
+        )
+
+
+else:
+    prev_fork: Any
+    prev_fork = import_module(f"ethereum.{PREV_FORK}.trie")
+    prev_fork_encode_node = prev_fork
+
+
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None
@@ -165,7 +184,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     elif isinstance(node, Bytes):
         return node
     else:
-        return ethereum.dao_fork.trie.encode_node(node, storage_root)
+        return prev_fork_encode_node(node, storage_root)
 
 
 @dataclass


### PR DESCRIPTION
This pull request adds a `PREV_FORK` variable to each fork and uses it to refer back to the previous fork in `trie.py`. As a result the `trie.py` file is now identical in each fork.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/uxhr641q86b81.jpg)
