### PR TITLE
Gas and memory refactoring

### DIFF
--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -70,7 +70,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -109,41 +109,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         raise OutOfGasError
 
 
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
-
-
 def calculate_call_gas_cost(
     gas: U256, gas_left: U256, extra_gas: U256
 ) -> U256:

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -15,6 +15,7 @@ from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)
@@ -59,14 +60,15 @@ GAS_IDENTITY_WORD = U256(3)
 GAS_RETURN_DATA_COPY = U256(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def subtract_gas(evm: Evm, amount: U256) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`. Raise `OutOfGasError` if that is
+    not possible.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        Current `evm` instance.
     amount :
         The amount of gas the current operation requires.
 
@@ -75,10 +77,10 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
-
-    return gas_left - amount
+    else:
+        evm.gas_left -= amount
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:

--- a/src/ethereum/byzantium/vm/instructions/arithmetic.py
+++ b/src/ethereum/byzantium/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/bitwise.py
+++ b/src/ethereum/byzantium/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/block.py
+++ b/src/ethereum/byzantium/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/comparison.py
+++ b/src/ethereum/byzantium/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/byzantium/vm/instructions/control_flow.py
+++ b/src/ethereum/byzantium/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -49,7 +49,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -73,7 +73,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -100,7 +100,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -120,7 +120,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -140,7 +140,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -163,7 +163,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -191,7 +191,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -235,7 +235,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -266,7 +266,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -310,7 +310,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -342,7 +342,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -366,7 +366,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -416,7 +416,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -445,7 +445,7 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     return_size = U256(len(evm.return_data))
     push(evm.stack, return_size)
     evm.pc += 1
@@ -483,7 +483,7 @@ def returndatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -231,13 +231,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -303,13 +303,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -403,6 +403,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
@@ -465,6 +466,7 @@ def returndatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     value = evm.return_data[
         return_data_start_position : Uint(return_data_start_position)

--- a/src/ethereum/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/byzantium/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/byzantium/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/byzantium/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -73,7 +73,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -22,7 +22,7 @@ from ...vm.error import OutOfGasError
 from .. import Evm
 from ..error import WriteInStaticContext
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -64,6 +64,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/byzantium/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/byzantium/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/byzantium/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/byzantium/vm/instructions/stack.py
+++ b/src/ethereum/byzantium/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/byzantium/vm/instructions/storage.py
+++ b/src/ethereum/byzantium/vm/instructions/storage.py
@@ -43,7 +43,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -82,7 +82,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -149,7 +149,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)

--- a/src/ethereum/byzantium/vm/memory.py
+++ b/src/ethereum/byzantium/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/byzantium/vm/memory.py
+++ b/src/ethereum/byzantium/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/byzantium/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/alt_bn128.py
@@ -59,7 +59,7 @@ def alt_bn128_add(evm: Evm) -> None:
 
     p = p0 + p1
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(500))
+    subtract_gas(evm, U256(500))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -89,7 +89,7 @@ def alt_bn128_mul(evm: Evm) -> None:
 
     p = p0.mul_by(n)
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(40000))
+    subtract_gas(evm, U256(40000))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -104,9 +104,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     """
     if len(evm.message.data) % 192 != 0:
         raise OutOfGasError
-    evm.gas_left = subtract_gas(
-        evm.gas_left, U256(80000 * (len(evm.message.data) // 192) + 100000)
-    )
+    subtract_gas(evm, U256(80000 * (len(evm.message.data) // 192) + 100000))
     result = BNF12.from_int(1)
     for i in range(len(evm.message.data) // 192):
         values = []

--- a/src/ethereum/byzantium/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = right_pad_zero_bytes(evm.message.data, 128)
     message_hash_bytes = data[:32]
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/byzantium/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
@@ -72,7 +72,7 @@ def modexp(evm: Evm) -> None:
     # here. However, for this to happen without triggering the earlier check
     # would require providing more than 2**250 gas, which is obviously
     # not realistic.
-    evm.gas_left = subtract_gas(evm.gas_left, U256(gas_used))
+    subtract_gas(evm, U256(gas_used))
     if modulus == 0:
         evm.output = Bytes(b"\x00") * modulus_length
     else:

--- a/src/ethereum/byzantium/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/byzantium/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -69,7 +69,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -82,30 +82,6 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
         evm.gas_left -= amount
 
 
-def check_gas(evm: Evm, amount: U256) -> None:
-    """
-    Check that at least `amount` gas is available in `evm`. Raise
-    `OutOfGasError` if it isn't.
-
-    This is useful to guard a potentially expensive operation with a gas check
-    when the full gas cost will be calculated later.
-
-    Parameters
-    ----------
-    evm :
-        Current `evm` instance.
-    amount :
-        The amount of gas the current operation requires.
-
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
-        If `gas_left` is less than `amount`.
-    """
-    if evm.gas_left < amount:
-        raise OutOfGasError
-
-
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     """
     Calculates the gas cost for allocating memory
@@ -130,41 +106,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         return U256(total_gas_cost)
     except ValueError:
         raise OutOfGasError
-
-
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
 
 
 def calculate_call_gas_cost(

--- a/src/ethereum/dao_fork/vm/instructions/arithmetic.py
+++ b/src/ethereum/dao_fork/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/bitwise.py
+++ b/src/ethereum/dao_fork/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/block.py
+++ b/src/ethereum/dao_fork/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/comparison.py
+++ b/src/ethereum/dao_fork/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/dao_fork/vm/instructions/control_flow.py
+++ b/src/ethereum/dao_fork/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -71,7 +71,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -98,7 +98,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -118,7 +118,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -138,7 +138,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -161,7 +161,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -189,7 +189,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -233,7 +233,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -264,7 +264,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -308,7 +308,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -340,7 +340,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -364,7 +364,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -414,7 +414,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -229,13 +229,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -301,13 +301,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -401,6 +401,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 

--- a/src/ethereum/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/dao_fork/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/dao_fork/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/dao_fork/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -20,7 +20,7 @@ from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -61,6 +61,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -70,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -13,20 +13,14 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -51,7 +45,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1
     # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     gas_cost_log_data = u256_safe_multiply(
@@ -60,19 +54,13 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     gas_cost_log_topic = u256_safe_multiply(
         GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
     )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     gas_cost = u256_safe_add(
         GAS_LOG,
         gas_cost_log_data,
         gas_cost_log_topic,
-        gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
@@ -82,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
-        data=memory_read_bytes(evm.memory, memory_start_index, size),
+        data=memory_read_bytes(evm, memory_start_index, size),
     )
 
     evm.logs = evm.logs + (log_entry,)

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/dao_fork/vm/instructions/stack.py
+++ b/src/ethereum/dao_fork/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/dao_fork/vm/instructions/storage.py
+++ b/src/ethereum/dao_fork/vm/instructions/storage.py
@@ -41,7 +41,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -79,7 +79,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -61,7 +61,7 @@ def create(evm: Evm) -> None:
         extend_memory_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -87,7 +87,7 @@ def create(evm: Evm) -> None:
     increment_nonce(evm.env.state, evm.message.current_target)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
+    subtract_gas(evm, create_message_gas)
 
     contract_address = compute_contract_address(
         evm.message.current_target,
@@ -135,7 +135,7 @@ def return_(evm: Evm) -> None:
     gas_cost = GAS_ZERO + calculate_gas_extend_memory(
         evm.memory, memory_start_position, memory_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -166,12 +166,12 @@ def call(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -183,7 +183,7 @@ def call(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -255,12 +255,12 @@ def callcode(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -272,7 +272,7 @@ def callcode(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -374,12 +374,12 @@ def delegatecall(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -387,7 +387,7 @@ def delegatecall(evm: Evm) -> None:
 
     call_gas_fee = GAS_CALL + gas
     message_call_gas_fee = gas
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     evm.pc += 1
 

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -52,9 +52,10 @@ def create(evm: Evm) -> None:
     memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
-
     subtract_gas(evm, GAS_CREATE)
+    touch_memory(evm, memory_start_position, memory_size)
+
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
 
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -123,6 +124,7 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     subtract_gas(evm, GAS_ZERO)
+    touch_memory(evm, memory_start_position, memory_size)
 
     evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
@@ -148,10 +150,12 @@ def call(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -228,10 +232,12 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -338,10 +344,12 @@ def delegatecall(evm: Evm) -> None:
     value = evm.message.value
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = GAS_CALL + gas
     message_call_gas_fee = gas

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/dao_fork/vm/memory.py
+++ b/src/ethereum/dao_fork/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/dao_fork/vm/memory.py
+++ b/src/ethereum/dao_fork/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = evm.message.data
     message_hash_bytes = left_pad_zero_bytes(data[:32], 32)
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -108,41 +108,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         raise OutOfGasError
 
 
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
-
-
 def calculate_call_gas_cost(
     state: State, gas: U256, to: Address, value: U256
 ) -> U256:

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -69,7 +69,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -17,6 +17,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ..eth_types import Address
 from ..state import State, account_exists
+from . import Evm
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)
@@ -58,14 +59,15 @@ GAS_IDENTITY = U256(15)
 GAS_IDENTITY_WORD = U256(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def subtract_gas(evm: Evm, amount: U256) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`. Raise `OutOfGasError` if that is
+    not possible.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        Current `evm` instance.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,10 +76,10 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
-
-    return gas_left - amount
+    else:
+        evm.gas_left -= amount
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:

--- a/src/ethereum/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/frontier/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/bitwise.py
+++ b/src/ethereum/frontier/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/block.py
+++ b/src/ethereum/frontier/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/comparison.py
+++ b/src/ethereum/frontier/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -71,7 +71,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -98,7 +98,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -118,7 +118,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -138,7 +138,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -161,7 +161,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -189,7 +189,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -233,7 +233,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -264,7 +264,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -308,7 +308,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -340,7 +340,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -364,7 +364,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -414,7 +414,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -229,13 +229,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -301,13 +301,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -401,6 +401,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -20,7 +20,7 @@ from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -61,6 +61,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -13,20 +13,14 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -51,7 +45,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1
     # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     gas_cost_log_data = u256_safe_multiply(
@@ -60,29 +54,22 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     gas_cost_log_topic = u256_safe_multiply(
         GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
     )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     gas_cost = u256_safe_add(
         GAS_LOG,
         gas_cost_log_data,
         gas_cost_log_topic,
-        gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
-
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
-        data=memory_read_bytes(evm.memory, memory_start_index, size),
+        data=memory_read_bytes(evm, memory_start_index, size),
     )
 
     evm.logs = evm.logs + (log_entry,)

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -70,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/frontier/vm/instructions/storage.py
+++ b/src/ethereum/frontier/vm/instructions/storage.py
@@ -41,7 +41,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~:py:class:`~ethereum.frontier.vm.error.OutOfGasError``
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -79,7 +79,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -60,7 +60,7 @@ def create(evm: Evm) -> None:
         extend_memory_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -86,7 +86,7 @@ def create(evm: Evm) -> None:
     increment_nonce(evm.env.state, evm.message.current_target)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
+    subtract_gas(evm, create_message_gas)
 
     contract_address = compute_contract_address(
         evm.message.current_target,
@@ -133,7 +133,7 @@ def return_(evm: Evm) -> None:
     gas_cost = GAS_ZERO + calculate_gas_extend_memory(
         evm.memory, memory_start_position, memory_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -164,12 +164,12 @@ def call(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -181,7 +181,7 @@ def call(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -252,12 +252,12 @@ def callcode(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -269,7 +269,7 @@ def callcode(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -51,9 +51,10 @@ def create(evm: Evm) -> None:
     memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
-
     subtract_gas(evm, GAS_CREATE)
+    touch_memory(evm, memory_start_position, memory_size)
+
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
 
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -121,6 +122,7 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     subtract_gas(evm, GAS_ZERO)
+    touch_memory(evm, memory_start_position, memory_size)
 
     evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
@@ -146,10 +148,12 @@ def call(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -225,10 +229,12 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -27,11 +27,10 @@ from ..gas import (
     GAS_CREATE,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
     subtract_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -49,19 +48,13 @@ def create(evm: Evm) -> None:
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
+
+    subtract_gas(evm, GAS_CREATE)
+
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -78,10 +71,6 @@ def create(evm: Evm) -> None:
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
 
     increment_nonce(evm.env.state, evm.message.current_target)
 
@@ -128,16 +117,12 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    subtract_gas(evm, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    evm.output = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
+
+    subtract_gas(evm, GAS_ZERO)
+
+    evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
     evm.running = False
 
@@ -156,24 +141,15 @@ def call(evm: Evm) -> None:
     gas = pop(evm.stack)
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -221,7 +197,7 @@ def call(evm: Evm) -> None:
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
@@ -243,25 +219,16 @@ def callcode(evm: Evm) -> None:
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -308,7 +275,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -133,7 +133,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             evm.output = b""
         else:

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/frontier/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = right_pad_zero_bytes(evm.message.data, 128)
     message_hash_bytes = data[:32]
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/frontier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -69,7 +69,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -17,6 +17,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ..eth_types import Address
 from ..state import State, account_exists
+from . import Evm
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)
@@ -58,14 +59,15 @@ GAS_IDENTITY = U256(15)
 GAS_IDENTITY_WORD = U256(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def subtract_gas(evm: Evm, amount: U256) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`. Raise `OutOfGasError` if that is
+    not possible.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        Current `evm` instance.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,10 +76,34 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= amount
 
-    return gas_left - amount
+
+def check_gas(evm: Evm, amount: U256) -> None:
+    """
+    Check that at least `amount` gas is available in `evm`. Raise
+    `OutOfGasError` if it isn't.
+
+    This is useful to guard a potentially expensive operation with a gas check
+    when the full gas cost will be calculated later.
+
+    Parameters
+    ----------
+    evm :
+        Current `evm` instance.
+    amount :
+        The amount of gas the current operation requires.
+
+    Raises
+    ------
+    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
+        If `gas_left` is less than `amount`.
+    """
+    if evm.gas_left < amount:
+        raise OutOfGasError
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -82,30 +82,6 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
         evm.gas_left -= amount
 
 
-def check_gas(evm: Evm, amount: U256) -> None:
-    """
-    Check that at least `amount` gas is available in `evm`. Raise
-    `OutOfGasError` if it isn't.
-
-    This is useful to guard a potentially expensive operation with a gas check
-    when the full gas cost will be calculated later.
-
-    Parameters
-    ----------
-    evm :
-        Current `evm` instance.
-    amount :
-        The amount of gas the current operation requires.
-
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
-        If `gas_left` is less than `amount`.
-    """
-    if evm.gas_left < amount:
-        raise OutOfGasError
-
-
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     """
     Calculates the gas cost for allocating memory
@@ -130,41 +106,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         return U256(total_gas_cost)
     except ValueError:
         raise OutOfGasError
-
-
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
 
 
 def calculate_call_gas_cost(

--- a/src/ethereum/homestead/vm/instructions/arithmetic.py
+++ b/src/ethereum/homestead/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/bitwise.py
+++ b/src/ethereum/homestead/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/block.py
+++ b/src/ethereum/homestead/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/comparison.py
+++ b/src/ethereum/homestead/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/homestead/vm/instructions/control_flow.py
+++ b/src/ethereum/homestead/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -71,7 +71,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -98,7 +98,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -118,7 +118,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -138,7 +138,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -161,7 +161,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -189,7 +189,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -233,7 +233,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -264,7 +264,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -308,7 +308,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -340,7 +340,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -364,7 +364,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -414,7 +414,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -229,13 +229,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -301,13 +301,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -401,6 +401,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 

--- a/src/ethereum/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/homestead/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/homestead/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/homestead/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -20,7 +20,7 @@ from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -61,6 +61,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -70,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -13,20 +13,14 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -51,7 +45,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1
     # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     gas_cost_log_data = u256_safe_multiply(
@@ -60,19 +54,13 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     gas_cost_log_topic = u256_safe_multiply(
         GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
     )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     gas_cost = u256_safe_add(
         GAS_LOG,
         gas_cost_log_data,
         gas_cost_log_topic,
-        gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
@@ -82,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
-        data=memory_read_bytes(evm.memory, memory_start_index, size),
+        data=memory_read_bytes(evm, memory_start_index, size),
     )
 
     evm.logs = evm.logs + (log_entry,)

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/homestead/vm/instructions/stack.py
+++ b/src/ethereum/homestead/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.homestead.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/homestead/vm/instructions/storage.py
+++ b/src/ethereum/homestead/vm/instructions/storage.py
@@ -41,7 +41,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~:py:class:`~ethereum.homestead.vm.error.OutOfGasError``
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -79,7 +79,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -61,7 +61,7 @@ def create(evm: Evm) -> None:
         extend_memory_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -87,7 +87,7 @@ def create(evm: Evm) -> None:
     increment_nonce(evm.env.state, evm.message.current_target)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
+    subtract_gas(evm, create_message_gas)
 
     contract_address = compute_contract_address(
         evm.message.current_target,
@@ -135,7 +135,7 @@ def return_(evm: Evm) -> None:
     gas_cost = GAS_ZERO + calculate_gas_extend_memory(
         evm.memory, memory_start_position, memory_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -166,12 +166,12 @@ def call(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -183,7 +183,7 @@ def call(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -255,12 +255,12 @@ def callcode(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -272,7 +272,7 @@ def callcode(evm: Evm) -> None:
         calculate_message_call_gas_stipend(value),
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -374,12 +374,12 @@ def delegatecall(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -387,7 +387,7 @@ def delegatecall(evm: Evm) -> None:
 
     call_gas_fee = GAS_CALL + gas
     message_call_gas_fee = gas
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     evm.pc += 1
 

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -52,9 +52,10 @@ def create(evm: Evm) -> None:
     memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
-
     subtract_gas(evm, GAS_CREATE)
+    touch_memory(evm, memory_start_position, memory_size)
+
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
 
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -123,6 +124,7 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     subtract_gas(evm, GAS_ZERO)
+    touch_memory(evm, memory_start_position, memory_size)
 
     evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
@@ -148,10 +150,12 @@ def call(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -228,10 +232,12 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
     message_call_gas_fee = u256_safe_add(
@@ -338,10 +344,12 @@ def delegatecall(evm: Evm) -> None:
     value = evm.message.value
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     call_gas_fee = GAS_CALL + gas
     message_call_gas_fee = gas

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/homestead/vm/memory.py
+++ b/src/ethereum/homestead/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/homestead/vm/memory.py
+++ b/src/ethereum/homestead/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/homestead/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = right_pad_zero_bytes(evm.message.data, 128)
     message_hash_bytes = data[:32]
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/homestead/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/homestead/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/homestead/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -15,6 +15,7 @@ from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)
@@ -58,14 +59,15 @@ GAS_IDENTITY = U256(15)
 GAS_IDENTITY_WORD = U256(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def subtract_gas(evm: Evm, amount: U256) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`. Raise `OutOfGasError` if that is
+    not possible.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        Current `evm` instance.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,10 +76,34 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= amount
 
-    return gas_left - amount
+
+def check_gas(evm: Evm, amount: U256) -> None:
+    """
+    Check that at least `amount` gas is available in `evm`. Raise
+    `OutOfGasError` if it isn't.
+
+    This is useful to guard a potentially expensive operation with a gas check
+    when the full gas cost will be calculated later.
+
+    Parameters
+    ----------
+    evm :
+        Current `evm` instance.
+    amount :
+        The amount of gas the current operation requires.
+
+    Raises
+    ------
+    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
+        If `gas_left` is less than `amount`.
+    """
+    if evm.gas_left < amount:
+        raise OutOfGasError
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -69,7 +69,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -82,30 +82,6 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
         evm.gas_left -= amount
 
 
-def check_gas(evm: Evm, amount: U256) -> None:
-    """
-    Check that at least `amount` gas is available in `evm`. Raise
-    `OutOfGasError` if it isn't.
-
-    This is useful to guard a potentially expensive operation with a gas check
-    when the full gas cost will be calculated later.
-
-    Parameters
-    ----------
-    evm :
-        Current `evm` instance.
-    amount :
-        The amount of gas the current operation requires.
-
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
-        If `gas_left` is less than `amount`.
-    """
-    if evm.gas_left < amount:
-        raise OutOfGasError
-
-
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     """
     Calculates the gas cost for allocating memory
@@ -130,41 +106,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         return U256(total_gas_cost)
     except ValueError:
         raise OutOfGasError
-
-
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
 
 
 def calculate_call_gas_cost(

--- a/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/block.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/comparison.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/environment.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -71,7 +71,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -98,7 +98,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -118,7 +118,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -138,7 +138,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -161,7 +161,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -189,7 +189,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -233,7 +233,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -264,7 +264,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -308,7 +308,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -340,7 +340,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -364,7 +364,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -414,7 +414,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 

--- a/src/ethereum/spurious_dragon/vm/instructions/environment.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/environment.py
@@ -229,13 +229,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -301,13 +301,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -401,6 +401,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 

--- a/src/ethereum/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -20,7 +20,7 @@ from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -61,6 +61,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -70,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -13,20 +13,14 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -51,7 +45,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1
     # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     gas_cost_log_data = u256_safe_multiply(
@@ -60,19 +54,13 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     gas_cost_log_topic = u256_safe_multiply(
         GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
     )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     gas_cost = u256_safe_add(
         GAS_LOG,
         gas_cost_log_data,
         gas_cost_log_topic,
-        gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
@@ -82,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
-        data=memory_read_bytes(evm.memory, memory_start_index, size),
+        data=memory_read_bytes(evm, memory_start_index, size),
     )
 
     evm.logs = evm.logs + (log_entry,)

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/spurious_dragon/vm/instructions/stack.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/spurious_dragon/vm/instructions/storage.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/storage.py
@@ -41,7 +41,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -79,7 +79,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -34,12 +34,11 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
     max_message_call_gas,
     subtract_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -57,19 +56,13 @@ def create(evm: Evm) -> None:
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
+
+    subtract_gas(evm, GAS_CREATE)
+
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -86,10 +79,6 @@ def create(evm: Evm) -> None:
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
 
     increment_nonce(evm.env.state, evm.message.current_target)
 
@@ -137,16 +126,12 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    subtract_gas(evm, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    evm.output = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
+
+    subtract_gas(evm, GAS_ZERO)
+
+    evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
     evm.running = False
 
@@ -167,24 +152,15 @@ def call(evm: Evm) -> None:
     gas = pop(evm.stack)
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     is_account_alive = account_exists(
         evm.env.state, to
@@ -243,7 +219,7 @@ def call(evm: Evm) -> None:
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
@@ -267,25 +243,16 @@ def callcode(evm: Evm) -> None:
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
     extra_gas = transfer_gas_cost
@@ -334,7 +301,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
@@ -397,26 +364,17 @@ def delegatecall(evm: Evm) -> None:
 
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
     value = evm.message.value
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     extra_gas = U256(0)
     call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
@@ -456,7 +414,7 @@ def delegatecall(evm: Evm) -> None:
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -59,9 +59,10 @@ def create(evm: Evm) -> None:
     memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
-
     subtract_gas(evm, GAS_CREATE)
+    touch_memory(evm, memory_start_position, memory_size)
+
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
 
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -130,6 +131,7 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     subtract_gas(evm, GAS_ZERO)
+    touch_memory(evm, memory_start_position, memory_size)
 
     evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
@@ -157,10 +159,12 @@ def call(evm: Evm) -> None:
     memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     is_account_alive = account_exists(
         evm.env.state, to
@@ -249,10 +253,12 @@ def callcode(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
     extra_gas = transfer_gas_cost
@@ -371,10 +377,12 @@ def delegatecall(evm: Evm) -> None:
     value = evm.message.value
     to = evm.message.current_target
 
+    touch_memory(evm, memory_input_start_position, memory_input_size)
+    touch_memory(evm, memory_output_start_position, memory_output_size)
+
     call_data = memory_read_bytes(
         evm, memory_input_start_position, memory_input_size
     )
-    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     extra_gas = U256(0)
     call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -148,7 +148,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)

--- a/src/ethereum/spurious_dragon/vm/memory.py
+++ b/src/ethereum/spurious_dragon/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/spurious_dragon/vm/memory.py
+++ b/src/ethereum/spurious_dragon/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = right_pad_zero_bytes(evm.message.data, 128)
     message_hash_bytes = data[:32]
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -15,6 +15,7 @@ from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .error import OutOfGasError
 
 GAS_JUMPDEST = U256(1)
@@ -58,14 +59,15 @@ GAS_IDENTITY = U256(15)
 GAS_IDENTITY_WORD = U256(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def subtract_gas(evm: Evm, amount: U256) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`. Raise `OutOfGasError` if that is
+    not possible.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        Current `evm` instance.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,10 +76,34 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= amount
 
-    return gas_left - amount
+
+def check_gas(evm: Evm, amount: U256) -> None:
+    """
+    Check that at least `amount` gas is available in `evm`. Raise
+    `OutOfGasError` if it isn't.
+
+    This is useful to guard a potentially expensive operation with a gas check
+    when the full gas cost will be calculated later.
+
+    Parameters
+    ----------
+    evm :
+        Current `evm` instance.
+    amount :
+        The amount of gas the current operation requires.
+
+    Raises
+    ------
+    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
+        If `gas_left` is less than `amount`.
+    """
+    if evm.gas_left < amount:
+        raise OutOfGasError
 
 
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -69,7 +69,7 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
     evm :
         Current `evm` instance.
     amount :
-        The amount of gas the current operation requires.
+        The amount of gas to deduct.
 
     Raises
     ------

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -82,30 +82,6 @@ def subtract_gas(evm: Evm, amount: U256) -> None:
         evm.gas_left -= amount
 
 
-def check_gas(evm: Evm, amount: U256) -> None:
-    """
-    Check that at least `amount` gas is available in `evm`. Raise
-    `OutOfGasError` if it isn't.
-
-    This is useful to guard a potentially expensive operation with a gas check
-    when the full gas cost will be calculated later.
-
-    Parameters
-    ----------
-    evm :
-        Current `evm` instance.
-    amount :
-        The amount of gas the current operation requires.
-
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.error.OutOfGasError`
-        If `gas_left` is less than `amount`.
-    """
-    if evm.gas_left < amount:
-        raise OutOfGasError
-
-
 def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     """
     Calculates the gas cost for allocating memory
@@ -130,41 +106,6 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
         return U256(total_gas_cost)
     except ValueError:
         raise OutOfGasError
-
-
-def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
-    """
-    Calculates the gas amount to extend memory
-
-    Parameters
-    ----------
-    memory :
-        Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
-
-    Returns
-    -------
-    to_be_paid : `ethereum.base_types.U256`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    """
-    if size == 0:
-        return U256(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return U256(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
 
 
 def calculate_call_gas_cost(

--- a/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
@@ -44,7 +44,7 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -72,7 +72,7 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -100,7 +100,7 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -128,7 +128,7 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
@@ -159,7 +159,7 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
@@ -194,7 +194,7 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack)
     y = pop(evm.stack)
@@ -225,7 +225,7 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
@@ -257,7 +257,7 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -290,7 +290,7 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
 
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
@@ -331,7 +331,7 @@ def exp(evm: Evm) -> None:
         exponent_bits = exponent.bit_length()
         exponent_bytes = (exponent_bits + 7) // 8
         gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    subtract_gas(evm, gas_used)
 
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
@@ -357,7 +357,7 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
+    subtract_gas(evm, GAS_LOW)
 
     # byte_num would be 0-indexed when inserted to the stack.
     byte_num = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
@@ -36,7 +36,7 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x & y)
@@ -61,7 +61,7 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x | y)
@@ -86,7 +86,7 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     y = pop(evm.stack)
     push(evm.stack, x ^ y)
@@ -111,7 +111,7 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     x = pop(evm.stack)
     push(evm.stack, ~x)
 
@@ -136,7 +136,7 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     # 0-indexed from left (most significant) to right (least significant)
     # in "Big Endian" representation.
     byte_index = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/block.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/block.py
@@ -36,7 +36,7 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
+    subtract_gas(evm, GAS_BLOCK_HASH)
 
     block_number = pop(evm.stack)
 
@@ -73,7 +73,7 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
     evm.pc += 1
@@ -99,7 +99,7 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.time)
 
     evm.pc += 1
@@ -124,7 +124,7 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.number))
 
     evm.pc += 1
@@ -149,7 +149,7 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.difficulty))
 
     evm.pc += 1
@@ -174,7 +174,7 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.env.gas_limit))
 
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
@@ -36,7 +36,7 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -63,7 +63,7 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -91,7 +91,7 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -118,7 +118,7 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
@@ -146,7 +146,7 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     left = pop(evm.stack)
     right = pop(evm.stack)
@@ -174,7 +174,7 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     x = pop(evm.stack)
     result = U256(x == 0)

--- a/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
@@ -55,7 +55,7 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    subtract_gas(evm, GAS_MID)
     jump_dest = pop(evm.stack)
 
     if jump_dest not in evm.valid_jump_destinations:
@@ -88,7 +88,7 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
+    subtract_gas(evm, GAS_HIGH)
 
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
@@ -120,7 +120,7 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(evm.pc))
     evm.pc += 1
 
@@ -142,7 +142,7 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.gas_left)
     evm.pc += 1
 
@@ -163,5 +163,5 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    subtract_gas(evm, GAS_JUMPDEST)
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
     evm.pc += 1
@@ -71,7 +71,7 @@ def balance(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
+    subtract_gas(evm, GAS_BALANCE)
 
     address = to_address(pop(evm.stack))
 
@@ -98,7 +98,7 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
     evm.pc += 1
@@ -118,7 +118,7 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
     evm.pc += 1
@@ -138,7 +138,7 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.message.value)
 
     evm.pc += 1
@@ -161,7 +161,7 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # Converting start_index to Uint from U256 as start_index + 32 can
     # overflow U256.
@@ -189,7 +189,7 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.message.data)))
 
     evm.pc += 1
@@ -233,7 +233,7 @@ def calldatacopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -264,7 +264,7 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, U256(len(evm.code)))
 
     evm.pc += 1
@@ -308,7 +308,7 @@ def codecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 
@@ -340,7 +340,7 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     push(evm.stack, evm.env.gas_price)
 
     evm.pc += 1
@@ -364,7 +364,7 @@ def extcodesize(evm: Evm) -> None:
     """
     # TODO: There are no test cases against this function. Need to write
     # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
+    subtract_gas(evm, GAS_EXTERNAL)
 
     address = to_address(pop(evm.stack))
 
@@ -414,7 +414,7 @@ def extcodecopy(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     evm.pc += 1
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -229,13 +229,13 @@ def calldatacopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.message.data[
         data_start_index : Uint(data_start_index) + Uint(size)
     ]
@@ -301,13 +301,13 @@ def codecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 
     if size == 0:
         return
 
-    touch_memory(evm, memory_start_index, size)
     value = evm.code[code_start_index : Uint(code_start_index) + Uint(size)]
     # But it is possible that code_start_index + size - 1 won't exist in
     # evm.code in which case we need to right pad the above obtained bytes
@@ -401,6 +401,7 @@ def extcodecopy(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     evm.pc += 1
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
@@ -20,7 +20,7 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop, push
 
 
@@ -56,6 +56,7 @@ def keccak(evm: Evm) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)

--- a/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
@@ -66,7 +66,7 @@ def keccak(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
@@ -19,13 +19,8 @@ from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -46,9 +41,7 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     words = ceil32(Uint(size)) // 32
@@ -57,20 +50,14 @@ def keccak(evm: Evm) -> None:
         words,
         exception_type=OutOfGasError,
     )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     total_gas_cost = u256_safe_add(
         GAS_KECCAK256,
         word_gas_cost,
-        memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, total_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
-    data = memory_read_bytes(evm.memory, memory_start_index, size)
+    data = memory_read_bytes(evm, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -20,7 +20,7 @@ from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
 from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
-from ..memory import memory_read_bytes
+from ..memory import memory_read_bytes, touch_memory
 from ..stack import pop
 
 
@@ -61,6 +61,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
+    touch_memory(evm, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -70,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     extend_memory(evm.memory, memory_start_index, size)
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -13,20 +13,14 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, subtract_gas
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -51,7 +45,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     """
     # Converting memory_start_index to Uint as memory_start_index + size - 1
     # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
     gas_cost_log_data = u256_safe_multiply(
@@ -60,19 +54,13 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     gas_cost_log_topic = u256_safe_multiply(
         GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
     )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
     gas_cost = u256_safe_add(
         GAS_LOG,
         gas_cost_log_data,
         gas_cost_log_topic,
-        gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
     subtract_gas(evm, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
@@ -82,7 +70,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
-        data=memory_read_bytes(evm.memory, memory_start_index, size),
+        data=memory_read_bytes(evm, memory_start_index, size),
     )
 
     evm.logs = evm.logs + (log_entry,)

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -15,7 +15,7 @@ from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
-from ..memory import memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -42,6 +42,8 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(len(value)))
+
     memory_write(evm, start_position, value)
 
     evm.pc += 1
@@ -73,6 +75,8 @@ def mstore8(evm: Evm) -> None:
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(1))
+
     memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
@@ -98,6 +102,7 @@ def mload(evm: Evm) -> None:
     # convert to Uint as start_position + size_to_extend can overflow.
     start_position = pop(evm.stack)
     subtract_gas(evm, GAS_VERY_LOW)
+    touch_memory(evm, start_position, U256(32))
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     value = U256.from_be_bytes(

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -11,18 +11,11 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
-from ...vm.error import OutOfGasError
 from .. import Evm
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -45,23 +38,11 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
-    memory_write(evm.memory, start_position, value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, value)
 
     evm.pc += 1
 
@@ -86,24 +67,13 @@ def mstore8(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
     # make sure that value doesn't exceed 1 byte
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
-    memory_write(evm.memory, start_position, normalized_bytes_value)
+    subtract_gas(evm, GAS_VERY_LOW)
+    memory_write(evm, start_position, normalized_bytes_value)
 
     evm.pc += 1
 
@@ -126,22 +96,12 @@ def mload(evm: Evm) -> None:
         `3` + gas needed to extend memory.
     """
     # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
+    start_position = pop(evm.stack)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
     value = U256.from_be_bytes(
-        memory_read_bytes(evm.memory, start_position, U256(32))
+        memory_read_bytes(evm, start_position, U256(32))
     )
     push(evm.stack, value)
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -57,7 +57,7 @@ def mstore(evm: Evm) -> None:
         gas_cost_memory_extend,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -99,7 +99,7 @@ def mstore8(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(1))
@@ -136,7 +136,7 @@ def mload(evm: Evm) -> None:
         memory_extend_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
 
     # extend memory and subtract gas for allocating 32 bytes of memory
     extend_memory(evm.memory, start_position, U256(32))
@@ -162,7 +162,7 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     memory_size = U256(len(evm.memory))
     push(evm.stack, memory_size)
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/stack.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/stack.py
@@ -38,7 +38,7 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    subtract_gas(evm, GAS_BASE)
     stack.pop(evm.stack)
 
     evm.pc += 1
@@ -64,7 +64,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
 
     data_to_push = U256.from_be_bytes(
         evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
@@ -92,7 +92,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
@@ -123,7 +123,7 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    subtract_gas(evm, GAS_VERY_LOW)
     ensure(item_number < len(evm.stack), StackUnderflowError)
 
     top_element_idx = len(evm.stack) - 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/storage.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/storage.py
@@ -41,7 +41,7 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.error.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
+    subtract_gas(evm, GAS_SLOAD)
 
     key = pop(evm.stack).to_be_bytes32()
     value = get_storage(evm.env.state, evm.message.current_target, key)
@@ -79,7 +79,7 @@ def sstore(evm: Evm) -> None:
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
 
     # TODO: Refund counter hasn't been tested yet. Testing this needs other
     # Opcodes to be implemented

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -33,12 +33,11 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
     max_message_call_gas,
     subtract_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write, touch_memory
 from ..stack import pop, push
 
 
@@ -56,19 +55,13 @@ def create(evm: Evm) -> None:
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    subtract_gas(evm, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    call_data = memory_read_bytes(evm, memory_start_position, memory_size)
+
+    subtract_gas(evm, GAS_CREATE)
+
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -85,10 +78,6 @@ def create(evm: Evm) -> None:
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         push(evm.stack, U256(0))
         return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
 
     increment_nonce(evm.env.state, evm.message.current_target)
 
@@ -136,16 +125,12 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    subtract_gas(evm, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    evm.output = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
+
+    subtract_gas(evm, GAS_ZERO)
+
+    evm.output = memory_read_bytes(evm, memory_start_position, memory_size)
     # HALT the execution
     evm.running = False
 
@@ -166,24 +151,15 @@ def call(evm: Evm) -> None:
     gas = pop(evm.stack)
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     _account_exists = account_exists(evm.env.state, to)
     create_gas_cost = U256(0) if _account_exists else GAS_NEW_ACCOUNT
@@ -238,7 +214,7 @@ def call(evm: Evm) -> None:
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
@@ -262,25 +238,16 @@ def callcode(evm: Evm) -> None:
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
     extra_gas = transfer_gas_cost
@@ -329,7 +296,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
@@ -388,26 +355,17 @@ def delegatecall(evm: Evm) -> None:
 
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
     value = evm.message.value
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    subtract_gas(evm, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    subtract_gas(evm, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
+        evm, memory_input_start_position, memory_input_size
     )
+    touch_memory(evm, memory_output_start_position, memory_output_size)
 
     extra_gas = U256(0)
     call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
@@ -447,7 +405,7 @@ def delegatecall(evm: Evm) -> None:
         push(evm.stack, U256(1))
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
-        evm.memory,
+        evm,
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -67,7 +67,7 @@ def create(evm: Evm) -> None:
         extend_memory_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
@@ -93,7 +93,7 @@ def create(evm: Evm) -> None:
     increment_nonce(evm.env.state, evm.message.current_target)
 
     create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
+    subtract_gas(evm, create_message_gas)
 
     contract_address = compute_contract_address(
         evm.message.current_target,
@@ -141,7 +141,7 @@ def return_(evm: Evm) -> None:
     gas_cost = GAS_ZERO + calculate_gas_extend_memory(
         evm.memory, memory_start_position, memory_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    subtract_gas(evm, gas_cost)
     extend_memory(evm.memory, memory_start_position, memory_size)
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -161,7 +161,7 @@ def call(evm: Evm) -> None:
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
+    subtract_gas(evm, GAS_CALL)
 
     gas = pop(evm.stack)
     to = to_address(pop(evm.stack))
@@ -174,12 +174,12 @@ def call(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -198,7 +198,7 @@ def call(evm: Evm) -> None:
         value, gas, evm.gas_left, extra_gas
     )
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -257,7 +257,7 @@ def callcode(evm: Evm) -> None:
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
+    subtract_gas(evm, GAS_CALL)
 
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
@@ -271,12 +271,12 @@ def callcode(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -289,7 +289,7 @@ def callcode(evm: Evm) -> None:
         value, gas, evm.gas_left, extra_gas
     )
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
@@ -346,13 +346,11 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    subtract_gas(evm, GAS_SELF_DESTRUCT)
     beneficiary = to_address(pop(evm.stack))
 
     if not account_exists(evm.env.state, beneficiary):
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+        subtract_gas(evm, GAS_SELF_DESTRUCT_NEW_ACCOUNT)
 
     originator = evm.message.current_target
     beneficiary_balance = get_account(evm.env.state, beneficiary).balance
@@ -386,7 +384,7 @@ def delegatecall(evm: Evm) -> None:
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
+    subtract_gas(evm, GAS_CALL)
 
     gas = pop(evm.stack)
     code_address = to_address(pop(evm.stack))
@@ -400,12 +398,12 @@ def delegatecall(evm: Evm) -> None:
     gas_input_memory = calculate_gas_extend_memory(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
+    subtract_gas(evm, gas_input_memory)
     extend_memory(evm.memory, memory_input_start_position, memory_input_size)
     gas_output_memory = calculate_gas_extend_memory(
         evm.memory, memory_output_start_position, memory_output_size
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
+    subtract_gas(evm, gas_output_memory)
     extend_memory(evm.memory, memory_output_start_position, memory_output_size)
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
@@ -417,7 +415,7 @@ def delegatecall(evm: Evm) -> None:
         value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
     )
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    subtract_gas(evm, call_gas_fee)
 
     evm.pc += 1
 

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            subtract_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/tangerine_whistle/vm/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/memory.py
@@ -22,8 +22,7 @@ from .gas import calculate_memory_gas_cost, subtract_gas
 
 def extend_memory(evm: Evm, new_size: U256) -> None:
     """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
+    Extend memory to `new_size` and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -47,7 +46,7 @@ def extend_memory(evm: Evm, new_size: U256) -> None:
 def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extend memory as if a read or write at `start_position` of length `size`
-    had occured.
+    had occured and charge the appropriate amount of gas.
 
     Parameters
     ----------
@@ -69,7 +68,8 @@ def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
 
 def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
-    Writes to memory.
+    Writes to memory. If necessary, extend memory and charge the appropriate
+    amount of gas.
 
     Parameters
     ----------
@@ -92,7 +92,8 @@ def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
 
 def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
-    Read bytes from memory.
+    Read bytes from memory. If necessary, extend memory and charge the
+    appropriate amount of gas.
 
     Parameters
     ----------

--- a/src/ethereum/tangerine_whistle/vm/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/memory.py
@@ -12,64 +12,92 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.numeric import ceil32
+from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .error import OutOfGasError
+from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, new_size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
+    new_size :
+        The new size of the memory.
+    """
+    before_size = Uint(len(evm.memory))
+    after_size = ceil32(Uint(new_size))
+    if after_size <= before_size:
+        return None
+    subtract_gas(
+        evm,
+        calculate_memory_gas_cost(after_size)
+        - calculate_memory_gas_cost(before_size),
+    )
+    evm.memory += b"\x00" * (after_size - before_size)
+
+
+def touch_memory(evm: Evm, start_position: U256, size: U256) -> None:
+    """
+    Extend memory as if a read or write at `start_position` of length `size`
+    had occured.
+
+    Parameters
+    ----------
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
-        Amount of bytes by which the memory needs to be extended.
+        Size of memory.
     """
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
-    if after_size <= before_size:
-        return None
-    size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+        return
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
 
 
-def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
-) -> None:
+def memory_write(evm: Evm, start_position: U256, value: Bytes) -> None:
     """
     Writes to memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the EVM.
     start_position :
         Starting pointer to the memory.
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    if len(value) == 0:
+        return
+    end_position = u256_safe_add(
+        start_position, U256(len(value)), exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    evm.memory[start_position:end_position] = value
 
 
-def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
-) -> bytearray:
+def memory_read_bytes(evm: Evm, start_position: U256, size: U256) -> Bytes:
     """
     Read bytes from memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        Current state of the Evm.
     start_position :
         Starting pointer to the memory.
     size :
@@ -80,4 +108,11 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    if size == 0:
+        return Bytes()
+    end_position = u256_safe_add(
+        start_position, size, exception_type=OutOfGasError
+    )
+    if len(evm.memory) < end_position:
+        extend_memory(evm, end_position)
+    return Bytes(evm.memory[start_position:end_position])

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ecrecover.py
@@ -30,7 +30,7 @@ def ecrecover(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_ECRECOVER)
+    subtract_gas(evm, GAS_ECRECOVER)
     data = right_pad_zero_bytes(evm.message.data, 128)
     message_hash_bytes = data[:32]
     message_hash = Hash32(message_hash_bytes)

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/identity.py
@@ -41,5 +41,5 @@ def identity(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = data

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
@@ -44,7 +44,7 @@ def ripemd160(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/sha256.py
@@ -43,5 +43,5 @@ def sha256(evm: Evm) -> None:
         word_count_gas_cost,
         exception_type=OutOfGasError,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    subtract_gas(evm, total_gas_cost)
     evm.output = hashlib.sha256(data).digest()


### PR DESCRIPTION
This PR does a couple of useful refactorings.

The first moves the gas deduction logic into `subtract_gas()` making invocation simpler. `vm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)` becomes `subtract_gas(evm, GAS_LOW)`.

The second makes memory extension an implicit part the memory access functions. This removes quite a lot of boilerplate from the instruction code. `touch_memory()` is required because `CALL` and friends extend memory based on region assigned for return data rather than the region actually written to.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/23f03t2jcir81.jpg)
