### PR TITLE
Mark tests that create 50000 recursive frames as `bigmem`

### DIFF
--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -49,19 +49,8 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stSStoreTest/InitCollision.json",
 )
 
-BIG_MEMORY_TESTS = (
-    "static_Return50000_2_d0g0v0_Berlin",
-    "static_Call50000_d1g0v0_Berlin",
-    "static_Call50000_identity2_d0g0v0_Berlin",
-    "static_Call50000_identity2_d1g0v0_Berlin",
-    "static_Call50000_ecrec_d1g0v0_Berlin",
-    "static_Call50000_d0g0v0_Berlin",
-    "Return50000_d0g1v0_Berlin",
-    "Return50000_2_d0g1v0_Berlin",
-    "static_Call50000_rip160_d1g0v0_Berlin",
-    "static_Call50000_rip160_d0g0v0_Berlin",
-    "static_Call50000_ecrec_d0g0v0_Berlin",
-)
+# All tests that recursively create a large number of frames (50000)
+BIG_MEMORY_TESTS = ("50000_",)
 
 
 @pytest.mark.parametrize(

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -34,15 +34,8 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stRevertTest/RevertInCreateInInit_d0g0v0.json",
 )
 
-BIG_MEMORY_TESTS = (
-    "static_Call50000_d1g0v0_Byzantium",
-    "static_Call50000_ecrec_d1g0v0_Byzantium",
-    "static_Call50000_sha256_d1g0v0_Byzantium",
-    "static_Call50000_sha256_d0g0v0_Byzantium",
-    "static_Call50000_rip160_d1g0v0_Byzantium",
-    "static_Call50000_rip160_d0g0v0_Byzantium",
-    "Return50000_d0g1v0_Byzantium",
-)
+# All tests that recursively create a large number of frames (50000)
+BIG_MEMORY_TESTS = ("50000_",)
 
 
 @pytest.mark.parametrize(

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -52,16 +52,8 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stSStoreTest/InitCollision_d3g0v0.json",
 )
 
-BIG_MEMORY_TESTS = (
-    "static_Call50000_d1g0v0_ConstantinopleFix",
-    "static_Call50000_ecrec_d1g0v0_ConstantinopleFix",
-    "static_Call50000_sha256_d0g0v0_ConstantinopleFix",
-    "static_Call50000_sha256_d1g0v0_ConstantinopleFix",
-    "static_Call50000_rip160_d1g0v0_ConstantinopleFix",
-    "static_Call50000_rip160_d0g0v0_ConstantinopleFix",
-    "Return50000_d0g1v0_ConstantinopleFix",
-    "Return50000_2_d0g1v0_ConstantinopleFix",
-)
+# All tests that recursively create a large number of frames (50000)
+BIG_MEMORY_TESTS = ("50000_",)
 
 
 @pytest.mark.parametrize(

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -49,19 +49,8 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     "stSStoreTest/InitCollision.json",
 )
 
-BIG_MEMORY_TESTS = (
-    "static_Return50000_2_d0g0v0_Istanbul",
-    "static_Call50000_d1g0v0_Istanbul",
-    "static_Call50000_identity2_d0g0v0_Istanbul",
-    "static_Call50000_identity2_d1g0v0_Istanbul",
-    "static_Call50000_ecrec_d1g0v0_Istanbul",
-    "static_Call50000_d0g0v0_Istanbul",
-    "Return50000_d0g1v0_Istanbul",
-    "Return50000_2_d0g1v0_Istanbul",
-    "static_Call50000_rip160_d1g0v0_Istanbul",
-    "static_Call50000_rip160_d0g0v0_Istanbul",
-    "static_Call50000_ecrec_d0g0v0_Istanbul",
-)
+# All tests that recursively create a large number of frames (50000)
+BIG_MEMORY_TESTS = ("50000_",)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
Post Berlin merge, the GitHub Actions worker crashes due to insufficient memory.


### How was it fixed?
Mark all tests that call 50000 frames recursively as `bigmem` and run them separately/non-parallely.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/3/31/SlothDWA.jpg)
