### PR TITLE
Upgrade state testing framework for upcoming forks

### DIFF
--- a/tests/byzantium/blockchain_st_test_helpers.py
+++ b/tests/byzantium/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("Byzantium", "byzantium")
-
-run_byzantium_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -1,25 +1,29 @@
 from functools import partial
+from typing import Dict
 
 import pytest
 
 from ethereum.exceptions import InvalidBlock
-from tests.byzantium.blockchain_st_test_helpers import (
-    FIXTURES_LOADER,
-    run_byzantium_blockchain_st_tests,
+from tests.helpers.load_state_tests import (
+    Load,
+    fetch_state_test_files,
+    idfn,
+    run_blockchain_st_test,
 )
-from tests.helpers.load_state_tests import fetch_state_test_files
+
+fetch_byzantium_tests = partial(fetch_state_test_files, network="Byzantium")
+
+FIXTURES_LOADER = Load("Byzantium", "byzantium")
+
+run_byzantium_blockchain_st_tests = partial(
+    run_blockchain_st_test, load=FIXTURES_LOADER
+)
 
 # Run legacy general state tests
 test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
-
-run_general_state_tests = partial(run_byzantium_blockchain_st_tests, test_dir)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ()
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
@@ -32,17 +36,18 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 
 
 @pytest.mark.parametrize(
-    "test_file",
-    fetch_state_test_files(
-        test_dir, SLOW_TESTS, INCORRECT_UPSTREAM_STATE_TESTS, FIXTURES_LOADER
+    "test_case",
+    fetch_byzantium_tests(
+        test_dir, ignore_list=INCORRECT_UPSTREAM_STATE_TESTS
     ),
+    ids=idfn,
 )
-def test_general_state_tests(test_file: str) -> None:
+def test_general_state_tests(test_case: Dict) -> None:
     try:
-        run_general_state_tests(test_file)
+        run_byzantium_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy valid block tests
@@ -50,26 +55,24 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-run_valid_block_test = partial(
-    run_byzantium_blockchain_st_tests,
-    test_dir,
+custom_file_list = (
+    "bcUncleTest/oneUncle.json",
+    "bcUncleTest/oneUncleGeneration2.json",
+    "bcUncleTest/oneUncleGeneration3.json",
+    "bcUncleTest/oneUncleGeneration4.json",
+    "bcUncleTest/oneUncleGeneration5.json",
+    "bcUncleTest/oneUncleGeneration6.json",
+    "bcUncleTest/twoUncle.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_uncle_correctness",
-    [
-        "bcUncleTest/oneUncle.json",
-        "bcUncleTest/oneUncleGeneration2.json",
-        "bcUncleTest/oneUncleGeneration3.json",
-        "bcUncleTest/oneUncleGeneration4.json",
-        "bcUncleTest/oneUncleGeneration5.json",
-        "bcUncleTest/oneUncleGeneration6.json",
-        "bcUncleTest/twoUncle.json",
-    ],
+    "test_case",
+    fetch_byzantium_tests(test_dir, custom_file_list=custom_file_list),
+    ids=idfn,
 )
-def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
-    run_valid_block_test(test_file_uncle_correctness)
+def test_uncles_correctness(test_case: Dict) -> None:
+    run_byzantium_blockchain_st_tests(test_case)
 
 
 # Run legacy invalid block tests
@@ -77,48 +80,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 )
 
-run_invalid_block_test = partial(
-    run_byzantium_blockchain_st_tests,
-    test_dir,
-)
+xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
 
 
 @pytest.mark.parametrize(
-    "test_file", fetch_state_test_files(test_dir, (), (), FIXTURES_LOADER)
+    "test_case",
+    fetch_byzantium_tests(test_dir),
+    ids=idfn,
 )
-def test_invalid_block_tests(test_file: str) -> None:
+def test_invalid_block_tests(test_case: Dict) -> None:
     try:
         # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_file == "bcUncleHeaderValidity/correct.json":
-            run_invalid_block_test(test_file)
-        elif test_file == "bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json":
+        if test_case["test_key"] == "correct_Byzantium":
+            run_byzantium_blockchain_st_tests(test_case)
+        elif test_case["test_key"] in xfail_candidates:
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:
             with pytest.raises(InvalidBlock):
-                run_invalid_block_test(test_file)
+                run_byzantium_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(
+            "{} doesn't have post state".format(test_case["test_key"])
+        )
 
 
 # Run Non-Legacy GeneralStateTests
-run_general_state_tests_new = partial(
-    run_byzantium_blockchain_st_tests,
-    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+
+non_legacy_custom_file_list = (
+    "stCreateTest/CREATE_HighNonce.json",
+    "stCreateTest/CREATE_HighNonceMinus1.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_new",
-    [
-        "stCreateTest/CREATE_HighNonce.json",
-        "stCreateTest/CREATE_HighNonceMinus1.json",
-    ],
+    "test_case",
+    fetch_byzantium_tests(
+        test_dir, custom_file_list=non_legacy_custom_file_list
+    ),
+    ids=idfn,
 )
-def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no tests for byzantium
-        pytest.skip(f"{test_file_new} has no tests for byzantium")
+def test_general_state_tests_new(test_case: Dict) -> None:
+    run_byzantium_blockchain_st_tests(test_case)

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -55,7 +55,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -68,7 +68,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_byzantium_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_byzantium_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -109,7 +109,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -117,9 +117,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_byzantium_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_byzantium_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/constantinople/blockchain_st_test_helpers.py
+++ b/tests/constantinople/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("ConstantinopleFix", "constantinople")
-
-run_constantinople_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -1,15 +1,25 @@
-import os
 from functools import partial
-from typing import Iterator
+from typing import Dict
 
 import pytest
 
 from ethereum.exceptions import InvalidBlock
-from tests.constantinople.blockchain_st_test_helpers import (
-    FIXTURES_LOADER,
-    run_constantinople_blockchain_st_tests,
+from tests.helpers.load_state_tests import (
+    Load,
+    fetch_state_test_files,
+    idfn,
+    run_blockchain_st_test,
 )
-from tests.helpers.load_state_tests import fetch_state_test_files
+
+fetch_constantinople_tests = partial(
+    fetch_state_test_files, network="ConstantinopleFix"
+)
+
+FIXTURES_LOADER = Load("ConstantinopleFix", "constantinople")
+
+run_constantinople_blockchain_st_tests = partial(
+    run_blockchain_st_test, load=FIXTURES_LOADER
+)
 
 # Run legacy general state tests
 test_dir = (
@@ -17,13 +27,6 @@ test_dir = (
     "GeneralStateTests/"
 )
 
-run_general_state_tests = partial(
-    run_constantinople_blockchain_st_tests, test_dir
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ()
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
@@ -51,17 +54,18 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 
 
 @pytest.mark.parametrize(
-    "test_file",
-    fetch_state_test_files(
-        test_dir, SLOW_TESTS, INCORRECT_UPSTREAM_STATE_TESTS, FIXTURES_LOADER
+    "test_case",
+    fetch_constantinople_tests(
+        test_dir, ignore_list=INCORRECT_UPSTREAM_STATE_TESTS
     ),
+    ids=idfn,
 )
-def test_general_state_tests(test_file: str) -> None:
+def test_general_state_tests(test_case: Dict) -> None:
     try:
-        run_general_state_tests(test_file)
+        run_constantinople_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy valid block tests
@@ -69,26 +73,24 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-run_valid_block_test = partial(
-    run_constantinople_blockchain_st_tests,
-    test_dir,
+custom_file_list = (
+    "bcUncleTest/oneUncle.json",
+    "bcUncleTest/oneUncleGeneration2.json",
+    "bcUncleTest/oneUncleGeneration3.json",
+    "bcUncleTest/oneUncleGeneration4.json",
+    "bcUncleTest/oneUncleGeneration5.json",
+    "bcUncleTest/oneUncleGeneration6.json",
+    "bcUncleTest/twoUncle.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_uncle_correctness",
-    [
-        "bcUncleTest/oneUncle.json",
-        "bcUncleTest/oneUncleGeneration2.json",
-        "bcUncleTest/oneUncleGeneration3.json",
-        "bcUncleTest/oneUncleGeneration4.json",
-        "bcUncleTest/oneUncleGeneration5.json",
-        "bcUncleTest/oneUncleGeneration6.json",
-        "bcUncleTest/twoUncle.json",
-    ],
+    "test_case",
+    fetch_constantinople_tests(test_dir, custom_file_list=custom_file_list),
+    ids=idfn,
 )
-def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
-    run_valid_block_test(test_file_uncle_correctness)
+def test_uncles_correctness(test_case: Dict) -> None:
+    run_constantinople_blockchain_st_tests(test_case)
 
 
 # Run legacy invalid block tests
@@ -96,48 +98,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 )
 
-run_invalid_block_test = partial(
-    run_constantinople_blockchain_st_tests,
-    test_dir,
-)
+xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
 
 
 @pytest.mark.parametrize(
-    "test_file", fetch_state_test_files(test_dir, (), (), FIXTURES_LOADER)
+    "test_case",
+    fetch_constantinople_tests(test_dir),
+    ids=idfn,
 )
-def test_invalid_block_tests(test_file: str) -> None:
+def test_invalid_block_tests(test_case: Dict) -> None:
     try:
         # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_file == "bcUncleHeaderValidity/correct.json":
-            run_invalid_block_test(test_file)
-        elif test_file == "bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json":
+        if test_case["test_key"] == "correct_ConstantinopleFix":
+            run_constantinople_blockchain_st_tests(test_case)
+        elif test_case["test_key"] in xfail_candidates:
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:
             with pytest.raises(InvalidBlock):
-                run_invalid_block_test(test_file)
+                run_constantinople_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(
+            "{} doesn't have post state".format(test_case["test_key"])
+        )
 
 
 # Run Non-Legacy GeneralStateTests
-run_general_state_tests_new = partial(
-    run_constantinople_blockchain_st_tests,
-    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+
+non_legacy_custom_file_list = (
+    "stCreateTest/CREATE_HighNonce.json",
+    "stCreateTest/CREATE_HighNonceMinus1.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_new",
-    [
-        "stCreateTest/CREATE_HighNonce.json",
-        "stCreateTest/CREATE_HighNonceMinus1.json",
-    ],
+    "test_case",
+    fetch_constantinople_tests(
+        test_dir, custom_file_list=non_legacy_custom_file_list
+    ),
+    ids=idfn,
 )
-def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no tests for constantinople
-        pytest.skip(f"{test_file_new} has no tests for constantinople")
+def test_general_state_tests_new(test_case: Dict) -> None:
+    run_constantinople_blockchain_st_tests(test_case)

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -73,7 +73,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -86,7 +86,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_constantinople_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_constantinople_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -127,7 +127,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -135,9 +135,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_constantinople_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_constantinople_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("Frontier", "frontier")
-
-run_frontier_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -1,13 +1,24 @@
 from functools import partial
+from typing import Dict
 
 import pytest
 
 from ethereum.exceptions import InvalidBlock
-from tests.frontier.blockchain_st_test_helpers import (
-    FIXTURES_LOADER,
-    run_frontier_blockchain_st_tests,
+from tests.helpers.load_state_tests import (
+    Load,
+    fetch_state_test_files,
+    idfn,
+    run_blockchain_st_test,
 )
-from tests.helpers.load_state_tests import fetch_state_test_files
+
+fetch_frontier_tests = partial(fetch_state_test_files, network="Frontier")
+
+FIXTURES_LOADER = Load("Frontier", "frontier")
+
+run_frontier_blockchain_st_tests = partial(
+    run_blockchain_st_test, load=FIXTURES_LOADER
+)
+
 
 # Run legacy general state tests
 test_dir = (
@@ -15,27 +26,18 @@ test_dir = (
     "GeneralStateTests/"
 )
 
-run_general_state_tests = partial(run_frontier_blockchain_st_tests, test_dir)
-
-SLOW_TESTS = ()
-
-# These are tests that are considered to be incorrect,
-# Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = ()
-
 
 @pytest.mark.parametrize(
-    "test_file",
-    fetch_state_test_files(
-        test_dir, SLOW_TESTS, INCORRECT_UPSTREAM_STATE_TESTS, FIXTURES_LOADER
-    ),
+    "test_case",
+    fetch_frontier_tests(test_dir),
+    ids=idfn,
 )
-def test_general_state_tests(test_file: str) -> None:
+def test_general_state_tests(test_case: Dict) -> None:
     try:
-        run_general_state_tests(test_file)
+        run_frontier_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy valid block tests
@@ -43,29 +45,27 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-run_valid_block_test = partial(
-    run_frontier_blockchain_st_tests,
-    test_dir,
+custom_file_list = (
+    "bcUncleTest/oneUncle.json",
+    "bcUncleTest/oneUncleGeneration2.json",
+    "bcUncleTest/oneUncleGeneration3.json",
+    "bcUncleTest/oneUncleGeneration4.json",
+    "bcUncleTest/oneUncleGeneration5.json",
+    "bcUncleTest/oneUncleGeneration6.json",
+    "bcUncleTest/twoUncle.json",
+    "bcUncleTest/uncleHeaderAtBlock2.json",
+    "bcUncleSpecialTests/uncleBloomNot0.json",
+    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_uncle_correctness",
-    [
-        "bcUncleTest/oneUncle.json",
-        "bcUncleTest/oneUncleGeneration2.json",
-        "bcUncleTest/oneUncleGeneration3.json",
-        "bcUncleTest/oneUncleGeneration4.json",
-        "bcUncleTest/oneUncleGeneration5.json",
-        "bcUncleTest/oneUncleGeneration6.json",
-        "bcUncleTest/twoUncle.json",
-        "bcUncleTest/uncleHeaderAtBlock2.json",
-        "bcUncleSpecialTests/uncleBloomNot0.json",
-        "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
-    ],
+    "test_case",
+    fetch_frontier_tests(test_dir, custom_file_list=custom_file_list),
+    ids=idfn,
 )
-def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
-    run_valid_block_test(test_file_uncle_correctness)
+def test_uncles_correctness(test_case: Dict) -> None:
+    run_frontier_blockchain_st_tests(test_case)
 
 
 # Run legacy invalid block tests
@@ -73,48 +73,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 )
 
-run_invalid_block_test = partial(
-    run_frontier_blockchain_st_tests,
-    test_dir,
-)
+xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
 
 
 @pytest.mark.parametrize(
-    "test_file", fetch_state_test_files(test_dir, (), (), FIXTURES_LOADER)
+    "test_case",
+    fetch_frontier_tests(test_dir),
+    ids=idfn,
 )
-def test_invalid_block_tests(test_file: str) -> None:
+def test_invalid_block_tests(test_case: Dict) -> None:
     try:
         # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_file == "bcUncleHeaderValidity/correct.json":
-            run_invalid_block_test(test_file)
-        elif test_file == "bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json":
+        if test_case["test_key"] == "correct_Frontier":
+            run_frontier_blockchain_st_tests(test_case)
+        elif test_case["test_key"] in xfail_candidates:
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:
             with pytest.raises(InvalidBlock):
-                run_invalid_block_test(test_file)
+                run_frontier_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(
+            "{} doesn't have post state".format(test_case["test_key"])
+        )
 
 
 # Run Non-Legacy GeneralStateTests
-run_general_state_tests_new = partial(
-    run_frontier_blockchain_st_tests,
-    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+
+non_legacy_custom_file_list = (
+    "stCreateTest/CREATE_HighNonce.json",
+    "stCreateTest/CREATE_HighNonceMinus1.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_new",
-    [
-        "stCreateTest/CREATE_HighNonce.json",
-        "stCreateTest/CREATE_HighNonceMinus1.json",
-    ],
+    "test_case",
+    fetch_frontier_tests(
+        test_dir, custom_file_list=non_legacy_custom_file_list
+    ),
+    ids=idfn,
 )
-def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no tests for frontier
-        pytest.skip(f"{test_file_new} has no tests for frontier")
+def test_general_state_tests_new(test_case: Dict) -> None:
+    run_frontier_blockchain_st_tests(test_case)

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -45,7 +45,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -61,7 +61,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_frontier_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -102,7 +102,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -110,9 +110,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_frontier_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -1,8 +1,10 @@
 import importlib
 import json
+import logging
 import os.path
 import re
 from abc import ABC, abstractmethod
+from glob import glob
 from typing import Any, Dict, Generator, List, Tuple, Union, cast
 from unittest.mock import call, patch
 
@@ -220,41 +222,17 @@ class Load(BaseLoad):
         )
 
 
-def load_json_fixture(
-    test_dir: str, test_file: str, load: BaseLoad
-) -> Dict[str, Any]:
-    # Extract the pure basename of the file without the path to the file.
-    # Ex: Extract "world.json" from "path/to/file/world.json"
-    pure_test_file = os.path.basename(test_file)
-    # Extract the filename without the extension. Ex: Extract "world" from
-    # "world.json"
-    test_name = os.path.splitext(pure_test_file)[0]
-    path = os.path.join(test_dir, test_file)
-    with open(path, "r") as fp:
-        data = json.load(fp)
+def load_test(test_case: Dict, load: BaseLoad) -> Dict:
 
-        # Some newer test files have patterns like _d0g0v0_
-        # between test_name and network
-        keys_to_search = re.compile(
-            f"{re.escape(test_name)}.*{re.escape(load.network)}"
-        )
-        found_keys = list(filter(keys_to_search.match, data.keys()))
-
-        if len(found_keys) > 0:
-            json_data = data[found_keys[0]]
-        else:
-            raise KeyError
-    return json_data
-
-
-def load_test(test_dir: str, test_file: str, load: BaseLoad) -> Dict[str, Any]:
-    json_data = load_json_fixture(test_dir, test_file, load)
+    json_data = test_case["test_data"]
 
     blocks, block_header_hashes, block_rlps = load.json_to_blocks(
         json_data["blocks"]
     )
 
     return {
+        "test_file": test_case["test_file"],
+        "test_key": test_case["test_key"],
         "genesis_header": load.json_to_header(json_data["genesisBlockHeader"]),
         "genesis_header_hash": hex_to_bytes(
             json_data["genesisBlockHeader"]["hash"]
@@ -270,10 +248,9 @@ def load_test(test_dir: str, test_file: str, load: BaseLoad) -> Dict[str, Any]:
     }
 
 
-def run_blockchain_st_test(
-    test_dir: str, test_file: str, load: BaseLoad
-) -> None:
-    test_data = load_test(test_dir, test_file, load)
+def run_blockchain_st_test(test_case: Dict, load: BaseLoad) -> None:
+
+    test_data = load_test(test_case, load)
 
     genesis_header = test_data["genesis_header"]
     genesis_block = load.Block(
@@ -325,24 +302,86 @@ def add_blocks_to_chain(
         load.state_transition(chain, block)
 
 
+# Functions that fetch individual test cases
+def load_json_fixture(test_file: str, network: str) -> Generator:
+    # Extract the pure basename of the file without the path to the file.
+    # Ex: Extract "world.json" from "path/to/file/world.json"
+    pure_test_file = os.path.basename(test_file)
+    # Extract the filename without the extension. Ex: Extract "world" from
+    # "world.json"
+    test_name = os.path.splitext(pure_test_file)[0]
+    with open(test_file, "r") as fp:
+        data = json.load(fp)
+
+        # Some newer test files have patterns like _d0g0v0_
+        # between test_name and network
+        keys_to_search = re.compile(
+            f"{re.escape(test_name)}.*{re.escape(network)}"
+        )
+        found_keys = list(filter(keys_to_search.match, data.keys()))
+
+        if not any(found_keys):
+            raise KeyError
+
+        for _key in found_keys:
+            yield {
+                "test_file": test_file,
+                "test_key": _key,
+                "test_data": data[_key],
+            }
+
+
 def fetch_state_test_files(
     test_dir: str,
-    slow_test_list: Tuple[str, ...],
-    incorrect_tests_list: Tuple[str, ...],
-    load: BaseLoad,
-) -> Generator[Union[str, ParameterSet], None, None]:
-    for _dir in os.listdir(test_dir):
-        test_file_path = os.path.join(test_dir, _dir)
-        for _file in os.listdir(test_file_path):
-            _test_file = os.path.join(_dir, _file)
-            if _test_file in incorrect_tests_list:
-                continue
-            elif _test_file in slow_test_list:
-                yield pytest.param(_test_file, marks=pytest.mark.slow)
-            else:
-                try:
-                    load_json_fixture(test_dir, _test_file, load)
-                    yield _test_file
-                except KeyError:
-                    # file doesn't contain tests for the given fork
-                    pass
+    network: str,
+    custom_file_list: Tuple[str, ...] = (),
+    slow_list: Tuple[str, ...] = (),
+    ignore_list: Tuple[str, ...] = (),
+) -> Generator[Union[Dict, ParameterSet], None, None]:
+
+    all_slow = [re.compile(x) for x in slow_list]
+    all_ignore = [re.compile(x) for x in ignore_list]
+
+    # Get all the files to iterate over
+    # Maybe from the custom file list or entire test_dir
+    files_to_iterate = []
+    if any(custom_file_list):
+        # Get file list from custom list, if one is specified
+        for _file in custom_file_list:
+            files_to_iterate.append(os.path.join(test_dir, _file))
+    else:
+        # If there isnt a custom list, iterate over the test_dir
+        all_jsons = [
+            y
+            for x in os.walk(test_dir)
+            for y in glob(os.path.join(x[0], "*.json"))
+        ]
+
+        for _full_path in all_jsons:
+            if not any(x.search(_full_path) for x in all_ignore):
+                # If a file or folder is marked for ignore,
+                # it can already be dropped at this stage
+                files_to_iterate.append(_full_path)
+
+    # Start yielding individual test cases from the file list
+    for _test_file in files_to_iterate:
+        try:
+            for _test_case in load_json_fixture(_test_file, network):
+                # identifier could identifiy files, folders or individual cases
+                _identifier = _test_case["test_file"] + _test_case["test_key"]
+                if any(x.search(_identifier) for x in all_ignore):
+                    continue
+                elif any(x.search(_identifier) for x in all_slow):
+                    yield pytest.param(_test_case, marks=pytest.mark.slow)
+                else:
+                    yield _test_case
+        except KeyError:
+            # file doesn't contain tests for the given fork
+            continue
+
+
+# Test case Identifier
+def idfn(test_case: Dict) -> str:
+    folder_name = test_case["test_file"].split("/")[-2]
+    # Assign Folder name and test_key to identify tests in output
+    return folder_name + " - " + test_case["test_key"]

--- a/tests/homestead/blockchain_st_test_helpers.py
+++ b/tests/homestead/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("Homestead", "homestead")
-
-run_homestead_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -129,7 +129,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -144,7 +144,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_homestead_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -185,7 +185,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -193,9 +193,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_homestead_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/spurious_dragon/blockchain_st_test_helpers.py
+++ b/tests/spurious_dragon/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("EIP158", "spurious_dragon")
-
-run_spurious_dragon_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -45,7 +45,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -61,7 +61,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_spurious_dragon_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -102,7 +102,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -110,9 +110,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_spurious_dragon_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -1,13 +1,24 @@
 from functools import partial
+from typing import Dict
 
 import pytest
 
 from ethereum.exceptions import InvalidBlock
-from tests.helpers.load_state_tests import fetch_state_test_files
-from tests.spurious_dragon.blockchain_st_test_helpers import (
-    FIXTURES_LOADER,
-    run_spurious_dragon_blockchain_st_tests,
+from tests.helpers.load_state_tests import (
+    Load,
+    fetch_state_test_files,
+    idfn,
+    run_blockchain_st_test,
 )
+
+fetch_spurious_dragon_tests = partial(fetch_state_test_files, network="EIP158")
+
+FIXTURES_LOADER = Load("EIP158", "spurious_dragon")
+
+run_spurious_dragon_blockchain_st_tests = partial(
+    run_blockchain_st_test, load=FIXTURES_LOADER
+)
+
 
 # Run legacy general state tests
 test_dir = (
@@ -15,31 +26,18 @@ test_dir = (
     "GeneralStateTests/"
 )
 
-run_general_state_tests = partial(
-    run_spurious_dragon_blockchain_st_tests, test_dir
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ()
-
-# These are tests that are considered to be incorrect,
-# Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = ()
-
 
 @pytest.mark.parametrize(
-    "test_file",
-    fetch_state_test_files(
-        test_dir, SLOW_TESTS, INCORRECT_UPSTREAM_STATE_TESTS, FIXTURES_LOADER
-    ),
+    "test_case",
+    fetch_spurious_dragon_tests(test_dir),
+    ids=idfn,
 )
-def test_general_state_tests(test_file: str) -> None:
+def test_general_state_tests(test_case: Dict) -> None:
     try:
-        run_general_state_tests(test_file)
+        run_spurious_dragon_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy valid block tests
@@ -47,29 +45,27 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-run_valid_block_test = partial(
-    run_spurious_dragon_blockchain_st_tests,
-    test_dir,
+custom_file_list = (
+    "bcUncleTest/oneUncle.json",
+    "bcUncleTest/oneUncleGeneration2.json",
+    "bcUncleTest/oneUncleGeneration3.json",
+    "bcUncleTest/oneUncleGeneration4.json",
+    "bcUncleTest/oneUncleGeneration5.json",
+    "bcUncleTest/oneUncleGeneration6.json",
+    "bcUncleTest/twoUncle.json",
+    "bcUncleTest/uncleHeaderAtBlock2.json",
+    "bcUncleSpecialTests/uncleBloomNot0.json",
+    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_uncle_correctness",
-    [
-        "bcUncleTest/oneUncle.json",
-        "bcUncleTest/oneUncleGeneration2.json",
-        "bcUncleTest/oneUncleGeneration3.json",
-        "bcUncleTest/oneUncleGeneration4.json",
-        "bcUncleTest/oneUncleGeneration5.json",
-        "bcUncleTest/oneUncleGeneration6.json",
-        "bcUncleTest/twoUncle.json",
-        "bcUncleTest/uncleHeaderAtBlock2.json",
-        "bcUncleSpecialTests/uncleBloomNot0.json",
-        "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
-    ],
+    "test_case",
+    fetch_spurious_dragon_tests(test_dir, custom_file_list=custom_file_list),
+    ids=idfn,
 )
-def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
-    run_valid_block_test(test_file_uncle_correctness)
+def test_uncles_correctness(test_case: Dict) -> None:
+    run_spurious_dragon_blockchain_st_tests(test_case)
 
 
 # Run legacy invalid block tests
@@ -77,48 +73,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 )
 
-run_invalid_block_test = partial(
-    run_spurious_dragon_blockchain_st_tests,
-    test_dir,
-)
+xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
 
 
 @pytest.mark.parametrize(
-    "test_file", fetch_state_test_files(test_dir, (), (), FIXTURES_LOADER)
+    "test_case",
+    fetch_spurious_dragon_tests(test_dir),
+    ids=idfn,
 )
-def test_invalid_block_tests(test_file: str) -> None:
+def test_invalid_block_tests(test_case: Dict) -> None:
     try:
         # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_file == "bcUncleHeaderValidity/correct.json":
-            run_invalid_block_test(test_file)
-        elif test_file == "bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json":
+        if test_case["test_key"] == "correct_EIP158":
+            run_spurious_dragon_blockchain_st_tests(test_case)
+        elif test_case["test_key"] in xfail_candidates:
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:
             with pytest.raises(InvalidBlock):
-                run_invalid_block_test(test_file)
+                run_spurious_dragon_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(
+            "{} doesn't have post state".format(test_case["test_key"])
+        )
 
 
 # Run Non-Legacy GeneralStateTests
-run_general_state_tests_new = partial(
-    run_spurious_dragon_blockchain_st_tests,
-    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+
+non_legacy_custom_file_list = (
+    "stCreateTest/CREATE_HighNonce.json",
+    "stCreateTest/CREATE_HighNonceMinus1.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_new",
-    [
-        "stCreateTest/CREATE_HighNonce.json",
-        "stCreateTest/CREATE_HighNonceMinus1.json",
-    ],
+    "test_case",
+    fetch_spurious_dragon_tests(
+        test_dir, custom_file_list=non_legacy_custom_file_list
+    ),
+    ids=idfn,
 )
-def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no tests for spurious_dragon
-        pytest.skip(f"{test_file_new} has no tests for spurious_dragon")
+def test_general_state_tests_new(test_case: Dict) -> None:
+    run_spurious_dragon_blockchain_st_tests(test_case)

--- a/tests/tangerine_whistle/blockchain_st_test_helpers.py
+++ b/tests/tangerine_whistle/blockchain_st_test_helpers.py
@@ -1,9 +1,0 @@
-from functools import partial
-
-from ..helpers.load_state_tests import Load, run_blockchain_st_test
-
-FIXTURES_LOADER = Load("EIP150", "tangerine_whistle")
-
-run_tangerine_whistle_blockchain_st_tests = partial(
-    run_blockchain_st_test, load=FIXTURES_LOADER
-)

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -47,7 +47,7 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-custom_file_list = (
+only_in = (
     "bcUncleTest/oneUncle.json",
     "bcUncleTest/oneUncleGeneration2.json",
     "bcUncleTest/oneUncleGeneration3.json",
@@ -62,7 +62,7 @@ custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(test_dir, custom_file_list=custom_file_list),
+    fetch_tangerine_whistle_tests(test_dir, only_in=only_in),
     ids=idfn,
 )
 def test_uncles_correctness(test_case: Dict) -> None:
@@ -103,7 +103,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 # Run Non-Legacy GeneralStateTests
 test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
-non_legacy_custom_file_list = (
+non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
     "stCreateTest/CREATE_HighNonceMinus1.json",
 )
@@ -111,9 +111,7 @@ non_legacy_custom_file_list = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(
-        test_dir, custom_file_list=non_legacy_custom_file_list
-    ),
+    fetch_tangerine_whistle_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
 def test_general_state_tests_new(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -1,13 +1,26 @@
 from functools import partial
+from typing import Dict
 
 import pytest
 
 from ethereum.exceptions import InvalidBlock
-from tests.helpers.load_state_tests import fetch_state_test_files
-from tests.tangerine_whistle.blockchain_st_test_helpers import (
-    FIXTURES_LOADER,
-    run_tangerine_whistle_blockchain_st_tests,
+from tests.helpers.load_state_tests import (
+    Load,
+    fetch_state_test_files,
+    idfn,
+    run_blockchain_st_test,
 )
+
+fetch_tangerine_whistle_tests = partial(
+    fetch_state_test_files, network="EIP150"
+)
+
+FIXTURES_LOADER = Load("EIP150", "tangerine_whistle")
+
+run_tangerine_whistle_blockchain_st_tests = partial(
+    run_blockchain_st_test, load=FIXTURES_LOADER
+)
+
 
 # Run legacy general state tests
 test_dir = (
@@ -15,32 +28,18 @@ test_dir = (
     "GeneralStateTests/"
 )
 
-run_general_state_tests = partial(
-    run_tangerine_whistle_blockchain_st_tests, test_dir
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ()
-
-
-# These are tests that are considered to be incorrect,
-# Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = ()
-
 
 @pytest.mark.parametrize(
-    "test_file",
-    fetch_state_test_files(
-        test_dir, SLOW_TESTS, INCORRECT_UPSTREAM_STATE_TESTS, FIXTURES_LOADER
-    ),
+    "test_case",
+    fetch_tangerine_whistle_tests(test_dir),
+    ids=idfn,
 )
-def test_general_state_tests(test_file: str) -> None:
+def test_general_state_tests(test_case: Dict) -> None:
     try:
-        run_general_state_tests(test_file)
+        run_tangerine_whistle_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy valid block tests
@@ -48,28 +47,26 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-run_valid_block_test = partial(
-    run_tangerine_whistle_blockchain_st_tests,
-    test_dir,
+custom_file_list = (
+    "bcUncleTest/oneUncle.json",
+    "bcUncleTest/oneUncleGeneration2.json",
+    "bcUncleTest/oneUncleGeneration3.json",
+    "bcUncleTest/oneUncleGeneration4.json",
+    "bcUncleTest/oneUncleGeneration5.json",
+    "bcUncleTest/oneUncleGeneration6.json",
+    "bcUncleTest/twoUncle.json",
+    "bcUncleTest/uncleHeaderAtBlock2.json",
+    "bcUncleSpecialTests/uncleBloomNot0.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_uncle_correctness",
-    [
-        "bcUncleTest/oneUncle.json",
-        "bcUncleTest/oneUncleGeneration2.json",
-        "bcUncleTest/oneUncleGeneration3.json",
-        "bcUncleTest/oneUncleGeneration4.json",
-        "bcUncleTest/oneUncleGeneration5.json",
-        "bcUncleTest/oneUncleGeneration6.json",
-        "bcUncleTest/twoUncle.json",
-        "bcUncleTest/uncleHeaderAtBlock2.json",
-        "bcUncleSpecialTests/uncleBloomNot0.json",
-    ],
+    "test_case",
+    fetch_tangerine_whistle_tests(test_dir, custom_file_list=custom_file_list),
+    ids=idfn,
 )
-def test_uncles_correctness(test_file_uncle_correctness: str) -> None:
-    run_valid_block_test(test_file_uncle_correctness)
+def test_uncles_correctness(test_case: Dict) -> None:
+    run_tangerine_whistle_blockchain_st_tests(test_case)
 
 
 # Run legacy invalid block tests
@@ -77,49 +74,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 )
 
-run_invalid_block_test = partial(
-    run_tangerine_whistle_blockchain_st_tests,
-    test_dir,
-)
+xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
 
 
 @pytest.mark.parametrize(
-    "test_file", fetch_state_test_files(test_dir, (), (), FIXTURES_LOADER)
+    "test_case",
+    fetch_tangerine_whistle_tests(test_dir),
+    ids=idfn,
 )
-def test_invalid_block_tests(test_file: str) -> None:
+def test_invalid_block_tests(test_case: Dict) -> None:
     try:
         # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_file == "bcUncleHeaderValidity/correct.json":
-            run_invalid_block_test(test_file)
-        elif test_file == "bcInvalidHeaderTest/GasLimitHigherThan2p63m1.json":
+        if test_case["test_key"] == "correct_EIP150":
+            run_tangerine_whistle_blockchain_st_tests(test_case)
+        elif test_case["test_key"] in xfail_candidates:
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:
             with pytest.raises(InvalidBlock):
-                run_invalid_block_test(test_file)
+                run_tangerine_whistle_blockchain_st_tests(test_case)
     except KeyError:
         # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_file} doesn't have post state")
+        pytest.xfail(
+            "{} doesn't have post state".format(test_case["test_key"])
+        )
 
 
 # Run Non-Legacy GeneralStateTests
-run_general_state_tests_new = partial(
-    run_tangerine_whistle_blockchain_st_tests,
-    "tests/fixtures/BlockchainTests/GeneralStateTests/",
+test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+
+non_legacy_custom_file_list = (
+    "stCreateTest/CREATE_HighNonce.json",
+    "stCreateTest/CREATE_HighNonceMinus1.json",
 )
 
 
 @pytest.mark.parametrize(
-    "test_file_new",
-    [
-        "stCreateTest/CREATE_HighNonce.json",
-        "stCreateTest/CREATE_HighNonceMinus1.json",
-    ],
+    "test_case",
+    fetch_tangerine_whistle_tests(
+        test_dir, custom_file_list=non_legacy_custom_file_list
+    ),
+    ids=idfn,
 )
-def test_general_state_tests_new(test_file_new: str) -> None:
-    try:
-        run_general_state_tests_new(test_file_new)
-    except KeyError:
-        # KeyError is raised when a test_file has no
-        # tests for tangerine_whistle
-        pytest.skip(f"{test_file_new} has no tests for tangerine_whistle")
+def test_general_state_tests_new(test_case: Dict) -> None:
+    run_tangerine_whistle_blockchain_st_tests(test_case)


### PR DESCRIPTION
### What was wrong?
The current state testing framework assumes that there is only a single test case for every json test fixture. While this may be true for a large majority of the tests for the forks that have thus far been implemented, it certainly does not hold for the upcoming forks (non-legacy tests)

### How was it fixed?
Updates state tests to be able to run multiple tests per json. i.e. looking at a key within a json file rather than the file itself, as an individual test case.

Additionally, the small optimisation has been implemented where `fetch_state_test_files` is only responsible for fetching the test cases and `run_<fork>_blockchain_st_tests` is only responsible for running them. This separation of duties was not entirely clear in the current set-up.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/4/4d/Coucang.jpg)
