### PR TITLE
Update/optimise `meaningful_diffs` calculation in diff tool

### DIFF
--- a/src/ethereum/berlin/utils/__init__.py
+++ b/src/ethereum/berlin/utils/__init__.py
@@ -1,6 +1,6 @@
 """
-Berlin Utility Functions
-^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/berlin/utils/address.py
+++ b/src/ethereum/berlin/utils/address.py
@@ -1,6 +1,6 @@
 """
-Berlin Utility Functions For Addresses
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none

--- a/src/ethereum/berlin/utils/message.py
+++ b/src/ethereum/berlin/utils/message.py
@@ -1,6 +1,6 @@
 """
-Berlin Utility Functions For The Message Data-structure
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hardfork Utility Functions For The Message Data-structure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. contents:: Table of Contents
     :backlinks: none


### PR DESCRIPTION
(closes #572 )

### What was wrong?
Under the current logic, minor differences such as a new line character in the doctoring are treated as non-trivial. See [dao](https://github.com/ethereum/execution-specs/blob/10dcc75108c84f396e61bd7e1b720648f36cd1eb/src/ethereum/dao_fork/utils/address.py#L12) vs [tangerine whistle](https://github.com/ethereum/execution-specs/blob/10dcc75108c84f396e61bd7e1b720648f36cd1eb/src/ethereum/tangerine_whistle/utils/address.py#L12)

Related to Issue #572 

### How was it fixed?
Updated the `meaningful_diffs` calculation as follows

- Treat the old and new documents as a string instead of traversing each of its nodes individually. (This also has a nice side-effect of  calculating the diffs faster - ~2 mins on GitHub Actions)
- Strip `\n`, `\t` and `\s` from both strings since these differences are trivial
- Strip the fork and package names from both strings using regex
- Compare if the two strings are the same

Additionally, I have updated some docstrings of Berlin to port the changes from #566 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/1/15/Sea_otter_cropped.jpg)