### PR TITLE
Add doc to extras in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ extras =
     test
     lint
     optimized
+    doc
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"


### PR DESCRIPTION
### What was wrong?

I was getting `mypy` errors in `nav.py`.

### How was it fixed?

Make `tox` install `doc` dependencies in `testenv`. Presumably my machine has a different version of the dependencies.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/5y4zfkzemk591.jpg)
