### PR TITLE
Byzantium fixes

### DIFF
--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -126,6 +126,7 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.return_data = child_evm.output
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
         evm.return_data = b""
     evm.gas_left += child_evm.gas_left
@@ -250,6 +251,7 @@ def call(evm: Evm) -> None:
         else:
             evm.return_data = b""
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
         evm.return_data = child_evm.output
 
@@ -349,6 +351,7 @@ def callcode(evm: Evm) -> None:
         else:
             evm.return_data = b""
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
         evm.return_data = child_evm.output
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -480,6 +483,7 @@ def delegatecall(evm: Evm) -> None:
         else:
             evm.return_data = b""
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
         evm.return_data = child_evm.output
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -117,7 +117,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         touched_accounts=collect_touched_accounts(evm),
         has_erred=evm.has_erred,
@@ -352,32 +352,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete.keys(),
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -115,6 +115,7 @@ def create(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
     evm.gas_left = child_evm.gas_left
     child_evm.gas_left = U256(0)
@@ -218,6 +219,7 @@ def call(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -306,6 +308,7 @@ def callcode(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -412,6 +415,7 @@ def delegatecall(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -106,7 +106,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         has_erred=evm.has_erred,
     )
@@ -276,32 +276,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete,
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -113,6 +113,7 @@ def create(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
     evm.gas_left = child_evm.gas_left
     child_evm.gas_left = U256(0)
@@ -215,6 +216,7 @@ def call(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -302,6 +304,7 @@ def callcode(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -106,7 +106,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         has_erred=evm.has_erred,
     )
@@ -268,32 +268,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete,
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -115,6 +115,7 @@ def create(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
     evm.gas_left = child_evm.gas_left
     child_evm.gas_left = U256(0)
@@ -218,6 +219,7 @@ def call(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -306,6 +308,7 @@ def callcode(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -412,6 +415,7 @@ def delegatecall(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -106,7 +106,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         has_erred=evm.has_erred,
     )
@@ -276,32 +276,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete,
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -122,6 +122,7 @@ def create(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
     evm.gas_left += child_evm.gas_left
     child_evm.gas_left = U256(0)
@@ -237,6 +238,7 @@ def call(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -328,6 +330,7 @@ def callcode(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -451,6 +454,7 @@ def delegatecall(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -116,7 +116,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         touched_accounts=collect_touched_accounts(evm),
         has_erred=evm.has_erred,
@@ -344,32 +344,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete.keys(),
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -121,6 +121,7 @@ def create(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
     evm.gas_left += child_evm.gas_left
     child_evm.gas_left = U256(0)
@@ -232,6 +233,7 @@ def call(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
@@ -323,6 +325,7 @@ def callcode(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -442,6 +445,7 @@ def delegatecall(evm: Evm) -> None:
     if child_evm.has_erred:
         push(evm.stack, U256(0))
     else:
+        evm.logs += child_evm.logs
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -106,7 +106,7 @@ def process_message_call(
     return MessageCallOutput(
         gas_left=evm.gas_left,
         refund_counter=refund_counter,
-        logs=collect_logs(evm),
+        logs=evm.logs if not evm.has_erred else (),
         accounts_to_delete=accounts_to_delete,
         has_erred=evm.has_erred,
     )
@@ -276,32 +276,6 @@ def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
             chain(
                 evm.accounts_to_delete,
                 *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def collect_logs(evm: Evm) -> Tuple[Log, ...]:
-    """
-    Collects all the logs emitted while executing the message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    logs: `tuple`
-        returns all the logs that were emitted while executing the
-        message call.
-    """
-    if evm.has_erred:
-        return ()
-    else:
-        return tuple(
-            chain(
-                evm.logs,
-                *(collect_logs(child_evm) for child_evm in evm.children),
             )
         )
 

--- a/src/ethereum_optimized/__init__.py
+++ b/src/ethereum_optimized/__init__.py
@@ -24,6 +24,7 @@ def monkey_patch(state_path: Optional[str]) -> None:
     Apply all monkey patches to the specification.
     """
     from . import (
+        byzantium,
         dao_fork,
         frontier,
         homestead,
@@ -36,3 +37,4 @@ def monkey_patch(state_path: Optional[str]) -> None:
     dao_fork.monkey_patch(state_path)
     tangerine_whistle.monkey_patch(state_path)
     spurious_dragon.monkey_patch(state_path)
+    byzantium.monkey_patch(state_path)

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -706,7 +706,7 @@ class Sync:
                 end - start,
             )
 
-            if block_number > 2220000 and block_number > 2463000:
+            if block_number > 2220000 and block_number < 2463000:
                 # Excessive DB load due to the Shanghai DOS attacks, requires
                 # more regular DB commits
                 if block_number % 100 == 0:


### PR DESCRIPTION
*Marked draft until #468 gets merged.*

This PR contains fixes for issues found when I started syncing Byzantium. I have successfully synced from block 4370001 to block 4412454 (as of time of writing) with this branch.

I have had to change the way logs work in order to get the ordering correct. I cannot see a way to get this to work with the `collect_logs()` approach. The problem is illustrated by the following execution, which should result in logs in order `1, 2, 3` or the receipt root will be wrong:
```
A emits log 1
A calls B
    B emits log 2
A emits log 3
```

@voith Since this is your code, do you have any opinions?

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/zam0p6855en81.jpg)
