### PR TITLE
Add CFI EIPs

### DIFF
--- a/network-upgrades/mainnet-upgrades/shanghai.md
+++ b/network-upgrades/mainnet-upgrades/shanghai.md
@@ -8,6 +8,7 @@ Specifies changes potentially included in the Network Upgrade, pending successfu
 
 * [EIP-3540: EVM Object Format (EOF) v1](https://eips.ethereum.org/EIPS/eip-3540)
 * [EIP-3670: EOF - Code Validation](https://eips.ethereum.org/EIPS/eip-3670)
+* [EIP-3855: PUSH0 instruction](https://eips.ethereum.org/EIPS/eip-3855)
 * [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
 
 ### Readiness Checklist

--- a/network-upgrades/mainnet-upgrades/shanghai.md
+++ b/network-upgrades/mainnet-upgrades/shanghai.md
@@ -3,6 +3,12 @@
 ### Included EIPs
 Specifies changes included in the Network Upgrade.
 
+### EIPs Considered for Inclusion
+Specifies changes potentially included in the Network Upgrade, pending successful deployment on Client Integration Testnets.
+
+* [EIP-3540: EVM Object Format (EOF) v1](https://eips.ethereum.org/EIPS/eip-3540)
+* [EIP-3670: EOF - Code Validation](https://eips.ethereum.org/EIPS/eip-3670)
+* [EIP-3860: Limit and meter initcode](https://eips.ethereum.org/EIPS/eip-3860)
 
 ### Readiness Checklist
 


### PR DESCRIPTION
On ACD131, we agreed to move EIPs 3540, 3670 and 3860 to CFI. 