### PR TITLE
Bump Python version to 3.8

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Checkout
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, pypy-3.7]
+        python: [3.8, pypy-3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,17 +25,17 @@ jobs:
           $GITHUB_WORKSPACE/scripts/download_geth_linux.py --dir $GITHUB_WORKSPACE/bin
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Run Tox (PyPy)
-        if: ${{ matrix.python == 'pypy-3.7' }}
+        if: ${{ matrix.python == 'pypy-3.8' }}
         run: tox -e pypy3
       - name: Run Tox (CPython)
-        if: ${{ matrix.python != 'pypy-3.7' }}
+        if: ${{ matrix.python != 'pypy-3.8' }}
         run: tox -e py3
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python != 'pypy-3.7' }}
+        if: ${{ matrix.python != 'pypy-3.8' }}
         uses: codecov/codecov-action@v1
         with:
           files: .tox/coverage.xml
           flags: unittests
       - name: Build docs
-        if: ${{ matrix.python != 'pypy-3.7' }}
+        if: ${{ matrix.python != 'pypy-3.8' }}
         run: tox -e doc

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The consensus specification is a python implementation of Ethereum that prioriti
 
 The Ethereum specification is maintained as a Python library, for better integration with tooling and testing.
 
-Requires Python 3.7+
+Requires Python 3.8+
 
 ### Building
 
@@ -67,7 +67,7 @@ $ tox -e doc-autobuild
 
 Running the tests necessary to merge into the repository requires:
 
- * Python 3.7.x (not 3.8 or later), and
+ * Python 3.8.x (not 3.9 or later), and
  * [PyPy 7.3.x](https://www.pypy.org/).
  * `geth` installed and present in `$PATH`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ packages =
 package_dir =
     =src
 
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     pysha3>=1,<2
     coincurve>=15,<16


### PR DESCRIPTION
(closes #474)

This PR bumps the Python version to 3.8. This lets us pass negative exponents to modular `pow()`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/q6xfgJz.jpg)
