### PR TITLE
Move lint parse code into super class

### DIFF
--- a/src/ethereum_spec_tools/lint/__init__.py
+++ b/src/ethereum_spec_tools/lint/__init__.py
@@ -5,6 +5,7 @@ Lints
 Checks specific to the Ethereum specification source code.
 """
 
+import ast
 import importlib
 import inspect
 import pkgutil
@@ -56,6 +57,16 @@ class Lint(metaclass=ABCMeta):
         position :
             The particular hardfork to lint.
         """
+
+    def _parse(
+        self, source: str, visitor: ast.NodeVisitor, attr: str
+    ) -> Sequence[str]:
+        """
+        Walks the source string and extracts a sequence of identifiers.
+        """
+        parsed = ast.parse(source)
+        visitor.visit(parsed)
+        return getattr(visitor, attr)
 
 
 class Linter:

--- a/src/ethereum_spec_tools/lint/lints/import_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/import_hygiene.py
@@ -55,7 +55,7 @@ class ImportHygiene(Lint):
             else tuple()
         )
 
-        current_imports = self.parse(source)
+        current_imports = self._parse(source, _Visitor(), "item_imports")
 
         for item in current_imports:
             if item is None:
@@ -88,16 +88,6 @@ class ImportHygiene(Lint):
                 diagnostics.append(diagnostic)
 
         return diagnostics
-
-    def parse(self, source: str) -> List[str]:
-        """
-        Walks the source string and extracts an ordered list of
-        imports.
-        """
-        parsed = ast.parse(source)
-        visitor = _Visitor()
-        visitor.visit(parsed)
-        return visitor.item_imports
 
 
 class _Visitor(ast.NodeVisitor):

--- a/src/ethereum_spec_tools/lint/lints/patch_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/patch_hygiene.py
@@ -50,9 +50,12 @@ class PatchHygiene(Lint):
             # Entire file is new, so nothing to compare!
             return []
 
-        current_nodes = self.parse(current_source)
+        current_nodes = self._parse(current_source, _Visitor(), "items")
         previous_nodes = {
-            item: idx for (idx, item) in enumerate(self.parse(previous_source))
+            item: idx
+            for (idx, item) in enumerate(
+                self._parse(previous_source, _Visitor(), "items")
+            )
         }
 
         diagnostics: List[Diagnostic] = []
@@ -75,16 +78,6 @@ class PatchHygiene(Lint):
                 diagnostics.append(diagnostic)
 
         return diagnostics
-
-    def parse(self, source: str) -> Sequence[str]:
-        """
-        Walks the source string and extracts an ordered sequence of
-        identifiers.
-        """
-        parsed = ast.parse(source)
-        visitor = _Visitor()
-        visitor.visit(parsed)
-        return visitor.items
 
 
 class _Visitor(ast.NodeVisitor):


### PR DESCRIPTION
(closes #452 )

### What was wrong?
`parse` function was being defined by every sub-class of `Lint`. This is not needed since it is essentially the same function with different `Visitors`

Related to Issue #452 

### How was it fixed?
Move the `parse` function into the `Lint` class and pass the `Visitor` instance as an argument

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.insider.com/5cdedc95021b4c12a50f46f6?width=2000&format=jpeg&auto=webp)
