### PR TITLE
Backport and refactor destroy_storage()

### DIFF
--- a/src/ethereum/byzantium/state.py
+++ b/src/ethereum/byzantium/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum/constantinople/state.py
+++ b/src/ethereum/constantinople/state.py
@@ -182,8 +182,7 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
-    if address in state._storage_tries:
-        del state._storage_tries[address]
+    destroy_storage(state, address)
     set_account(state, address, None)
 
 

--- a/src/ethereum/dao_fork/state.py
+++ b/src/ethereum/dao_fork/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum/frontier/state.py
+++ b/src/ethereum/frontier/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum/homestead/state.py
+++ b/src/ethereum/homestead/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum/istanbul/state.py
+++ b/src/ethereum/istanbul/state.py
@@ -182,8 +182,7 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
-    if address in state._storage_tries:
-        del state._storage_tries[address]
+    destroy_storage(state, address)
     set_account(state, address, None)
 
 

--- a/src/ethereum/muir_glacier/state.py
+++ b/src/ethereum/muir_glacier/state.py
@@ -182,8 +182,7 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
-    if address in state._storage_tries:
-        del state._storage_tries[address]
+    destroy_storage(state, address)
     set_account(state, address, None)
 
 

--- a/src/ethereum/spurious_dragon/state.py
+++ b/src/ethereum/spurious_dragon/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum/tangerine_whistle/state.py
+++ b/src/ethereum/tangerine_whistle/state.py
@@ -182,9 +182,23 @@ def destroy_account(state: State, address: Address) -> None:
     address : `Address`
         Address of account to destroy.
     """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def destroy_storage(state: State, address: Address) -> None:
+    """
+    Completely remove the storage at `address`.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account whose storage is to be deleted.
+    """
     if address in state._storage_tries:
         del state._storage_tries[address]
-    set_account(state, address, None)
 
 
 def get_storage(state: State, address: Address, key: Bytes) -> U256:

--- a/src/ethereum_optimized/byzantium/__init__.py
+++ b/src/ethereum_optimized/byzantium/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/byzantium/state_db.py
+++ b/src/ethereum_optimized/byzantium/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.byzantium.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/constantinople/__init__.py
+++ b/src/ethereum_optimized/constantinople/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/constantinople/state_db.py
+++ b/src/ethereum_optimized/constantinople/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.constantinople.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/dao_fork/__init__.py
+++ b/src/ethereum_optimized/dao_fork/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/dao_fork/state_db.py
+++ b/src/ethereum_optimized/dao_fork/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.dao_fork.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/frontier/__init__.py
+++ b/src/ethereum_optimized/frontier/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/frontier/state_db.py
+++ b/src/ethereum_optimized/frontier/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.frontier.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/homestead/__init__.py
+++ b/src/ethereum_optimized/homestead/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/homestead/state_db.py
+++ b/src/ethereum_optimized/homestead/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.homestead.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/istanbul/__init__.py
+++ b/src/ethereum_optimized/istanbul/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/istanbul/state_db.py
+++ b/src/ethereum_optimized/istanbul/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.istanbul.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/muir_glacier/__init__.py
+++ b/src/ethereum_optimized/muir_glacier/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/muir_glacier/state_db.py
+++ b/src/ethereum_optimized/muir_glacier/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.muir_glacier.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/spurious_dragon/__init__.py
+++ b/src/ethereum_optimized/spurious_dragon/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/spurious_dragon/state_db.py
+++ b/src/ethereum_optimized/spurious_dragon/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.spurious_dragon.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/src/ethereum_optimized/tangerine_whistle/__init__.py
+++ b/src/ethereum_optimized/tangerine_whistle/__init__.py
@@ -27,7 +27,7 @@ def monkey_patch_optimized_state_db(state_path: Optional[str]) -> None:
         "get_account": fast_state.get_account,
         "get_account_optional": fast_state.get_account_optional,
         "set_account": fast_state.set_account,
-        "destroy_account": fast_state.destroy_account,
+        "destroy_storage": fast_state.destroy_storage,
         "get_storage": fast_state.get_storage,
         "set_storage": fast_state.set_storage,
         "state_root": fast_state.state_root,

--- a/src/ethereum_optimized/tangerine_whistle/state_db.py
+++ b/src/ethereum_optimized/tangerine_whistle/state_db.py
@@ -223,7 +223,7 @@ def commit_transaction(state: State) -> None:
         state._dirty_accounts[-1][address] = account
     state._destroyed_accounts[-2] |= state._destroyed_accounts[-1]
     for address in state._destroyed_accounts.pop():
-        state._dirty_storage[-2].pop(address)
+        state._dirty_storage[-2].pop(address, None)
     for (address, cache) in state._dirty_storage.pop().items():
         if address not in state._dirty_storage[-1]:
             state._dirty_storage[-1][address] = {}
@@ -335,13 +335,13 @@ def set_account(
         state._dirty_accounts[-1][address] = account
 
 
-def destroy_account(state: State, address: Address) -> None:
+def destroy_storage(state: State, address: Address) -> None:
     """
     See `ethereum.tangerine_whistle.state`.
     """
     state._destroyed_accounts[-1].add(address)
     state._dirty_storage[-1].pop(address, None)
-    state._dirty_accounts[-1][address] = None
+    state._dirty_accounts[-1][address] = get_account_optional(state, address)
 
 
 def clear_destroyed_account(state: State, address: Bytes) -> None:

--- a/tests/byzantium/optimized/test_state_db.py
+++ b/tests/byzantium/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/constantinople/optimized/test_state_db.py
+++ b/tests/constantinople/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/frontier/optimized/test_state_db.py
+++ b/tests/frontier/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/homestead/optimized/test_state_db.py
+++ b/tests/homestead/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/istanbul/optimized/test_state_db.py
+++ b/tests/istanbul/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/spurious_dragon/optimized/test_state_db.py
+++ b/tests/spurious_dragon/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj

--- a/tests/tangerine_whistle/optimized/test_state_db.py
+++ b/tests/tangerine_whistle/optimized/test_state_db.py
@@ -102,7 +102,7 @@ def test_resurrection() -> None:
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         impl.set_storage(obj, ADDRESS_FOO, b"", U256(42))
         impl.state_root(obj)
-        impl.destroy_account(obj, ADDRESS_FOO)
+        impl.destroy_storage(obj, ADDRESS_FOO)
         impl.state_root(obj)
         impl.set_account(obj, ADDRESS_FOO, EMPTY_ACCOUNT)
         return obj


### PR DESCRIPTION
### What was wrong?

`destroy_storage()` wasn't supported by the optimized state.

### How was it fixed?

Backport `destroy_storage()` to previous forks, make `destroy_account()` use `destroy_storage()` internally and switch from `destroy_account()` to `destroy_storage()` in optimized state.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/3myrgns7p5x81.jpg)
