### PR TITLE
Button to display only elements of diffs that changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ The following will have to however, be updated manually
  2. Any absolute package imports from other forks eg. in trie.py
  3. Package names under setup.cfg
  4. Add the new fork to the monkey_patch() function in src/ethereum_optimized/__init__.py
- 5. Adjust the underline in fork/__init__.py as well as __init__.py, address.py, message.py in fork/utils
+ 5. Adjust the underline in fork/__init__.py

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -96,6 +96,11 @@ dl.field-list > dt {
     display: none;
 }
 
+.toctree-l3 .change-replaced, .toctree-l3 .change-replacement {
+    background-color: #c9c9c9;
+    border-color: #c9c9c9;
+}
+
 @media (min-width: 876px) {
     #disclaimer {
         position: fixed;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -91,6 +91,11 @@ dl.field-list > dt {
     top: 4em;
 }
 
+.hideElement {
+    visibility: "hidden";
+    display: none;
+}
+
 @media (min-width: 876px) {
     #disclaimer {
         position: fixed;

--- a/doc/_static/js/toggle_diffs.js
+++ b/doc/_static/js/toggle_diffs.js
@@ -1,5 +1,15 @@
+// Click Event Listner for toggle button
+window.addEventListener("load", (e) => {
+    const btn = document.getElementById("diff-toggle")
+    if (btn){
+        btn.addEventListener("click", toggleElements);
+    }
+})
+
 // All diffs will have one of the below classes
-const changeClasses = ["change-replaced", "change-replacement", "change-added", "change-removed"];
+const changeClassList = ["change-replaced", "change-replacement", "change-added", "change-removed"];
+const changeClassString = "." + changeClassList.join(", .");
+
 // The list of components to be scanned for diffs - selected by ID
 const componentsList = [
     '#module-details > *',
@@ -11,14 +21,14 @@ const componentsList = [
     '#table-of-contents',
     '#introduction'
 ];
-const components = componentsList.join(", ")
+const componentsString = componentsList.join(", ");
 
 function toggleElements() {
 
     // Check if the entire page is replaced. If yes, do nothing
     var fullPageReplaced = false;
     const pageElement = document.querySelector('span.target');
-    if (changeClasses.some(r => pageElement.classList.value.includes(r))){
+    if (changeClassList.some(r => pageElement.classList.value.includes(r))){
         fullPageReplaced = true;
     }
 
@@ -26,7 +36,7 @@ function toggleElements() {
     if (!fullPageReplaced){
         // Examine the contents of the individual sections
         // Hide sections that do not have diffs in any of the children
-        const all = document.querySelectorAll(components);
+        const all = document.querySelectorAll(componentsString);
 
         for (i=0; i < all.length; i++){
     
@@ -38,7 +48,7 @@ function toggleElements() {
     }
 
     // Toggle button text depending on what is currently displayed
-    const btn = document.querySelector('.diff-toggle');
+    const btn = document.getElementById('diff-toggle');
     if (btn.innerHTML === "Only Show Diffs") {
         btn.innerHTML = "Show All";
     } else {
@@ -47,22 +57,15 @@ function toggleElements() {
 }
 
 function childrenHaveDiffs(element){
-    
-    
-    var hasDiffs = false;
 
-    if (changeClasses.some(r => element.classList.value.includes(r))){
-        hasDiffs = true;
+    if (changeClassList.some(r => element.classList.value.includes(r))){
+        return true;
     } else {
-        const children = element.querySelectorAll('*');
-
-        for (j = 0; j < children.length; j++){
-            if (changeClasses.some(r => children[j].classList.value.includes(r))){
-                hasDiffs = true;
-                break;
-            } 
+        const children = element.querySelectorAll(changeClassString);
+        if (children.length > 0){
+                return true;
         }
     }
 
-    return hasDiffs;
+    return false;
 }

--- a/doc/_static/js/toggle_diffs.js
+++ b/doc/_static/js/toggle_diffs.js
@@ -1,0 +1,68 @@
+// All diffs will have one of the below classes
+const changeClasses = ["change-replaced", "change-replacement", "change-added", "change-removed"];
+// The list of components to be scanned for diffs - selected by ID
+const componentsList = [
+    '#module-details > *',
+    '#module-contents > *',
+    '#package-details > *',
+    '#package-contents > *', 
+    '#subpackages',
+    '#submodules',
+    '#table-of-contents',
+    '#introduction'
+];
+const components = componentsList.join(", ")
+
+function toggleElements() {
+
+    // Check if the entire page is replaced. If yes, do nothing
+    var fullPageReplaced = false;
+    const pageElement = document.querySelector('span.target');
+    if (changeClasses.some(r => pageElement.classList.value.includes(r))){
+        fullPageReplaced = true;
+    }
+
+    // Do nothing if the full page is replaced
+    if (!fullPageReplaced){
+        // Examine the contents of the individual sections
+        // Hide sections that do not have diffs in any of the children
+        const all = document.querySelectorAll(components);
+
+        for (i=0; i < all.length; i++){
+    
+            const hasDiffs = childrenHaveDiffs(all[i]);
+            if (!hasDiffs){
+                all[i].classList.toggle("hideElement");
+            };
+        }
+    }
+
+    // Toggle button text depending on what is currently displayed
+    const btn = document.querySelector('.diff-toggle');
+    if (btn.innerHTML === "Only Show Diffs") {
+        btn.innerHTML = "Show All";
+    } else {
+        btn.innerHTML = "Only Show Diffs";
+    }
+}
+
+function childrenHaveDiffs(element){
+    
+    
+    var hasDiffs = false;
+
+    if (changeClasses.some(r => element.classList.value.includes(r))){
+        hasDiffs = true;
+    } else {
+        const children = element.querySelectorAll('*');
+
+        for (j = 0; j < children.length; j++){
+            if (changeClasses.some(r => children[j].classList.value.includes(r))){
+                hasDiffs = true;
+                break;
+            } 
+        }
+    }
+
+    return hasDiffs;
+}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -23,6 +23,10 @@
         </li>
     </ol>
 </nav>
+{% elif "diffs/" in pagename %}
+<nav class="menu">
+    <button class="diff-toggle" onclick="toggleElements()">Only Show Diffs</button>
+</nav>
 {% endif %}
 
 {{ super() }}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -23,9 +23,9 @@
         </li>
     </ol>
 </nav>
-{% elif "diffs/" in pagename %}
+{% elif "diffs/" in pagename and "/index" in pagename %}
 <nav class="menu">
-    <button class="diff-toggle" onclick="toggleElements()">Only Show Diffs</button>
+    <button id="diff-toggle">Only Show Diffs</button>
 </nav>
 {% endif %}
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,3 +106,7 @@ html_css_files = [
     "css/dropdown.css",
     "css/custom.css",
 ]
+
+html_js_files = [
+    "js/toggle_diffs.js",
+]

--- a/src/ethereum/byzantium/utils/__init__.py
+++ b/src/ethereum/byzantium/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Byzantium Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/byzantium/utils/address.py
+++ b/src/ethereum/byzantium/utils/address.py
@@ -1,6 +1,6 @@
 """
-Byzantium Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/byzantium/utils/message.py
+++ b/src/ethereum/byzantium/utils/message.py
@@ -1,6 +1,6 @@
 """
-Byzantium Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/constantinople/utils/__init__.py
+++ b/src/ethereum/constantinople/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Constantinople Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/constantinople/utils/address.py
+++ b/src/ethereum/constantinople/utils/address.py
@@ -1,6 +1,6 @@
 """
-Constantinople Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/constantinople/utils/message.py
+++ b/src/ethereum/constantinople/utils/message.py
@@ -1,6 +1,6 @@
 """
-Constantinople Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/dao_fork/utils/__init__.py
+++ b/src/ethereum/dao_fork/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Dao Fork Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/dao_fork/utils/address.py
+++ b/src/ethereum/dao_fork/utils/address.py
@@ -1,6 +1,6 @@
 """
-Dao Fork Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/dao_fork/utils/message.py
+++ b/src/ethereum/dao_fork/utils/message.py
@@ -1,6 +1,6 @@
 """
-Dao Fork Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/frontier/utils/__init__.py
+++ b/src/ethereum/frontier/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-Frontier Utility Functions
+Hardfork Utility Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/frontier/utils/address.py
+++ b/src/ethereum/frontier/utils/address.py
@@ -1,5 +1,5 @@
 """
-Frontier Utility Functions For Addresses
+Hardfork Utility Functions For Addresses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/frontier/utils/message.py
+++ b/src/ethereum/frontier/utils/message.py
@@ -1,5 +1,5 @@
 """
-Frontier Utility Functions For The Message Data-structure
+Hardfork Utility Functions For The Message Data-structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/homestead/utils/__init__.py
+++ b/src/ethereum/homestead/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Homestead Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/homestead/utils/address.py
+++ b/src/ethereum/homestead/utils/address.py
@@ -1,6 +1,6 @@
 """
-Homestead Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/homestead/utils/message.py
+++ b/src/ethereum/homestead/utils/message.py
@@ -1,6 +1,6 @@
 """
-Homestead Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/istanbul/utils/__init__.py
+++ b/src/ethereum/istanbul/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-Istanbul Utility Functions
+Hardfork Utility Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/istanbul/utils/address.py
+++ b/src/ethereum/istanbul/utils/address.py
@@ -1,5 +1,5 @@
 """
-Istanbul Utility Functions For Addresses
+Hardfork Utility Functions For Addresses
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/istanbul/utils/message.py
+++ b/src/ethereum/istanbul/utils/message.py
@@ -1,5 +1,5 @@
 """
-Istanbul Utility Functions For The Message Data-structure
+Hardfork Utility Functions For The Message Data-structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents

--- a/src/ethereum/muir_glacier/utils/__init__.py
+++ b/src/ethereum/muir_glacier/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Muir Glacier Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/muir_glacier/utils/address.py
+++ b/src/ethereum/muir_glacier/utils/address.py
@@ -1,6 +1,6 @@
 """
-Muir Glacier Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/muir_glacier/utils/message.py
+++ b/src/ethereum/muir_glacier/utils/message.py
@@ -1,6 +1,6 @@
 """
-Muir Glacier Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/spurious_dragon/utils/__init__.py
+++ b/src/ethereum/spurious_dragon/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Spurious Dragon Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/spurious_dragon/utils/address.py
+++ b/src/ethereum/spurious_dragon/utils/address.py
@@ -1,6 +1,6 @@
 """
-Spurious Dragon Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/spurious_dragon/utils/message.py
+++ b/src/ethereum/spurious_dragon/utils/message.py
@@ -1,6 +1,6 @@
 """
-Spurious Dragon Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/tangerine_whistle/utils/__init__.py
+++ b/src/ethereum/tangerine_whistle/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Tangerine Whistle Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/tangerine_whistle/utils/address.py
+++ b/src/ethereum/tangerine_whistle/utils/address.py
@@ -1,6 +1,6 @@
 """
-Tangerine Whistle Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/tangerine_whistle/utils/message.py
+++ b/src/ethereum/tangerine_whistle/utils/message.py
@@ -1,6 +1,6 @@
 """
-Tangerine Whistle Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum_spec_tools/diff.py
+++ b/src/ethereum_spec_tools/diff.py
@@ -150,18 +150,9 @@ def _diff(
     pub.writer.assemble_parts()
 
     index_entry_file_name = os.path.relpath(diff_pickle_path, output_path)
-    # Split the index_entry, discard the first and last items,
-    # since those are just the fork name and index file name
-    # then join the remaining parts of the path with a "."
-    # to get the page title
-    index_entry_title = ".".join(index_entry_file_name.split("/")[1:-1])
-    if not index_entry_title:
-        # top-level __init__.py file
-        index_entry_title = "__init__"
-    index_entry = index_entry_title + " <" + index_entry_file_name + ">"
 
     with open(diff_index_path, "a") as f:
-        f.write(f"   {index_entry}\n")
+        f.write(f"   {index_entry_file_name}\n")
 
 
 def diff(

--- a/src/ethereum_spec_tools/new_fork.py
+++ b/src/ethereum_spec_tools/new_fork.py
@@ -35,8 +35,7 @@ The following will have to however, be updated manually
     3. Package Names under setup.cfg
     4. Add the new fork to the monkey_patch() function in \
 src/ethereum_optimized/__init__.py
-    5. Adjust the underline in fork/__init__.py as well as \
-__init__.py, address.py, message.py in fork/utils
+    5. Adjust the underline in fork/__init__.py
 """
 
 parser = argparse.ArgumentParser(
@@ -190,8 +189,7 @@ PLEASE REMEMBER TO UPDATE THE FOLLOWING MANUALLY:
     3. Package Names under setup.cfg
     4. Add the new fork to the monkey_patch() function in \
 src/ethereum_optimized/__init__.py
-    5. Adjust the underline in src/{package}/__init__.py as well as \
-__init__.py, address.py, message.py in src/{package}/utils
+    5. Adjust the underline in src/{package}/__init__.py
 """.format(
         fork=fork_creator.to_fork,
         package=fork_creator.to_package,


### PR DESCRIPTION
This is an additional feature. It allows users to narrow down to only those parts of the diffs that actually changed. The diffs pages will have a button that allows one to toggle the two views.

Also updated the rendered spec to display meaningful names for diff files instead of just the module names.

The final result of this PR will look something like [this](https://gurukamath.github.io/execution-specs/index.html).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/2/22/Kangur.rudy.drs.jpg)
