### PR TITLE
Disclaimer header isn't aligned

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -77,7 +77,7 @@ dl.field-list > dt {
     text-align: center;
     font-family: sans-serif;
     box-shadow: 0px 3px 2px -2px rgba(0,0,0,0.3);
-    width: 80%;
+    width: 100%;
     top: 0;
     right: 0;
     z-index: 2;
@@ -87,9 +87,14 @@ dl.field-list > dt {
     color: #000;
 }
 
+.wy-nav-side, .wy-nav-content-wrap {
+    top: 4em;
+}
+
 @media (min-width: 876px) {
     #disclaimer {
         position: fixed;
+        height: 4em;
     }
 
     body {


### PR DESCRIPTION
(closes #542)

### What was wrong?
The disclaimer header isn't aligned

Related to Issue #542 

### How was it fixed?
Updated the custom css

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://redpandanetwork.org/get/files/image/galleries/28138502587_a0a020ae9a_k.jpeg?resize=1920x0&crop=1920x1040)
