### PR TITLE
EIP-2681: Limit account nonce to 2^64-1 - Create Test Cases

### DIFF
--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -93,17 +93,17 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     with open(path, "r") as fp:
         data = json.load(fp)
 
-        # Some newer test files have for example _d0g0v0_
+        # Some newer test files have patterns like _d0g0v0_
         # between test_name and network
         keys_to_search = re.compile(
-            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+            f"{re.escape(test_name)}.*{re.escape(network)}"
         )
         found_keys = list(filter(keys_to_search.match, data.keys()))
 
         if len(found_keys) > 0:
             json_data = data[found_keys[0]]
         else:
-            json_data = data[f"{test_name}_{network}"]
+            raise KeyError
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -49,3 +49,25 @@ run_invalid_header_test = partial(
 def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
     with pytest.raises(EnsureError):
         run_invalid_header_test(test_file_parent_hash)
+
+
+# Run Non-Legacy GeneralStateTests
+run_general_state_tests_new = partial(
+    run_frontier_blockchain_st_tests,
+    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_new",
+    [
+        "stCreateTest/CREATE_HighNonce.json",
+        "stCreateTest/CREATE_HighNonceMinus1.json",
+    ],
+)
+def test_general_state_tests_new(test_file_new: str) -> None:
+    try:
+        run_general_state_tests_new(test_file_new)
+    except KeyError:
+        # KeyError is raised when a test_file has no tests for frontier
+        raise pytest.skip(f"{test_file_new} has no tests for frontier")

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -93,17 +93,17 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     with open(path, "r") as fp:
         data = json.load(fp)
 
-        # Some newer test files have for example _d0g0v0_
+        # Some newer test files have patterns like _d0g0v0_
         # between test_name and network
         keys_to_search = re.compile(
-            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+            f"{re.escape(test_name)}.*{re.escape(network)}"
         )
         found_keys = list(filter(keys_to_search.match, data.keys()))
 
         if len(found_keys) > 0:
             json_data = data[found_keys[0]]
         else:
-            json_data = data[f"{test_name}_{network}"]
+            raise KeyError
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -134,3 +134,25 @@ run_invalid_header_test = partial(
 def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
     with pytest.raises(EnsureError):
         run_invalid_header_test(test_file_parent_hash)
+
+
+# Run Non-Legacy GeneralStateTests
+run_general_state_tests_new = partial(
+    run_homestead_blockchain_st_tests,
+    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_new",
+    [
+        "stCreateTest/CREATE_HighNonce.json",
+        "stCreateTest/CREATE_HighNonceMinus1.json",
+    ],
+)
+def test_general_state_tests_new(test_file_new: str) -> None:
+    try:
+        run_general_state_tests_new(test_file_new)
+    except KeyError:
+        # KeyError is raised when a test_file has no tests for homestead
+        raise pytest.skip(f"{test_file_new} has no tests for homestead")

--- a/tests/spurious_dragon/blockchain_st_test_helpers.py
+++ b/tests/spurious_dragon/blockchain_st_test_helpers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from functools import partial
 from typing import Any, Dict, List, Tuple, cast
 from unittest.mock import call, patch
@@ -94,7 +95,19 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     test_name = os.path.splitext(pure_test_file)[0]
     path = os.path.join(test_dir, test_file)
     with open(path, "r") as fp:
-        json_data = json.load(fp)[f"{test_name}_{network}"]
+        data = json.load(fp)
+
+        # Some newer test files have for example _d0g0v0_
+        # between test_name and network
+        keys_to_search = re.compile(
+            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+        )
+        found_keys = list(filter(keys_to_search.match, data.keys()))
+
+        if len(found_keys) > 0:
+            json_data = data[found_keys[0]]
+        else:
+            json_data = data[f"{test_name}_{network}"]
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/spurious_dragon/blockchain_st_test_helpers.py
+++ b/tests/spurious_dragon/blockchain_st_test_helpers.py
@@ -97,17 +97,17 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     with open(path, "r") as fp:
         data = json.load(fp)
 
-        # Some newer test files have for example _d0g0v0_
+        # Some newer test files have patterns like _d0g0v0_
         # between test_name and network
         keys_to_search = re.compile(
-            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+            f"{re.escape(test_name)}.*{re.escape(network)}"
         )
         found_keys = list(filter(keys_to_search.match, data.keys()))
 
         if len(found_keys) > 0:
             json_data = data[found_keys[0]]
         else:
-            json_data = data[f"{test_name}_{network}"]
+            raise KeyError
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -4,6 +4,7 @@ from typing import Generator
 
 import pytest
 
+from ethereum.utils.ensure import EnsureError
 from tests.spurious_dragon.blockchain_st_test_helpers import (
     run_spurious_dragon_blockchain_st_tests,
 )
@@ -41,3 +42,44 @@ def test_general_state_tests(test_file: str) -> None:
     except KeyError:
         # KeyError is raised when a test_file has no tests for spurious_dragon
         raise pytest.skip(f"{test_file} has no tests for spurious_dragon")
+
+
+# Test Invalid Block Headers
+run_invalid_header_test = partial(
+    run_spurious_dragon_blockchain_st_tests,
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_parent_hash",
+    [
+        "wrongParentHash.json",
+        "wrongParentHash2.json",
+    ],
+)
+def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
+    with pytest.raises(EnsureError):
+        run_invalid_header_test(test_file_parent_hash)
+
+
+# Run Non-Legacy GeneralStateTests
+run_general_state_tests_new = partial(
+    run_spurious_dragon_blockchain_st_tests,
+    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_new",
+    [
+        "stCreateTest/CREATE_HighNonce.json",
+        "stCreateTest/CREATE_HighNonceMinus1.json",
+    ],
+)
+def test_general_state_tests_new(test_file_new: str) -> None:
+    try:
+        run_general_state_tests_new(test_file_new)
+    except KeyError:
+        # KeyError is raised when a test_file has no tests for spurious_dragon
+        raise pytest.skip(f"{test_file_new} has no tests for spurious_dragon")

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from functools import partial
 from typing import Any, Dict, List, Tuple, cast
 from unittest.mock import call, patch
@@ -94,7 +95,19 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     test_name = os.path.splitext(pure_test_file)[0]
     path = os.path.join(test_dir, test_file)
     with open(path, "r") as fp:
-        json_data = json.load(fp)[f"{test_name}_{network}"]
+        data = json.load(fp)
+
+        # Some newer test files have for example _d0g0v0_
+        # between test_name and network
+        keys_to_search = re.compile(
+            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+        )
+        found_keys = list(filter(keys_to_search.match, data.keys()))
+
+        if len(found_keys) > 0:
+            json_data = data[found_keys[0]]
+        else:
+            json_data = data[f"{test_name}_{network}"]
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -97,17 +97,17 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
     with open(path, "r") as fp:
         data = json.load(fp)
 
-        # Some newer test files have for example _d0g0v0_
+        # Some newer test files have patterns like _d0g0v0_
         # between test_name and network
         keys_to_search = re.compile(
-            f"{test_name}_d[0-9]g[0-9]v[0-9]_{network}"
+            f"{re.escape(test_name)}.*{re.escape(network)}"
         )
         found_keys = list(filter(keys_to_search.match, data.keys()))
 
         if len(found_keys) > 0:
             json_data = data[found_keys[0]]
         else:
-            json_data = data[f"{test_name}_{network}"]
+            raise KeyError
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -4,6 +4,7 @@ from typing import Generator
 
 import pytest
 
+from ethereum.utils.ensure import EnsureError
 from tests.tangerine_whistle.blockchain_st_test_helpers import (
     run_tangerine_whistle_blockchain_st_tests,
 )
@@ -41,3 +42,47 @@ def test_general_state_tests(test_file: str) -> None:
     except KeyError:
         # KeyError is raised when a test_file has no tests for tangerine_whistle
         raise pytest.skip(f"{test_file} has no tests for tangerine_whistle")
+
+
+# Test Invalid Block Headers
+run_invalid_header_test = partial(
+    run_tangerine_whistle_blockchain_st_tests,
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_parent_hash",
+    [
+        "wrongParentHash.json",
+        "wrongParentHash2.json",
+    ],
+)
+def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
+    with pytest.raises(EnsureError):
+        run_invalid_header_test(test_file_parent_hash)
+
+
+# Run Non-Legacy GeneralStateTests
+run_general_state_tests_new = partial(
+    run_tangerine_whistle_blockchain_st_tests,
+    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_new",
+    [
+        "stCreateTest/CREATE_HighNonce.json",
+        "stCreateTest/CREATE_HighNonceMinus1.json",
+    ],
+)
+def test_general_state_tests_new(test_file_new: str) -> None:
+    try:
+        run_general_state_tests_new(test_file_new)
+    except KeyError:
+        # KeyError is raised when a test_file has no
+        # tests for tangerine_whistle
+        raise pytest.skip(
+            f"{test_file_new} has no tests for tangerine_whistle"
+        )


### PR DESCRIPTION
(closes #401 )

### What was wrong?
The Non-Legacy tests were not implemented.
These tests include ones for exceptional halting of CREATE opcode when the nonce is high

Related to Issue #401 

### How was it fixed?
Added the High Nonce tests out of `tests/fixtures/BlockchainTests/GeneralStateTests/`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/02wlz8cmini61.jpg)