### PR TITLE
Add BlockChainTests that were accidentally removed

### DIFF
--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -2,12 +2,14 @@ from functools import partial
 
 import pytest
 
+from ethereum.utils.ensure import EnsureError
 from tests.byzantium.blockchain_st_test_helpers import (
     FIXTURES_LOADER,
     run_byzantium_blockchain_st_tests,
 )
 from tests.helpers.load_state_tests import fetch_state_test_files
 
+# Run legacy general state tests
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
@@ -1493,3 +1495,79 @@ def test_general_state_tests(test_file: str) -> None:
     except KeyError:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_file} doesn't have post state")
+
+
+# Run legacy valid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+)
+
+run_valid_block_test = partial(
+    run_byzantium_blockchain_st_tests,
+    test_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_uncle_correctness",
+    [
+        "bcUncleTest/oneUncle.json",
+        "bcUncleTest/oneUncleGeneration2.json",
+        "bcUncleTest/oneUncleGeneration3.json",
+        "bcUncleTest/oneUncleGeneration4.json",
+        "bcUncleTest/oneUncleGeneration5.json",
+        "bcUncleTest/oneUncleGeneration6.json",
+        "bcUncleTest/twoUncle.json",
+    ],
+)
+def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
+    run_valid_block_test(test_file_uncle_correctness)
+
+
+# Run legacy invalid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+)
+
+run_invalid_block_test = partial(
+    run_byzantium_blockchain_st_tests,
+    test_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, (), FIXTURES_LOADER)
+)
+def test_invalid_block_tests(test_file: str) -> None:
+    try:
+        # Ideally correct.json should not have been in the InvalidBlocks folder
+        if test_file == "bcUncleHeaderValidity/correct.json":
+            run_invalid_block_test(test_file)
+        else:
+            with pytest.raises((EnsureError, AssertionError, ValueError)):
+                run_invalid_block_test(test_file)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
+
+
+# Run Non-Legacy GeneralStateTests
+run_general_state_tests_new = partial(
+    run_byzantium_blockchain_st_tests,
+    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file_new",
+    [
+        "stCreateTest/CREATE_HighNonce.json",
+        "stCreateTest/CREATE_HighNonceMinus1.json",
+    ],
+)
+def test_general_state_tests_new(test_file_new: str) -> None:
+    try:
+        run_general_state_tests_new(test_file_new)
+    except KeyError:
+        # KeyError is raised when a test_file has no tests for frontier
+        raise pytest.skip(f"{test_file_new} has no tests for frontier")

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -9,6 +9,7 @@ from tests.frontier.blockchain_st_test_helpers import (
 )
 from tests.helpers.load_state_tests import fetch_state_test_files
 
+# Run legacy general state tests
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
@@ -31,23 +32,61 @@ def test_general_state_tests(test_file: str) -> None:
         pytest.xfail(f"{test_file} doesn't have post state")
 
 
-# Test Invalid Block Headers
-run_invalid_header_test = partial(
+# Run legacy valid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+)
+
+run_valid_block_test = partial(
     run_frontier_blockchain_st_tests,
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+    test_dir,
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_parent_hash",
+    "test_file_uncle_correctness",
     [
-        "wrongParentHash.json",
-        "wrongParentHash2.json",
+        "bcUncleTest/oneUncle.json",
+        "bcUncleTest/oneUncleGeneration2.json",
+        "bcUncleTest/oneUncleGeneration3.json",
+        "bcUncleTest/oneUncleGeneration4.json",
+        "bcUncleTest/oneUncleGeneration5.json",
+        "bcUncleTest/oneUncleGeneration6.json",
+        "bcUncleTest/twoUncle.json",
+        "bcUncleTest/uncleHeaderAtBlock2.json",
+        "bcUncleSpecialTests/uncleBloomNot0.json",
+        "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
     ],
 )
-def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
-    with pytest.raises(EnsureError):
-        run_invalid_header_test(test_file_parent_hash)
+def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
+    run_valid_block_test(test_file_uncle_correctness)
+
+
+# Run legacy invalid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+)
+
+run_invalid_block_test = partial(
+    run_frontier_blockchain_st_tests,
+    test_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, (), FIXTURES_LOADER)
+)
+def test_invalid_block_tests(test_file: str) -> None:
+    try:
+        # Ideally correct.json should not have been in the InvalidBlocks folder
+        if test_file == "bcUncleHeaderValidity/correct.json":
+            run_invalid_block_test(test_file)
+        else:
+            with pytest.raises((EnsureError, AssertionError, ValueError)):
+                run_invalid_block_test(test_file)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Run Non-Legacy GeneralStateTests

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -9,6 +9,7 @@ from tests.homestead.blockchain_st_test_helpers import (
     run_homestead_blockchain_st_tests,
 )
 
+# Run legacy general state tests
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
@@ -107,23 +108,60 @@ def test_general_state_tests(test_file: str) -> None:
         pytest.xfail(f"{test_file} doesn't have post state")
 
 
-# Test Invalid Block Headers
-run_invalid_header_test = partial(
+# Run legacy valid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+)
+
+run_valid_block_test = partial(
     run_homestead_blockchain_st_tests,
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+    test_dir,
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_parent_hash",
+    "test_file_uncle_correctness",
     [
-        "wrongParentHash.json",
-        "wrongParentHash2.json",
+        "bcUncleTest/oneUncle.json",
+        "bcUncleTest/oneUncleGeneration2.json",
+        "bcUncleTest/oneUncleGeneration3.json",
+        "bcUncleTest/oneUncleGeneration4.json",
+        "bcUncleTest/oneUncleGeneration5.json",
+        "bcUncleTest/oneUncleGeneration6.json",
+        "bcUncleTest/twoUncle.json",
+        "bcUncleTest/uncleHeaderAtBlock2.json",
+        "bcUncleSpecialTests/uncleBloomNot0.json",
     ],
 )
-def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
-    with pytest.raises(EnsureError):
-        run_invalid_header_test(test_file_parent_hash)
+def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
+    run_valid_block_test(test_file_uncle_correctness)
+
+
+# Run legacy invalid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+)
+
+run_invalid_block_test = partial(
+    run_homestead_blockchain_st_tests,
+    test_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, (), FIXTURES_LOADER)
+)
+def test_invalid_block_tests(test_file: str) -> None:
+    try:
+        # Ideally correct.json should not have been in the InvalidBlocks folder
+        if test_file == "bcUncleHeaderValidity/correct.json":
+            run_invalid_block_test(test_file)
+        else:
+            with pytest.raises((EnsureError, AssertionError, ValueError)):
+                run_invalid_block_test(test_file)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Run Non-Legacy GeneralStateTests

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -9,6 +9,7 @@ from tests.tangerine_whistle.blockchain_st_test_helpers import (
     run_tangerine_whistle_blockchain_st_tests,
 )
 
+# Run legacy general state tests
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
@@ -34,23 +35,60 @@ def test_general_state_tests(test_file: str) -> None:
         pytest.xfail(f"{test_file} doesn't have post state")
 
 
-# Test Invalid Block Headers
-run_invalid_header_test = partial(
+# Run legacy valid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+)
+
+run_valid_block_test = partial(
     run_tangerine_whistle_blockchain_st_tests,
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks/bcInvalidHeaderTest",
+    test_dir,
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_parent_hash",
+    "test_file_uncle_correctness",
     [
-        "wrongParentHash.json",
-        "wrongParentHash2.json",
+        "bcUncleTest/oneUncle.json",
+        "bcUncleTest/oneUncleGeneration2.json",
+        "bcUncleTest/oneUncleGeneration3.json",
+        "bcUncleTest/oneUncleGeneration4.json",
+        "bcUncleTest/oneUncleGeneration5.json",
+        "bcUncleTest/oneUncleGeneration6.json",
+        "bcUncleTest/twoUncle.json",
+        "bcUncleTest/uncleHeaderAtBlock2.json",
+        "bcUncleSpecialTests/uncleBloomNot0.json",
     ],
 )
-def test_invalid_parent_hash(test_file_parent_hash: str) -> None:
-    with pytest.raises(EnsureError):
-        run_invalid_header_test(test_file_parent_hash)
+def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
+    run_valid_block_test(test_file_uncle_correctness)
+
+
+# Run legacy invalid block tests
+test_dir = (
+    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+)
+
+run_invalid_block_test = partial(
+    run_tangerine_whistle_blockchain_st_tests,
+    test_dir,
+)
+
+
+@pytest.mark.parametrize(
+    "test_file", fetch_state_test_files(test_dir, (), FIXTURES_LOADER)
+)
+def test_invalid_block_tests(test_file: str) -> None:
+    try:
+        # Ideally correct.json should not have been in the InvalidBlocks folder
+        if test_file == "bcUncleHeaderValidity/correct.json":
+            run_invalid_block_test(test_file)
+        else:
+            with pytest.raises((EnsureError, AssertionError, ValueError)):
+                run_invalid_block_test(test_file)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_file} doesn't have post state")
 
 
 # Run Non-Legacy GeneralStateTests


### PR DESCRIPTION
(closes #415)

### What was wrong?
Some blockchain tests were accidentally deleted in this [commit](https://github.com/ethereum/execution-specs/commit/750c066022b8e4c0a18b63d3a8ebdbd61153ea7a)

Related to Issue #415 

### How was it fixed?
Added the deleted tests as well as the rest of the legacy invalid block tests

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://qph.fs.quoracdn.net/main-qimg-1b55c31a6b5f0fa57b257cdf44bdb85a-lq)
