### PR TITLE
Include folder names for xfail tests check

### DIFF
--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -96,17 +96,29 @@ def test_uncles_correctness(test_case: Dict) -> None:
 # Run legacy invalid block tests
 test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
 
-# TODO: Investigate why some of the below tests pass
+# TODO: Handle once https://github.com/ethereum/tests/issues/1037
+# is resolved
 # All except GasLimitHigherThan2p63m1_Istanbul
 xfail_candidates = (
-    "timestampTooLow_Istanbul",
-    "timestampTooHigh_Istanbul",
-    "wrongStateRoot_Istanbul",
-    "incorrectUncleTimestamp4_Istanbul",
-    "incorrectUncleTimestamp5_Istanbul",
-    "futureUncleTimestamp3_Istanbul",
-    "GasLimitHigherThan2p63m1_Istanbul",
+    ("bcUncleHeaderValidity", "timestampTooLow_Istanbul"),
+    ("bcUncleHeaderValidity", "timestampTooHigh_Istanbul"),
+    ("bcUncleHeaderValidity", "wrongStateRoot_Istanbul"),
+    ("bcUncleHeaderValidity", "incorrectUncleTimestamp4_Istanbul"),
+    ("bcUncleHeaderValidity", "incorrectUncleTimestamp5_Istanbul"),
+    ("bcUncleSpecialTests", "futureUncleTimestamp3_Istanbul"),
+    ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Istanbul"),
 )
+
+
+def is_in_xfail(test_case: Dict) -> bool:
+    for _dir, _test_key in xfail_candidates:
+        if (
+            _dir in test_case["test_file"]
+            and test_case["test_key"] == _test_key
+        ):
+            return True
+
+    return False
 
 
 @pytest.mark.parametrize(
@@ -119,7 +131,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         # Ideally correct.json should not have been in the InvalidBlocks folder
         if test_case["test_key"] == "correct_Istanbul":
             run_istanbul_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
+        elif is_in_xfail(test_case):
             # Unclear where this failed requirement comes from
             pytest.xfail()
         else:


### PR DESCRIPTION
### What was wrong?
The tests under InvalidBlocks are supposed to fail. However, [some of them](https://github.com/gurukamath/execution-specs/blob/db3ff58b41fc127bb8c351ab2c212f7d0b26862d/tests/istanbul/test_state_transition.py#L105) do not fail in Istanbul.

Related to Issue #510 

### How was it fixed?
The issue seems to be with the ethereum tests repository since the tests pass without raising any exceptions when executed with `retesteth` either. I have created an [issue](https://github.com/ethereum/tests/issues/1037) in the tests repository.

I noticed however, that the tests `bcUncleHeaderValidity/wrongStateRoot.json` and `bcInvalidHeaderTest/wrongStateRoot.json` have exactly the same name which should ideally not have been the case.

This PR adds an additional check of folder name to determine if it is a case of `xfail`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](
![](https://www.theslothinstitute.org/wp-content/uploads/2021/09/amy-and-aretha-the-baby-sloths-hugging.jpg)
)
