### PR TITLE
Current version is incompatible with click 8.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ test =
 lint =
     isort>=5.8,<6
     mypy==0.812; implementation_name == "cpython"
+    click==8.0.4
     black==21.5b2; implementation_name == "cpython"
     flake8-spellcheck>=0.24,<0.25
     flake8-docstrings>=1.6,<2


### PR DESCRIPTION
### What was wrong?
The version of `black` used in specs is incompatible with the latest version of click (see [issue](https://github.com/psf/black/issues/2964))

Since the version of click is not locked-in within the spec `setup.cfg`, CI on `Github Actions` fails.


### How was it fixed?
We have two options here.
1. Start using the newer version of `black`. However, there seem to be some rule changes in black which will lead to errors on many spec files (about 40 of them)
2. Lock-in the version of click in `setup.cfg`. This has been implemented in the PR

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rd.com/wp-content/uploads/2019/01/shutterstock_115329475.jpg?w=1000)
