### PR TITLE
run non-parallel tests on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,10 @@ jobs:
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Run Tox (PyPy)
         if: ${{ matrix.python == 'pypy-3.8' }}
-        run: tox -e pypy3
+        run: tox -e pypy3 -- -n 0
       - name: Run Tox (CPython)
         if: ${{ matrix.python != 'pypy-3.8' }}
-        run: tox -e py3
+        run: tox -e py3 -- -n 0
       - name: Upload coverage to Codecov
         if: ${{ matrix.python != 'pypy-3.8' }}
         uses: codecov/codecov-action@v1

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' -n 2 --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" {posargs: -n 2}
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -22,7 +22,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" --ignore-glob='tests/fixtures/*' -n 2 --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" {posargs: -n 2}
     ethereum-spec-lint
 
 [testenv:doc]


### PR DESCRIPTION
### What was wrong?
The memory usage of the hardfork tests (yes, even excluding ethash) has been increasing, and limited parallelization

Related to Issue #516 

### How was it fixed?
This PR tries to work around this by running only a single thread in CI while maintaining multiple threads for local runs with the `tox` command. See the Issue #516 for details about the full analysis

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/01/Quinlingpandabearr.jpg)
