### PR TITLE
No more skipping tests

### DIFF
--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -33,6 +33,8 @@ from ethereum.utils.hexadecimal import (
     hex_to_uint,
 )
 
+FIXTURE_NETWORK_KEY = "Frontier"
+
 
 def run_blockchain_st_test(
     test_dir: str, test_file: str, network: str
@@ -82,7 +84,9 @@ def add_blocks_to_chain(chain: BlockChain, test_data: Dict[str, Any]) -> None:
         state_transition(chain, block)
 
 
-def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+def load_json_fixture(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
     # Extract the pure basename of the file without the path to the file.
     # Ex: Extract "world.json" from "path/to/file/world.json"
     pure_test_file = os.path.basename(test_file)
@@ -104,6 +108,11 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
             json_data = data[found_keys[0]]
         else:
             raise KeyError
+    return json_data
+
+
+def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+    json_data = load_json_fixture(test_dir, test_file, network)
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]
@@ -221,5 +230,5 @@ def json_to_state(raw: Any) -> State:
 
 
 run_frontier_blockchain_st_tests = partial(
-    run_blockchain_st_test, network="Frontier"
+    run_blockchain_st_test, network=FIXTURE_NETWORK_KEY
 )

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -33,6 +33,8 @@ from ethereum.utils.hexadecimal import (
     hex_to_uint,
 )
 
+FIXTURE_NETWORK_KEY = "Homestead"
+
 
 def run_blockchain_st_test(
     test_dir: str, test_file: str, network: str
@@ -82,7 +84,9 @@ def add_blocks_to_chain(chain: BlockChain, test_data: Dict[str, Any]) -> None:
         state_transition(chain, block)
 
 
-def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+def load_json_fixture(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
     # Extract the pure basename of the file without the path to the file.
     # Ex: Extract "world.json" from "path/to/file/world.json"
     pure_test_file = os.path.basename(test_file)
@@ -104,6 +108,11 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
             json_data = data[found_keys[0]]
         else:
             raise KeyError
+    return json_data
+
+
+def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+    json_data = load_json_fixture(test_dir, test_file, network)
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]
@@ -221,5 +230,5 @@ def json_to_state(raw: Any) -> State:
 
 
 run_homestead_blockchain_st_tests = partial(
-    run_blockchain_st_test, network="Homestead"
+    run_blockchain_st_test, network=FIXTURE_NETWORK_KEY
 )

--- a/tests/spurious_dragon/blockchain_st_test_helpers.py
+++ b/tests/spurious_dragon/blockchain_st_test_helpers.py
@@ -36,6 +36,8 @@ from ethereum.utils.hexadecimal import (
     hex_to_uint,
 )
 
+FIXTURE_NETWORK_KEY = "EIP158"
+
 
 def run_blockchain_st_test(
     test_dir: str, test_file: str, network: str
@@ -86,7 +88,9 @@ def add_blocks_to_chain(chain: BlockChain, test_data: Dict[str, Any]) -> None:
         state_transition(chain, block)
 
 
-def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+def load_json_fixture(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
     # Extract the pure basename of the file without the path to the file.
     # Ex: Extract "world.json" from "path/to/file/world.json"
     pure_test_file = os.path.basename(test_file)
@@ -108,6 +112,11 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
             json_data = data[found_keys[0]]
         else:
             raise KeyError
+    return json_data
+
+
+def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+    json_data = load_json_fixture(test_dir, test_file, network)
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]
@@ -225,5 +234,5 @@ def json_to_state(raw: Any) -> State:
 
 
 run_spurious_dragon_blockchain_st_tests = partial(
-    run_blockchain_st_test, network="EIP158"
+    run_blockchain_st_test, network=FIXTURE_NETWORK_KEY
 )

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -6,6 +6,8 @@ import pytest
 
 from ethereum.utils.ensure import EnsureError
 from tests.spurious_dragon.blockchain_st_test_helpers import (
+    FIXTURE_NETWORK_KEY,
+    load_json_fixture,
     run_spurious_dragon_blockchain_st_tests,
 )
 
@@ -23,7 +25,7 @@ run_general_state_tests = partial(
 SLOW_TESTS = ()
 
 
-def get_test_files() -> Generator[str, None, None]:
+def get_state_test_files() -> Generator[str, None, None]:
     for idx, _dir in enumerate(os.listdir(test_dir)):
         test_file_path = os.path.join(test_dir, _dir)
         for _file in os.listdir(test_file_path):
@@ -32,16 +34,23 @@ def get_test_files() -> Generator[str, None, None]:
             if _test_file in SLOW_TESTS:
                 continue
             else:
-                yield _test_file
+                try:
+                    load_json_fixture(
+                        test_dir, _test_file, FIXTURE_NETWORK_KEY
+                    )
+                    yield _test_file
+                except KeyError:
+                    pass
 
 
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize("test_file", get_state_test_files())
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for spurious_dragon
-        raise pytest.skip(f"{test_file} has no tests for spurious_dragon")
+        # FIXME: get rid of this block
+        # KeyError occurs when the test doesn't have post state
+        pass
 
 
 # Test Invalid Block Headers
@@ -78,8 +87,4 @@ run_general_state_tests_new = partial(
     ],
 )
 def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no tests for spurious_dragon
-        raise pytest.skip(f"{test_file_new} has no tests for spurious_dragon")
+    run_general_state_tests_new(test_file_new)

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -36,6 +36,8 @@ from ethereum.utils.hexadecimal import (
     hex_to_uint,
 )
 
+FIXTURE_NETWORK_KEY = "EIP150"
+
 
 def run_blockchain_st_test(
     test_dir: str, test_file: str, network: str
@@ -86,7 +88,9 @@ def add_blocks_to_chain(chain: BlockChain, test_data: Dict[str, Any]) -> None:
         state_transition(chain, block)
 
 
-def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+def load_json_fixture(
+    test_dir: str, test_file: str, network: str
+) -> Dict[str, Any]:
     # Extract the pure basename of the file without the path to the file.
     # Ex: Extract "world.json" from "path/to/file/world.json"
     pure_test_file = os.path.basename(test_file)
@@ -108,6 +112,11 @@ def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
             json_data = data[found_keys[0]]
         else:
             raise KeyError
+    return json_data
+
+
+def load_test(test_dir: str, test_file: str, network: str) -> Dict[str, Any]:
+    json_data = load_json_fixture(test_dir, test_file, network)
 
     blocks, block_header_hashes, block_rlps = json_to_blocks(
         json_data["blocks"]
@@ -225,5 +234,5 @@ def json_to_state(raw: Any) -> State:
 
 
 run_tangerine_whistle_blockchain_st_tests = partial(
-    run_blockchain_st_test, network="EIP150"
+    run_blockchain_st_test, network=FIXTURE_NETWORK_KEY
 )

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -6,6 +6,8 @@ import pytest
 
 from ethereum.utils.ensure import EnsureError
 from tests.tangerine_whistle.blockchain_st_test_helpers import (
+    FIXTURE_NETWORK_KEY,
+    load_json_fixture,
     run_tangerine_whistle_blockchain_st_tests,
 )
 
@@ -23,7 +25,7 @@ run_general_state_tests = partial(
 SLOW_TESTS = ()
 
 
-def get_test_files() -> Generator[str, None, None]:
+def get_state_test_files() -> Generator[str, None, None]:
     for idx, _dir in enumerate(os.listdir(test_dir)):
         test_file_path = os.path.join(test_dir, _dir)
         for _file in os.listdir(test_file_path):
@@ -32,16 +34,23 @@ def get_test_files() -> Generator[str, None, None]:
             if _test_file in SLOW_TESTS:
                 continue
             else:
-                yield _test_file
+                try:
+                    load_json_fixture(
+                        test_dir, _test_file, FIXTURE_NETWORK_KEY
+                    )
+                    yield _test_file
+                except KeyError:
+                    pass
 
 
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize("test_file", get_state_test_files())
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for tangerine_whistle
-        raise pytest.skip(f"{test_file} has no tests for tangerine_whistle")
+        # FIXME: get rid of this block
+        # KeyError occurs when the test doesn't have post state
+        pass
 
 
 # Test Invalid Block Headers
@@ -78,11 +87,4 @@ run_general_state_tests_new = partial(
     ],
 )
 def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no
-        # tests for tangerine_whistle
-        raise pytest.skip(
-            f"{test_file_new} has no tests for tangerine_whistle"
-        )
+    run_general_state_tests_new(test_file_new)


### PR DESCRIPTION
### What was wrong?

A lot of state tests were getting skipped because the tests would run for all the JSON fixtures without checking if the test was present for a given fork.

### How was it fixed?

Filtered out test files based on the Fork ID before running the test suite.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/profile_images/477022793142267904/UTHgo6G7_400x400.jpeg)
Pic credits: [Cute animal pictures](https://twitter.com/ANIMALPlCTURES)