### PR TITLE
Add Suggested Goerli TTD

### DIFF
--- a/network-upgrades/mainnet-upgrades/paris.md
+++ b/network-upgrades/mainnet-upgrades/paris.md
@@ -22,7 +22,7 @@ This network upgrade requires changes to both Ethereum's execution and consensus
 |---------|------------|---------------|--------------|
 | Ropsten | 50000000000000000 | June 8, 2022 | `0x7119B6B3` (unchanged from [London](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)) |
 | Sepolia | 17000000000000000 | July 6, 2022 | `0xfe3366e7` (unchanged from [Genesis](https://github.com/ethereum/go-ethereum/pull/23730)) |
-| Goerli  | TBD | TBD | TBD |
+| Goerli  | 10790000 | August 10, 2022 | TBD |
 | Mainnet | TBD | TBD | TBD |
 
 ### Readiness Checklist


### PR DESCRIPTION
#### What does this do? 

Proposes a terminal total difficulty of `10,790,000` for the Goerli merge. To get to this value, I looked at the last ~1m blocks on the network, and estimated the highest/lowest average difficulty increase per block over all 50,000 block windows, as well as the average over the entire set, and used https://ttd.goerli.net/ to sanity check the last 100,000 block average. 

Assuming Bellatrix is scheduled for August 4, 2022, this TTD would not be hit before even at the highest rolling average we've seen in the past 1m blocks. Assuming things keep following the current short/medium term averages, we should expect TTD to be hit around August 9-11th, and if the difficulty per block was at its lowest in the past 1m blocks, we'd hit it a few days later, around August 13. 

* [Spreadsheet with calculations](https://docs.google.com/spreadsheets/d/1zAOM5UsSzZaY0Mu0UEohOogzJwmSiawBwdEyHNukJvg/edit?usp=sharing)
* [Script used for estimation](https://gist.github.com/timbeiko/c46ff87b5007352800ad048e2a868d43)
   * Cross-verified with @parithosh
* [Raw data](https://gist.githubusercontent.com/ryanschneider/abfafa802b90f962e53f2edac4b8d5e7/raw/4eafdfff57dfe7c2253bd2e2f57b8c9ffdb219b8/goerli_td_1m.csv) (thanks @ryanschneider!)
    * Also cross-verified with etherscan and @lightclient  


#### Cute Animal Picture

<img width="627" alt="Screen Shot 2022-07-17 at 10 09 44 AM" src="https://user-images.githubusercontent.com/9390255/179416901-9c3486de-ae6f-459a-bce7-447a074a6a36.png">
