### PR TITLE
Fix unhandled overflow in homestead delegatecall

### DIFF
--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -385,7 +385,7 @@ def delegatecall(evm: Evm) -> None:
         evm.memory, memory_input_start_position, memory_input_size
     )
 
-    call_gas_fee = GAS_CALL + gas
+    call_gas_fee = u256_safe_add(GAS_CALL, gas, exception_type=OutOfGasError)
     message_call_gas_fee = gas
     evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
 

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -385,7 +385,7 @@ def delegatecall(evm: Evm) -> None:
         evm.memory, memory_input_start_position, memory_input_size
     )
 
-    call_gas_fee = GAS_CALL + gas
+    call_gas_fee = u256_safe_add(GAS_CALL, gas, exception_type=OutOfGasError)
     message_call_gas_fee = gas
     evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
 


### PR DESCRIPTION
### What was wrong?

Homestead could fail with an overflow error if `DELEGATECALL` was given too much gas.

### How was it fixed?

Make if fail out of gas instead.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/wctn4jf00a491.jpg)
