### PR TITLE
Change post_state: Root to succeeded: bool in Byzantium

### DIFF
--- a/src/ethereum/byzantium/eth_types.py
+++ b/src/ethereum/byzantium/eth_types.py
@@ -149,7 +149,7 @@ class Receipt:
     Result of a transaction.
     """
 
-    post_state: Bytes
+    succeeded: bool
     cumulative_gas_used: Uint
     bloom: Bloom
     logs: Tuple[Log, ...]

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -365,7 +365,7 @@ def apply_body(
             receipts_trie,
             rlp.encode(Uint(i)),
             Receipt(
-                post_state=Bytes(b"") if has_erred else Bytes(b"\x01"),
+                succeeded=not has_erred,
                 cumulative_gas_used=(block_gas_limit - gas_available),
                 bloom=logs_bloom(logs),
                 logs=logs,

--- a/src/ethereum/rlp.py
+++ b/src/ethereum/rlp.py
@@ -52,6 +52,11 @@ def encode(raw_data: RLP) -> Bytes:
         return encode(raw_data.to_be_bytes())
     elif isinstance(raw_data, str):
         return encode_bytes(raw_data.encode())
+    elif isinstance(raw_data, bool):
+        if raw_data:
+            return encode_bytes(b"\x01")
+        else:
+            return encode_bytes(b"")
     elif isinstance(raw_data, Sequence):
         return encode_sequence(raw_data)
     elif is_dataclass(raw_data):
@@ -232,6 +237,13 @@ def _decode_to(cls: Type[T], raw_rlp: RLP) -> T:
             raise TypeError(
                 "RLP Decoding to type {} is not supported".format(cls)
             )
+    elif issubclass(cls, bool):
+        if raw_rlp == b"\x01":
+            return cls(True)  # type: ignore
+        elif raw_rlp == b"":
+            return cls(False)  # type: ignore
+        else:
+            raise TypeError("Cannot decode {} as {}".format(raw_rlp, cls))
     elif issubclass(cls, Bytes):
         ensure(type(raw_rlp) == Bytes)
         return raw_rlp

--- a/tests/byzantium/test_rlp.py
+++ b/tests/byzantium/test_rlp.py
@@ -98,7 +98,7 @@ log2 = Log(
 )
 
 receipt = Receipt(
-    post_state=hash1,
+    succeeded=True,
     cumulative_gas_used=Uint(1),
     bloom=bloom,
     logs=(log1, log2),


### PR DESCRIPTION
Adds a `bool` type to the rlp code and uses it to represent the post Byzantium replacement for `post_state` in receipts. The JSON-RPC api calls this value `status`, but I went with `succeeded because it is more descriptive.



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/ca07s7so3ik81.jpg)
