### PR TITLE
Implement EVM trace in Pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ pytest -m "not slow"              # Runs tests which execute quickly.
 It is recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) to keep your system Python installation clean.
 
 
-A trace of the EVM execution for any test case can be obtained by adding the `--evm-trace` to pytest.
+A trace of the EVM execution for any test case can be obtained by providing the `--evm-trace` argument to pytest.
 Note: Make sure to run the EVM trace on a small number of tests at a time. The log might otherwise get very big.
 Below is an example.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ $ pytest -m "not slow"              # Runs tests which execute quickly.
 
 It is recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) to keep your system Python installation clean.
 
+
+A trace of the EVM execution for any test case can be obtained by adding the `--evm-trace` to pytest.
+Note: Make sure to run the EVM trace on a small number of tests at a time. The log might otherwise get very big.
+Below is an example.
+
+```bash
+pytest tests/frontier/test_state_transition.py -k 'test_general_state_tests_new' --evm-trace
+```
+
+
 ## Contribution Guidelines
 
 This specification aims to be:

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,0 @@
-
-def pytest_addoption(parser):
-    parser.addoption("--evm-trace", dest='vmtrace', default=1, action='store_const', const=10, help="Run trace")
-
-
-def pytest_configure(config):
-    if config.getoption("vmtrace", default=1) == 10:
-        config.option.__dict__["log_cli_level"] = "10"
-        config.option.__dict__["log_format"] = "%(message)s"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+
+def pytest_addoption(parser):
+    parser.addoption("--evm-trace", dest='vmtrace', default=1, action='store_const', const=10, help="Run trace")
+
+
+def pytest_configure(config):
+    if config.getoption("vmtrace", default=1) == 10:
+        config.option.__dict__["log_cli_level"] = "10"
+        config.option.__dict__["log_format"] = "%(message)s"

--- a/src/ethereum/__init__.py
+++ b/src/ethereum/__init__.py
@@ -5,6 +5,7 @@ Ethereum Specification
 Core specifications for Ethereum clients.
 """
 import sys
+from typing import Any
 
 __version__ = "0.1.0"
 
@@ -13,3 +14,11 @@ __version__ = "0.1.0"
 #
 EVM_RECURSION_LIMIT = 1024 * 12
 sys.setrecursionlimit(max(EVM_RECURSION_LIMIT, sys.getrecursionlimit()))
+
+
+def evm_trace(evm: Any, op: Any) -> None:
+    """
+    Placeholder for an evm trace function. The spec does not trace evm by
+    default. EVM tracing will be injected if the user requests it.
+    """
+    pass

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -13,10 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Iterable, Set, Tuple, Union
+from typing import Any, Callable, Iterable, Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError, ensure
+from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -213,6 +214,14 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
+@trace_evm
+def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
+    """
+    Implement the individual opcodes or precompiles
+    """
+    function(evm)
+
+
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -253,7 +262,11 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
+            implement_evm_code(
+                evm=evm,
+                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
+                op=evm.message.code_address,
+            )
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -262,7 +275,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            op_implementation[op](evm)
+            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
 
     except (
         OutOfBoundsRead,

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -13,11 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
+from ethereum import evm_trace
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
-from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -199,14 +199,6 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
-@trace_evm
-def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
-    """
-    Implement the individual opcodes or precompiles
-    """
-    function(evm)
-
-
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -245,11 +237,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            implement_evm_code(
-                evm=evm,
-                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
-                op=evm.message.code_address,
-            )
+            evm_trace(evm, evm.message.code_address)
+            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -258,7 +247,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
+            evm_trace(evm, op)
+            op_implementation[op](evm)
 
     except (
         OutOfGasError,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -13,10 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Set, Tuple, Union
+from typing import Any, Callable, Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
+from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -190,6 +191,14 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
+@trace_evm
+def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
+    """
+    Implement the individual opcodes or precompiles
+    """
+    function(evm)
+
+
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -228,7 +237,11 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
+            implement_evm_code(
+                evm=evm,
+                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
+                op=evm.message.code_address,
+            )
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -237,7 +250,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            op_implementation[op](evm)
+            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
 
     except (
         OutOfGasError,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -13,11 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
+from ethereum import evm_trace
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
-from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -191,14 +191,6 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
-@trace_evm
-def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
-    """
-    Implement the individual opcodes or precompiles
-    """
-    function(evm)
-
-
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -237,11 +229,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            implement_evm_code(
-                evm=evm,
-                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
-                op=evm.message.code_address,
-            )
+            evm_trace(evm, evm.message.code_address)
+            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -250,7 +239,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
+            evm_trace(evm, op)
+            op_implementation[op](evm)
 
     except (
         OutOfGasError,

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -13,11 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
+from ethereum import evm_trace
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
-from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -199,14 +199,6 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
-@trace_evm
-def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
-    """
-    Implement the individual opcodes or precompiles
-    """
-    function(evm)
-
-
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -245,11 +237,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            implement_evm_code(
-                evm=evm,
-                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
-                op=evm.message.code_address,
-            )
+            evm_trace(evm, evm.message.code_address)
+            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -258,7 +247,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
+            evm_trace(evm, op)
+            op_implementation[op](evm)
 
     except (
         OutOfGasError,

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -13,10 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Iterable, Set, Tuple, Union
+from typing import Any, Callable, Iterable, Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError, ensure
+from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -209,6 +210,14 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
+@trace_evm
+def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
+    """
+    Implement the individual opcodes or precompiles
+    """
+    function(evm)
+
+
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -247,7 +256,11 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
+            implement_evm_code(
+                evm=evm,
+                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
+                op=evm.message.code_address,
+            )
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -256,7 +269,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            op_implementation[op](evm)
+            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
 
     except (
         OutOfGasError,

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -13,11 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Iterable, Set, Tuple, Union
+from typing import Iterable, Set, Tuple, Union
 
+from ethereum import evm_trace
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError, ensure
-from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -210,14 +210,6 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
-@trace_evm
-def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
-    """
-    Implement the individual opcodes or precompiles
-    """
-    function(evm)
-
-
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -256,11 +248,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            implement_evm_code(
-                evm=evm,
-                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
-                op=evm.message.code_address,
-            )
+            evm_trace(evm, evm.message.code_address)
+            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -269,7 +258,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
+            evm_trace(evm, op)
+            op_implementation[op](evm)
 
     except (
         OutOfGasError,

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -13,11 +13,11 @@ A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
+from ethereum import evm_trace
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import EnsureError
-from ethereum_spec_tools.evm_trace import trace_evm
 
 from ..eth_types import Address, Log
 from ..state import (
@@ -199,14 +199,6 @@ def process_message(message: Message, env: Environment) -> Evm:
     return evm
 
 
-@trace_evm
-def implement_evm_code(evm: Evm, function: Callable, op: Any) -> None:
-    """
-    Implement the individual opcodes or precompiles
-    """
-    function(evm)
-
-
 def execute_code(message: Message, env: Environment) -> Evm:
     """
     Executes bytecode present in the `message`.
@@ -245,11 +237,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
     try:
 
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            implement_evm_code(
-                evm=evm,
-                function=PRE_COMPILED_CONTRACTS[evm.message.code_address],
-                op=evm.message.code_address,
-            )
+            evm_trace(evm, evm.message.code_address)
+            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             return evm
 
         while evm.running and evm.pc < len(evm.code):
@@ -258,7 +247,8 @@ def execute_code(message: Message, env: Environment) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            implement_evm_code(evm=evm, function=op_implementation[op], op=op)
+            evm_trace(evm, op)
+            op_implementation[op](evm)
 
     except (
         OutOfGasError,

--- a/src/ethereum_spec_tools/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_trace.py
@@ -1,0 +1,85 @@
+"""
+The module implements the raw EVM tracer for pytest
+"""
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, List
+
+from ethereum.base_types import U256, Bytes, Uint
+
+
+@dataclass
+class EvmTrace:
+    """
+    The object that is logged when pytest log_cli_level
+    is set to 10. This can be used to create a raw trace of the evm.
+
+    Contains the following:
+
+          1. `depth`: depth of the message
+          2. `pc`: programcounter before opcode execution
+          3. `op`: the opcode to be executed
+          4. `has_erred`: has the evm erred before execution
+          5. `start_gas`: evm.gas_left before execution starts
+          6. `refund`: refund counter before opcode execution
+          7. `output`: evm output
+          8. `stack`: the stack before opcode execution
+    """
+
+    depth: Uint
+    pc: Uint
+    op: str
+    has_erred: bool
+    start_gas: U256
+    refund: U256
+    output: Bytes
+    stack: List[U256]
+
+    def custom_repr(self) -> str:
+        """
+        Add indentation for child evms (depth > 0)
+        """
+        tabs = "\t" * self.depth
+        rep = tabs + self.__repr__()
+        return rep
+
+
+def new_trace_from_evm(evm: Any, op: Any) -> EvmTrace:
+    """
+    Create a new trace instance before opcode execution
+    """
+    if isinstance(op, bytes):
+        opcode = "0x" + op.hex()[-2:]
+    else:
+        opcode = str(op).split(".")[-1]
+
+    return EvmTrace(
+        depth=evm.message.depth,
+        pc=evm.pc,
+        op=opcode,
+        has_erred=False,
+        start_gas=evm.gas_left,
+        refund=evm.refund_counter,
+        output=evm.output,
+        stack=evm.stack.copy(),
+    )
+
+
+def trace_evm(function: Callable) -> Callable:
+    """
+    Decorator to generate EVM Trace in pytest.
+    Trace can be activated by passing `--evm-trace`
+    to pytest
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> None:
+        if logging.root.level != 10:
+            function(*args, **kwargs)
+        else:
+            # Capture parameters before OPCode execution in a new trace
+            trace = new_trace_from_evm(kwargs["evm"], kwargs["op"])
+            logging.info(trace.custom_repr())
+
+            function(*args, **kwargs)
+
+    return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+
+import ethereum
+from ethereum_spec_tools.evm_trace import evm_trace
+
+
+def pytest_addoption(parser: Parser) -> None:
+    """
+    Accept --evm-trace option in pytest.
+    """
+    parser.addoption(
+        "--evm-trace",
+        dest="vmtrace",
+        default=1,
+        action="store_const",
+        const=10,
+        help="Run trace",
+    )
+
+
+def pytest_configure(config: Config) -> None:
+    """
+    Configure the ethereum module and log levels to output evm trace.
+    """
+    if config.getoption("vmtrace", default=1) == 10:
+        config.option.__dict__["log_cli_level"] = "10"
+        config.option.__dict__["log_format"] = "%(message)s"
+        setattr(ethereum, "evm_trace", evm_trace)


### PR DESCRIPTION
(closes #235 )

### What was wrong?
The current spec does not have a tool to generate EVM traces.

Related to Issue #235 

### How was it fixed?
Created a plugin-like tool to generate evm traces inside pytest commands with minimal changes to the fork code.
The traces can be generated by using the `--evm-trace` flag in pytest

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/58fdbaac3329b_qWDL5Lq__700.jpg)
