### PR TITLE
EIP-2681: Limit account nonce to 2^64-1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
+          submodules: recursive
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Python virtual environment
+venv/
+
 # pycharm
 .idea/
 

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -583,7 +583,7 @@ def validate_transaction(tx: Transaction) -> bool:
     verified : `bool`
         True if the transaction can be executed, or False otherwise.
     """
-    return calculate_intrinsic_cost(tx) <= tx.gas
+    return calculate_intrinsic_cost(tx) <= tx.gas and tx.nonce < 2 ** 64 - 1
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Uint:

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -72,6 +72,10 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         return None
 
+    if sender.nonce == Uint(2 ** 64 - 1):
+        push(evm.stack, U256(0))
+        return None
+
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -602,7 +602,7 @@ def validate_transaction(tx: Transaction) -> bool:
     verified : `bool`
         True if the transaction can be executed, or False otherwise.
     """
-    return calculate_intrinsic_cost(tx) <= tx.gas
+    return calculate_intrinsic_cost(tx) <= tx.gas and tx.nonce < 2 ** 64 - 1
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Uint:

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -71,6 +71,10 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         return None
 
+    if sender.nonce == Uint(2 ** 64 - 1):
+        push(evm.stack, U256(0))
+        return None
+
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -572,7 +572,7 @@ def validate_transaction(tx: Transaction) -> bool:
     verified : `bool`
         True if the transaction can be executed, or False otherwise.
     """
-    return calculate_intrinsic_cost(tx) <= tx.gas
+    return calculate_intrinsic_cost(tx) <= tx.gas and tx.nonce < 2 ** 64 - 1
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Uint:

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -72,6 +72,10 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         return None
 
+    if sender.nonce == Uint(2 ** 64 - 1):
+        push(evm.stack, U256(0))
+        return None
+
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -572,7 +572,7 @@ def validate_transaction(tx: Transaction) -> bool:
     verified : `bool`
         True if the transaction can be executed, or False otherwise.
     """
-    return calculate_intrinsic_cost(tx) <= tx.gas
+    return calculate_intrinsic_cost(tx) <= tx.gas and tx.nonce < 2 ** 64 - 1
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Uint:

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -80,6 +80,10 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         return None
 
+    if sender.nonce == Uint(2 ** 64 - 1):
+        push(evm.stack, U256(0))
+        return None
+
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -207,24 +207,6 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
-def load_test_transaction(
-    test_dir: str, test_file: str, network: str
-) -> Dict[str, Any]:
-    pure_test_file = os.path.basename(test_file)
-    test_name = os.path.splitext(pure_test_file)[0]
-    path = os.path.join(test_dir, test_file)
-
-    with open(path, "r") as fp:
-        json_data = json.load(fp)[f"{test_name}"]
-
-    tx_rlp = hex_to_bytes(json_data["txbytes"])
-    tx = rlp.decode_to(Transaction, tx_rlp)
-
-    test_result = json_data["result"][network]
-
-    return {"transaction": tx, "test_result": test_result}
-
-
 run_frontier_blockchain_st_tests = partial(
     run_blockchain_st_test, network="Frontier"
 )

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -207,6 +207,24 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
+def load_test_transaction(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
+    pure_test_file = os.path.basename(test_file)
+    test_name = os.path.splitext(pure_test_file)[0]
+    path = os.path.join(test_dir, test_file)
+
+    with open(path, "r") as fp:
+        json_data = json.load(fp)[f"{test_name}"]
+
+    tx_rlp = hex_to_bytes(json_data["txbytes"])
+    tx = rlp.decode_to(Transaction, tx_rlp)
+
+    test_result = json_data["result"][network]
+
+    return {"transaction": tx, "test_result": test_result}
+
+
 run_frontier_blockchain_st_tests = partial(
     run_blockchain_st_test, network="Frontier"
 )

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -1,6 +1,3 @@
-import json
-import os
-import sys
 from functools import partial
 
 import pytest
@@ -11,8 +8,9 @@ from ethereum.frontier.spec import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
-from tests.frontier.blockchain_st_test_helpers import load_test_transaction
+from ethereum.utils.hexadecimal import hex_to_uint
+
+from ..helpers.eth_types_helpers import load_test_transaction
 
 test_dir = "tests/fixtures/TransactionTests"
 
@@ -30,7 +28,9 @@ load_frontier_transaction = partial(load_test_transaction, network="Frontier")
 def test_high_nonce(test_file_high_nonce: str) -> None:
     test = load_frontier_transaction(test_dir, test_file_high_nonce)
 
-    assert validate_transaction(test["transaction"]) == False
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
+    assert validate_transaction(tx) == False
 
 
 @pytest.mark.parametrize(
@@ -43,12 +43,11 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 def test_nonce(test_file_nonce: str) -> None:
     test = load_frontier_transaction(test_dir, test_file_nonce)
 
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
     result_intrinsic_gas_cost = hex_to_uint(
         test["test_result"]["intrinsicGas"]
     )
 
-    assert validate_transaction(test["transaction"]) == True
-    assert (
-        calculate_intrinsic_cost(test["transaction"])
-        == result_intrinsic_gas_cost
-    )
+    assert validate_transaction(tx) == True
+    assert calculate_intrinsic_cost(tx) == result_intrinsic_gas_cost

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -1,0 +1,54 @@
+import json
+import os
+import sys
+from functools import partial
+
+import pytest
+
+from ethereum import rlp
+from ethereum.frontier.eth_types import Transaction
+from ethereum.frontier.spec import (
+    calculate_intrinsic_cost,
+    validate_transaction,
+)
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
+from tests.frontier.blockchain_st_test_helpers import load_test_transaction
+
+test_dir = "tests/fixtures/TransactionTests"
+
+load_frontier_transaction = partial(load_test_transaction, network="Frontier")
+
+
+@pytest.mark.parametrize(
+    "test_file_high_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce64Minus1.json",
+        "ttNonce/TransactionWithHighNonce64.json",
+        "ttNonce/TransactionWithHighNonce64Plus1.json",
+    ],
+)
+def test_high_nonce(test_file_high_nonce: str) -> None:
+    test = load_frontier_transaction(test_dir, test_file_high_nonce)
+
+    assert validate_transaction(test["transaction"]) == False
+
+
+@pytest.mark.parametrize(
+    "test_file_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce32.json",
+        "ttNonce/TransactionWithHighNonce64Minus2.json",
+    ],
+)
+def test_nonce(test_file_nonce: str) -> None:
+    test = load_frontier_transaction(test_dir, test_file_nonce)
+
+    result_intrinsic_gas_cost = hex_to_uint(
+        test["test_result"]["intrinsicGas"]
+    )
+
+    assert validate_transaction(test["transaction"]) == True
+    assert (
+        calculate_intrinsic_cost(test["transaction"])
+        == result_intrinsic_gas_cost
+    )

--- a/tests/helpers/eth_types_helpers.py
+++ b/tests/helpers/eth_types_helpers.py
@@ -1,0 +1,22 @@
+import json
+import os
+from typing import Any, Dict
+
+from ethereum.utils.hexadecimal import hex_to_bytes
+
+
+def load_test_transaction(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
+    pure_test_file = os.path.basename(test_file)
+    test_name = os.path.splitext(pure_test_file)[0]
+    path = os.path.join(test_dir, test_file)
+
+    with open(path, "r") as fp:
+        json_data = json.load(fp)[f"{test_name}"]
+
+    tx_rlp = hex_to_bytes(json_data["txbytes"])
+
+    test_result = json_data["result"][network]
+
+    return {"tx_rlp": tx_rlp, "test_result": test_result}

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -207,24 +207,6 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
-def load_test_transaction(
-    test_dir: str, test_file: str, network: str
-) -> Dict[str, Any]:
-    pure_test_file = os.path.basename(test_file)
-    test_name = os.path.splitext(pure_test_file)[0]
-    path = os.path.join(test_dir, test_file)
-
-    with open(path, "r") as fp:
-        json_data = json.load(fp)[f"{test_name}"]
-
-    tx_rlp = hex_to_bytes(json_data["txbytes"])
-    tx = rlp.decode_to(Transaction, tx_rlp)
-
-    test_result = json_data["result"][network]
-
-    return {"transaction": tx, "test_result": test_result}
-
-
 run_homestead_blockchain_st_tests = partial(
     run_blockchain_st_test, network="Homestead"
 )

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -207,6 +207,24 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
+def load_test_transaction(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
+    pure_test_file = os.path.basename(test_file)
+    test_name = os.path.splitext(pure_test_file)[0]
+    path = os.path.join(test_dir, test_file)
+
+    with open(path, "r") as fp:
+        json_data = json.load(fp)[f"{test_name}"]
+
+    tx_rlp = hex_to_bytes(json_data["txbytes"])
+    tx = rlp.decode_to(Transaction, tx_rlp)
+
+    test_result = json_data["result"][network]
+
+    return {"transaction": tx, "test_result": test_result}
+
+
 run_homestead_blockchain_st_tests = partial(
     run_blockchain_st_test, network="Homestead"
 )

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -1,0 +1,56 @@
+import json
+import os
+import sys
+from functools import partial
+
+import pytest
+
+from ethereum import rlp
+from ethereum.homestead.eth_types import Transaction
+from ethereum.homestead.spec import (
+    calculate_intrinsic_cost,
+    validate_transaction,
+)
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
+from tests.homestead.blockchain_st_test_helpers import load_test_transaction
+
+test_dir = "tests/fixtures/TransactionTests"
+
+load_homestead_transaction = partial(
+    load_test_transaction, network="Homestead"
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_high_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce64Minus1.json",
+        "ttNonce/TransactionWithHighNonce64.json",
+        "ttNonce/TransactionWithHighNonce64Plus1.json",
+    ],
+)
+def test_high_nonce(test_file_high_nonce: str) -> None:
+    test = load_homestead_transaction(test_dir, test_file_high_nonce)
+
+    assert validate_transaction(test["transaction"]) == False
+
+
+@pytest.mark.parametrize(
+    "test_file_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce32.json",
+        "ttNonce/TransactionWithHighNonce64Minus2.json",
+    ],
+)
+def test_nonce(test_file_nonce: str) -> None:
+    test = load_homestead_transaction(test_dir, test_file_nonce)
+
+    result_intrinsic_gas_cost = hex_to_uint(
+        test["test_result"]["intrinsicGas"]
+    )
+
+    assert validate_transaction(test["transaction"]) == True
+    assert (
+        calculate_intrinsic_cost(test["transaction"])
+        == result_intrinsic_gas_cost
+    )

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -1,6 +1,3 @@
-import json
-import os
-import sys
 from functools import partial
 
 import pytest
@@ -11,8 +8,9 @@ from ethereum.homestead.spec import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
-from tests.homestead.blockchain_st_test_helpers import load_test_transaction
+from ethereum.utils.hexadecimal import hex_to_uint
+
+from ..helpers.eth_types_helpers import load_test_transaction
 
 test_dir = "tests/fixtures/TransactionTests"
 
@@ -32,7 +30,9 @@ load_homestead_transaction = partial(
 def test_high_nonce(test_file_high_nonce: str) -> None:
     test = load_homestead_transaction(test_dir, test_file_high_nonce)
 
-    assert validate_transaction(test["transaction"]) == False
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
+    assert validate_transaction(tx) == False
 
 
 @pytest.mark.parametrize(
@@ -45,12 +45,11 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 def test_nonce(test_file_nonce: str) -> None:
     test = load_homestead_transaction(test_dir, test_file_nonce)
 
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
     result_intrinsic_gas_cost = hex_to_uint(
         test["test_result"]["intrinsicGas"]
     )
 
-    assert validate_transaction(test["transaction"]) == True
-    assert (
-        calculate_intrinsic_cost(test["transaction"])
-        == result_intrinsic_gas_cost
-    )
+    assert validate_transaction(tx) == True
+    assert calculate_intrinsic_cost(tx) == result_intrinsic_gas_cost

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -211,24 +211,6 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
-def load_test_transaction(
-    test_dir: str, test_file: str, network: str
-) -> Dict[str, Any]:
-    pure_test_file = os.path.basename(test_file)
-    test_name = os.path.splitext(pure_test_file)[0]
-    path = os.path.join(test_dir, test_file)
-
-    with open(path, "r") as fp:
-        json_data = json.load(fp)[f"{test_name}"]
-
-    tx_rlp = hex_to_bytes(json_data["txbytes"])
-    tx = rlp.decode_to(Transaction, tx_rlp)
-
-    test_result = json_data["result"][network]
-
-    return {"transaction": tx, "test_result": test_result}
-
-
 run_tangerine_whistle_blockchain_st_tests = partial(
     run_blockchain_st_test, network="EIP150"
 )

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -211,6 +211,24 @@ def json_to_state(raw: Any) -> State:
     return state
 
 
+def load_test_transaction(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
+    pure_test_file = os.path.basename(test_file)
+    test_name = os.path.splitext(pure_test_file)[0]
+    path = os.path.join(test_dir, test_file)
+
+    with open(path, "r") as fp:
+        json_data = json.load(fp)[f"{test_name}"]
+
+    tx_rlp = hex_to_bytes(json_data["txbytes"])
+    tx = rlp.decode_to(Transaction, tx_rlp)
+
+    test_result = json_data["result"][network]
+
+    return {"transaction": tx, "test_result": test_result}
+
+
 run_tangerine_whistle_blockchain_st_tests = partial(
     run_blockchain_st_test, network="EIP150"
 )

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -1,6 +1,3 @@
-import json
-import os
-import sys
 from functools import partial
 
 import pytest
@@ -11,10 +8,9 @@ from ethereum.tangerine_whistle.spec import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
-from tests.tangerine_whistle.blockchain_st_test_helpers import (
-    load_test_transaction,
-)
+from ethereum.utils.hexadecimal import hex_to_uint
+
+from ..helpers.eth_types_helpers import load_test_transaction
 
 test_dir = "tests/fixtures/TransactionTests"
 
@@ -34,7 +30,9 @@ load_tangerine_whistle_transaction = partial(
 def test_high_nonce(test_file_high_nonce: str) -> None:
     test = load_tangerine_whistle_transaction(test_dir, test_file_high_nonce)
 
-    assert validate_transaction(test["transaction"]) == False
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
+    assert validate_transaction(tx) == False
 
 
 @pytest.mark.parametrize(
@@ -47,12 +45,11 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 def test_nonce(test_file_nonce: str) -> None:
     test = load_tangerine_whistle_transaction(test_dir, test_file_nonce)
 
+    tx = rlp.decode_to(Transaction, test["tx_rlp"])
+
     result_intrinsic_gas_cost = hex_to_uint(
         test["test_result"]["intrinsicGas"]
     )
 
-    assert validate_transaction(test["transaction"]) == True
-    assert (
-        calculate_intrinsic_cost(test["transaction"])
-        == result_intrinsic_gas_cost
-    )
+    assert validate_transaction(tx) == True
+    assert calculate_intrinsic_cost(tx) == result_intrinsic_gas_cost

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -1,0 +1,58 @@
+import json
+import os
+import sys
+from functools import partial
+
+import pytest
+
+from ethereum import rlp
+from ethereum.tangerine_whistle.eth_types import Transaction
+from ethereum.tangerine_whistle.spec import (
+    calculate_intrinsic_cost,
+    validate_transaction,
+)
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_uint
+from tests.tangerine_whistle.blockchain_st_test_helpers import (
+    load_test_transaction,
+)
+
+test_dir = "tests/fixtures/TransactionTests"
+
+load_tangerine_whistle_transaction = partial(
+    load_test_transaction, network="EIP150"
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_high_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce64Minus1.json",
+        "ttNonce/TransactionWithHighNonce64.json",
+        "ttNonce/TransactionWithHighNonce64Plus1.json",
+    ],
+)
+def test_high_nonce(test_file_high_nonce: str) -> None:
+    test = load_tangerine_whistle_transaction(test_dir, test_file_high_nonce)
+
+    assert validate_transaction(test["transaction"]) == False
+
+
+@pytest.mark.parametrize(
+    "test_file_nonce",
+    [
+        "ttNonce/TransactionWithHighNonce32.json",
+        "ttNonce/TransactionWithHighNonce64Minus2.json",
+    ],
+)
+def test_nonce(test_file_nonce: str) -> None:
+    test = load_tangerine_whistle_transaction(test_dir, test_file_nonce)
+
+    result_intrinsic_gas_cost = hex_to_uint(
+        test["test_result"]["intrinsicGas"]
+    )
+
+    assert validate_transaction(test["transaction"]) == True
+    assert (
+        calculate_intrinsic_cost(test["transaction"])
+        == result_intrinsic_gas_cost
+    )


### PR DESCRIPTION
### What was wrong?

Related to Issue #401 

### How was it fixed?
1. Updated the fixtures module to the latest commit
2. Updated GitHub test.yml to fetch submodules recursively, since LegacyTests itself is now a submodule in the latest commit of the fixtures submodule
3. Implemented the two conditions specified in [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681). Updated the CREATE instruction and validate_transaction function
4. Added transaction tests for high nonce to all the hard forks where tests have been implemented

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/8d/Lightmatter_panda.jpg)
