### PR TITLE
Only show materially changed files in the diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ venv/
 # pycharm
 .idea/
 
+# VS Code
+.vscode
+
 *.manifest
 *.spec
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,7 +33,6 @@ extensions = [
     'autoapi.extension',
     'undocinclude.extension',
     'picklebuilder.picklebuilder',
-    'ethereum_spec_tools.nav',
 ]
 
 autoapi_type = 'python'
@@ -70,6 +69,8 @@ if tags.has('stage0'):
 elif tags.has('stage1'):
     root_doc = 'index'
     exclude_patterns.append('stage0.rst')
+
+    extensions.append('ethereum_spec_tools.nav')
 else:
     raise Exception("Pass either `-t stage0` or `-t stage1` to sphinx-build")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,12 @@ packages =
     ethereum/istanbul/vm/instructions
     ethereum/istanbul/vm/precompiled_contracts
     ethereum_optimized/istanbul
+    ethereum/muir_glacier
+    ethereum/muir_glacier/utils
+    ethereum/muir_glacier/vm
+    ethereum/muir_glacier/vm/instructions
+    ethereum/muir_glacier/vm/precompiled_contracts
+    ethereum_optimized/muir_glacier
 
 
 package_dir =
@@ -116,7 +122,7 @@ doc =
     sphinx-autoapi>=1.8.1,<2
     undocinclude>=0.2.0,<0.3
     sphinx==4.0.2
-    rstdiff>=0.5.0,<0.6
+    rstdiff>=0.5.1,<0.6
     picklebuilder>=0.1.0,<0.2
 
 doc-autobuild =

--- a/src/ethereum_spec_tools/diff.py
+++ b/src/ethereum_spec_tools/diff.py
@@ -54,15 +54,11 @@ def meaningful_diffs(
     opcode_counter = rstdiff.OpcodeCounter(opcodes)
     opcode_counter.count()
 
-    if (
+    return bool(
         opcode_counter.replace
-        == opcode_counter.delete
-        == opcode_counter.insert
-        == 0
-    ):
-        return False
-    else:
-        return True
+        or opcode_counter.delete
+        or opcode_counter.insert
+    )
 
 
 def diff(

--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -80,6 +80,13 @@ class Hardfork:
         """
         return self.mod.__name__
 
+    @property
+    def title_case_name(self) -> str:
+        """
+        Name of the hard fork.
+        """
+        return self.short_name.replace("_", " ").title()
+
     def __repr__(self) -> str:
         """
         Return repr(self).

--- a/src/ethereum_spec_tools/nav.py
+++ b/src/ethereum_spec_tools/nav.py
@@ -2,7 +2,7 @@
 Sphinx extension to collect navigation metadata for hard forks.
 """
 
-import os.path
+import os
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
 
@@ -104,6 +104,15 @@ class HardforkIndex(Index):
                 doc_name = (
                     f"diffs/{prev_fork.short_name}_{fork.short_name}/{module}"
                 )
+
+                diff_file_path = os.path.join(
+                    os.getcwd(), "doc", doc_name + ".pickle64"
+                )
+
+                if not os.path.isfile(diff_file_path):
+                    # diff tool did not find any meaningful differences
+                    continue
+
                 content[fork].comparisons.append(
                     IndexEntry(
                         rel_name,

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -327,3 +327,5 @@ linefunc
 metavar
 const
 keepends
+Replacer
+Publisher3


### PR DESCRIPTION
(closes #508 )

### What was wrong?
Right now every file appears in the [Hardforks Index](https://ethereum.github.io/execution-specs/py-hardforks.html), even if the changes are minimal like just changing the hardfork name.


Related to Issue #508 

### How was it fixed?
First check if there are meaningful differences between documents and publish a diff only if there are any.

The PR in its current form depends on another [PR](https://github.com/SamWilsn/rstdiff/pull/1) that I have created on the `rstdiff` repo. That PR will have to be merged first and a new release of `rstdiff` will have to be created. 
<strong>Build docs for this PR will FAIL until that point.</strong>


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/c/ce/2014-06-20_Vulpes_vulpes_vulpes%2C_Bönhamn%2C_Västernorrlands_Län%2C_Sverige_1.jpg)
