### PR TITLE
Add incantations to make ripemd work on OpenSSL 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ install_requires =
     pysha3>=1,<2
     coincurve>=17,<18
     typing_extensions>=4
+    cffi>=1.15
 
 [options.package_data]
 ethereum =

--- a/src/ethereum/__init__.py
+++ b/src/ethereum/__init__.py
@@ -19,7 +19,31 @@ possible, to aid in defining the behavior of Ethereum clients.
 import sys
 from typing import Any
 
+import cffi
+
 __version__ = "0.1.0"
+
+try:
+    # These incantations are necessary to make ripemd160 work on OpenSSL 3
+    ffi = cffi.FFI()
+    ffi.cdef("void *OSSL_PROVIDER_load(void *libctx, const char *name);")
+    lib = ffi.dlopen("crypto")
+    assert (
+        lib.OSSL_PROVIDER_load(
+            ffi.NULL, ffi.new("char[]", "default".encode("ascii"))
+        )
+        is not ffi.NULL
+    )
+    assert (
+        lib.OSSL_PROVIDER_load(
+            ffi.NULL, ffi.new("char[]", "legacy".encode("ascii"))
+        )
+        is not ffi.NULL
+    )
+except Exception:
+    # Ignore all failures, the code above is fragile and will fail in
+    # situations when it is not needed (e.g. you don't have OpenSSL 3).
+    pass
 
 #
 #  Ensure we can reach 1024 frames of recursion

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -350,3 +350,10 @@ attrname
 expr
 subpackages
 toctree
+
+cffi
+ffi
+FFI
+cdef
+dlopen
+OSSL


### PR DESCRIPTION
(fixes #506)

### What was wrong?

OpenSSL 3 disabled legacy crypto algorithms by default, including RIPEMD (which we use).

### How was it fixed?

Add some incantations to `__init__.py` to load the "legacy" provider, which will reenable RIPEMD. I have decided to go with an approach of silently ignoring all failures in the incantations, since the code is inherently quite hacky (It uses the C ABI, not the API) and in some failure cases (e.g. not having OpenSSL 3) things are likely to work anyway.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/pgsjbv59hqw41.jpg)
