### PR TITLE
Bump rust glue to v0.0.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,3 +39,6 @@ jobs:
       - name: Build docs
         if: ${{ matrix.python != 'pypy-3.8' }}
         run: tox -e doc
+      - name: Run Tox (optimized state/ethash)
+        if: ${{ matrix.python != 'pypy-3.8' }}
+        run: tox -e optimized

--- a/setup.cfg
+++ b/setup.cfg
@@ -130,7 +130,7 @@ doc-autobuild =
     sphinx-autobuild==2021.3.14
 
 optimized =
-    rust-pyspec-glue>=0.0.3,<0.1.0
+    rust-pyspec-glue>=0.0.5,<0.1.0
     ethash==0.5.1a1
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -66,3 +66,11 @@ extras =
     doc-autobuild
 commands =
     sphinx-autobuild doc --watch src "{toxworkdir}/docs_out" {posargs}
+
+[testenv:optimized]
+extras =
+    test
+    optimized
+commands =
+    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m bigmem --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --optimized


### PR DESCRIPTION
This PR bumps `rust-pyspec-glue` to `v0.0.5`. Previous versions had performance and correctness bugs. I've also added a run of the testsuite with `--optimized` to the CI. This should help catch issues with the optimized code earlier.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/bbq95ucz5k991.jpg)
