### PR TITLE
Use multiprocess in diff tool (#546)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -341,3 +341,5 @@ R4
 
 pyspec
 unoptimized
+
+starmap


### PR DESCRIPTION
### What was wrong?

Related to Issue #546

### How was it fixed?

Use the `multiprocessing` package to parallelize the diff generation process.

On my machine, the doc build took:

```
real	36m14.936s
user	35m47.537s
sys	0m17.459s
```

With these changes:

```
real	19m23.582s
user	62m1.858s
sys	0m59.292s
```

So a wall clock savings of ~17 minutes.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/8vp85ngl4i791.jpg?width=576&auto=webp&s=8a65ba30d158ee788d418ba0b4e76b2142990756)
