### PR TITLE
Add EthereumJS

### DIFF
--- a/network-upgrades/mainnet-upgrades/gray-glacier.md
+++ b/network-upgrades/mainnet-upgrades/gray-glacier.md
@@ -18,3 +18,4 @@ Specifies changes included in the Network Upgrade.
    - [x]  Besu: https://github.com/hyperledger/besu/releases/tag/22.4.3
    - [x]  Nethermind: https://github.com/NethermindEth/nethermind/releases/tag/1.13.3
    - [x]  Erigon: https://github.com/ledgerwatch/erigon/releases/tag/v2022.06.03
+   - [x]  EthereumJS: https://github.com/ethereumjs/ethereumjs-monorepo/releases/tag/@ethereumjs/vm@5.9.3


### PR DESCRIPTION
### What was wrong?

Related to Issue #537 

### How was it fixed?

The EthereumJS client has a new release that adds support for gray-glacier hardfork.  [@ethereumjs/vm v5.9.3](https://github.com/ethereumjs/ethereumjs-monorepo/releases/tag/%40ethereumjs%2Fvm%405.9.3).

I have added the EthJs link to the list in `gray-glacier.md`


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/20/01/57/200157aa37a51005c6e2fe7a1b320f58.jpg)
