### PR TITLE
Upgrade to the latest coincurve version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ package_dir =
 python_requires = >=3.8
 install_requires =
     pysha3>=1,<2
-    coincurve>=15,<16
+    coincurve>=17,<18
     typing_extensions>=4
 
 [options.package_data]


### PR DESCRIPTION
### What was wrong?

The currently used version of coincurve `15.0.1` does not have a wheel for M1 Macs and all attempts to build the wheel locally fail.

### How was it fixed?
Tested that the specs are also compatible with the latest version of coincurve i.e. `17.0.0` and updated the setup file to use this version instead.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/0b/Probosciger_aterrimus-20030511.jpg)
