### PR TITLE
Return an object from EVM execution

### DIFF
--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -535,18 +535,12 @@ def process_transaction(
         env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message, env)
+    output = process_message_call(message, env)
 
-    gas_used = tx.gas - gas_left
-    gas_refund = min(gas_used // 2, refund_counter)
-    gas_refund_amount = (gas_left + gas_refund) * tx.gas_price
-    transaction_fee = (tx.gas - gas_left - gas_refund) * tx.gas_price
+    gas_used = tx.gas - output.gas_left
+    gas_refund = min(gas_used // 2, output.refund_counter)
+    gas_refund_amount = (output.gas_left + gas_refund) * tx.gas_price
+    transaction_fee = (tx.gas - output.gas_left - gas_refund) * tx.gas_price
     total_gas_used = gas_used - gas_refund
 
     # refund gas
@@ -563,10 +557,10 @@ def process_transaction(
         env.state, env.coinbase, coinbase_balance_after_mining_fee
     )
 
-    for address in accounts_to_delete:
+    for address in output.accounts_to_delete:
         destroy_account(env.state, address)
 
-    return total_gas_used, logs
+    return total_gas_used, output.logs
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
@@ -58,15 +58,13 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          5. `has_erred`: True if execution has caused an error.
     """
 
     gas_left: U256
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
     has_erred: bool
 
 
@@ -95,9 +93,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
-            )
+            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -110,7 +106,6 @@ def process_message_call(
         refund_counter=evm.refund_counter,
         logs=evm.logs,
         accounts_to_delete=evm.accounts_to_delete,
-        touched_accounts=set(),
         has_erred=evm.has_erred,
     )
 

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -554,18 +554,12 @@ def process_transaction(
         env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message, env)
+    output = process_message_call(message, env)
 
-    gas_used = tx.gas - gas_left
-    gas_refund = min(gas_used // 2, refund_counter)
-    gas_refund_amount = (gas_left + gas_refund) * tx.gas_price
-    transaction_fee = (tx.gas - gas_left - gas_refund) * tx.gas_price
+    gas_used = tx.gas - output.gas_left
+    gas_refund = min(gas_used // 2, output.refund_counter)
+    gas_refund_amount = (output.gas_left + gas_refund) * tx.gas_price
+    transaction_fee = (tx.gas - output.gas_left - gas_refund) * tx.gas_price
     total_gas_used = gas_used - gas_refund
 
     # refund gas
@@ -582,10 +576,10 @@ def process_transaction(
         env.state, env.coinbase, coinbase_balance_after_mining_fee
     )
 
-    for address in accounts_to_delete:
+    for address in output.accounts_to_delete:
         destroy_account(env.state, address)
 
-    return total_gas_used, logs
+    return total_gas_used, output.logs
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
@@ -58,15 +58,13 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          5. `has_erred`: True if execution has caused an error.
     """
 
     gas_left: U256
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
     has_erred: bool
 
 
@@ -95,9 +93,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
-            )
+            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -110,7 +106,6 @@ def process_message_call(
         refund_counter=evm.refund_counter,
         logs=evm.logs,
         accounts_to_delete=evm.accounts_to_delete,
-        touched_accounts=set(),
         has_erred=evm.has_erred,
     )
 

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -524,18 +524,12 @@ def process_transaction(
         env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message, env)
+    output = process_message_call(message, env)
 
-    gas_used = tx.gas - gas_left
-    gas_refund = min(gas_used // 2, refund_counter)
-    gas_refund_amount = (gas_left + gas_refund) * tx.gas_price
-    transaction_fee = (tx.gas - gas_left - gas_refund) * tx.gas_price
+    gas_used = tx.gas - output.gas_left
+    gas_refund = min(gas_used // 2, output.refund_counter)
+    gas_refund_amount = (output.gas_left + gas_refund) * tx.gas_price
+    transaction_fee = (tx.gas - output.gas_left - gas_refund) * tx.gas_price
     total_gas_used = gas_used - gas_refund
 
     # refund gas
@@ -552,10 +546,10 @@ def process_transaction(
         env.state, env.coinbase, coinbase_balance_after_mining_fee
     )
 
-    for address in accounts_to_delete:
+    for address in output.accounts_to_delete:
         destroy_account(env.state, address)
 
-    return total_gas_used, logs
+    return total_gas_used, output.logs
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
@@ -58,15 +58,13 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          5. `has_erred`: True if execution has caused an error.
     """
 
     gas_left: U256
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
     has_erred: bool
 
 
@@ -95,9 +93,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
-            )
+            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -110,7 +106,6 @@ def process_message_call(
         refund_counter=evm.refund_counter,
         logs=evm.logs,
         accounts_to_delete=evm.accounts_to_delete,
-        touched_accounts=set(),
         has_erred=evm.has_erred,
     )
 

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -524,18 +524,12 @@ def process_transaction(
         env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message, env)
+    output = process_message_call(message, env)
 
-    gas_used = tx.gas - gas_left
-    gas_refund = min(gas_used // 2, refund_counter)
-    gas_refund_amount = (gas_left + gas_refund) * tx.gas_price
-    transaction_fee = (tx.gas - gas_left - gas_refund) * tx.gas_price
+    gas_used = tx.gas - output.gas_left
+    gas_refund = min(gas_used // 2, output.refund_counter)
+    gas_refund_amount = (output.gas_left + gas_refund) * tx.gas_price
+    transaction_fee = (tx.gas - output.gas_left - gas_refund) * tx.gas_price
     total_gas_used = gas_used - gas_refund
 
     # refund gas
@@ -552,10 +546,10 @@ def process_transaction(
         env.state, env.coinbase, coinbase_balance_after_mining_fee
     )
 
-    for address in accounts_to_delete:
+    for address in output.accounts_to_delete:
         destroy_account(env.state, address)
 
-    return total_gas_used, logs
+    return total_gas_used, output.logs
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
@@ -58,15 +58,13 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          5. `has_erred`: True if execution has caused an error.
     """
 
     gas_left: U256
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
     has_erred: bool
 
 
@@ -95,9 +93,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
-            )
+            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -110,7 +106,6 @@ def process_message_call(
         refund_counter=evm.refund_counter,
         logs=evm.logs,
         accounts_to_delete=evm.accounts_to_delete,
-        touched_accounts=set(),
         has_erred=evm.has_erred,
     )
 

--- a/tests/frontier/vm/vm_test_helpers.py
+++ b/tests/frontier/vm/vm_test_helpers.py
@@ -39,17 +39,14 @@ def run_test(test_dir: str, test_file: str) -> None:
         env=env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message=message, env=env)
+    output = process_message_call(message, env)
 
     if test_data["has_post_state"]:
-        assert gas_left == test_data["expected_gas_left"]
-        assert keccak256(rlp.encode(logs)) == test_data["expected_logs_hash"]
+        assert output.gas_left == test_data["expected_gas_left"]
+        assert (
+            keccak256(rlp.encode(output.logs))
+            == test_data["expected_logs_hash"]
+        )
         # We are checking only the storage here and not the whole state, as the
         # balances in the testcases don't change even though some value is
         # transferred along with code invocation. But our evm execution transfers
@@ -59,7 +56,7 @@ def run_test(test_dir: str, test_file: str) -> None:
                 test_data["expected_post_state"], addr
             ) == storage_root(env.state, addr)
     else:
-        assert has_erred is True
+        assert output.has_erred is True
     close_state(env.state)
     close_state(test_data["expected_post_state"])
 

--- a/tests/homestead/vm/vm_test_helpers.py
+++ b/tests/homestead/vm/vm_test_helpers.py
@@ -39,17 +39,14 @@ def run_test(test_dir: str, test_file: str) -> None:
         env=env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message=message, env=env)
+    output = process_message_call(message, env)
 
     if test_data["has_post_state"]:
-        assert gas_left == test_data["expected_gas_left"]
-        assert keccak256(rlp.encode(logs)) == test_data["expected_logs_hash"]
+        assert output.gas_left == test_data["expected_gas_left"]
+        assert (
+            keccak256(rlp.encode(output.logs))
+            == test_data["expected_logs_hash"]
+        )
         # We are checking only the storage here and not the whole state, as the
         # balances in the testcases don't change even though some value is
         # transferred along with code invocation. But our evm execution transfers
@@ -59,7 +56,7 @@ def run_test(test_dir: str, test_file: str) -> None:
                 test_data["expected_post_state"], addr
             ) == storage_root(env.state, addr)
     else:
-        assert has_erred is True
+        assert output.has_erred is True
     close_state(env.state)
     close_state(test_data["expected_post_state"])
 

--- a/tests/spurious_dragon/vm/vm_test_helpers.py
+++ b/tests/spurious_dragon/vm/vm_test_helpers.py
@@ -41,19 +41,15 @@ def run_test(
         env=env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        touched_accounts,
-        has_erred,
-    ) = process_message_call(message=message, env=env)
+    output = process_message_call(message, env)
 
     if test_data["has_post_state"]:
         if check_gas_left:
-            assert gas_left == test_data["expected_gas_left"]
-        assert keccak256(rlp.encode(logs)) == test_data["expected_logs_hash"]
+            assert output.gas_left == test_data["expected_gas_left"]
+        assert (
+            keccak256(rlp.encode(output.logs))
+            == test_data["expected_logs_hash"]
+        )
         # We are checking only the storage here and not the whole state, as the
         # balances in the testcases don't change even though some value is
         # transferred along with code invocation. But our evm execution transfers
@@ -63,7 +59,7 @@ def run_test(
                 test_data["expected_post_state"], addr
             ) == storage_root(env.state, addr)
     else:
-        assert has_erred is True
+        assert output.has_erred is True
     close_state(env.state)
     close_state(test_data["expected_post_state"])
 

--- a/tests/tangerine_whistle/vm/vm_test_helpers.py
+++ b/tests/tangerine_whistle/vm/vm_test_helpers.py
@@ -44,18 +44,15 @@ def run_test(
         env=env,
     )
 
-    (
-        gas_left,
-        refund_counter,
-        logs,
-        accounts_to_delete,
-        has_erred,
-    ) = process_message_call(message=message, env=env)
+    output = process_message_call(message, env)
 
     if test_data["has_post_state"]:
         if check_gas_left:
-            assert gas_left == test_data["expected_gas_left"]
-        assert keccak256(rlp.encode(logs)) == test_data["expected_logs_hash"]
+            assert output.gas_left == test_data["expected_gas_left"]
+        assert (
+            keccak256(rlp.encode(output.logs))
+            == test_data["expected_logs_hash"]
+        )
         # We are checking only the storage here and not the whole state, as the
         # balances in the testcases don't change even though some value is
         # transferred along with code invocation. But our evm execution transfers
@@ -65,7 +62,7 @@ def run_test(
                 test_data["expected_post_state"], addr
             ) == storage_root(env.state, addr)
     else:
-        assert has_erred is True
+        assert output.has_erred is True
     close_state(env.state)
     close_state(test_data["expected_post_state"])
 


### PR DESCRIPTION
### What was wrong?
The EVM execution in `interpreter.py` had a tuple as its output which was difficult to manage/update

Related to Issue #439

### How was it fixed?
Added a data class to represent the message call output

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.jakpost.net/c/2020/07/25/2020_07_25_100945_1595646234._large.jpg)
