### PR TITLE
[Spelling] Update /retrospectives/London.md

### DIFF
--- a/network-upgrades/retrospectives/london.md
+++ b/network-upgrades/retrospectives/london.md
@@ -85,7 +85,7 @@ July 22, 2021
 assert sender.balance >= gasLimit * transaction.max_fee_per_gas
 ```
 
-A few lines above (L207), though, `sender.balance` is modified to substract from it the transaction's amount (`sender.balance -= transaction.amount`). This led to confusion, as some client teams used the full `sender.balance` (i.e. pre-subtraction of `transactiion.amount`) when checking the assertion defined on line 217, rather than the updated value. 
+A few lines above (L207), though, `sender.balance` is modified to substract from it the transaction's amount (`sender.balance -= transaction.amount`). This led to confusion, as some client teams used the full `sender.balance` (i.e. pre-subtraction of `transaction.amount`) when checking the assertion defined on line 217, rather than the updated value. 
 
 One suggested fix is to move this assertion closer to when the `sender.balance` value is updated, similarly to the other assertion on line 208. 
 


### PR DESCRIPTION
### What was wrong?

Double 'i' in "transaction.amount"

### How was it fixed?

Updated /retrospectives/London.md with correct spelling

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://th.bing.com/th/id/R.614808da417ae36533660e0eb8c4259f?rik=qxaPKc%2ftzbkU0w&riu=http%3a%2f%2fbgwall.net%2fwp-content%2fuploads%2f2014%2f08%2fcute_cat_is_sitting_in_a_cup_of_tea_wallpaper.jpg&ehk=yOGOUMMAtd9vht%2bvF8CRtIV9MTyw6nYh371ghOuO1%2f0%3d&risl=&pid=ImgRaw&r=0)
