### PR TITLE
Mark Big Memory Tests and run them separately

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,10 +26,10 @@ jobs:
           echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
       - name: Run Tox (PyPy)
         if: ${{ matrix.python == 'pypy-3.8' }}
-        run: tox -e pypy3 -- -n 0
+        run: tox -e pypy3
       - name: Run Tox (CPython)
         if: ${{ matrix.python != 'pypy-3.8' }}
-        run: tox -e py3 -- -n 0
+        run: tox -e py3
       - name: Upload coverage to Codecov
         if: ${{ matrix.python != 'pypy-3.8' }}
         uses: codecov/codecov-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ line-length = 79
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "bigmem: marks tests as big memory (deselect with '-m \"not bigmem\"')",
 ]

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -34,11 +34,23 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stRevertTest/RevertInCreateInInit_d0g0v0.json",
 )
 
+BIG_MEMORY_TESTS = (
+    "static_Call50000_d1g0v0_Byzantium",
+    "static_Call50000_ecrec_d1g0v0_Byzantium",
+    "static_Call50000_sha256_d1g0v0_Byzantium",
+    "static_Call50000_sha256_d0g0v0_Byzantium",
+    "static_Call50000_rip160_d1g0v0_Byzantium",
+    "static_Call50000_rip160_d0g0v0_Byzantium",
+    "Return50000_d0g1v0_Byzantium",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
     fetch_byzantium_tests(
-        test_dir, ignore_list=INCORRECT_UPSTREAM_STATE_TESTS
+        test_dir,
+        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+        big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -52,11 +52,24 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stSStoreTest/InitCollision_d3g0v0.json",
 )
 
+BIG_MEMORY_TESTS = (
+    "static_Call50000_d1g0v0_ConstantinopleFix",
+    "static_Call50000_ecrec_d1g0v0_ConstantinopleFix",
+    "static_Call50000_sha256_d0g0v0_ConstantinopleFix",
+    "static_Call50000_sha256_d1g0v0_ConstantinopleFix",
+    "static_Call50000_rip160_d1g0v0_ConstantinopleFix",
+    "static_Call50000_rip160_d0g0v0_ConstantinopleFix",
+    "Return50000_d0g1v0_ConstantinopleFix",
+    "Return50000_2_d0g1v0_ConstantinopleFix",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
     fetch_constantinople_tests(
-        test_dir, ignore_list=INCORRECT_UPSTREAM_STATE_TESTS
+        test_dir,
+        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+        big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -338,10 +338,12 @@ def fetch_state_test_files(
     network: str,
     only_in: Tuple[str, ...] = (),
     slow_list: Tuple[str, ...] = (),
+    big_memory_list: Tuple[str, ...] = (),
     ignore_list: Tuple[str, ...] = (),
 ) -> Generator[Union[Dict, ParameterSet], None, None]:
 
     all_slow = [re.compile(x) for x in slow_list]
+    all_big_memory = [re.compile(x) for x in big_memory_list]
     all_ignore = [re.compile(x) for x in ignore_list]
 
     # Get all the files to iterate over
@@ -382,6 +384,8 @@ def fetch_state_test_files(
                     continue
                 elif any(x.search(_identifier) for x in all_slow):
                     yield pytest.param(_test_case, marks=pytest.mark.slow)
+                elif any(x.search(_identifier) for x in all_big_memory):
+                    yield pytest.param(_test_case, marks=pytest.mark.bigmem)
                 else:
                     yield _test_case
         except KeyError:

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -49,6 +49,20 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stSStoreTest/InitCollision.json",
 )
 
+BIG_MEMORY_TESTS = (
+    "static_Return50000_2_d0g0v0_Istanbul",
+    "static_Call50000_d1g0v0_Istanbul",
+    "static_Call50000_identity2_d0g0v0_Istanbul",
+    "static_Call50000_identity2_d1g0v0_Istanbul",
+    "static_Call50000_ecrec_d1g0v0_Istanbul",
+    "static_Call50000_d0g0v0_Istanbul",
+    "Return50000_d0g1v0_Istanbul",
+    "Return50000_2_d0g1v0_Istanbul",
+    "static_Call50000_rip160_d1g0v0_Istanbul",
+    "static_Call50000_rip160_d0g0v0_Istanbul",
+    "static_Call50000_ecrec_d0g0v0_Istanbul",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
@@ -56,6 +70,7 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
         slow_list=SLOW_TESTS,
+        big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" {posargs: -n 2}
+    pytest -m "not slow and not bigmem" -n 2 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m bigmem --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --cov-append --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -22,7 +23,8 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" {posargs: -n 2}
+    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m bigmem --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]


### PR DESCRIPTION
(closes #516 )

### What was wrong?
The memory usage of the hardfork tests (yes, even excluding ethash) has been increasing, and limited parallelization

Related to Issue #516 

### How was it fixed?
Mark big memory tests and run them separately without parallel threads. Run other tests with 2 parallel threads. > 3 GB was chosen as  big memory. Any tests using 3 GB will be fine with 2 threads since Github Actions provides workers with 8 GB Memory (including OS)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/f/f7/Squirrel%2C_Manyara_National_Park%2C_Tanzania_%282010%29.jpg)
