### PR TITLE
add `-j` option to sphinx-build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,7 @@ lint =
     flake8>=3.9,<4
 
 doc =
-    sphinx-autoapi>=1.8.1,<2
+    sphinx-autoapi>=1.9.0,<2
     undocinclude>=0.2.0,<0.3
     sphinx==4.0.2
     rstdiff>=0.5.1,<0.6

--- a/src/ethereum_spec_tools/toctree.py
+++ b/src/ethereum_spec_tools/toctree.py
@@ -7,6 +7,7 @@ Plug-in that modifies/re-orders the toc-tree before writing.
 
 from typing import Any
 
+import ethereum
 from ethereum_spec_tools.forks import Hardfork
 
 forks = Hardfork.discover()
@@ -45,8 +46,14 @@ def modify_toctree(
     return skip
 
 
-def setup(sphinx: Any) -> None:
+def setup(sphinx: Any) -> Any:
     """
     Update documentation structure before writing the files
     """
     sphinx.connect("autoapi-skip-member", modify_toctree)
+
+    return {
+        "version": ethereum.__version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ basepython = python3
 extras = doc
 commands =
     sphinx-build \
+        -j auto \
         -t stage0 \
         -d "{toxworkdir}/docs/stage0_doctree" \
         doc \
@@ -48,6 +49,7 @@ commands =
         --compare-sections-normally
 
     sphinx-build \
+        -j auto \
         -t stage1 \
         -d "{toxworkdir}/docs/stage1_doctree" \
         doc \


### PR DESCRIPTION
(closes #546 )

### What was wrong?
`sphinx-build` was not running in parallel

Related to Issue #546 

### How was it fixed?
Added `-j` option to `sphinx-build` reducing the overall docs build time by about 2 mins.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1535930749574-1399327ce78f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3136&q=80)
