### PR TITLE
No more skipping tests

### DIFF
--- a/tests/byzantium/blockchain_st_test_helpers.py
+++ b/tests/byzantium/blockchain_st_test_helpers.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from ..helpers.load_state_tests import Load, run_blockchain_st_test
 
+FIXTURES_LOADER = Load("Byzantium", "byzantium")
+
 run_byzantium_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=Load("Byzantium", "byzantium")
+    run_blockchain_st_test, load=FIXTURES_LOADER
 )

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -1,12 +1,12 @@
-import os
 from functools import partial
-from typing import Generator
 
 import pytest
 
 from tests.byzantium.blockchain_st_test_helpers import (
+    FIXTURES_LOADER,
     run_byzantium_blockchain_st_tests,
 )
+from tests.helpers.load_state_tests import fetch_state_test_files
 
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
@@ -1484,22 +1484,12 @@ SLOW_TESTS = (
 )
 
 
-def get_test_files() -> Generator[str, None, None]:
-    for idx, _dir in enumerate(os.listdir(test_dir)):
-        test_file_path = os.path.join(test_dir, _dir)
-        for _file in os.listdir(test_file_path):
-            _test_file = os.path.join(_dir, _file)
-            # TODO: provide a way to run slow tests
-            if _test_file in SLOW_TESTS:
-                continue
-            else:
-                yield _test_file
-
-
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, SLOW_TESTS, FIXTURES_LOADER)
+)
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for byzantium
-        raise pytest.skip(f"{test_file} has no tests for byzantium")
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from ..helpers.load_state_tests import Load, run_blockchain_st_test
 
+FIXTURES_LOADER = Load("Frontier", "frontier")
+
 run_frontier_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=Load("Frontier", "frontier")
+    run_blockchain_st_test, load=FIXTURES_LOADER
 )

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -1,12 +1,13 @@
-import os
 from functools import partial
 
 import pytest
 
 from ethereum.utils.ensure import EnsureError
 from tests.frontier.blockchain_st_test_helpers import (
+    FIXTURES_LOADER,
     run_frontier_blockchain_st_tests,
 )
+from tests.helpers.load_state_tests import fetch_state_test_files
 
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
@@ -16,20 +17,18 @@ test_dir = (
 run_general_state_tests = partial(run_frontier_blockchain_st_tests, test_dir)
 
 
+SLOW_TESTS = ()
+
+
 @pytest.mark.parametrize(
-    "test_file",
-    [
-        os.path.join(_dir, _file)
-        for _dir in os.listdir(test_dir)
-        for _file in os.listdir(os.path.join(test_dir, _dir))
-    ],
+    "test_file", fetch_state_test_files(test_dir, SLOW_TESTS, FIXTURES_LOADER)
 )
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for frontier
-        raise pytest.skip(f"{test_file} has no tests for frontier")
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Test Invalid Block Headers

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from ..helpers.load_state_tests import Load, run_blockchain_st_test
 
+FIXTURES_LOADER = Load("Homestead", "homestead")
+
 run_homestead_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=Load("Homestead", "homestead")
+    run_blockchain_st_test, load=FIXTURES_LOADER
 )

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -1,11 +1,11 @@
-import os
 from functools import partial
-from typing import Generator
 
 import pytest
 
 from ethereum.utils.ensure import EnsureError
+from tests.helpers.load_state_tests import fetch_state_test_files
 from tests.homestead.blockchain_st_test_helpers import (
+    FIXTURES_LOADER,
     run_homestead_blockchain_st_tests,
 )
 
@@ -96,25 +96,15 @@ SLOW_TESTS = (
 )
 
 
-def get_test_files() -> Generator[str, None, None]:
-    for idx, _dir in enumerate(os.listdir(test_dir)):
-        test_file_path = os.path.join(test_dir, _dir)
-        for _file in os.listdir(test_file_path):
-            _test_file = os.path.join(_dir, _file)
-            # TODO: provide a way to run slow tests
-            if _test_file in SLOW_TESTS:
-                continue
-            else:
-                yield _test_file
-
-
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, SLOW_TESTS, FIXTURES_LOADER)
+)
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for homestead
-        raise pytest.skip(f"{test_file} has no tests for homestead")
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Test Invalid Block Headers

--- a/tests/spurious_dragon/blockchain_st_test_helpers.py
+++ b/tests/spurious_dragon/blockchain_st_test_helpers.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from ..helpers.load_state_tests import Load, run_blockchain_st_test
 
+FIXTURES_LOADER = Load("EIP158", "spurious_dragon")
+
 run_spurious_dragon_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=Load("EIP158", "spurious_dragon")
+    run_blockchain_st_test, load=FIXTURES_LOADER
 )

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -1,11 +1,11 @@
-import os
 from functools import partial
-from typing import Generator
 
 import pytest
 
 from ethereum.utils.ensure import EnsureError
+from tests.helpers.load_state_tests import fetch_state_test_files
 from tests.spurious_dragon.blockchain_st_test_helpers import (
+    FIXTURES_LOADER,
     run_spurious_dragon_blockchain_st_tests,
 )
 
@@ -23,25 +23,15 @@ run_general_state_tests = partial(
 SLOW_TESTS = ()
 
 
-def get_test_files() -> Generator[str, None, None]:
-    for idx, _dir in enumerate(os.listdir(test_dir)):
-        test_file_path = os.path.join(test_dir, _dir)
-        for _file in os.listdir(test_file_path):
-            _test_file = os.path.join(_dir, _file)
-            # TODO: provide a way to run slow tests
-            if _test_file in SLOW_TESTS:
-                continue
-            else:
-                yield _test_file
-
-
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, SLOW_TESTS, FIXTURES_LOADER)
+)
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for spurious_dragon
-        raise pytest.skip(f"{test_file} has no tests for spurious_dragon")
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Test Invalid Block Headers

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -2,6 +2,8 @@ from functools import partial
 
 from ..helpers.load_state_tests import Load, run_blockchain_st_test
 
+FIXTURES_LOADER = Load("EIP150", "tangerine_whistle")
+
 run_tangerine_whistle_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=Load("EIP150", "tangerine_whistle")
+    run_blockchain_st_test, load=FIXTURES_LOADER
 )

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -1,11 +1,11 @@
-import os
 from functools import partial
-from typing import Generator
 
 import pytest
 
 from ethereum.utils.ensure import EnsureError
+from tests.helpers.load_state_tests import fetch_state_test_files
 from tests.tangerine_whistle.blockchain_st_test_helpers import (
+    FIXTURES_LOADER,
     run_tangerine_whistle_blockchain_st_tests,
 )
 
@@ -23,25 +23,15 @@ run_general_state_tests = partial(
 SLOW_TESTS = ()
 
 
-def get_test_files() -> Generator[str, None, None]:
-    for idx, _dir in enumerate(os.listdir(test_dir)):
-        test_file_path = os.path.join(test_dir, _dir)
-        for _file in os.listdir(test_file_path):
-            _test_file = os.path.join(_dir, _file)
-            # TODO: provide a way to run slow tests
-            if _test_file in SLOW_TESTS:
-                continue
-            else:
-                yield _test_file
-
-
-@pytest.mark.parametrize("test_file", get_test_files())
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, SLOW_TESTS, FIXTURES_LOADER)
+)
 def test_general_state_tests(test_file: str) -> None:
     try:
         run_general_state_tests(test_file)
     except KeyError:
-        # KeyError is raised when a test_file has no tests for tangerine_whistle
-        raise pytest.skip(f"{test_file} has no tests for tangerine_whistle")
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Test Invalid Block Headers


### PR DESCRIPTION
### What was wrong?

A lot of state tests were getting skipped because the tests would run for all the JSON fixtures without checking if the test was present for a given fork.

### How was it fixed?

Filtered out test files based on the Fork ID before running the test suite.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/profile_images/477022793142267904/UTHgo6G7_400x400.jpeg)
Pic credits: [Cute animal pictures](https://twitter.com/ANIMALPlCTURES)