### PR TITLE
Update paris.md

### DIFF
--- a/network-upgrades/mainnet-upgrades/paris.md
+++ b/network-upgrades/mainnet-upgrades/paris.md
@@ -86,7 +86,7 @@ See https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md
 - Sepolia
     - [Besu](https://github.com/hyperledger/besu/releases/tag/22.7.0-RC1)
     - [Erigon](https://github.com/ledgerwatch/erigon/releases/tag/v2022.07.01)
-    - [go-ethereum (geth)] TBD
+    - [go-ethereum (geth)] (https://github.com/ethereum/go-ethereum/releases/tag/v1.10.21)
     - [Nethermind](https://github.com/NethermindEth/nethermind/releases/tag/1.13.4)
 - Goerli
 - Mainnet 


### PR DESCRIPTION
### What was wrong?

"Client Releases" section of Paris.md did not have Geth's Sepolia-Merge compatible release linked.

### How was it fixed?

Updated Paris.md to include link to the Sepolia-Merge compatible release of Geth

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://th.bing.com/th/id/OIP.8oHVFkPt5yuIH3jdUghixQHaE5?pid=ImgDet&rs=1)
