### PR TITLE
ethereum-spec-lint to prevent absolute imports within forks

### DIFF
--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -123,3 +123,12 @@ class Hardfork:
             raise ValueError(f"cannot walk {self.name}, path is None")
 
         return pkgutil.iter_modules(self.path, self.name + ".")
+
+    def walk_packages(self) -> Iterator[ModuleInfo]:
+        """
+        Iterate recursively through the (sub-)modules describing this hardfork.
+        """
+        if self.path is None:
+            raise ValueError(f"cannot walk {self.name}, path is None")
+
+        return pkgutil.walk_packages(self.path, self.name + ".")

--- a/src/ethereum_spec_tools/visitors.py
+++ b/src/ethereum_spec_tools/visitors.py
@@ -1,0 +1,114 @@
+"""
+Visitors
+^^^^^
+
+Defines node visitors for the various Lint subclasses.
+"""
+import ast
+from collections import OrderedDict
+from typing import List, Sequence
+
+
+class PatchHygieneVisitor(ast.NodeVisitor):
+    """
+    Visits nodes in a syntax tree and collects functions, classes, and
+    assignments.
+    """
+
+    path: List[str]
+    _items: "OrderedDict[str, None]"
+    in_assign: int
+
+    def __init__(self) -> None:
+        self.path = []
+        self._items = OrderedDict()
+        self.in_assign = 0
+
+    def _insert(self, item: str) -> None:
+        item = ".".join(self.path + [item])
+        if item in self._items:
+            raise ValueError(f"duplicate path {item}")
+        self._items[item] = None
+
+    @property
+    def items(self) -> Sequence[str]:
+        """
+        Sequence of all identifiers found while visiting the source.
+        """
+        return list(self._items.keys())
+
+    def visit_AsyncFunctionDef(self, function: ast.AsyncFunctionDef) -> None:
+        """
+        Visit an asynchronous function.
+        """
+        self._insert(function.name)
+        # Explicitly don't visit the children of functions.
+
+    def visit_FunctionDef(self, function: ast.FunctionDef) -> None:
+        """
+        Visit a function.
+        """
+        self._insert(function.name)
+        # Explicitly don't visit the children of functions.
+
+    def visit_ClassDef(self, klass: ast.ClassDef) -> None:
+        """
+        Visit a class.
+        """
+        self._insert(klass.name)
+        self.path.append(klass.name)
+        self.generic_visit(klass)
+        got = self.path.pop()
+        assert klass.name == got
+
+    def visit_Assign(self, assign: ast.Assign) -> None:
+        """
+        Visit an assignment.
+        """
+        self.in_assign += 1
+        for target in assign.targets:
+            self.visit(target)
+        self.in_assign -= 1
+        self.visit(assign.value)
+
+    def visit_AnnAssign(self, assign: ast.AnnAssign) -> None:
+        """
+        Visit an annotated assignment.
+        """
+        self.in_assign += 1
+        self.visit(assign.target)
+        self.in_assign -= 1
+        self.visit(assign.annotation)
+        if assign.value is not None:
+            self.visit(assign.value)
+
+    def visit_Name(self, identifier: ast.Name) -> None:
+        """
+        Visit an identifier.
+        """
+        if self.in_assign > 0:
+            self._insert(identifier.id)
+
+
+class ImportHygieneVisitor(ast.NodeVisitor):
+    """
+    Visits nodes in a syntax tree and collects functions, classes, and
+    assignments.
+    """
+
+    item_imports: List[str]
+
+    def __init__(self) -> None:
+        self.item_imports = []
+
+    def visit_Import(self, mod: ast.Import) -> None:
+        """
+        Visit an Import.
+        """
+        self.item_imports.append(mod.names[0].name)
+
+    def visit_ImportFrom(self, mod: ast.ImportFrom) -> None:
+        """
+        Visit an ImportFrom.
+        """
+        self.item_imports.append(str(mod.module))

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,6 +1,7 @@
 AnnAssign
 AsyncFunctionDef
 ClassDef
+ImportFrom
 radd
 Hash64
 Bytes20


### PR DESCRIPTION
### What was wrong?
There were no existing checks in `ethereum-spec-lint` for controlling the hygiene of import statements

Related to Issue #418 

### How was it fixed?
Added `check_import` to enforce rules outlined in #418 

Additionally extended the existing linting such that, the linting is performed recursively. E.g:- individual modules in `vm.instructions` were not being checked earlier.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/a/a9/Dolphin_Encounter-9563.jpg)
