### PR TITLE
Refactor EVM opcodes

### DIFF
--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -649,6 +649,8 @@ class U256(FixedUInt):
     inclusive.
     """
 
+    MAX_VALUE: "U256"
+
     __slots__ = ()
 
     @classmethod

--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -15,7 +15,7 @@ Integer and array types which are used by—but not unique to—Ethereum.
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any, Callable, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, ClassVar, Optional, Tuple, Type, TypeVar
 
 U8_MAX_VALUE = (2**8) - 1
 UINT32_MAX_VALUE = (2**32) - 1
@@ -299,7 +299,7 @@ class FixedUInt(int):
     directly, but rather to be subclassed.
     """
 
-    MAX_VALUE: "FixedUInt"
+    MAX_VALUE: ClassVar["FixedUInt"]
 
     __slots__ = ()
 
@@ -649,7 +649,7 @@ class U256(FixedUInt):
     inclusive.
     """
 
-    MAX_VALUE: "U256"
+    MAX_VALUE: ClassVar["U256"]
 
     __slots__ = ()
 
@@ -740,7 +740,7 @@ class Uint32(FixedUInt):
     inclusive.
     """
 
-    MAX_VALUE: "Uint32"
+    MAX_VALUE: ClassVar["Uint32"]
 
     __slots__ = ()
 
@@ -792,7 +792,7 @@ class Uint64(FixedUInt):
     inclusive.
     """
 
-    MAX_VALUE: "Uint64"
+    MAX_VALUE: ClassVar["Uint64"]
 
     __slots__ = ()
 

--- a/src/ethereum/berlin/state.py
+++ b/src/ethereum/berlin/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -73,7 +73,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -13,76 +13,76 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
-GAS_RETURN_DATA_COPY = U256(3)
-GAS_FAST_STEP = U256(5)
-GAS_BLAKE2_PER_ROUND = U256(1)
-GAS_COLD_SLOAD = U256(2100)
-GAS_COLD_ACCOUNT_ACCESS = U256(2600)
-GAS_WARM_ACCESS = U256(100)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
+GAS_RETURN_DATA_COPY = Uint(3)
+GAS_FAST_STEP = Uint(5)
+GAS_BLAKE2_PER_ROUND = Uint(1)
+GAS_COLD_SLOAD = Uint(2100)
+GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
+GAS_WARM_ACCESS = Uint(100)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -95,7 +95,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -103,14 +103,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -125,18 +125,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -144,8 +144,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -161,7 +161,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -169,24 +169,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -201,36 +196,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -182,6 +182,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -196,6 +197,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -212,10 +214,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -103,7 +103,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/berlin/vm/instructions/arithmetic.py
+++ b/src/ethereum/berlin/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/bitwise.py
+++ b/src/ethereum/berlin/vm/instructions/bitwise.py
@@ -262,7 +262,7 @@ def bitwise_sar(evm: Evm) -> None:
     elif signed_value >= 0:
         result = U256(0)
     else:
-        result = U256(U256.MAX_VALUE)
+        result = U256.MAX_VALUE
 
     push(evm.stack, result)
 

--- a/src/ethereum/berlin/vm/instructions/bitwise.py
+++ b/src/ethereum/berlin/vm/instructions/bitwise.py
@@ -31,9 +31,9 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -62,9 +62,9 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -93,9 +93,9 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -124,9 +124,9 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -155,9 +155,9 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK

--- a/src/ethereum/berlin/vm/instructions/bitwise.py
+++ b/src/ethereum/berlin/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256, U256_CEIL_VALUE
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -31,16 +31,22 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -56,16 +62,22 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -81,16 +93,22 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -106,15 +124,21 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -131,17 +155,19 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,6 +180,7 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -161,68 +188,77 @@ def bitwise_shl(evm: Evm) -> None:
     """
     Logical shift left (SHL) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
     value = pop(evm.stack)
 
-    evm.pc += 1
-    shifted_value = 0
-    if shift < 256:
-        shifted_value = (value << shift) % U256_CEIL_VALUE
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    push(evm.stack, U256(shifted_value))
+    # OPERATION
+    if shift < 256:
+        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+    else:
+        push(evm.stack, U256(0))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def bitwise_shr(evm: Evm) -> None:
     """
     Logical shift right (SHR) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
     value = pop(evm.stack)
 
-    evm.pc += 1
-    shifted_value = U256(0)
-    if shift < 256:
-        shifted_value = value >> shift
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    push(evm.stack, shifted_value)
+    # OPERATION
+    if shift < 256:
+        push(evm.stack, value >> shift)
+    else:
+        push(evm.stack, U256(0))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def bitwise_sar(evm: Evm) -> None:
     """
     Arithmetic shift right (SAR) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
-    value = pop(evm.stack)
+    signed_value = pop(evm.stack).to_signed()
 
-    signed_value = value.to_signed()
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    evm.pc += 1
+    # OPERATION
     if shift < 256:
-        shifted_value = signed_value >> shift
+        push(evm.stack, U256.from_signed(signed_value >> shift))
     elif signed_value >= 0:
-        shifted_value = 0
+        push(evm.stack, U256(0))
     else:
-        shifted_value = U256.MAX_VALUE
+        push(evm.stack, U256(U256.MAX_VALUE))
 
-    push(evm.stack, U256.from_signed(shifted_value))
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/bitwise.py
+++ b/src/ethereum/berlin/vm/instructions/bitwise.py
@@ -202,9 +202,11 @@ def bitwise_shl(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+        result = U256((value << shift) % U256_CEIL_VALUE)
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -228,9 +230,11 @@ def bitwise_shr(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, value >> shift)
+        result = value >> shift
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -254,11 +258,13 @@ def bitwise_sar(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256.from_signed(signed_value >> shift))
+        result = U256.from_signed(signed_value >> shift)
     elif signed_value >= 0:
-        push(evm.stack, U256(0))
+        result = U256(0)
     else:
-        push(evm.stack, U256(U256.MAX_VALUE))
+        result = U256(U256.MAX_VALUE)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/block.py
+++ b/src/ethereum/berlin/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,9 +206,16 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -196,7 +235,14 @@ def chain_id(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.chain_id))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/comparison.py
+++ b/src/ethereum/berlin/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/control_flow.py
+++ b/src/ethereum/berlin/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/control_flow.py
+++ b/src/ethereum/berlin/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -521,9 +521,11 @@ def extcodehash(evm: Evm) -> None:
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
-        push(evm.stack, U256(0))
+        codehash = U256(0)
     else:
-        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+        codehash = U256.from_be_bytes(keccak256(account.code))
+
+    push(evm.stack, codehash)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -14,17 +14,15 @@ Implementations of the EVM environment related instructions.
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfBoundsRead, OutOfGasError
+from ..exceptions import OutOfBoundsRead
 from ..gas import (
     GAS_BASE,
     GAS_COLD_ACCOUNT_ACCESS,
@@ -33,8 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -50,12 +47,19 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,27 +74,28 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
     if address in evm.accessed_addresses:
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_WARM_ACCESS)
+        charge_gas(evm, GAS_WARM_ACCESS)
     else:
         evm.accessed_addresses.add(address)
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_COLD_ACCOUNT_ACCESS)
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS)
 
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -106,12 +111,19 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -126,12 +138,19 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,12 +165,19 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -167,22 +193,23 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -197,12 +224,19 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -220,45 +254,26 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -272,12 +287,19 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -295,46 +317,26 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -348,12 +350,19 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -368,26 +377,28 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
     if address in evm.accessed_addresses:
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_WARM_ACCESS)
+        charge_gas(evm, GAS_WARM_ACCESS)
     else:
         evm.accessed_addresses.add(address)
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_COLD_ACCOUNT_ACCESS)
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS)
 
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -402,58 +413,33 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
 
     if address in evm.accessed_addresses:
-        access_gas_cost = GAS_WARM_ACCESS
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
     else:
         evm.accessed_addresses.add(address)
-        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
 
-    total_gas_cost = u256_safe_add(
-        access_gas_cost,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def returndatasize(evm: Evm) -> None:
@@ -465,9 +451,16 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    return_size = U256(len(evm.return_data))
-    push(evm.stack, return_size)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.return_data)))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -480,66 +473,60 @@ def returndatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
-    return_data_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    return_data_start_position = pop(evm.stack)
     size = pop(evm.stack)
+
+    # GAS
+    words = ceil32(Uint(size)) // 32
+    copy_gas_cost = GAS_RETURN_DATA_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+
+    # OPERATION
     ensure(
-        return_data_start_position + size <= len(evm.return_data),
+        Uint(return_data_start_position) + Uint(size) <= len(evm.return_data),
         OutOfBoundsRead,
     )
 
-    words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_RETURN_DATA_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
 def extcodehash(evm: Evm) -> None:
     """
     Returns the keccak256 hash of a contract’s bytecode
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
     if address in evm.accessed_addresses:
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_WARM_ACCESS)
+        charge_gas(evm, GAS_WARM_ACCESS)
     else:
         evm.accessed_addresses.add(address)
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_COLD_ACCOUNT_ACCESS)
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS)
 
-    evm.pc += 1
-
+    # OPERATION
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
         push(evm.stack, U256(0))
     else:
-        code = account.code
-        code_hash = keccak256(code)
-        push(evm.stack, U256.from_be_bytes(code_hash))
+        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def self_balance(evm: Evm) -> None:
@@ -553,15 +540,22 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_FAST_STEP.
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+        If `len(stack)` is less than `1`.
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+        If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_FAST_STEP)
+    # STACK
+    pass
 
-    address = evm.message.current_target
+    # GAS
+    charge_gas(evm, GAS_FAST_STEP)
 
-    balance = get_account(evm.env.state, address).balance
+    # OPERATION
+    # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
+    balance = get_account(evm.env.state, evm.message.current_target).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -74,9 +74,9 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -111,7 +111,7 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -138,7 +138,7 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -165,7 +165,7 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -193,9 +193,9 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
     # STACK
@@ -224,7 +224,7 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -254,7 +254,7 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -287,7 +287,7 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -317,7 +317,7 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -350,7 +350,7 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -377,9 +377,9 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -413,7 +413,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
     # STACK
@@ -540,9 +540,9 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK

--- a/src/ethereum/berlin/vm/instructions/keccak.py
+++ b/src/ethereum/berlin/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/log.py
+++ b/src/ethereum/berlin/vm/instructions/log.py
@@ -13,20 +13,13 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError, WriteInStaticContext
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..exceptions import WriteInStaticContext
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -47,40 +40,24 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -89,6 +66,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/berlin/vm/instructions/log.py
+++ b/src/ethereum/berlin/vm/instructions/log.py
@@ -40,7 +40,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK

--- a/src/ethereum/berlin/vm/instructions/memory.py
+++ b/src/ethereum/berlin/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/memory.py
+++ b/src/ethereum/berlin/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/berlin/vm/instructions/stack.py
+++ b/src/ethereum/berlin/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/berlin/vm/instructions/storage.py
+++ b/src/ethereum/berlin/vm/instructions/storage.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM storage related instructions.
 """
-from ethereum.base_types import U256
+from ethereum.base_types import Uint
 from ethereum.utils.ensure import ensure
 
 from ...state import get_storage, get_storage_original, set_storage
@@ -24,7 +24,7 @@ from ..gas import (
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
     GAS_WARM_ACCESS,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -41,22 +41,27 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
-    value = get_storage(evm.env.state, evm.message.current_target, key)
 
+    # GAS
     if (evm.message.current_target, key) in evm.accessed_storage_keys:
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_WARM_ACCESS)
+        charge_gas(evm, GAS_WARM_ACCESS)
     else:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_COLD_SLOAD)
+        charge_gas(evm, GAS_COLD_SLOAD)
+
+    # OPERATION
+    value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -71,24 +76,25 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
-    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
+
+    # GAS
+    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
 
     original_value = get_storage_original(
         evm.env.state, evm.message.current_target, key
     )
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # Gas Cost Calculation
-    gas_cost = U256(0)
+    gas_cost = Uint(0)
+
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GAS_COLD_SLOAD
@@ -100,6 +106,8 @@ def sstore(evm: Evm) -> None:
             gas_cost += GAS_STORAGE_UPDATE - GAS_COLD_SLOAD
     else:
         gas_cost += GAS_WARM_ACCESS
+
+    charge_gas(evm, gas_cost)
 
     # Refund Counter Calculation
     if current_value != new_value:
@@ -122,8 +130,9 @@ def sstore(evm: Evm) -> None:
                     GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS
                 )
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/storage.py
+++ b/src/ethereum/berlin/vm/instructions/storage.py
@@ -41,9 +41,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
     # STACK
@@ -76,9 +76,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
     # STACK

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -17,7 +17,6 @@ from ethereum.utils.numeric import ceil32
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -390,7 +389,6 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -398,18 +396,17 @@ def callcode(evm: Evm) -> None:
         evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
         gas,
         Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        access_gas_cost + transfer_gas_cost,
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        access_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -21,7 +21,7 @@ from ...state import (
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
-    is_account_empty,
+    is_account_alive,
     set_account_balance,
 )
 from ...utils.address import (
@@ -312,9 +312,6 @@ def call(evm: Evm) -> None:
     # GAS
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    is_account_alive = account_exists(
-        evm.env.state, to
-    ) and not is_account_empty(evm.env.state, to)
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -323,7 +320,9 @@ def call(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     create_gas_cost = (
-        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0)
+        if is_account_alive(evm.env.state, to) or value == 0
+        else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
@@ -459,12 +458,8 @@ def selfdestruct(evm: Evm) -> None:
         evm.accessed_addresses.add(beneficiary)
         charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS)
 
-    is_dead_account = not account_exists(
-        evm.env.state, beneficiary
-    ) or is_account_empty(evm.env.state, beneficiary)
-
     if (
-        is_dead_account
+        not is_account_alive(evm.env.state, beneficiary)
         and get_account(evm.env.state, evm.message.current_target).balance != 0
     ):
         charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -14,8 +14,8 @@ Implementations of the EVM system related instructions.
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -30,7 +30,7 @@ from ...utils.address import (
     to_address,
 )
 from .. import Evm, Message
-from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
+from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL_VALUE,
     GAS_COLD_ACCOUNT_ACCESS,
@@ -42,13 +42,85 @@ from ..gas import (
     GAS_WARM_ACCESS,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
+
+
+def do_create(
+    evm: Evm,
+    endowment: U256,
+    contract_address: Address,
+    memory_start_position: U256,
+    memory_size: U256,
+) -> None:
+    """
+    Common code shared between both types of CREATE*.
+    """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
+
+    evm.accessed_addresses.add(contract_address)
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.return_data = b""
+
+    sender_address = evm.message.current_target
+    sender = get_account(evm.env.state, sender_address)
+
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+            is_static=False,
+            accessed_addresses=evm.accessed_addresses.copy(),
+            accessed_storage_keys=evm.accessed_storage_keys.copy(),
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            evm.accessed_addresses = child_evm.accessed_addresses
+            evm.accessed_storage_keys = child_evm.accessed_storage_keys
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -60,92 +132,27 @@ def create(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
+    # OPERATION
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
     )
 
-    evm.accessed_addresses.add(contract_address)
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
 
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
-
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def create2(evm: Evm) -> None:
@@ -160,102 +167,30 @@ def create2(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create2_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
     salt = pop(evm.stack).to_be_bytes32()
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
     call_data_words = ceil32(Uint(memory_size)) // 32
-    hash_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        call_data_words,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        hash_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
+    # OPERATION
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
-        call_data,
+        memory_read_bytes(evm.memory, memory_start_position, memory_size),
     )
 
-    evm.accessed_addresses.add(contract_address)
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
-
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create2_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -267,18 +202,93 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    is_staticcall: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    evm.return_data = b""
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+            is_static=True if is_staticcall else evm.message.is_static,
+            accessed_addresses=evm.accessed_addresses.copy(),
+            accessed_storage_keys=evm.accessed_storage_keys.copy(),
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            if isinstance(child_evm.error, Revert):
+                evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            evm.accessed_addresses = child_evm.accessed_addresses
+            evm.accessed_storage_keys = child_evm.accessed_storage_keys
+            push(evm.stack, U256(1))
+            evm.return_data = child_evm.output
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -290,111 +300,72 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    is_account_alive = account_exists(
+        evm.env.state, to
+    ) and not is_account_empty(evm.env.state, to)
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
         evm.accessed_addresses.add(to)
+        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    is_account_alive = account_exists(
-        evm.env.state, to
-    ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        U256(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
     )
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        access_gas_cost,
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas,
+        Uint(evm.gas_left),
+        access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
+    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -406,104 +377,69 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
         evm.accessed_addresses.add(code_address)
+        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        transfer_gas_cost,
-        access_gas_cost,
-        exception_type=OutOfGasError,
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas,
+        Uint(evm.gas_left),
+        access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -515,29 +451,32 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
+    # GAS
     if beneficiary not in evm.accessed_addresses:
         evm.accessed_addresses.add(beneficiary)
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_COLD_ACCOUNT_ACCESS + GAS_SELF_DESTRUCT
-        )
-    else:
-        evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
-
-    originator = evm.message.current_target
-    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
-    originator_balance = get_account(evm.env.state, originator).balance
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS)
 
     is_dead_account = not account_exists(
         evm.env.state, beneficiary
     ) or is_account_empty(evm.env.state, beneficiary)
 
-    if is_dead_account and originator_balance != 0:
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    if (
+        is_dead_account
+        and get_account(evm.env.state, evm.message.current_target).balance != 0
+    ):
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+
+    originator = evm.message.current_target
+    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
+    originator_balance = get_account(evm.env.state, originator).balance
 
     # First Transfer to beneficiary
     set_account_balance(
@@ -554,224 +493,143 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
         evm.accessed_addresses.add(code_address)
+        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    extra_gas = access_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), access_gas_cost
     )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-        is_static=evm.message.is_static,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), access_gas_cost
     )
+    charge_gas(evm, call_gas_fee)
 
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def staticcall(evm: Evm) -> None:
     """
-    Make a static message-call into an account that prevents all
-    state modifying operations.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
         evm.accessed_addresses.add(to)
+        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    create_gas_cost = U256(0)
-    transfer_gas_cost = U256(0)
-    extra_gas = u256_safe_add(
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), access_gas_cost
+    )
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0),
+        gas,
+        Uint(evm.gas_left),
         access_gas_cost,
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        U256(0), gas, evm.gas_left, extra_gas
-    )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=U256(0),
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=True,
-        accessed_addresses=evm.accessed_addresses.copy(),
-        accessed_storage_keys=evm.accessed_storage_keys.copy(),
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        U256(0),
+        evm.message.current_target,
+        to,
+        to,
+        True,
+        True,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def revert(evm: Evm) -> None:
     """
     Stop execution and revert state changes, without consuming all provided gas
     and also has the ability to return a reason
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, memory_extend_gas_cost)
-    extend_memory(evm.memory, memory_start_index, size)
+    # GAS
+    extend_memory(evm, memory_start_index, size)
 
+    # OPERATION
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert
+
+    # PROGRAM COUNTER
+    pass

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -57,7 +57,7 @@ def generic_create(
     memory_size: U256,
 ) -> None:
     """
-    Core logic used by the `CREATE* family of opcodes.
+    Core logic used by the `CREATE*` family of opcodes.
     """
     # This import causes a circular import error
     # if it's not moved inside this method

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -50,7 +50,7 @@ from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
-def do_create(
+def generic_create(
     evm: Evm,
     endowment: U256,
     contract_address: Address,
@@ -58,7 +58,7 @@ def do_create(
     memory_size: U256,
 ) -> None:
     """
-    Common code shared between both types of CREATE*.
+    Core logic used by the `CREATE* family of opcodes.
     """
     # This import causes a circular import error
     # if it's not moved inside this method
@@ -80,47 +80,48 @@ def do_create(
         or sender.nonce == Uint(2**64 - 1)
         or evm.message.depth + 1 > STACK_DEPTH_LIMIT
     ):
-        push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
-    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        push(evm.stack, U256(0))
+        return
+
+    if account_has_code_or_nonce(evm.env.state, contract_address):
         increment_nonce(evm.env.state, evm.message.current_target)
         push(evm.stack, U256(0))
+        return
+
+    call_data = memory_read_bytes(
+        evm.memory, memory_start_position, memory_size
+    )
+
+    increment_nonce(evm.env.state, evm.message.current_target)
+
+    child_message = Message(
+        caller=evm.message.current_target,
+        target=Bytes0(),
+        gas=U256(create_message_gas),
+        value=endowment,
+        data=b"",
+        code=call_data,
+        current_target=contract_address,
+        depth=evm.message.depth + 1,
+        code_address=None,
+        should_transfer_value=True,
+        is_static=False,
+        accessed_addresses=evm.accessed_addresses.copy(),
+        accessed_storage_keys=evm.accessed_storage_keys.copy(),
+    )
+    child_evm = process_create_message(child_message, evm.env)
+    evm.children.append(child_evm)
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
+        evm.return_data = child_evm.output
     else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_start_position, memory_size
-        )
-
-        increment_nonce(evm.env.state, evm.message.current_target)
-
-        child_message = Message(
-            caller=evm.message.current_target,
-            target=Bytes0(),
-            gas=U256(create_message_gas),
-            value=endowment,
-            data=b"",
-            code=call_data,
-            current_target=contract_address,
-            depth=evm.message.depth + 1,
-            code_address=None,
-            should_transfer_value=True,
-            is_static=False,
-            accessed_addresses=evm.accessed_addresses.copy(),
-            accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        )
-        child_evm = process_create_message(child_message, evm.env)
-        evm.children.append(child_evm)
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-            evm.return_data = child_evm.output
-        else:
-            evm.logs += child_evm.logs
-            evm.accessed_addresses = child_evm.accessed_addresses
-            evm.accessed_storage_keys = child_evm.accessed_storage_keys
-            push(
-                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
-            )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+        evm.logs += child_evm.logs
+        evm.accessed_addresses = child_evm.accessed_addresses
+        evm.accessed_storage_keys = child_evm.accessed_storage_keys
+        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -147,7 +148,7 @@ def create(evm: Evm) -> None:
         get_account(evm.env.state, evm.message.current_target).nonce,
     )
 
-    do_create(
+    generic_create(
         evm, endowment, contract_address, memory_start_position, memory_size
     )
 
@@ -185,7 +186,7 @@ def create2(evm: Evm) -> None:
         memory_read_bytes(evm.memory, memory_start_position, memory_size),
     )
 
-    do_create(
+    generic_create(
         evm, endowment, contract_address, memory_start_position, memory_size
     )
 
@@ -221,7 +222,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -236,7 +237,7 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
@@ -245,50 +246,49 @@ def do_call(
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
-    else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-            should_transfer_value=should_transfer_value,
-            is_static=True if is_staticcall else evm.message.is_static,
-            accessed_addresses=evm.accessed_addresses.copy(),
-            accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        return
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-            if isinstance(child_evm.error, Revert):
-                evm.return_data = child_evm.output
-        else:
-            evm.logs += child_evm.logs
-            evm.accessed_addresses = child_evm.accessed_addresses
-            evm.accessed_storage_keys = child_evm.accessed_storage_keys
-            push(evm.stack, U256(1))
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+        should_transfer_value=should_transfer_value,
+        is_static=True if is_staticcall else evm.message.is_static,
+        accessed_addresses=evm.accessed_addresses.copy(),
+        accessed_storage_keys=evm.accessed_storage_keys.copy(),
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
+        if isinstance(child_evm.error, Revert):
             evm.return_data = child_evm.output
+    else:
+        evm.logs += child_evm.logs
+        evm.accessed_addresses = child_evm.accessed_addresses
+        evm.accessed_storage_keys = child_evm.accessed_storage_keys
+        push(evm.stack, U256(1))
+        evm.return_data = child_evm.output
 
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -349,7 +349,7 @@ def call(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -423,7 +423,7 @@ def callcode(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -533,7 +533,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, call_gas_fee)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         message_call_gas,
         evm.message.value,
@@ -591,7 +591,7 @@ def staticcall(evm: Evm) -> None:
     charge_gas(evm, call_gas_fee)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         message_call_gas,
         U256(0),

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -34,7 +34,7 @@ from ..state import (
 )
 from ..utils.address import to_address
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -110,7 +110,7 @@ def process_message_call(
         evm = process_message(message, env)
 
     accounts_to_delete = collect_accounts_to_delete(evm)
-    refund_counter = (
+    refund_counter = U256(
         calculate_gas_refund(evm)
         + len(accounts_to_delete) * REFUND_SELF_DESTRUCT
     )
@@ -138,47 +138,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.berlin.vm.Evm`
-        Items containing execution specific objects.
-    """
-    # take snapshot of state before processing the message
-    begin_transaction(env.state)
-
-    increment_nonce(env.state, message.current_target)
-    evm = process_message(message, env)
-    if not evm.has_erred:
-        contract_code = evm.output
-        contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
-        try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
-            ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
-            rollback_transaction(env.state)
-            evm.gas_left = U256(0)
-            evm.output = b""
-            evm.has_erred = True
-        else:
-            set_code(env.state, message.current_target, contract_code)
-            commit_transaction(env.state)
-    else:
-        rollback_transaction(env.state)
-    return evm
-
-
-def process_create2_message(message: Message, env: Environment) -> Evm:
-    """
-    Executes a call to create a smart contract via CREATE2 opcode.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-    env :
-        External items required for EVM execution.
-
-    Returns
-    -------
-    evm: :py:class:`~ethereum.berlin.vm.Evm`
+    evm: :py:class:`~ethereum.constantinople.vm.Evm`
         Items containing execution specific objects.
     """
     # take snapshot of state before processing the message
@@ -195,9 +155,9 @@ def process_create2_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except OutOfGasError:
+        except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)
             evm.output = b""
@@ -223,7 +183,7 @@ def process_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.berlin.vm.Evm`
+    evm: :py:class:`~ethereum.constantinople.vm.Evm`
         Items containing execution specific objects
     """
     if message.depth > STACK_DEPTH_LIMIT:

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -138,7 +138,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.berlin.vm.Evm`
         Items containing execution specific objects.
     """
     # take snapshot of state before processing the message
@@ -183,7 +183,7 @@ def process_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.berlin.vm.Evm`
         Items containing execution specific objects
     """
     if message.depth > STACK_DEPTH_LIMIT:

--- a/src/ethereum/berlin/vm/memory.py
+++ b/src/ethereum/berlin/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/berlin/vm/precompiled_contracts/blake2f.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/blake2f.py
@@ -15,7 +15,7 @@ from ethereum.crypto.blake2 import Blake2b
 from ethereum.utils.ensure import ensure
 
 from ...vm import Evm
-from ...vm.gas import GAS_BLAKE2_PER_ROUND, subtract_gas
+from ...vm.gas import GAS_BLAKE2_PER_ROUND, charge_gas
 from ..exceptions import InvalidParameter
 
 
@@ -30,15 +30,15 @@ def blake2f(evm: Evm) -> None:
     """
     data = evm.message.data
 
+    # GAS
     ensure(len(data) == 213, InvalidParameter)
 
     blake2b = Blake2b()
     rounds, h, m, t_0, t_1, f = blake2b.get_blake2_parameters(data)
 
+    charge_gas(evm, GAS_BLAKE2_PER_ROUND * rounds)
+
+    # OPERATION
     ensure(f in [0, 1], InvalidParameter)
-
-    total_gas_cost = GAS_BLAKE2_PER_ROUND * rounds
-
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
 
     evm.output = blake2b.compress(rounds, h, m, t_0, t_1, f)

--- a/src/ethereum/berlin/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/berlin/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/byzantium/state.py
+++ b/src/ethereum/byzantium/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -181,6 +181,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -195,6 +196,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -211,10 +213,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -102,7 +102,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -13,75 +13,75 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(200)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(400)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
-GAS_RETURN_DATA_COPY = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(200)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(400)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
+GAS_RETURN_DATA_COPY = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -72,7 +72,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -94,7 +94,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -102,14 +102,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -124,18 +124,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -143,8 +143,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -160,7 +160,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -168,24 +168,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -200,36 +195,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/byzantium/vm/instructions/arithmetic.py
+++ b/src/ethereum/byzantium/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/bitwise.py
+++ b/src/ethereum/byzantium/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/block.py
+++ b/src/ethereum/byzantium/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/comparison.py
+++ b/src/ethereum/byzantium/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/control_flow.py
+++ b/src/ethereum/byzantium/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/byzantium/vm/instructions/control_flow.py
+++ b/src/ethereum/byzantium/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -402,7 +402,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
     # STACK

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -13,16 +13,14 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfBoundsRead, OutOfGasError
+from ..exceptions import OutOfBoundsRead
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
@@ -30,8 +28,7 @@ from ..gas import (
     GAS_EXTERNAL,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -50,9 +47,16 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,17 +76,19 @@ def balance(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -101,9 +107,16 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -121,9 +134,16 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -141,9 +161,16 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -164,17 +191,18 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -192,9 +220,16 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -215,42 +250,23 @@ def calldatacopy(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -267,9 +283,16 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,43 +313,23 @@ def codecopy(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -343,9 +346,16 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -365,17 +375,19 @@ def extcodesize(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -390,51 +402,28 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def returndatasize(evm: Evm) -> None:
@@ -446,9 +435,16 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    return_size = U256(len(evm.return_data))
-    push(evm.stack, return_size)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.return_data)))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -461,34 +457,27 @@ def returndatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
-    return_data_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    return_data_start_position = pop(evm.stack)
     size = pop(evm.stack)
+
+    # GAS
+    words = ceil32(Uint(size)) // 32
+    copy_gas_cost = GAS_RETURN_DATA_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+
+    # OPERATION
     ensure(
-        return_data_start_position + size <= len(evm.return_data),
+        Uint(return_data_start_position) + Uint(size) <= len(evm.return_data),
         OutOfBoundsRead,
     )
 
-    words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_RETURN_DATA_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/byzantium/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -89,6 +89,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -40,7 +40,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -13,20 +13,13 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError, WriteInStaticContext
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..exceptions import WriteInStaticContext
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -47,40 +40,24 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/byzantium/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/byzantium/vm/instructions/stack.py
+++ b/src/ethereum/byzantium/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/byzantium/vm/instructions/storage.py
+++ b/src/ethereum/byzantium/vm/instructions/storage.py
@@ -21,7 +21,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -43,13 +43,18 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/byzantium/vm/instructions/storage.py
+++ b/src/ethereum/byzantium/vm/instructions/storage.py
@@ -38,9 +38,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
     # STACK
@@ -69,9 +69,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
     # STACK

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -16,7 +16,6 @@ from ethereum.utils.ensure import ensure
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -310,17 +309,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -20,7 +20,7 @@ from ...state import (
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
-    is_account_empty,
+    is_account_alive,
     set_account_balance,
 )
 from ...utils.address import compute_contract_address, to_address
@@ -241,11 +241,10 @@ def call(evm: Evm) -> None:
     # GAS
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    is_account_alive = account_exists(
-        evm.env.state, to
-    ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0)
+        if value == 0 or is_account_alive(evm.env.state, to)
+        else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
@@ -366,12 +365,8 @@ def selfdestruct(evm: Evm) -> None:
     beneficiary = to_address(pop(evm.stack))
 
     # GAS
-    is_dead_account = not account_exists(
-        evm.env.state, beneficiary
-    ) or is_account_empty(evm.env.state, beneficiary)
-
     if (
-        is_dead_account
+        not is_account_alive(evm.env.state, beneficiary)
         and get_account(evm.env.state, evm.message.current_target).balance != 0
     ):
         charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -13,8 +13,8 @@ Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -25,7 +25,7 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
+from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -56,81 +56,75 @@ def create(evm: Evm) -> None:
     # if it's not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.return_data = b""
+
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
         push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+            is_static=False,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -169,6 +163,7 @@ def do_call(
     to: Address,
     code_address: Address,
     should_transfer_value: bool,
+    is_staticcall: bool,
     memory_input_start_position: U256,
     memory_input_size: U256,
     memory_output_start_position: U256,
@@ -178,6 +173,8 @@ def do_call(
     Do a message-call. Used by all the `CALL*` opcode family.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    evm.return_data = b""
 
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
@@ -198,15 +195,19 @@ def do_call(
             depth=evm.message.depth + 1,
             code_address=code_address,
             should_transfer_value=should_transfer_value,
+            is_static=True if is_staticcall else evm.message.is_static,
         )
         child_evm = process_message(child_message, evm.env)
         evm.children.append(child_evm)
 
         if child_evm.has_erred:
             push(evm.stack, U256(0))
+            if isinstance(child_evm.error, Revert):
+                evm.return_data = child_evm.output
         else:
             evm.logs += child_evm.logs
             push(evm.stack, U256(1))
+            evm.return_data = child_evm.output
 
         actual_output_size = min(
             memory_output_size, U256(len(child_evm.output))
@@ -229,102 +230,63 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     is_account_alive = account_exists(
         evm.env.state, to
     ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        U256(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
     )
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
+    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -336,92 +298,60 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -433,22 +363,28 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
-    originator = evm.message.current_target
-    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
-    originator_balance = get_account(evm.env.state, originator).balance
-
+    # GAS
     is_dead_account = not account_exists(
         evm.env.state, beneficiary
     ) or is_account_empty(evm.env.state, beneficiary)
 
-    if is_dead_account and originator_balance != 0:
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    if (
+        is_dead_account
+        and get_account(evm.env.state, evm.message.current_target).balance != 0
+    ):
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+
+    originator = evm.message.current_target
+    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
+    originator_balance = get_account(evm.env.state, originator).balance
 
     # First Transfer to beneficiary
     set_account_balance(
@@ -465,207 +401,125 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def staticcall(evm: Evm) -> None:
     """
-    Make a static message-call into an account that prevents all
-    state modifying operations.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0),
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    create_gas_cost = U256(0)
-    transfer_gas_cost = U256(0)
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        U256(0), gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=U256(0),
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        U256(0),
+        evm.message.current_target,
+        to,
+        to,
+        True,
+        True,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def revert(evm: Evm) -> None:
     """
     Stop execution and revert state changes, without consuming all provided gas
     and also has the ability to return a reason
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, memory_extend_gas_cost)
-    extend_memory(evm.memory, memory_start_index, size)
+    # GAS
+    extend_memory(evm, memory_start_index, size)
 
+    # OPERATION
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert
+
+    # PROGRAM COUNTER
+    pass

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -155,7 +155,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -170,7 +170,7 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
@@ -179,46 +179,45 @@ def do_call(
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
-    else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-            should_transfer_value=should_transfer_value,
-            is_static=True if is_staticcall else evm.message.is_static,
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        return
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-            if isinstance(child_evm.error, Revert):
-                evm.return_data = child_evm.output
-        else:
-            evm.logs += child_evm.logs
-            push(evm.stack, U256(1))
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+        should_transfer_value=should_transfer_value,
+        is_static=True if is_staticcall else evm.message.is_static,
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
+        if isinstance(child_evm.error, Revert):
             evm.return_data = child_evm.output
+    else:
+        evm.logs += child_evm.logs
+        push(evm.stack, U256(1))
+        evm.return_data = child_evm.output
 
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -270,7 +269,7 @@ def call(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -335,7 +334,7 @@ def callcode(evm: Evm) -> None:
         evm.return_data = b""
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -432,7 +431,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, call_gas_fee)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         message_call_gas,
         evm.message.value,
@@ -481,7 +480,7 @@ def staticcall(evm: Evm) -> None:
     charge_gas(evm, call_gas_fee)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         message_call_gas,
         U256(0),

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -33,7 +33,7 @@ from ..state import (
 )
 from ..utils.address import to_address
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -149,7 +149,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)

--- a/src/ethereum/byzantium/vm/memory.py
+++ b/src/ethereum/byzantium/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/byzantium/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/alt_bn128.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementation of the ALT_BN128 precompiled contracts.
 """
-from ethereum.base_types import U256
+from ethereum.base_types import U256, Uint
 from ethereum.crypto.alt_bn128 import (
     ALT_BN128_CURVE_ORDER,
     ALT_BN128_PRIME,
@@ -22,11 +22,11 @@ from ethereum.crypto.alt_bn128 import (
     BNP2,
     pairing,
 )
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 
 from ...vm import Evm
-from ...vm.gas import subtract_gas
+from ...vm.gas import charge_gas
+from ...vm.memory import buffer_read
 from ..exceptions import OutOfGasError
 
 
@@ -39,13 +39,19 @@ def alt_bn128_add(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    x0_bytes = right_pad_zero_bytes(evm.message.data[:32], 32)
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(500))
+
+    # OPERATION
+    x0_bytes = buffer_read(data, U256(0), U256(32))
     x0_value = U256.from_be_bytes(x0_bytes)
-    y0_bytes = right_pad_zero_bytes(evm.message.data[32:64], 32)
+    y0_bytes = buffer_read(data, U256(32), U256(32))
     y0_value = U256.from_be_bytes(y0_bytes)
-    x1_bytes = right_pad_zero_bytes(evm.message.data[64:96], 32)
+    x1_bytes = buffer_read(data, U256(64), U256(32))
     x1_value = U256.from_be_bytes(x1_bytes)
-    y1_bytes = right_pad_zero_bytes(evm.message.data[96:128], 32)
+    y1_bytes = buffer_read(data, U256(96), U256(32))
     y1_value = U256.from_be_bytes(y1_bytes)
 
     for i in (x0_value, y0_value, x1_value, y1_value):
@@ -60,7 +66,6 @@ def alt_bn128_add(evm: Evm) -> None:
 
     p = p0 + p1
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(500))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -73,11 +78,17 @@ def alt_bn128_mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    x0_bytes = right_pad_zero_bytes(evm.message.data[:32], 32)
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(40000))
+
+    # OPERATION
+    x0_bytes = buffer_read(data, U256(0), U256(32))
     x0_value = U256.from_be_bytes(x0_bytes)
-    y0_bytes = right_pad_zero_bytes(evm.message.data[32:64], 32)
+    y0_bytes = buffer_read(data, U256(32), U256(32))
     y0_value = U256.from_be_bytes(y0_bytes)
-    n = U256.from_be_bytes(right_pad_zero_bytes(evm.message.data[64:96], 32))
+    n = U256.from_be_bytes(buffer_read(data, U256(64), U256(32)))
 
     for i in (x0_value, y0_value):
         if i >= ALT_BN128_PRIME:
@@ -90,7 +101,6 @@ def alt_bn128_mul(evm: Evm) -> None:
 
     p = p0.mul_by(n)
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(40000))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -103,17 +113,20 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    if len(evm.message.data) % 192 != 0:
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(80000 * (len(data) // 192) + 100000))
+
+    # OPERATION
+    if len(data) % 192 != 0:
         raise OutOfGasError
-    evm.gas_left = subtract_gas(
-        evm.gas_left, U256(80000 * (len(evm.message.data) // 192) + 100000)
-    )
     result = BNF12.from_int(1)
-    for i in range(len(evm.message.data) // 192):
+    for i in range(len(data) // 192):
         values = []
         for j in range(6):
             value = U256.from_be_bytes(
-                evm.message.data[i * 192 + 32 * j : i * 192 + 32 * (j + 1)]
+                data[i * 192 + 32 * j : i * 192 + 32 * (j + 1)]
             )
             if value >= ALT_BN128_PRIME:
                 raise OutOfGasError

--- a/src/ethereum/byzantium/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/byzantium/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/constantinople/state.py
+++ b/src/ethereum/constantinople/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -73,7 +73,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -182,6 +182,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -196,6 +197,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -212,10 +214,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -13,76 +13,76 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(200)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(400)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
-GAS_RETURN_DATA_COPY = U256(3)
-GAS_CODE_HASH = U256(400)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(200)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(400)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
+GAS_RETURN_DATA_COPY = Uint(3)
+GAS_CODE_HASH = Uint(400)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -95,7 +95,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -103,14 +103,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -125,18 +125,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -144,8 +144,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -161,7 +161,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -169,24 +169,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -201,36 +196,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -103,7 +103,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/constantinople/vm/instructions/arithmetic.py
+++ b/src/ethereum/constantinople/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/bitwise.py
+++ b/src/ethereum/constantinople/vm/instructions/bitwise.py
@@ -262,7 +262,7 @@ def bitwise_sar(evm: Evm) -> None:
     elif signed_value >= 0:
         result = U256(0)
     else:
-        result = U256(U256.MAX_VALUE)
+        result = U256.MAX_VALUE
 
     push(evm.stack, result)
 

--- a/src/ethereum/constantinople/vm/instructions/bitwise.py
+++ b/src/ethereum/constantinople/vm/instructions/bitwise.py
@@ -31,9 +31,9 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -62,9 +62,9 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -93,9 +93,9 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -124,9 +124,9 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -155,9 +155,9 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK

--- a/src/ethereum/constantinople/vm/instructions/bitwise.py
+++ b/src/ethereum/constantinople/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256, U256_CEIL_VALUE
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,6 +180,7 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/constantinople/vm/instructions/bitwise.py
+++ b/src/ethereum/constantinople/vm/instructions/bitwise.py
@@ -202,9 +202,11 @@ def bitwise_shl(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+        result = U256((value << shift) % U256_CEIL_VALUE)
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -228,9 +230,11 @@ def bitwise_shr(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, value >> shift)
+        result = value >> shift
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -254,11 +258,13 @@ def bitwise_sar(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256.from_signed(signed_value >> shift))
+        result = U256.from_signed(signed_value >> shift)
     elif signed_value >= 0:
-        push(evm.stack, U256(0))
+        result = U256(0)
     else:
-        push(evm.stack, U256(U256.MAX_VALUE))
+        result = U256(U256.MAX_VALUE)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/block.py
+++ b/src/ethereum/constantinople/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/comparison.py
+++ b/src/ethereum/constantinople/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/control_flow.py
+++ b/src/ethereum/constantinople/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/control_flow.py
+++ b/src/ethereum/constantinople/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/constantinople/vm/instructions/environment.py
@@ -504,9 +504,11 @@ def extcodehash(evm: Evm) -> None:
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
-        push(evm.stack, U256(0))
+        codehash = U256(0)
     else:
-        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+        codehash = U256.from_be_bytes(keccak256(account.code))
+
+    push(evm.stack, codehash)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/constantinople/vm/instructions/environment.py
@@ -47,7 +47,7 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -74,9 +74,9 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -107,7 +107,7 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -134,7 +134,7 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -161,7 +161,7 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -189,9 +189,9 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
     # STACK
@@ -220,7 +220,7 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -250,7 +250,7 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -283,7 +283,7 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -313,7 +313,7 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -346,7 +346,7 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -373,9 +373,9 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -405,7 +405,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
     # STACK

--- a/src/ethereum/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/constantinople/vm/instructions/environment.py
@@ -14,17 +14,15 @@ Implementations of the EVM environment related instructions.
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfBoundsRead, OutOfGasError
+from ..exceptions import OutOfBoundsRead
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
@@ -33,8 +31,7 @@ from ..gas import (
     GAS_EXTERNAL,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -50,12 +47,19 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,22 +74,24 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -101,12 +107,19 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -121,12 +134,19 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -141,12 +161,19 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,22 +189,23 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -192,12 +220,19 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -215,45 +250,26 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -267,12 +283,19 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,46 +313,26 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -343,12 +346,19 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -363,22 +373,24 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -393,51 +405,28 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def returndatasize(evm: Evm) -> None:
@@ -449,9 +438,16 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    return_size = U256(len(evm.return_data))
-    push(evm.stack, return_size)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.return_data)))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -464,59 +460,53 @@ def returndatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
-    return_data_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    return_data_start_position = pop(evm.stack)
     size = pop(evm.stack)
+
+    # GAS
+    words = ceil32(Uint(size)) // 32
+    copy_gas_cost = GAS_RETURN_DATA_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+
+    # OPERATION
     ensure(
-        return_data_start_position + size <= len(evm.return_data),
+        Uint(return_data_start_position) + Uint(size) <= len(evm.return_data),
         OutOfBoundsRead,
     )
 
-    words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_RETURN_DATA_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
 def extcodehash(evm: Evm) -> None:
     """
     Returns the keccak256 hash of a contract’s bytecode
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
+    # STACK
     address = to_address(pop(evm.stack))
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CODE_HASH)
+    # GAS
+    charge_gas(evm, GAS_CODE_HASH)
 
-    evm.pc += 1
-
+    # OPERATION
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
         push(evm.stack, U256(0))
     else:
-        code = account.code
-        code_hash = keccak256(code)
-        push(evm.stack, U256.from_be_bytes(code_hash))
+        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/keccak.py
+++ b/src/ethereum/constantinople/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/log.py
+++ b/src/ethereum/constantinople/vm/instructions/log.py
@@ -40,7 +40,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK

--- a/src/ethereum/constantinople/vm/instructions/log.py
+++ b/src/ethereum/constantinople/vm/instructions/log.py
@@ -13,20 +13,13 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError, WriteInStaticContext
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..exceptions import WriteInStaticContext
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -47,40 +40,24 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -89,6 +66,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/constantinople/vm/instructions/memory.py
+++ b/src/ethereum/constantinople/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/constantinople/vm/instructions/memory.py
+++ b/src/ethereum/constantinople/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/stack.py
+++ b/src/ethereum/constantinople/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/constantinople/vm/instructions/storage.py
+++ b/src/ethereum/constantinople/vm/instructions/storage.py
@@ -21,7 +21,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -38,18 +38,23 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,31 +69,30 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # TODO: SSTORE gas usage hasn't been tested yet. Testing this needs
-    # other opcodes to be implemented.
-    # Calculating the gas needed for the storage
+    # GAS
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
     if new_value != 0 and current_value == 0:
         gas_cost = GAS_STORAGE_SET
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    charge_gas(evm, gas_cost)
 
-    # TODO: Refund counter hasn't been tested yet. Testing this needs other
-    # Opcodes to be implemented
     if new_value == 0 and current_value != 0:
         evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/storage.py
+++ b/src/ethereum/constantinople/vm/instructions/storage.py
@@ -38,9 +38,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
     # STACK
@@ -69,9 +69,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
     # STACK

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -14,8 +14,8 @@ Implementations of the EVM system related instructions.
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -30,7 +30,7 @@ from ...utils.address import (
     to_address,
 )
 from .. import Evm, Message
-from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
+from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -41,13 +41,79 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
+
+
+def do_create(
+    evm: Evm,
+    endowment: U256,
+    contract_address: Address,
+    memory_start_position: U256,
+    memory_size: U256,
+) -> None:
+    """
+    Common code shared between both types of CREATE*.
+    """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.return_data = b""
+
+    sender_address = evm.message.current_target
+    sender = get_account(evm.env.state, sender_address)
+
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+            is_static=False,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -59,85 +125,27 @@ def create(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def create2(evm: Evm) -> None:
@@ -152,95 +160,30 @@ def create2(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create2_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
     salt = pop(evm.stack).to_be_bytes32()
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
     call_data_words = ceil32(Uint(memory_size)) // 32
-    hash_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        call_data_words,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        hash_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
-        call_data,
+        memory_read_bytes(evm.memory, memory_start_position, memory_size),
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create2_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-        evm.logs += child_evm.logs
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -252,18 +195,89 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    is_staticcall: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    evm.return_data = b""
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+            is_static=True if is_staticcall else evm.message.is_static,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            if isinstance(child_evm.error, Revert):
+                evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+            evm.return_data = child_evm.output
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -275,102 +289,63 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     is_account_alive = account_exists(
         evm.env.state, to
     ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        U256(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
     )
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
+    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -382,92 +357,60 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -479,22 +422,28 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
-    originator = evm.message.current_target
-    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
-    originator_balance = get_account(evm.env.state, originator).balance
-
+    # GAS
     is_dead_account = not account_exists(
         evm.env.state, beneficiary
     ) or is_account_empty(evm.env.state, beneficiary)
 
-    if is_dead_account and originator_balance != 0:
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    if (
+        is_dead_account
+        and get_account(evm.env.state, evm.message.current_target).balance != 0
+    ):
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+
+    originator = evm.message.current_target
+    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
+    originator_balance = get_account(evm.env.state, originator).balance
 
     # First Transfer to beneficiary
     set_account_balance(
@@ -511,207 +460,125 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def staticcall(evm: Evm) -> None:
     """
-    Make a static message-call into an account that prevents all
-    state modifying operations.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0),
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    create_gas_cost = U256(0)
-    transfer_gas_cost = U256(0)
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        U256(0), gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=U256(0),
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        U256(0),
+        evm.message.current_target,
+        to,
+        to,
+        True,
+        True,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def revert(evm: Evm) -> None:
     """
     Stop execution and revert state changes, without consuming all provided gas
     and also has the ability to return a reason
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, memory_extend_gas_cost)
-    extend_memory(evm.memory, memory_start_index, size)
+    # GAS
+    extend_memory(evm, memory_start_index, size)
 
+    # OPERATION
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert
+
+    # PROGRAM COUNTER
+    pass

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -56,7 +56,7 @@ def generic_create(
     memory_size: U256,
 ) -> None:
     """
-    Core logic used by the `CREATE* family of opcodes.
+    Core logic used by the `CREATE*` family of opcodes.
     """
     # This import causes a circular import error
     # if it's not moved inside this method

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -17,7 +17,6 @@ from ethereum.utils.numeric import ceil32
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -370,17 +369,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -34,7 +34,7 @@ from ..state import (
 )
 from ..utils.address import to_address
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -150,7 +150,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -144,46 +144,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(env.state)
 
-    increment_nonce(env.state, message.current_target)
-    evm = process_message(message, env)
-    if not evm.has_erred:
-        contract_code = evm.output
-        contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
-        try:
-            charge_gas(evm, contract_code_gas)
-            ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
-            rollback_transaction(env.state)
-            evm.gas_left = U256(0)
-            evm.output = b""
-            evm.has_erred = True
-        else:
-            set_code(env.state, message.current_target, contract_code)
-            commit_transaction(env.state)
-    else:
-        rollback_transaction(env.state)
-    return evm
-
-
-def process_create2_message(message: Message, env: Environment) -> Evm:
-    """
-    Executes a call to create a smart contract via CREATE2 opcode.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-    env :
-        External items required for EVM execution.
-
-    Returns
-    -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
-        Items containing execution specific objects.
-    """
-    # take snapshot of state before processing the message
-    begin_transaction(env.state)
-
     # It's expected that the creation operation works on empty storage. Hence
     # we delete the storage and restore the account's state if there is an
     # error in the initialization code execution.
@@ -195,9 +155,9 @@ def process_create2_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except OutOfGasError:
+        except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)
             evm.output = b""

--- a/src/ethereum/constantinople/vm/memory.py
+++ b/src/ethereum/constantinople/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/constantinople/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/alt_bn128.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementation of the ALT_BN128 precompiled contracts.
 """
-from ethereum.base_types import U256
+from ethereum.base_types import U256, Uint
 from ethereum.crypto.alt_bn128 import (
     ALT_BN128_CURVE_ORDER,
     ALT_BN128_PRIME,
@@ -22,11 +22,11 @@ from ethereum.crypto.alt_bn128 import (
     BNP2,
     pairing,
 )
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 
 from ...vm import Evm
-from ...vm.gas import subtract_gas
+from ...vm.gas import charge_gas
+from ...vm.memory import buffer_read
 from ..exceptions import OutOfGasError
 
 
@@ -39,13 +39,19 @@ def alt_bn128_add(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    x0_bytes = right_pad_zero_bytes(evm.message.data[:32], 32)
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(500))
+
+    # OPERATION
+    x0_bytes = buffer_read(data, U256(0), U256(32))
     x0_value = U256.from_be_bytes(x0_bytes)
-    y0_bytes = right_pad_zero_bytes(evm.message.data[32:64], 32)
+    y0_bytes = buffer_read(data, U256(32), U256(32))
     y0_value = U256.from_be_bytes(y0_bytes)
-    x1_bytes = right_pad_zero_bytes(evm.message.data[64:96], 32)
+    x1_bytes = buffer_read(data, U256(64), U256(32))
     x1_value = U256.from_be_bytes(x1_bytes)
-    y1_bytes = right_pad_zero_bytes(evm.message.data[96:128], 32)
+    y1_bytes = buffer_read(data, U256(96), U256(32))
     y1_value = U256.from_be_bytes(y1_bytes)
 
     for i in (x0_value, y0_value, x1_value, y1_value):
@@ -60,7 +66,6 @@ def alt_bn128_add(evm: Evm) -> None:
 
     p = p0 + p1
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(500))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -73,11 +78,17 @@ def alt_bn128_mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    x0_bytes = right_pad_zero_bytes(evm.message.data[:32], 32)
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(40000))
+
+    # OPERATION
+    x0_bytes = buffer_read(data, U256(0), U256(32))
     x0_value = U256.from_be_bytes(x0_bytes)
-    y0_bytes = right_pad_zero_bytes(evm.message.data[32:64], 32)
+    y0_bytes = buffer_read(data, U256(32), U256(32))
     y0_value = U256.from_be_bytes(y0_bytes)
-    n = U256.from_be_bytes(right_pad_zero_bytes(evm.message.data[64:96], 32))
+    n = U256.from_be_bytes(buffer_read(data, U256(64), U256(32)))
 
     for i in (x0_value, y0_value):
         if i >= ALT_BN128_PRIME:
@@ -90,7 +101,6 @@ def alt_bn128_mul(evm: Evm) -> None:
 
     p = p0.mul_by(n)
 
-    evm.gas_left = subtract_gas(evm.gas_left, U256(40000))
     evm.output = p.x.to_be_bytes32() + p.y.to_be_bytes32()
 
 
@@ -103,17 +113,20 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    if len(evm.message.data) % 192 != 0:
+    data = evm.message.data
+
+    # GAS
+    charge_gas(evm, Uint(80000 * (len(data) // 192) + 100000))
+
+    # OPERATION
+    if len(data) % 192 != 0:
         raise OutOfGasError
-    evm.gas_left = subtract_gas(
-        evm.gas_left, U256(80000 * (len(evm.message.data) // 192) + 100000)
-    )
     result = BNF12.from_int(1)
-    for i in range(len(evm.message.data) // 192):
+    for i in range(len(data) // 192):
         values = []
         for j in range(6):
             value = U256.from_be_bytes(
-                evm.message.data[i * 192 + 32 * j : i * 192 + 32 * (j + 1)]
+                data[i * 192 + 32 * j : i * 192 + 32 * (j + 1)]
             )
             if value >= ALT_BN128_PRIME:
                 raise OutOfGasError

--- a/src/ethereum/constantinople/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/constantinople/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -163,8 +163,7 @@ def calculate_call_gas_cost(
     call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
-    _account_exists = account_exists(state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -101,7 +101,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -13,59 +13,59 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ..eth_types import Address
 from ..state import State, account_exists
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(50)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(10)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(20)
-GAS_BALANCE = U256(20)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(40)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(50)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(10)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(20)
+GAS_BALANCE = Uint(20)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(40)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,13 +74,13 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -93,7 +93,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -101,14 +101,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -123,18 +123,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -142,8 +142,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    state: State, gas: U256, to: Address, value: U256
-) -> U256:
+    state: State, gas: Uint, to: Address, value: U256
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -160,22 +160,16 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     _account_exists = account_exists(state, to)
-    create_gas_cost = U256(0) if _account_exists else GAS_NEW_ACCOUNT
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    return u256_safe_add(
-        GAS_CALL,
-        gas,
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 
 
-def calculate_message_call_gas_stipend(value: U256) -> U256:
+def calculate_message_call_gas_stipend(value: U256) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
@@ -186,7 +180,7 @@ def calculate_message_call_gas_stipend(value: U256) -> U256:
         The amount of `ETH` that needs to be transferred.
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
-    return U256(0) if value == 0 else GAS_CALL_STIPEND
+    return Uint(0) if value == 0 else GAS_CALL_STIPEND

--- a/src/ethereum/dao_fork/vm/instructions/arithmetic.py
+++ b/src/ethereum/dao_fork/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/bitwise.py
+++ b/src/ethereum/dao_fork/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/block.py
+++ b/src/ethereum/dao_fork/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/comparison.py
+++ b/src/ethereum/dao_fork/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/control_flow.py
+++ b/src/ethereum/dao_fork/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/dao_fork/vm/instructions/control_flow.py
+++ b/src/ethereum/dao_fork/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -13,23 +13,19 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -48,9 +44,16 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,17 +73,19 @@ def balance(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +104,16 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -119,9 +131,16 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -139,9 +158,16 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,17 +188,18 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -190,9 +217,16 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -213,42 +247,23 @@ def calldatacopy(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -265,9 +280,16 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -288,43 +310,23 @@ def codecopy(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -341,9 +343,16 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -363,17 +372,19 @@ def extcodesize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -391,45 +402,22 @@ def extcodecopy(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/dao_fork/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -13,19 +13,11 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
+from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -49,36 +41,20 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -87,6 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/dao_fork/vm/instructions/stack.py
+++ b/src/ethereum/dao_fork/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/dao_fork/vm/instructions/storage.py
+++ b/src/ethereum/dao_fork/vm/instructions/storage.py
@@ -19,7 +19,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -41,13 +41,18 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -67,25 +72,24 @@ def sstore(evm: Evm) -> None:
     :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # TODO: SSTORE gas usage hasn't been tested yet. Testing this needs
-    # other opcodes to be implemented.
-    # Calculating the gas needed for the storage
+    # GAS
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
     if new_value != 0 and current_value == 0:
         gas_cost = GAS_STORAGE_SET
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    charge_gas(evm, gas_cost)
 
-    # TODO: Refund counter hasn't been tested yet. Testing this needs other
-    # Opcodes to be implemented
     if new_value == 0 and current_value != 0:
         evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
+    # OPERATION
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -141,7 +141,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -155,49 +155,48 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
+        return
+
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+        should_transfer_value=should_transfer_value,
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
     else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-            should_transfer_value=should_transfer_value,
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        evm.logs += child_evm.logs
+        push(evm.stack, U256(1))
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-        else:
-            evm.logs += child_evm.logs
-            push(evm.stack, U256(1))
-
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -233,7 +232,7 @@ def call(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -286,7 +285,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -366,7 +365,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, GAS_CALL + gas)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         gas,
         evm.message.value,

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -22,7 +22,6 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import ExceptionalHalt
 from ..gas import (
     GAS_CALL,
     GAS_CREATE,
@@ -77,7 +76,8 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
     elif account_has_code_or_nonce(evm.env.state, contract_address):
-        raise ExceptionalHalt
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
     else:
         call_data = memory_read_bytes(
             evm.memory, memory_start_position, memory_size

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -12,8 +12,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...eth_types import Address
 from ...state import (
     account_has_code_or_nonce,
     get_account,
@@ -22,15 +22,14 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import OutOfGasError
+from ..exceptions import ExceptionalHalt
 from ..gas import (
     GAS_CALL,
     GAS_CREATE,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
-    subtract_gas,
+    charge_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -49,76 +48,69 @@ def create(evm: Evm) -> None:
     # if it's not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
+
+    create_message_gas = evm.gas_left
+    evm.gas_left = U256(0)
+
+    # OPERATION
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
-    evm.pc += 1
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
         push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        raise ExceptionalHalt
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left = child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=create_message_gas,
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left = child_evm.gas_left
+        child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -130,18 +122,82 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -153,83 +209,46 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    charge_gas(evm, call_gas_fee)
 
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
+    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -241,83 +260,48 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    charge_gas(evm, call_gas_fee)
 
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
+    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -329,7 +313,13 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
     beneficiary = to_address(pop(evm.stack))
+
+    # GAS
+    pass
+
+    # OPERATION
     originator = evm.message.current_target
     beneficiary_balance = get_account(evm.env.state, beneficiary).balance
     originator_balance = get_account(evm.env.state, originator).balance
@@ -349,79 +339,46 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    charge_gas(evm, GAS_CALL + gas)
 
-    call_gas_fee = u256_safe_add(GAS_CALL, gas, exception_type=OutOfGasError)
-    message_call_gas_fee = gas
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -30,7 +30,7 @@ from ..state import (
     touch_account,
 )
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/dao_fork/vm/memory.py
+++ b/src/ethereum/dao_fork/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -13,59 +13,59 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ..eth_types import Address
 from ..state import State, account_exists
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(50)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(10)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(20)
-GAS_BALANCE = U256(20)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(40)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(50)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(10)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(20)
+GAS_BALANCE = Uint(20)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(40)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,13 +74,13 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -93,7 +93,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -101,14 +101,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -123,18 +123,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -142,8 +142,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    state: State, gas: U256, to: Address, value: U256
-) -> U256:
+    state: State, gas: Uint, to: Address, value: U256
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -160,22 +160,16 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     _account_exists = account_exists(state, to)
-    create_gas_cost = U256(0) if _account_exists else GAS_NEW_ACCOUNT
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    return u256_safe_add(
-        GAS_CALL,
-        gas,
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 
 
-def calculate_message_call_gas_stipend(value: U256) -> U256:
+def calculate_message_call_gas_stipend(value: U256) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
@@ -186,7 +180,7 @@ def calculate_message_call_gas_stipend(value: U256) -> U256:
         The amount of `ETH` that needs to be transferred.
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
-    return U256(0) if value == 0 else GAS_CALL_STIPEND
+    return Uint(0) if value == 0 else GAS_CALL_STIPEND

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -163,8 +163,7 @@ def calculate_call_gas_cost(
     call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
-    _account_exists = account_exists(state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -101,7 +101,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/frontier/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/bitwise.py
+++ b/src/ethereum/frontier/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/block.py
+++ b/src/ethereum/frontier/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/comparison.py
+++ b/src/ethereum/frontier/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -13,23 +13,19 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -48,9 +44,16 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,17 +73,19 @@ def balance(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +104,16 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -119,9 +131,16 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -139,9 +158,16 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,17 +188,18 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -190,9 +217,16 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -213,42 +247,23 @@ def calldatacopy(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -265,9 +280,16 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -288,43 +310,23 @@ def codecopy(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -341,9 +343,16 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -363,17 +372,19 @@ def extcodesize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -391,45 +402,22 @@ def extcodecopy(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -13,19 +13,11 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
+from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -49,36 +41,20 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -87,6 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -139,7 +139,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -152,48 +152,47 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
+        return
+
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
     else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        evm.logs += child_evm.logs
+        push(evm.stack, U256(1))
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-        else:
-            evm.logs += child_evm.logs
-            push(evm.stack, U256(1))
-
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -229,7 +228,7 @@ def call(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -281,7 +280,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -22,7 +22,6 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import ExceptionalHalt
 from ..gas import (
     GAS_CREATE,
     GAS_ZERO,
@@ -76,7 +75,8 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
     elif account_has_code_or_nonce(evm.env.state, contract_address):
-        raise ExceptionalHalt
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
     else:
         call_data = memory_read_bytes(
             evm.memory, memory_start_position, memory_size

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -30,7 +30,7 @@ from ..state import (
     touch_account,
 )
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -133,7 +133,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             evm.output = b""
         else:

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -13,59 +13,59 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
 from ..eth_types import Address
 from ..state import State, account_exists
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(50)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(10)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(20)
-GAS_BALANCE = U256(20)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(40)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(50)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(10)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(20)
+GAS_BALANCE = Uint(20)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(40)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
@@ -74,13 +74,13 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -93,7 +93,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -101,14 +101,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -123,18 +123,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -142,8 +142,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    state: State, gas: U256, to: Address, value: U256
-) -> U256:
+    state: State, gas: Uint, to: Address, value: U256
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -160,22 +160,16 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     _account_exists = account_exists(state, to)
-    create_gas_cost = U256(0) if _account_exists else GAS_NEW_ACCOUNT
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    return u256_safe_add(
-        GAS_CALL,
-        gas,
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 
 
-def calculate_message_call_gas_stipend(value: U256) -> U256:
+def calculate_message_call_gas_stipend(value: U256) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
@@ -186,7 +180,7 @@ def calculate_message_call_gas_stipend(value: U256) -> U256:
         The amount of `ETH` that needs to be transferred.
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
-    return U256(0) if value == 0 else GAS_CALL_STIPEND
+    return Uint(0) if value == 0 else GAS_CALL_STIPEND

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -163,8 +163,7 @@ def calculate_call_gas_cost(
     call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
-    _account_exists = account_exists(state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
 

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -101,7 +101,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/homestead/vm/instructions/arithmetic.py
+++ b/src/ethereum/homestead/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/bitwise.py
+++ b/src/ethereum/homestead/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/block.py
+++ b/src/ethereum/homestead/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/comparison.py
+++ b/src/ethereum/homestead/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/control_flow.py
+++ b/src/ethereum/homestead/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/homestead/vm/instructions/control_flow.py
+++ b/src/ethereum/homestead/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -13,23 +13,19 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -48,9 +44,16 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,17 +73,19 @@ def balance(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +104,16 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -119,9 +131,16 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -139,9 +158,16 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,17 +188,18 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -190,9 +217,16 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -213,42 +247,23 @@ def calldatacopy(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -265,9 +280,16 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -288,43 +310,23 @@ def codecopy(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -341,9 +343,16 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -363,17 +372,19 @@ def extcodesize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -391,45 +402,22 @@ def extcodecopy(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/homestead/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -13,19 +13,11 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
+from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -49,36 +41,20 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -87,6 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/homestead/vm/instructions/stack.py
+++ b/src/ethereum/homestead/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/homestead/vm/instructions/storage.py
+++ b/src/ethereum/homestead/vm/instructions/storage.py
@@ -19,7 +19,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -41,13 +41,18 @@ def sload(evm: Evm) -> None:
     :py:class:`~:py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError``
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -67,25 +72,24 @@ def sstore(evm: Evm) -> None:
     :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # TODO: SSTORE gas usage hasn't been tested yet. Testing this needs
-    # other opcodes to be implemented.
-    # Calculating the gas needed for the storage
+    # GAS
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
     if new_value != 0 and current_value == 0:
         gas_cost = GAS_STORAGE_SET
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    charge_gas(evm, gas_cost)
 
-    # TODO: Refund counter hasn't been tested yet. Testing this needs other
-    # Opcodes to be implemented
     if new_value == 0 and current_value != 0:
         evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
+    # OPERATION
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -141,7 +141,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -155,49 +155,48 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
+        return
+
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+        should_transfer_value=should_transfer_value,
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
     else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-            should_transfer_value=should_transfer_value,
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        evm.logs += child_evm.logs
+        push(evm.stack, U256(1))
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-        else:
-            evm.logs += child_evm.logs
-            push(evm.stack, U256(1))
-
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -233,7 +232,7 @@ def call(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -286,7 +285,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -366,7 +365,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, GAS_CALL + gas)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         gas,
         evm.message.value,

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -22,7 +22,6 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import ExceptionalHalt
 from ..gas import (
     GAS_CALL,
     GAS_CREATE,
@@ -77,7 +76,8 @@ def create(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += create_message_gas
     elif account_has_code_or_nonce(evm.env.state, contract_address):
-        raise ExceptionalHalt
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
     else:
         call_data = memory_read_bytes(
             evm.memory, memory_start_position, memory_size

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -12,8 +12,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...eth_types import Address
 from ...state import (
     account_has_code_or_nonce,
     get_account,
@@ -22,15 +22,14 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import OutOfGasError
+from ..exceptions import ExceptionalHalt
 from ..gas import (
     GAS_CALL,
     GAS_CREATE,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
-    subtract_gas,
+    charge_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -49,76 +48,69 @@ def create(evm: Evm) -> None:
     # if it's not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
+
+    create_message_gas = evm.gas_left
+    evm.gas_left = U256(0)
+
+    # OPERATION
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
-    evm.pc += 1
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = evm.gas_left
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
         push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        raise ExceptionalHalt
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left = child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=create_message_gas,
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left = child_evm.gas_left
+        child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -130,18 +122,82 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -153,83 +209,46 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    charge_gas(evm, call_gas_fee)
 
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
+    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -241,83 +260,48 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    message_call_gas_fee = u256_safe_add(
-        gas,
-        calculate_message_call_gas_stipend(value),
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    charge_gas(evm, call_gas_fee)
 
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
+    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -329,7 +313,13 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
     beneficiary = to_address(pop(evm.stack))
+
+    # GAS
+    pass
+
+    # OPERATION
     originator = evm.message.current_target
     beneficiary_balance = get_account(evm.env.state, beneficiary).balance
     originator_balance = get_account(evm.env.state, originator).balance
@@ -349,79 +339,46 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    charge_gas(evm, GAS_CALL + gas)
 
-    call_gas_fee = u256_safe_add(GAS_CALL, gas, exception_type=OutOfGasError)
-    message_call_gas_fee = gas
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -30,7 +30,7 @@ from ..state import (
     touch_account,
 )
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/homestead/vm/memory.py
+++ b/src/ethereum/homestead/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/homestead/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/homestead/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/istanbul/state.py
+++ b/src/ethereum/istanbul/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -75,7 +75,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -184,6 +184,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -198,6 +199,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -214,10 +216,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -13,78 +13,78 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(800)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(700)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
-GAS_RETURN_DATA_COPY = U256(3)
-GAS_CODE_HASH = U256(700)
-GAS_FAST_STEP = U256(5)
-GAS_BLAKE2_PER_ROUND = U256(1)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(800)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(700)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
+GAS_RETURN_DATA_COPY = Uint(3)
+GAS_CODE_HASH = Uint(700)
+GAS_FAST_STEP = Uint(5)
+GAS_BLAKE2_PER_ROUND = Uint(1)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -97,7 +97,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -105,14 +105,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -127,18 +127,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -146,8 +146,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -163,7 +163,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -171,24 +171,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -203,36 +198,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -105,7 +105,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/istanbul/vm/instructions/arithmetic.py
+++ b/src/ethereum/istanbul/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/bitwise.py
+++ b/src/ethereum/istanbul/vm/instructions/bitwise.py
@@ -262,7 +262,7 @@ def bitwise_sar(evm: Evm) -> None:
     elif signed_value >= 0:
         result = U256(0)
     else:
-        result = U256(U256.MAX_VALUE)
+        result = U256.MAX_VALUE
 
     push(evm.stack, result)
 

--- a/src/ethereum/istanbul/vm/instructions/bitwise.py
+++ b/src/ethereum/istanbul/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256, U256_CEIL_VALUE
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -31,16 +31,22 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -56,16 +62,22 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -81,16 +93,22 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -106,15 +124,21 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -131,17 +155,19 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,6 +180,7 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -161,68 +188,77 @@ def bitwise_shl(evm: Evm) -> None:
     """
     Logical shift left (SHL) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
     value = pop(evm.stack)
 
-    evm.pc += 1
-    shifted_value = 0
-    if shift < 256:
-        shifted_value = (value << shift) % U256_CEIL_VALUE
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    push(evm.stack, U256(shifted_value))
+    # OPERATION
+    if shift < 256:
+        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+    else:
+        push(evm.stack, U256(0))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def bitwise_shr(evm: Evm) -> None:
     """
     Logical shift right (SHR) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
     value = pop(evm.stack)
 
-    evm.pc += 1
-    shifted_value = U256(0)
-    if shift < 256:
-        shifted_value = value >> shift
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    push(evm.stack, shifted_value)
+    # OPERATION
+    if shift < 256:
+        push(evm.stack, value >> shift)
+    else:
+        push(evm.stack, U256(0))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def bitwise_sar(evm: Evm) -> None:
     """
     Arithmetic shift right (SAR) operation of the top 2 elements of the stack.
     Pushes the result back on the stack.
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     shift = pop(evm.stack)
-    value = pop(evm.stack)
+    signed_value = pop(evm.stack).to_signed()
 
-    signed_value = value.to_signed()
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
 
-    evm.pc += 1
+    # OPERATION
     if shift < 256:
-        shifted_value = signed_value >> shift
+        push(evm.stack, U256.from_signed(signed_value >> shift))
     elif signed_value >= 0:
-        shifted_value = 0
+        push(evm.stack, U256(0))
     else:
-        shifted_value = U256.MAX_VALUE
+        push(evm.stack, U256(U256.MAX_VALUE))
 
-    push(evm.stack, U256.from_signed(shifted_value))
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/bitwise.py
+++ b/src/ethereum/istanbul/vm/instructions/bitwise.py
@@ -31,9 +31,9 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -62,9 +62,9 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -93,9 +93,9 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -124,9 +124,9 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -155,9 +155,9 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK

--- a/src/ethereum/istanbul/vm/instructions/bitwise.py
+++ b/src/ethereum/istanbul/vm/instructions/bitwise.py
@@ -202,9 +202,11 @@ def bitwise_shl(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+        result = U256((value << shift) % U256_CEIL_VALUE)
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -228,9 +230,11 @@ def bitwise_shr(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, value >> shift)
+        result = value >> shift
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -254,11 +258,13 @@ def bitwise_sar(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256.from_signed(signed_value >> shift))
+        result = U256.from_signed(signed_value >> shift)
     elif signed_value >= 0:
-        push(evm.stack, U256(0))
+        result = U256(0)
     else:
-        push(evm.stack, U256(U256.MAX_VALUE))
+        result = U256(U256.MAX_VALUE)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/block.py
+++ b/src/ethereum/istanbul/vm/instructions/block.py
@@ -235,7 +235,14 @@ def chain_id(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.chain_id))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/block.py
+++ b/src/ethereum/istanbul/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,9 +206,16 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/istanbul/vm/instructions/comparison.py
+++ b/src/ethereum/istanbul/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/control_flow.py
+++ b/src/ethereum/istanbul/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/istanbul/vm/instructions/control_flow.py
+++ b/src/ethereum/istanbul/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -505,9 +505,11 @@ def extcodehash(evm: Evm) -> None:
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
-        push(evm.stack, U256(0))
+        codehash = U256(0)
     else:
-        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+        codehash = U256.from_be_bytes(keccak256(account.code))
+
+    push(evm.stack, codehash)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -14,17 +14,15 @@ Implementations of the EVM environment related instructions.
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfBoundsRead, OutOfGasError
+from ..exceptions import OutOfBoundsRead
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
@@ -34,8 +32,7 @@ from ..gas import (
     GAS_FAST_STEP,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -51,12 +48,19 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -71,22 +75,24 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -102,12 +108,19 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -122,12 +135,19 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,12 +162,19 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,22 +190,23 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -193,12 +221,19 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -216,45 +251,26 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -268,12 +284,19 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -291,46 +314,26 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -344,12 +347,19 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -364,22 +374,24 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -394,51 +406,28 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def returndatasize(evm: Evm) -> None:
@@ -450,9 +439,16 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    return_size = U256(len(evm.return_data))
-    push(evm.stack, return_size)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.return_data)))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -465,62 +461,56 @@ def returndatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
-    return_data_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    return_data_start_position = pop(evm.stack)
     size = pop(evm.stack)
+
+    # GAS
+    words = ceil32(Uint(size)) // 32
+    copy_gas_cost = GAS_RETURN_DATA_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+
+    # OPERATION
     ensure(
-        return_data_start_position + size <= len(evm.return_data),
+        Uint(return_data_start_position) + Uint(size) <= len(evm.return_data),
         OutOfBoundsRead,
     )
 
-    words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_RETURN_DATA_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
 def extcodehash(evm: Evm) -> None:
     """
     Returns the keccak256 hash of a contract’s bytecode
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
+    # STACK
     address = to_address(pop(evm.stack))
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CODE_HASH)
+    # GAS
+    charge_gas(evm, GAS_CODE_HASH)
 
-    evm.pc += 1
-
+    # OPERATION
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
         push(evm.stack, U256(0))
     else:
-        code = account.code
-        code_hash = keccak256(code)
-        push(evm.stack, U256.from_be_bytes(code_hash))
+        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def self_balance(evm: Evm) -> None:
@@ -534,15 +524,22 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_FAST_STEP.
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+        If `len(stack)` is less than `1`.
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+        If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_FAST_STEP)
+    # STACK
+    pass
 
-    address = evm.message.current_target
+    # GAS
+    charge_gas(evm, GAS_FAST_STEP)
 
-    balance = get_account(evm.env.state, address).balance
+    # OPERATION
+    # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
+    balance = get_account(evm.env.state, evm.message.current_target).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -48,7 +48,7 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -75,9 +75,9 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -108,7 +108,7 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -135,7 +135,7 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -162,7 +162,7 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -190,9 +190,9 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
     # STACK
@@ -221,7 +221,7 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -251,7 +251,7 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -284,7 +284,7 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -314,7 +314,7 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -347,7 +347,7 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -374,9 +374,9 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -406,7 +406,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
     # STACK
@@ -524,9 +524,9 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK

--- a/src/ethereum/istanbul/vm/instructions/keccak.py
+++ b/src/ethereum/istanbul/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/log.py
+++ b/src/ethereum/istanbul/vm/instructions/log.py
@@ -40,7 +40,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK

--- a/src/ethereum/istanbul/vm/instructions/log.py
+++ b/src/ethereum/istanbul/vm/instructions/log.py
@@ -13,20 +13,13 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError, WriteInStaticContext
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..exceptions import WriteInStaticContext
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -47,40 +40,24 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -89,6 +66,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/istanbul/vm/instructions/memory.py
+++ b/src/ethereum/istanbul/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/memory.py
+++ b/src/ethereum/istanbul/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/istanbul/vm/instructions/stack.py
+++ b/src/ethereum/istanbul/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/istanbul/vm/instructions/storage.py
+++ b/src/ethereum/istanbul/vm/instructions/storage.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -39,18 +39,23 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -65,30 +70,32 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
-    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
+
+    # GAS
+    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
 
     original_value = get_storage_original(
         evm.env.state, evm.message.current_target, key
     )
-
-    # Gas Cost Calculation
-    gas_cost = GAS_SLOAD
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
             gas_cost = GAS_STORAGE_SET
         else:
             gas_cost = GAS_STORAGE_UPDATE
+    else:
+        gas_cost = GAS_SLOAD
+
+    charge_gas(evm, gas_cost)
 
     # Refund Counter Calculation
     if current_value != new_value:
@@ -109,8 +116,9 @@ def sstore(evm: Evm) -> None:
                 # Slot was originally non-empty and was UPDATED earlier
                 evm.refund_counter += int(GAS_STORAGE_UPDATE - GAS_SLOAD)
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/storage.py
+++ b/src/ethereum/istanbul/vm/instructions/storage.py
@@ -39,9 +39,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
     # STACK
@@ -70,9 +70,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
     # STACK

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -14,8 +14,8 @@ Implementations of the EVM system related instructions.
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -30,7 +30,7 @@ from ...utils.address import (
     to_address,
 )
 from .. import Evm, Message
-from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
+from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -41,13 +41,79 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
+
+
+def do_create(
+    evm: Evm,
+    endowment: U256,
+    contract_address: Address,
+    memory_start_position: U256,
+    memory_size: U256,
+) -> None:
+    """
+    Common code shared between both types of CREATE*.
+    """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.return_data = b""
+
+    sender_address = evm.message.current_target
+    sender = get_account(evm.env.state, sender_address)
+
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+            is_static=False,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -59,85 +125,27 @@ def create(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def create2(evm: Evm) -> None:
@@ -152,95 +160,30 @@ def create2(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create2_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
     salt = pop(evm.stack).to_be_bytes32()
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
     call_data_words = ceil32(Uint(memory_size)) // 32
-    hash_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        call_data_words,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        hash_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
-        call_data,
+        memory_read_bytes(evm.memory, memory_start_position, memory_size),
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create2_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-        evm.logs += child_evm.logs
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -252,18 +195,89 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    is_staticcall: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    evm.return_data = b""
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+            is_static=True if is_staticcall else evm.message.is_static,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            if isinstance(child_evm.error, Revert):
+                evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+            evm.return_data = child_evm.output
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -275,102 +289,63 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     is_account_alive = account_exists(
         evm.env.state, to
     ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        U256(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
     )
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
+    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -382,92 +357,60 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -479,22 +422,28 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
-    originator = evm.message.current_target
-    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
-    originator_balance = get_account(evm.env.state, originator).balance
-
+    # GAS
     is_dead_account = not account_exists(
         evm.env.state, beneficiary
     ) or is_account_empty(evm.env.state, beneficiary)
 
-    if is_dead_account and originator_balance != 0:
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    if (
+        is_dead_account
+        and get_account(evm.env.state, evm.message.current_target).balance != 0
+    ):
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+
+    originator = evm.message.current_target
+    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
+    originator_balance = get_account(evm.env.state, originator).balance
 
     # First Transfer to beneficiary
     set_account_balance(
@@ -511,207 +460,125 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def staticcall(evm: Evm) -> None:
     """
-    Make a static message-call into an account that prevents all
-    state modifying operations.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0),
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    create_gas_cost = U256(0)
-    transfer_gas_cost = U256(0)
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        U256(0), gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=U256(0),
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        U256(0),
+        evm.message.current_target,
+        to,
+        to,
+        True,
+        True,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def revert(evm: Evm) -> None:
     """
     Stop execution and revert state changes, without consuming all provided gas
     and also has the ability to return a reason
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, memory_extend_gas_cost)
-    extend_memory(evm.memory, memory_start_index, size)
+    # GAS
+    extend_memory(evm, memory_start_index, size)
 
+    # OPERATION
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert
+
+    # PROGRAM COUNTER
+    pass

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -56,7 +56,7 @@ def generic_create(
     memory_size: U256,
 ) -> None:
     """
-    Core logic used by the `CREATE* family of opcodes.
+    Core logic used by the `CREATE*` family of opcodes.
     """
     # This import causes a circular import error
     # if it's not moved inside this method

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -17,7 +17,6 @@ from ethereum.utils.numeric import ceil32
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -370,17 +369,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -138,7 +138,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.istanbul.vm.Evm`
         Items containing execution specific objects.
     """
     # take snapshot of state before processing the message
@@ -183,7 +183,7 @@ def process_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.istanbul.vm.Evm`
         Items containing execution specific objects
     """
     if message.depth > STACK_DEPTH_LIMIT:

--- a/src/ethereum/istanbul/vm/memory.py
+++ b/src/ethereum/istanbul/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/istanbul/vm/precompiled_contracts/blake2f.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/blake2f.py
@@ -15,7 +15,7 @@ from ethereum.crypto.blake2 import Blake2b
 from ethereum.utils.ensure import ensure
 
 from ...vm import Evm
-from ...vm.gas import GAS_BLAKE2_PER_ROUND, subtract_gas
+from ...vm.gas import GAS_BLAKE2_PER_ROUND, charge_gas
 from ..exceptions import InvalidParameter
 
 
@@ -30,15 +30,15 @@ def blake2f(evm: Evm) -> None:
     """
     data = evm.message.data
 
+    # GAS
     ensure(len(data) == 213, InvalidParameter)
 
     blake2b = Blake2b()
     rounds, h, m, t_0, t_1, f = blake2b.get_blake2_parameters(data)
 
+    charge_gas(evm, GAS_BLAKE2_PER_ROUND * rounds)
+
+    # OPERATION
     ensure(f in [0, 1], InvalidParameter)
-
-    total_gas_cost = GAS_BLAKE2_PER_ROUND * rounds
-
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
 
     evm.output = blake2b.compress(rounds, h, m, t_0, t_1, f)

--- a/src/ethereum/istanbul/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/istanbul/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/muir_glacier/state.py
+++ b/src/ethereum/muir_glacier/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -13,78 +13,78 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(800)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(700)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
-GAS_RETURN_DATA_COPY = U256(3)
-GAS_CODE_HASH = U256(700)
-GAS_FAST_STEP = U256(5)
-GAS_BLAKE2_PER_ROUND = U256(1)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(800)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(700)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
+GAS_RETURN_DATA_COPY = Uint(3)
+GAS_CODE_HASH = Uint(700)
+GAS_FAST_STEP = Uint(5)
+GAS_BLAKE2_PER_ROUND = Uint(1)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -97,7 +97,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -105,14 +105,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -127,18 +127,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -146,8 +146,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -163,7 +163,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -171,24 +171,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -203,36 +198,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -184,6 +184,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -198,6 +199,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -214,10 +216,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -75,7 +75,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -105,7 +105,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/muir_glacier/vm/instructions/bitwise.py
@@ -31,9 +31,9 @@ def bitwise_and(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -62,9 +62,9 @@ def bitwise_or(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -93,9 +93,9 @@ def bitwise_xor(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -124,9 +124,9 @@ def bitwise_not(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
@@ -155,9 +155,9 @@ def get_byte(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK

--- a/src/ethereum/muir_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/muir_glacier/vm/instructions/bitwise.py
@@ -262,7 +262,7 @@ def bitwise_sar(evm: Evm) -> None:
     elif signed_value >= 0:
         result = U256(0)
     else:
-        result = U256(U256.MAX_VALUE)
+        result = U256.MAX_VALUE
 
     push(evm.stack, result)
 

--- a/src/ethereum/muir_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/muir_glacier/vm/instructions/bitwise.py
@@ -202,9 +202,11 @@ def bitwise_shl(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256((value << shift) % U256_CEIL_VALUE))
+        result = U256((value << shift) % U256_CEIL_VALUE)
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -228,9 +230,11 @@ def bitwise_shr(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, value >> shift)
+        result = value >> shift
     else:
-        push(evm.stack, U256(0))
+        result = U256(0)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -254,11 +258,13 @@ def bitwise_sar(evm: Evm) -> None:
 
     # OPERATION
     if shift < 256:
-        push(evm.stack, U256.from_signed(signed_value >> shift))
+        result = U256.from_signed(signed_value >> shift)
     elif signed_value >= 0:
-        push(evm.stack, U256(0))
+        result = U256(0)
     else:
-        push(evm.stack, U256(U256.MAX_VALUE))
+        result = U256(U256.MAX_VALUE)
+
+    push(evm.stack, result)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/block.py
+++ b/src/ethereum/muir_glacier/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,9 +206,16 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -196,7 +235,14 @@ def chain_id(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.chain_id))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/comparison.py
+++ b/src/ethereum/muir_glacier/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/control_flow.py
+++ b/src/ethereum/muir_glacier/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/muir_glacier/vm/instructions/control_flow.py
+++ b/src/ethereum/muir_glacier/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -505,9 +505,11 @@ def extcodehash(evm: Evm) -> None:
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
-        push(evm.stack, U256(0))
+        codehash = U256(0)
     else:
-        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+        codehash = U256.from_be_bytes(keccak256(account.code))
+
+    push(evm.stack, codehash)
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -14,17 +14,15 @@ Implementations of the EVM environment related instructions.
 
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfBoundsRead, OutOfGasError
+from ..exceptions import OutOfBoundsRead
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
@@ -34,8 +32,7 @@ from ..gas import (
     GAS_FAST_STEP,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -51,12 +48,19 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -71,22 +75,24 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -102,12 +108,19 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -122,12 +135,19 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,12 +162,19 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,22 +190,23 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -193,12 +221,19 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -216,45 +251,26 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -268,12 +284,19 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -291,46 +314,26 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -344,12 +347,19 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -364,22 +374,24 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -394,51 +406,28 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def returndatasize(evm: Evm) -> None:
@@ -450,9 +439,16 @@ def returndatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    return_size = U256(len(evm.return_data))
-    push(evm.stack, return_size)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.return_data)))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -465,62 +461,56 @@ def returndatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
-    return_data_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    return_data_start_position = pop(evm.stack)
     size = pop(evm.stack)
+
+    # GAS
+    words = ceil32(Uint(size)) // 32
+    copy_gas_cost = GAS_RETURN_DATA_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+
+    # OPERATION
     ensure(
-        return_data_start_position + size <= len(evm.return_data),
+        Uint(return_data_start_position) + Uint(size) <= len(evm.return_data),
         OutOfBoundsRead,
     )
 
-    words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_RETURN_DATA_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
 def extcodehash(evm: Evm) -> None:
     """
     Returns the keccak256 hash of a contract’s bytecode
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
+    # STACK
     address = to_address(pop(evm.stack))
 
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CODE_HASH)
+    # GAS
+    charge_gas(evm, GAS_CODE_HASH)
 
-    evm.pc += 1
-
+    # OPERATION
     account = get_account(evm.env.state, address)
 
     if account == EMPTY_ACCOUNT:
         push(evm.stack, U256(0))
     else:
-        code = account.code
-        code_hash = keccak256(code)
-        push(evm.stack, U256.from_be_bytes(code_hash))
+        push(evm.stack, U256.from_be_bytes(keccak256(account.code)))
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def self_balance(evm: Evm) -> None:
@@ -534,15 +524,22 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_FAST_STEP.
+    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+        If `len(stack)` is less than `1`.
+    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+        If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_FAST_STEP)
+    # STACK
+    pass
 
-    address = evm.message.current_target
+    # GAS
+    charge_gas(evm, GAS_FAST_STEP)
 
-    balance = get_account(evm.env.state, address).balance
+    # OPERATION
+    # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
+    balance = get_account(evm.env.state, evm.message.current_target).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -48,7 +48,7 @@ def address(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -75,9 +75,9 @@ def balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -108,7 +108,7 @@ def origin(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -135,7 +135,7 @@ def caller(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -162,7 +162,7 @@ def callvalue(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -190,9 +190,9 @@ def calldataload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
     # STACK
@@ -221,7 +221,7 @@ def calldatasize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -251,7 +251,7 @@ def calldatacopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -284,7 +284,7 @@ def codesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -314,7 +314,7 @@ def codecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
     # STACK
@@ -347,7 +347,7 @@ def gasprice(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
     # STACK
@@ -374,9 +374,9 @@ def extcodesize(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK
@@ -406,7 +406,7 @@ def extcodecopy(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
     # STACK
@@ -524,9 +524,9 @@ def self_balance(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
     # STACK

--- a/src/ethereum/muir_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/muir_glacier/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/log.py
+++ b/src/ethereum/muir_glacier/vm/instructions/log.py
@@ -40,7 +40,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK

--- a/src/ethereum/muir_glacier/vm/instructions/log.py
+++ b/src/ethereum/muir_glacier/vm/instructions/log.py
@@ -13,20 +13,13 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
+from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError, WriteInStaticContext
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..exceptions import WriteInStaticContext
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -47,40 +40,24 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -89,6 +66,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/muir_glacier/vm/instructions/memory.py
+++ b/src/ethereum/muir_glacier/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/memory.py
+++ b/src/ethereum/muir_glacier/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/muir_glacier/vm/instructions/stack.py
+++ b/src/ethereum/muir_glacier/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/muir_glacier/vm/instructions/storage.py
+++ b/src/ethereum/muir_glacier/vm/instructions/storage.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -39,18 +39,23 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -65,30 +70,32 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
-    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
+
+    # GAS
+    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError)
 
     original_value = get_storage_original(
         evm.env.state, evm.message.current_target, key
     )
-
-    # Gas Cost Calculation
-    gas_cost = GAS_SLOAD
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
             gas_cost = GAS_STORAGE_SET
         else:
             gas_cost = GAS_STORAGE_UPDATE
+    else:
+        gas_cost = GAS_SLOAD
+
+    charge_gas(evm, gas_cost)
 
     # Refund Counter Calculation
     if current_value != new_value:
@@ -109,8 +116,9 @@ def sstore(evm: Evm) -> None:
                 # Slot was originally non-empty and was UPDATED earlier
                 evm.refund_counter += int(GAS_STORAGE_UPDATE - GAS_SLOAD)
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/storage.py
+++ b/src/ethereum/muir_glacier/vm/instructions/storage.py
@@ -39,9 +39,9 @@ def sload(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
     # STACK
@@ -70,9 +70,9 @@ def sstore(evm: Evm) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
     # STACK

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -14,8 +14,8 @@ Implementations of the EVM system related instructions.
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.utils.ensure import ensure
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -30,7 +30,7 @@ from ...utils.address import (
     to_address,
 )
 from .. import Evm, Message
-from ..exceptions import OutOfGasError, Revert, WriteInStaticContext
+from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -41,13 +41,79 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
+
+
+def do_create(
+    evm: Evm,
+    endowment: U256,
+    contract_address: Address,
+    memory_start_position: U256,
+    memory_size: U256,
+) -> None:
+    """
+    Common code shared between both types of CREATE*.
+    """
+    # This import causes a circular import error
+    # if it's not moved inside this method
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.return_data = b""
+
+    sender_address = evm.message.current_target
+    sender = get_account(evm.env.state, sender_address)
+
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+            is_static=False,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -59,85 +125,27 @@ def create(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def create2(evm: Evm) -> None:
@@ -152,95 +160,30 @@ def create2(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    # This import causes a circular import error
-    # if it's not moved inside this method
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create2_message
-
-    ensure(not evm.message.is_static, WriteInStaticContext)
-
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
     salt = pop(evm.stack).to_be_bytes32()
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
     call_data_words = ceil32(Uint(memory_size)) // 32
-    hash_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        call_data_words,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        hash_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
-    sender_address = evm.message.current_target
-    sender = get_account(evm.env.state, sender_address)
+    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
 
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
+    # OPERATION
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
-        call_data,
+        memory_read_bytes(evm.memory, memory_start_position, memory_size),
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-        is_static=False,
+    do_create(
+        evm, endowment, contract_address, memory_start_position, memory_size
     )
-    child_evm = process_create2_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-        evm.logs += child_evm.logs
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -252,18 +195,89 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    is_staticcall: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    evm.return_data = b""
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+            is_static=True if is_staticcall else evm.message.is_static,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+            if isinstance(child_evm.error, Revert):
+                evm.return_data = child_evm.output
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+            evm.return_data = child_evm.output
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -275,102 +289,63 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     is_account_alive = account_exists(
         evm.env.state, to
     ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        U256(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
     )
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
+    ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -382,92 +357,60 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
+        evm.return_data = b""
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            False,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -479,22 +422,28 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    ensure(not evm.message.is_static, WriteInStaticContext)
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
-    originator = evm.message.current_target
-    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
-    originator_balance = get_account(evm.env.state, originator).balance
-
+    # GAS
     is_dead_account = not account_exists(
         evm.env.state, beneficiary
     ) or is_account_empty(evm.env.state, beneficiary)
 
-    if is_dead_account and originator_balance != 0:
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    if (
+        is_dead_account
+        and get_account(evm.env.state, evm.message.current_target).balance != 0
+    ):
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+
+    # OPERATION
+    ensure(not evm.message.is_static, WriteInStaticContext)
+
+    originator = evm.message.current_target
+    beneficiary_balance = get_account(evm.env.state, beneficiary).balance
+    originator_balance = get_account(evm.env.state, originator).balance
 
     # First Transfer to beneficiary
     set_account_balance(
@@ -511,207 +460,125 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-        is_static=evm.message.is_static,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def staticcall(evm: Evm) -> None:
     """
-    Make a static message-call into an account that prevents all
-    state modifying operations.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0),
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    create_gas_cost = U256(0)
-    transfer_gas_cost = U256(0)
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        U256(0), gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    evm.return_data = b""
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=U256(0),
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-        is_static=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        push(evm.stack, U256(1))
-        evm.return_data = child_evm.output
-
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        U256(0),
+        evm.message.current_target,
+        to,
+        to,
+        True,
+        True,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def revert(evm: Evm) -> None:
     """
     Stop execution and revert state changes, without consuming all provided gas
     and also has the ability to return a reason
-
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, memory_extend_gas_cost)
-    extend_memory(evm.memory, memory_start_index, size)
+    # GAS
+    extend_memory(evm, memory_start_index, size)
 
+    # OPERATION
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert
+
+    # PROGRAM COUNTER
+    pass

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -56,7 +56,7 @@ def generic_create(
     memory_size: U256,
 ) -> None:
     """
-    Core logic used by the `CREATE* family of opcodes.
+    Core logic used by the `CREATE*` family of opcodes.
     """
     # This import causes a circular import error
     # if it's not moved inside this method

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -17,7 +17,6 @@ from ethereum.utils.numeric import ceil32
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -370,17 +369,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -34,7 +34,7 @@ from ..state import (
 )
 from ..utils.address import to_address
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -110,7 +110,7 @@ def process_message_call(
         evm = process_message(message, env)
 
     accounts_to_delete = collect_accounts_to_delete(evm)
-    refund_counter = (
+    refund_counter = U256(
         calculate_gas_refund(evm)
         + len(accounts_to_delete) * REFUND_SELF_DESTRUCT
     )
@@ -138,47 +138,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.muir_glacier.vm.Evm`
-        Items containing execution specific objects.
-    """
-    # take snapshot of state before processing the message
-    begin_transaction(env.state)
-
-    increment_nonce(env.state, message.current_target)
-    evm = process_message(message, env)
-    if not evm.has_erred:
-        contract_code = evm.output
-        contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
-        try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
-            ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
-            rollback_transaction(env.state)
-            evm.gas_left = U256(0)
-            evm.output = b""
-            evm.has_erred = True
-        else:
-            set_code(env.state, message.current_target, contract_code)
-            commit_transaction(env.state)
-    else:
-        rollback_transaction(env.state)
-    return evm
-
-
-def process_create2_message(message: Message, env: Environment) -> Evm:
-    """
-    Executes a call to create a smart contract via CREATE2 opcode.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-    env :
-        External items required for EVM execution.
-
-    Returns
-    -------
-    evm: :py:class:`~ethereum.muir_glacier.vm.Evm`
+    evm: :py:class:`~ethereum.constantinople.vm.Evm`
         Items containing execution specific objects.
     """
     # take snapshot of state before processing the message
@@ -195,9 +155,9 @@ def process_create2_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except OutOfGasError:
+        except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)
             evm.output = b""
@@ -223,7 +183,7 @@ def process_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.muir_glacier.vm.Evm`
+    evm: :py:class:`~ethereum.constantinople.vm.Evm`
         Items containing execution specific objects
     """
     if message.depth > STACK_DEPTH_LIMIT:

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -138,7 +138,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.muir_glacier.vm.Evm`
         Items containing execution specific objects.
     """
     # take snapshot of state before processing the message
@@ -183,7 +183,7 @@ def process_message(message: Message, env: Environment) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.constantinople.vm.Evm`
+    evm: :py:class:`~ethereum.muir_glacier.vm.Evm`
         Items containing execution specific objects
     """
     if message.depth > STACK_DEPTH_LIMIT:

--- a/src/ethereum/muir_glacier/vm/memory.py
+++ b/src/ethereum/muir_glacier/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/blake2f.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/blake2f.py
@@ -15,7 +15,7 @@ from ethereum.crypto.blake2 import Blake2b
 from ethereum.utils.ensure import ensure
 
 from ...vm import Evm
-from ...vm.gas import GAS_BLAKE2_PER_ROUND, subtract_gas
+from ...vm.gas import GAS_BLAKE2_PER_ROUND, charge_gas
 from ..exceptions import InvalidParameter
 
 
@@ -30,15 +30,15 @@ def blake2f(evm: Evm) -> None:
     """
     data = evm.message.data
 
+    # GAS
     ensure(len(data) == 213, InvalidParameter)
 
     blake2b = Blake2b()
     rounds, h, m, t_0, t_1, f = blake2b.get_blake2_parameters(data)
 
+    charge_gas(evm, GAS_BLAKE2_PER_ROUND * rounds)
+
+    # OPERATION
     ensure(f in [0, 1], InvalidParameter)
-
-    total_gas_cost = GAS_BLAKE2_PER_ROUND * rounds
-
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
 
     evm.output = blake2b.compress(rounds, h, m, t_0, t_1, f)

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/spurious_dragon/state.py
+++ b/src/ethereum/spurious_dragon/state.py
@@ -369,6 +369,33 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def is_account_alive(state: State, address: Address) -> bool:
+    """
+    Check whether is an account is both in the state and non empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return not (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def modify_state(
     state: State, address: Address, f: Callable[[Account], None]
 ) -> None:

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -71,7 +71,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -101,7 +101,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -13,74 +13,74 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(200)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(50)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(400)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(200)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(50)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(400)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -180,6 +180,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -194,6 +195,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -210,10 +212,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/block.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/comparison.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -13,19 +13,11 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
+from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -49,36 +41,20 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -87,6 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/spurious_dragon/vm/instructions/stack.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/spurious_dragon/vm/instructions/storage.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/storage.py
@@ -19,7 +19,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -41,13 +41,18 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -67,25 +72,24 @@ def sstore(evm: Evm) -> None:
     :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # TODO: SSTORE gas usage hasn't been tested yet. Testing this needs
-    # other opcodes to be implemented.
-    # Calculating the gas needed for the storage
+    # GAS
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
     if new_value != 0 and current_value == 0:
         gas_cost = GAS_STORAGE_SET
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    charge_gas(evm, gas_cost)
 
-    # TODO: Refund counter hasn't been tested yet. Testing this needs other
-    # Opcodes to be implemented
     if new_value == 0 and current_value != 0:
         evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
+    # OPERATION
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -15,7 +15,6 @@ from ethereum.base_types import U256, Bytes0, Uint
 
 from ...eth_types import Address
 from ...state import (
-    account_exists,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -293,17 +292,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -12,8 +12,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -24,7 +24,6 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -34,10 +33,9 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -56,76 +54,70 @@ def create(evm: Evm) -> None:
     # if it's not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    # OPERATION
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
-    evm.pc += 1
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -137,18 +129,82 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -260,86 +316,58 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -382,85 +410,50 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -148,7 +148,7 @@ def return_(evm: Evm) -> None:
     pass
 
 
-def do_call(
+def generic_call(
     evm: Evm,
     gas: Uint,
     value: U256,
@@ -162,49 +162,48 @@ def do_call(
     memory_output_size: U256,
 ) -> None:
     """
-    Do a message-call. Used by all the `CALL*` opcode family.
+    Perform the core logic of the `CALL*` family of opcodes.
     """
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
 
     if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
         evm.gas_left += gas
         push(evm.stack, U256(0))
+        return
+
+    call_data = memory_read_bytes(
+        evm.memory, memory_input_start_position, memory_input_size
+    )
+    code = get_account(evm.env.state, code_address).code
+    child_message = Message(
+        caller=caller,
+        target=to,
+        gas=U256(gas),
+        value=value,
+        data=call_data,
+        code=code,
+        current_target=to,
+        depth=evm.message.depth + 1,
+        code_address=code_address,
+        should_transfer_value=should_transfer_value,
+    )
+    child_evm = process_message(child_message, evm.env)
+    evm.children.append(child_evm)
+
+    if child_evm.has_erred:
+        push(evm.stack, U256(0))
     else:
-        call_data = memory_read_bytes(
-            evm.memory, memory_input_start_position, memory_input_size
-        )
-        code = get_account(evm.env.state, code_address).code
-        child_message = Message(
-            caller=caller,
-            target=to,
-            gas=U256(gas),
-            value=value,
-            data=call_data,
-            code=code,
-            current_target=to,
-            depth=evm.message.depth + 1,
-            code_address=code_address,
-            should_transfer_value=should_transfer_value,
-        )
-        child_evm = process_message(child_message, evm.env)
-        evm.children.append(child_evm)
+        evm.logs += child_evm.logs
+        push(evm.stack, U256(1))
 
-        if child_evm.has_erred:
-            push(evm.stack, U256(0))
-        else:
-            evm.logs += child_evm.logs
-            push(evm.stack, U256(1))
-
-        actual_output_size = min(
-            memory_output_size, U256(len(child_evm.output))
-        )
-        memory_write(
-            evm.memory,
-            memory_output_start_position,
-            child_evm.output[:actual_output_size],
-        )
-        evm.gas_left += child_evm.gas_left
-        child_evm.gas_left = U256(0)
+    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
+    memory_write(
+        evm.memory,
+        memory_output_start_position,
+        child_evm.output[:actual_output_size],
+    )
+    evm.gas_left += child_evm.gas_left
+    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -254,7 +253,7 @@ def call(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -317,7 +316,7 @@ def callcode(evm: Evm) -> None:
         push(evm.stack, U256(0))
         evm.gas_left += message_call_gas
     else:
-        do_call(
+        generic_call(
             evm,
             message_call_gas,
             value,
@@ -411,7 +410,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, call_gas_fee)
 
     # OPERATION
-    do_call(
+    generic_call(
         evm,
         message_call_gas,
         evm.message.value,

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -19,7 +19,7 @@ from ...state import (
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
-    is_account_empty,
+    is_account_alive,
     set_account_balance,
 )
 from ...utils.address import compute_contract_address, to_address
@@ -227,11 +227,10 @@ def call(evm: Evm) -> None:
     # GAS
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    is_account_alive = account_exists(
-        evm.env.state, to
-    ) and not is_account_empty(evm.env.state, to)
     create_gas_cost = (
-        Uint(0) if is_account_alive or value == 0 else GAS_NEW_ACCOUNT
+        Uint(0)
+        if value == 0 or is_account_alive(evm.env.state, to)
+        else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
@@ -347,12 +346,8 @@ def selfdestruct(evm: Evm) -> None:
     beneficiary = to_address(pop(evm.stack))
 
     # GAS
-    is_dead_account = not account_exists(
-        evm.env.state, beneficiary
-    ) or is_account_empty(evm.env.state, beneficiary)
-
     if (
-        is_dead_account
+        not is_account_alive(evm.env.state, beneficiary)
         and get_account(evm.env.state, evm.message.current_target).balance != 0
     ):
         charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -148,7 +148,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -33,7 +33,7 @@ from ..state import (
 )
 from ..utils.address import to_address
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (

--- a/src/ethereum/spurious_dragon/vm/memory.py
+++ b/src/ethereum/spurious_dragon/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -71,7 +71,7 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
 
     Raises
     ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -13,74 +13,74 @@ EVM gas constants and calculators.
 """
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from . import Evm
 from .exceptions import OutOfGasError
 
-GAS_JUMPDEST = U256(1)
-GAS_BASE = U256(2)
-GAS_VERY_LOW = U256(3)
-GAS_SLOAD = U256(200)
-GAS_STORAGE_SET = U256(20000)
-GAS_STORAGE_UPDATE = U256(5000)
-GAS_STORAGE_CLEAR_REFUND = U256(15000)
-GAS_LOW = U256(5)
-GAS_MID = U256(8)
-GAS_HIGH = U256(10)
-GAS_EXPONENTIATION = U256(10)
-GAS_EXPONENTIATION_PER_BYTE = U256(10)
-GAS_MEMORY = U256(3)
-GAS_KECCAK256 = U256(30)
-GAS_KECCAK256_WORD = U256(6)
-GAS_COPY = U256(3)
-GAS_BLOCK_HASH = U256(20)
-GAS_EXTERNAL = U256(700)
-GAS_BALANCE = U256(400)
-GAS_LOG = U256(375)
-GAS_LOG_DATA = U256(8)
-GAS_LOG_TOPIC = U256(375)
-GAS_CREATE = U256(32000)
-GAS_CODE_DEPOSIT = U256(200)
-GAS_ZERO = U256(0)
-GAS_CALL = U256(700)
-GAS_NEW_ACCOUNT = U256(25000)
-GAS_CALL_VALUE = U256(9000)
-GAS_CALL_STIPEND = U256(2300)
-GAS_SELF_DESTRUCT = U256(5000)
-GAS_SELF_DESTRUCT_NEW_ACCOUNT = U256(25000)
-REFUND_SELF_DESTRUCT = U256(24000)
-GAS_ECRECOVER = U256(3000)
-GAS_SHA256 = U256(60)
-GAS_SHA256_WORD = U256(12)
-GAS_RIPEMD160 = U256(600)
-GAS_RIPEMD160_WORD = U256(120)
-GAS_IDENTITY = U256(15)
-GAS_IDENTITY_WORD = U256(3)
+GAS_JUMPDEST = Uint(1)
+GAS_BASE = Uint(2)
+GAS_VERY_LOW = Uint(3)
+GAS_SLOAD = Uint(200)
+GAS_STORAGE_SET = Uint(20000)
+GAS_STORAGE_UPDATE = Uint(5000)
+GAS_STORAGE_CLEAR_REFUND = Uint(15000)
+GAS_LOW = Uint(5)
+GAS_MID = Uint(8)
+GAS_HIGH = Uint(10)
+GAS_EXPONENTIATION = Uint(10)
+GAS_EXPONENTIATION_PER_BYTE = Uint(10)
+GAS_MEMORY = Uint(3)
+GAS_KECCAK256 = Uint(30)
+GAS_KECCAK256_WORD = Uint(6)
+GAS_COPY = Uint(3)
+GAS_BLOCK_HASH = Uint(20)
+GAS_EXTERNAL = Uint(700)
+GAS_BALANCE = Uint(400)
+GAS_LOG = Uint(375)
+GAS_LOG_DATA = Uint(8)
+GAS_LOG_TOPIC = Uint(375)
+GAS_CREATE = Uint(32000)
+GAS_CODE_DEPOSIT = Uint(200)
+GAS_ZERO = Uint(0)
+GAS_CALL = Uint(700)
+GAS_NEW_ACCOUNT = Uint(25000)
+GAS_CALL_VALUE = Uint(9000)
+GAS_CALL_STIPEND = Uint(2300)
+GAS_SELF_DESTRUCT = Uint(5000)
+GAS_SELF_DESTRUCT_NEW_ACCOUNT = Uint(25000)
+REFUND_SELF_DESTRUCT = Uint(24000)
+GAS_ECRECOVER = Uint(3000)
+GAS_SHA256 = Uint(60)
+GAS_SHA256_WORD = Uint(12)
+GAS_RIPEMD160 = Uint(600)
+GAS_RIPEMD160_WORD = Uint(120)
+GAS_IDENTITY = Uint(15)
+GAS_IDENTITY_WORD = Uint(3)
 
 
-def subtract_gas(gas_left: U256, amount: U256) -> U256:
+def charge_gas(evm: Evm, amount: Uint) -> None:
     """
-    Subtracts `amount` from `gas_left`.
+    Subtracts `amount` from `evm.gas_left`.
 
     Parameters
     ----------
-    gas_left :
-        The amount of gas left in the current frame.
+    evm :
+        The current EVM.
     amount :
         The amount of gas the current operation requires.
 
     Raises
     ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
+    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
         If `gas_left` is less than `amount`.
     """
-    if gas_left < amount:
+    if evm.gas_left < amount:
         raise OutOfGasError
+    else:
+        evm.gas_left -= U256(amount)
 
-    return gas_left - amount
 
-
-def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     """
     Calculates the gas cost for allocating memory
     to the smallest multiple of 32 bytes,
@@ -93,7 +93,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
 
     Returns
     -------
-    total_gas_cost : `ethereum.base_types.U256`
+    total_gas_cost : `ethereum.base_types.Uint`
         The gas cost for storing data in memory.
     """
     size_in_words = ceil32(size_in_bytes) // 32
@@ -101,14 +101,14 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return U256(total_gas_cost)
+        return Uint(total_gas_cost)
     except ValueError:
         raise OutOfGasError
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: Uint, size: U256
-) -> U256:
+    memory: bytearray, start_position: U256, size: U256
+) -> Uint:
     """
     Calculates the gas amount to extend memory
 
@@ -123,18 +123,18 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.U256`
+    to_be_paid : `ethereum.base_types.Uint`
         returns `0` if size=0 or if the
         size after extending memory is less than the size before extending
         else it returns the amount that needs to be paid for extendinng memory.
     """
     if size == 0:
-        return U256(0)
+        return Uint(0)
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return U256(0)
+        return Uint(0)
     already_paid = calculate_memory_gas_cost(before_size)
     total_cost = calculate_memory_gas_cost(after_size)
     to_be_paid = total_cost - already_paid
@@ -142,8 +142,8 @@ def calculate_gas_extend_memory(
 
 
 def calculate_call_gas_cost(
-    gas: U256, gas_left: U256, extra_gas: U256
-) -> U256:
+    gas: Uint, gas_left: Uint, extra_gas: Uint
+) -> Uint:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -159,7 +159,7 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.U256`
+    call_gas_cost: `ethereum.base_types.Uint`
         The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
     """
     if gas_left < extra_gas:
@@ -167,24 +167,19 @@ def calculate_call_gas_cost(
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
 
-    return u256_safe_add(
-        gas,
-        extra_gas,
-        exception_type=OutOfGasError,
-    )
+    return gas + extra_gas
 
 
 def calculate_message_call_gas_stipend(
     value: U256,
-    gas: U256,
-    gas_left: U256,
-    extra_gas: U256,
-    call_stipend: U256 = GAS_CALL_STIPEND,
-) -> U256:
+    gas: Uint,
+    gas_left: Uint,
+    extra_gas: Uint,
+    call_stipend: Uint = GAS_CALL_STIPEND,
+) -> Uint:
     """
     Calculates the gas stipend for making the message call
     with the given value.
-
     Parameters
     ----------
     value:
@@ -199,36 +194,29 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
-
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.U256`
+    message_call_gas_stipend : `ethereum.base_types.Uint`
         The gas stipend for making the message-call.
     """
     if gas_left < extra_gas:
         raise OutOfGasError
 
     gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-    call_stipend = U256(0) if value == 0 else call_stipend
-    return u256_safe_add(
-        gas,
-        call_stipend,
-        exception_type=OutOfGasError,
-    )
+    call_stipend = Uint(0) if value == 0 else call_stipend
+    return gas + call_stipend
 
 
-def max_message_call_gas(gas: U256) -> U256:
+def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
-
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
-
     Returns
     -------
-    max_allowed_message_call_gas: `ethereum.base_types.U256`
+    max_allowed_message_call_gas: `ethereum.base_types.Uint`
         The maximum gas allowed for making the message-call.
     """
     return gas - (gas // 64)

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -101,7 +101,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
     quadratic_cost = size_in_words**2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     try:
-        return Uint(total_gas_cost)
+        return total_gas_cost
     except ValueError:
         raise OutOfGasError
 

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -180,6 +180,7 @@ def calculate_message_call_gas_stipend(
     """
     Calculates the gas stipend for making the message call
     with the given value.
+
     Parameters
     ----------
     value:
@@ -194,6 +195,7 @@ def calculate_message_call_gas_stipend(
     call_stipend :
         The amount of stipend provided to a message call to execute code while
         transferring value(ETH).
+
     Returns
     -------
     message_call_gas_stipend : `ethereum.base_types.Uint`
@@ -210,10 +212,12 @@ def calculate_message_call_gas_stipend(
 def max_message_call_gas(gas: Uint) -> Uint:
     """
     Calculates the maximum gas that is allowed for making a message call
+
     Parameters
     ----------
     gas :
         The amount of gas provided to the message-call.
+
     Returns
     -------
     max_allowed_message_call_gas: `ethereum.base_types.Uint`

--- a/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
@@ -22,7 +22,7 @@ from ..gas import (
     GAS_LOW,
     GAS_MID,
     GAS_VERY_LOW,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -44,14 +44,19 @@ def add(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_add(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -72,14 +77,19 @@ def sub(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = x.wrapping_sub(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -100,14 +110,19 @@ def mul(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     result = x.wrapping_mul(y)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -128,10 +143,14 @@ def div(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack)
     divisor = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = U256(0)
     else:
@@ -139,6 +158,7 @@ def div(evm: Evm) -> None:
 
     push(evm.stack, quotient)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -159,11 +179,14 @@ def sdiv(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     dividend = pop(evm.stack).to_signed()
     divisor = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if divisor == 0:
         quotient = 0
     elif dividend == -U255_CEIL_VALUE and divisor == -1:
@@ -174,6 +197,7 @@ def sdiv(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(quotient))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -194,10 +218,14 @@ def mod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = U256(0)
     else:
@@ -205,6 +233,7 @@ def mod(evm: Evm) -> None:
 
     push(evm.stack, remainder)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -225,11 +254,14 @@ def smod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
+    # STACK
     x = pop(evm.stack).to_signed()
     y = pop(evm.stack).to_signed()
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if y == 0:
         remainder = 0
     else:
@@ -237,6 +269,7 @@ def smod(evm: Evm) -> None:
 
     push(evm.stack, U256.from_signed(remainder))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -257,12 +290,15 @@ def addmod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -270,6 +306,7 @@ def addmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -290,12 +327,15 @@ def mulmod(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
-
+    # STACK
     x = Uint(pop(evm.stack))
     y = Uint(pop(evm.stack))
     z = Uint(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
     if z == 0:
         result = U256(0)
     else:
@@ -303,6 +343,7 @@ def mulmod(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -321,22 +362,25 @@ def exp(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
+    # STACK
     base = Uint(pop(evm.stack))
     exponent = Uint(pop(evm.stack))
 
-    gas_used = GAS_EXPONENTIATION
-    if exponent != 0:
-        # This is equivalent to 1 + floor(log(y, 256)). But in python the log
-        # function is inaccurate leading to wrong results.
-        exponent_bits = exponent.bit_length()
-        exponent_bytes = (exponent_bits + 7) // 8
-        gas_used += GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
-    evm.gas_left = subtract_gas(evm.gas_left, gas_used)
+    # GAS
+    # This is equivalent to 1 + floor(log(y, 256)). But in python the log
+    # function is inaccurate leading to wrong results.
+    exponent_bits = exponent.bit_length()
+    exponent_bytes = (exponent_bits + 7) // 8
+    charge_gas(
+        evm, GAS_EXPONENTIATION + GAS_EXPONENTIATION_PER_BYTE * exponent_bytes
+    )
 
+    # OPERATION
     result = U256(pow(base, exponent, U256_CEIL_VALUE))
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -357,17 +401,19 @@ def signextend(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `5`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_LOW)
-
-    # byte_num would be 0-indexed when inserted to the stack.
+    # STACK
     byte_num = pop(evm.stack)
     value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_LOW)
+
+    # OPERATION
     if byte_num > 31:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'. # noqa: SC100
+        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
         value_bytes = bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
@@ -383,4 +429,5 @@ def signextend(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
@@ -15,7 +15,7 @@ Implementations of the EVM bitwise instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,11 +36,17 @@ def bitwise_and(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x & y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -61,11 +67,17 @@ def bitwise_or(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x | y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -86,11 +98,17 @@ def bitwise_xor(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
     y = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, x ^ y)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -111,10 +129,16 @@ def bitwise_not(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     push(evm.stack, ~x)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -136,12 +160,14 @@ def get_byte(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    # 0-indexed from left (most significant) to right (least significant)
-    # in "Big Endian" representation.
+    # STACK
     byte_index = pop(evm.stack)
     word = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     if byte_index >= 32:
         result = U256(0)
     else:
@@ -154,4 +180,5 @@ def get_byte(evm: Evm) -> None:
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/block.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/block.py
@@ -15,7 +15,7 @@ Implementations of the EVM block instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_BLOCK_HASH, subtract_gas
+from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
 
 
@@ -36,10 +36,13 @@ def block_hash(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BLOCK_HASH)
-
+    # STACK
     block_number = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BLOCK_HASH)
+
+    # OPERATION
     if evm.env.number <= block_number or evm.env.number > block_number + 256:
         # Default hash to 0, if the block of interest is not yet on the chain
         # (including the block which has the current executing transaction),
@@ -50,6 +53,7 @@ def block_hash(evm: Evm) -> None:
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -73,9 +77,16 @@ def coinbase(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.coinbase))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +110,16 @@ def timestamp(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.time)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -124,9 +142,16 @@ def number(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.number))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -149,9 +174,16 @@ def difficulty(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.difficulty))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,7 +206,14 @@ def gas_limit(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.env.gas_limit))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
@@ -15,7 +15,7 @@ Implementations of the EVM Comparison instructions.
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_VERY_LOW, charge_gas
 from ..stack import pop, push
 
 
@@ -36,14 +36,19 @@ def less_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -63,14 +68,19 @@ def signed_less_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left < right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -91,14 +101,19 @@ def greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -118,14 +133,19 @@ def signed_greater_than(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack).to_signed()
     right = pop(evm.stack).to_signed()
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left > right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -146,14 +166,19 @@ def equal(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     left = pop(evm.stack)
     right = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(left == right)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -174,11 +199,16 @@ def is_zero(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-
+    # STACK
     x = pop(evm.stack)
+
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     result = U256(x == 0)
 
     push(evm.stack, result)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
@@ -14,7 +14,7 @@ Implementations of the EVM control flow instructions.
 
 from ethereum.base_types import U256, Uint
 
-from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, subtract_gas
+from ...vm.gas import GAS_BASE, GAS_HIGH, GAS_JUMPDEST, GAS_MID, charge_gas
 from .. import Evm
 from ..exceptions import InvalidJumpDestError
 from ..stack import pop, push
@@ -29,7 +29,17 @@ def stop(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
+    # STACK
+    pass
+
+    # GAS
+    pass
+
+    # OPERATION
     evm.running = False
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def jump(evm: Evm) -> None:
@@ -55,9 +65,16 @@ def jump(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `8`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_MID)
+    # STACK
     jump_dest = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_MID)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
@@ -88,19 +105,24 @@ def jumpi(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `10`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_HIGH)
-
+    # STACK
     jump_dest = pop(evm.stack)
     conditional_value = pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_HIGH)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     if conditional_value == 0:
         evm.pc += 1
-        return
+    else:
+        if jump_dest not in evm.valid_jump_destinations:
+            raise InvalidJumpDestError
 
-    if jump_dest not in evm.valid_jump_destinations:
-        raise InvalidJumpDestError
-
-    evm.pc = Uint(jump_dest)
+        evm.pc = Uint(jump_dest)
 
 
 def pc(evm: Evm) -> None:
@@ -120,8 +142,16 @@ def pc(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(evm.pc))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -142,8 +172,16 @@ def gas_left(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    push(evm.stack, evm.gas_left)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(evm.gas_left))
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -163,5 +201,14 @@ def jumpdest(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `1`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_JUMPDEST)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_JUMPDEST)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
@@ -66,18 +66,16 @@ def jump(evm: Evm) -> None:
         If `evm.gas_left` is less than `8`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
 
     # GAS
     charge_gas(evm, GAS_MID)
 
     # OPERATION
-    pass
-
-    # PROGRAM COUNTER
     if jump_dest not in evm.valid_jump_destinations:
         raise InvalidJumpDestError
 
+    # PROGRAM COUNTER
     evm.pc = Uint(jump_dest)
 
 
@@ -106,23 +104,22 @@ def jumpi(evm: Evm) -> None:
         If `evm.gas_left` is less than `10`.
     """
     # STACK
-    jump_dest = pop(evm.stack)
+    jump_dest = Uint(pop(evm.stack))
     conditional_value = pop(evm.stack)
 
     # GAS
     charge_gas(evm, GAS_HIGH)
 
     # OPERATION
-    pass
+    if conditional_value == 0:
+        destination = evm.pc + 1
+    elif jump_dest not in evm.valid_jump_destinations:
+        raise InvalidJumpDestError
+    else:
+        destination = jump_dest
 
     # PROGRAM COUNTER
-    if conditional_value == 0:
-        evm.pc += 1
-    else:
-        if jump_dest not in evm.valid_jump_destinations:
-            raise InvalidJumpDestError
-
-        evm.pc = Uint(jump_dest)
+    evm.pc = Uint(destination)
 
 
 def pc(evm: Evm) -> None:

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -13,23 +13,19 @@ Implementations of the EVM environment related instructions.
 """
 
 from ethereum.base_types import U256, Uint
-from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import extend_memory, memory_write
+from ...vm.memory import buffer_read, extend_memory, memory_write
 from .. import Evm
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_BALANCE,
     GAS_BASE,
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -48,9 +44,16 @@ def address(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.current_target))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -70,17 +73,19 @@ def balance(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BALANCE)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_BALANCE)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(evm.env.state, address).balance
 
     push(evm.stack, balance)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -99,9 +104,16 @@ def origin(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.env.origin))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -119,9 +131,16 @@ def caller(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256.from_be_bytes(evm.message.caller))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -139,9 +158,16 @@ def callvalue(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.message.value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,17 +188,18 @@ def calldataload(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    start_index = pop(evm.stack)
 
-    # Converting start_index to Uint from U256 as start_index + 32 can
-    # overflow U256.
-    start_index = Uint(pop(evm.stack))
-    value = evm.message.data[start_index : start_index + 32]
-    # Right pad with 0 so that there are overall 32 bytes.
-    value = right_pad_zero_bytes(value, 32)
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    value = buffer_read(evm.message.data, start_index, U256(32))
 
     push(evm.stack, U256.from_be_bytes(value))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -190,9 +217,16 @@ def calldatasize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.message.data)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -213,42 +247,23 @@ def calldatacopy(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
-    data_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    data_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.message.data[data_start_index : data_start_index + size]
-    # But it is possible that data_start_index + size won't exist in evm.data
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def codesize(evm: Evm) -> None:
@@ -265,9 +280,16 @@ def codesize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, U256(len(evm.code)))
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -288,43 +310,23 @@ def codecopy(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `3`.
     """
-    # Converting below to Uint as though the start indices may belong to U256,
-    # the ending indices may not belong to U256.
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = evm.code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size - 1 won't exist in
-    # evm.code in which case we need to right pad the above obtained bytes
-    # with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    # OPERATION
+    value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def gasprice(evm: Evm) -> None:
@@ -341,9 +343,16 @@ def gasprice(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
+    pass
+
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
     push(evm.stack, evm.env.gas_price)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -363,17 +372,19 @@ def extcodesize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXTERNAL)
-
+    # STACK
     address = to_address(pop(evm.stack))
 
+    # GAS
+    charge_gas(evm, GAS_EXTERNAL)
+
+    # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
     codesize = U256(len(get_account(evm.env.state, address).code))
 
     push(evm.stack, codesize)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -391,45 +402,22 @@ def extcodecopy(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `4`.
     """
-    # TODO: There are no test cases against this function. Need to write
-    # custom test cases.
-
+    # STACK
     address = to_address(pop(evm.stack))
-
-    memory_start_index = Uint(pop(evm.stack))
-    code_start_index = Uint(pop(evm.stack))
+    memory_start_index = pop(evm.stack)
+    code_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    copy_gas_cost = u256_safe_multiply(
-        GAS_COPY,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_EXTERNAL,
-        copy_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    copy_gas_cost = GAS_COPY * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
 
-    evm.pc += 1
-
-    if size == 0:
-        return
-
-    # Non-existent accounts default to EMPTY_ACCOUNT, which has empty code.
+    # OPERATION
     code = get_account(evm.env.state, address).code
-
-    extend_memory(evm.memory, memory_start_index, size)
-
-    value = code[code_start_index : code_start_index + size]
-    # But it is possible that code_start_index + size won't exist in evm.code
-    # in which case we need to right pad the above obtained bytes with 0.
-    value = right_pad_zero_bytes(value, size)
-
+    value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
@@ -15,16 +15,9 @@ Implementations of the EVM keccak instructions.
 from ethereum.base_types import U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_KECCAK256,
-    GAS_KECCAK256_WORD,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop, push
 
@@ -46,33 +39,21 @@ def keccak(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2`.
     """
-    # Converting memory_start_index to Uint as memory_end_index can
-    # overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
 
+    # GAS
     words = ceil32(Uint(size)) // 32
-    word_gas_cost = u256_safe_multiply(
-        GAS_KECCAK256_WORD,
-        words,
-        exception_type=OutOfGasError,
-    )
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_KECCAK256,
-        word_gas_cost,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    word_gas_cost = GAS_KECCAK256_WORD * words
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
 
-    extend_memory(evm.memory, memory_start_index, size)
-
+    # OPERATION
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 
     push(evm.stack, U256.from_be_bytes(hash))
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -13,19 +13,11 @@ Implementations of the EVM logging instructions.
 """
 from functools import partial
 
-from ethereum.base_types import U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
+from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_LOG,
-    GAS_LOG_DATA,
-    GAS_LOG_TOPIC,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
 from ..memory import extend_memory, memory_read_bytes
 from ..stack import pop
 
@@ -49,36 +41,20 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
         If `len(stack)` is less than `2 + num_topics`.
     """
-    # Converting memory_start_index to Uint as memory_start_index + size - 1
-    # can overflow U256.
-    memory_start_index = Uint(pop(evm.stack))
+    # STACK
+    memory_start_index = pop(evm.stack)
     size = pop(evm.stack)
-
-    gas_cost_log_data = u256_safe_multiply(
-        GAS_LOG_DATA, size, exception_type=OutOfGasError
-    )
-    gas_cost_log_topic = u256_safe_multiply(
-        GAS_LOG_TOPIC, num_topics, exception_type=OutOfGasError
-    )
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, memory_start_index, size
-    )
-    gas_cost = u256_safe_add(
-        GAS_LOG,
-        gas_cost_log_data,
-        gas_cost_log_topic,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-
-    extend_memory(evm.memory, memory_start_index, size)
 
     topics = []
     for _ in range(num_topics):
         topic = pop(evm.stack).to_be_bytes32()
         topics.append(topic)
 
+    # GAS
+    extend_memory(evm, memory_start_index, size)
+    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+
+    # OPERATION
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),
@@ -87,6 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
 
     evm.logs = evm.logs + (log_entry,)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256
+from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
 from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
@@ -81,7 +81,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW)
 
     # OPERATION
-    normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
+    normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -11,17 +11,10 @@ Introduction
 
 Implementations of the EVM Memory instructions.
 """
-from ethereum.base_types import U8_MAX_VALUE, U256, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
+from ethereum.base_types import U8_MAX_VALUE, U256
 
 from .. import Evm
-from ..exceptions import OutOfGasError
-from ..gas import (
-    GAS_BASE,
-    GAS_VERY_LOW,
-    calculate_gas_extend_memory,
-    subtract_gas,
-)
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
 
@@ -45,24 +38,18 @@ def mstore(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memeory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack).to_be_bytes32()
 
-    gas_cost_memory_extend = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        gas_cost_memory_extend,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(len(value)))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     memory_write(evm.memory, start_position, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -85,26 +72,19 @@ def mstore8(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
     value = pop(evm.stack)
-    # make sure that value doesn't exceed 1 byte
+
+    # GAS
+    extend_memory(evm, start_position, U256(1))
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     normalized_bytes_value = (value & U8_MAX_VALUE).to_bytes(1, "big")
-
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(1)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(1))
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -125,26 +105,20 @@ def mload(evm: Evm) -> None:
         If `evm.gas_left` is less than
         `3` + gas needed to extend memory.
     """
-    # convert to Uint as start_position + size_to_extend can overflow.
-    start_position = Uint(pop(evm.stack))
+    # STACK
+    start_position = pop(evm.stack)
 
-    memory_extend_gas_cost = calculate_gas_extend_memory(
-        evm.memory, start_position, U256(32)
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_VERY_LOW,
-        memory_extend_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    # GAS
+    extend_memory(evm, start_position, U256(32))
+    charge_gas(evm, GAS_VERY_LOW)
 
-    # extend memory and subtract gas for allocating 32 bytes of memory
-    extend_memory(evm.memory, start_position, U256(32))
+    # OPERATION
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -162,8 +136,14 @@ def msize(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
-    memory_size = U256(len(evm.memory))
-    push(evm.stack, memory_size)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    push(evm.stack, U256(len(evm.memory)))
+
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/stack.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/stack.py
@@ -19,7 +19,8 @@ from ethereum.utils.ensure import ensure
 
 from .. import Evm, stack
 from ..exceptions import StackUnderflowError
-from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
+from ..memory import buffer_read
 
 
 def pop(evm: Evm) -> None:
@@ -38,9 +39,16 @@ def pop(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `2`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    # STACK
     stack.pop(evm.stack)
 
+    # GAS
+    charge_gas(evm, GAS_BASE)
+
+    # OPERATION
+    pass
+
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -64,13 +72,19 @@ def push_n(evm: Evm, num_bytes: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
     data_to_push = U256.from_be_bytes(
-        evm.code[evm.pc + 1 : evm.pc + num_bytes + 1]
+        buffer_read(evm.code, U256(evm.pc + 1), U256(num_bytes))
     )
     stack.push(evm.stack, data_to_push)
 
+    # PROGRAM COUNTER
     evm.pc += 1 + num_bytes
 
 
@@ -92,12 +106,18 @@ def dup_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
     data_to_duplicate = evm.stack[len(evm.stack) - 1 - item_number]
     stack.push(evm.stack, data_to_duplicate)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -123,16 +143,20 @@ def swap_n(evm: Evm, item_number: int) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `3`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
-    ensure(item_number < len(evm.stack), StackUnderflowError)
+    # STACK
+    pass
 
-    top_element_idx = len(evm.stack) - 1
-    nth_element_idx = len(evm.stack) - 1 - item_number
-    evm.stack[top_element_idx], evm.stack[nth_element_idx] = (
-        evm.stack[nth_element_idx],
-        evm.stack[top_element_idx],
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+
+    # OPERATION
+    ensure(item_number < len(evm.stack), StackUnderflowError)
+    evm.stack[-1], evm.stack[-1 - item_number] = (
+        evm.stack[-1 - item_number],
+        evm.stack[-1],
     )
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 

--- a/src/ethereum/tangerine_whistle/vm/instructions/storage.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/storage.py
@@ -19,7 +19,7 @@ from ..gas import (
     GAS_STORAGE_CLEAR_REFUND,
     GAS_STORAGE_SET,
     GAS_STORAGE_UPDATE,
-    subtract_gas,
+    charge_gas,
 )
 from ..stack import pop, push
 
@@ -41,13 +41,18 @@ def sload(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `50`.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SLOAD)
-
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
+
+    # GAS
+    charge_gas(evm, GAS_SLOAD)
+
+    # OPERATION
     value = get_storage(evm.env.state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
+    # PROGRAM COUNTER
     evm.pc += 1
 
 
@@ -67,25 +72,24 @@ def sstore(evm: Evm) -> None:
     :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
         If `evm.gas_left` is less than `20000`.
     """
+    # STACK
     key = pop(evm.stack).to_be_bytes32()
     new_value = pop(evm.stack)
-    current_value = get_storage(evm.env.state, evm.message.current_target, key)
 
-    # TODO: SSTORE gas usage hasn't been tested yet. Testing this needs
-    # other opcodes to be implemented.
-    # Calculating the gas needed for the storage
+    # GAS
+    current_value = get_storage(evm.env.state, evm.message.current_target, key)
     if new_value != 0 and current_value == 0:
         gas_cost = GAS_STORAGE_SET
     else:
         gas_cost = GAS_STORAGE_UPDATE
 
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+    charge_gas(evm, gas_cost)
 
-    # TODO: Refund counter hasn't been tested yet. Testing this needs other
-    # Opcodes to be implemented
     if new_value == 0 and current_value != 0:
         evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
+    # OPERATION
     set_storage(evm.env.state, evm.message.current_target, key, new_value)
 
+    # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -12,8 +12,8 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 from ethereum.base_types import U256, Bytes0, Uint
-from ethereum.utils.safe_arithmetic import u256_safe_add
 
+from ...eth_types import Address
 from ...state import (
     account_exists,
     account_has_code_or_nonce,
@@ -23,7 +23,6 @@ from ...state import (
 )
 from ...utils.address import compute_contract_address, to_address
 from .. import Evm, Message
-from ..exceptions import OutOfGasError
 from ..gas import (
     GAS_CALL,
     GAS_CALL_VALUE,
@@ -33,10 +32,9 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
     calculate_call_gas_cost,
-    calculate_gas_extend_memory,
     calculate_message_call_gas_stipend,
+    charge_gas,
     max_message_call_gas,
-    subtract_gas,
 )
 from ..memory import extend_memory, memory_read_bytes, memory_write
 from ..stack import pop, push
@@ -55,76 +53,70 @@ def create(evm: Evm) -> None:
     # if it's not moved inside this method
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
+    # STACK
     endowment = pop(evm.stack)
-    memory_start_position = Uint(pop(evm.stack))
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
 
-    extend_memory_gas_cost = calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_CREATE,
-        extend_memory_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_CREATE)
+
+    create_message_gas = max_message_call_gas(Uint(evm.gas_left))
+    evm.gas_left -= U256(create_message_gas)
+
+    # OPERATION
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
-    evm.pc += 1
-
-    if sender.balance < endowment:
-        push(evm.stack, U256(0))
-        return None
-
-    if sender.nonce == Uint(2**64 - 1):
-        push(evm.stack, U256(0))
-        return None
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        return None
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    increment_nonce(evm.env.state, evm.message.current_target)
-
-    create_message_gas = max_message_call_gas(evm.gas_left)
-    evm.gas_left = subtract_gas(evm.gas_left, create_message_gas)
-
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(evm.env.state, evm.message.current_target).nonce - U256(1),
+        get_account(evm.env.state, evm.message.current_target).nonce,
     )
-    is_collision = account_has_code_or_nonce(evm.env.state, contract_address)
-    if is_collision:
-        push(evm.stack, U256(0))
-        return
 
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=Bytes0(),
-        gas=create_message_gas,
-        value=endowment,
-        data=b"",
-        code=call_data,
-        current_target=contract_address,
-        depth=evm.message.depth + 1,
-        code_address=None,
-        should_transfer_value=True,
-    )
-    child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
+    if (
+        sender.balance < endowment
+        or sender.nonce == Uint(2**64 - 1)
+        or evm.message.depth + 1 > STACK_DEPTH_LIMIT
+    ):
+        push(evm.stack, U256(0))
+        evm.gas_left += create_message_gas
+    elif account_has_code_or_nonce(evm.env.state, contract_address):
+        increment_nonce(evm.env.state, evm.message.current_target)
         push(evm.stack, U256(0))
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        call_data = memory_read_bytes(
+            evm.memory, memory_start_position, memory_size
+        )
+
+        increment_nonce(evm.env.state, evm.message.current_target)
+
+        child_message = Message(
+            caller=evm.message.current_target,
+            target=Bytes0(),
+            gas=U256(create_message_gas),
+            value=endowment,
+            data=b"",
+            code=call_data,
+            current_target=contract_address,
+            depth=evm.message.depth + 1,
+            code_address=None,
+            should_transfer_value=True,
+        )
+        child_evm = process_create_message(child_message, evm.env)
+        evm.children.append(child_evm)
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(
+                evm.stack, U256.from_be_bytes(child_evm.message.current_target)
+            )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def return_(evm: Evm) -> None:
@@ -136,18 +128,82 @@ def return_(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    memory_start_position = Uint(pop(evm.stack))
+    # STACK
+    memory_start_position = pop(evm.stack)
     memory_size = pop(evm.stack)
-    gas_cost = GAS_ZERO + calculate_gas_extend_memory(
-        evm.memory, memory_start_position, memory_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
-    extend_memory(evm.memory, memory_start_position, memory_size)
+
+    # GAS
+    extend_memory(evm, memory_start_position, memory_size)
+    charge_gas(evm, GAS_ZERO)
+
+    # OPERATION
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    # HALT the execution
+
     evm.running = False
+
+    # PROGRAM COUNTER
+    pass
+
+
+def do_call(
+    evm: Evm,
+    gas: Uint,
+    value: U256,
+    caller: Address,
+    to: Address,
+    code_address: Address,
+    should_transfer_value: bool,
+    memory_input_start_position: U256,
+    memory_input_size: U256,
+    memory_output_start_position: U256,
+    memory_output_size: U256,
+) -> None:
+    """
+    Do a message-call. Used by all the `CALL*` opcode family.
+    """
+    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
+
+    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
+        evm.gas_left += gas
+        push(evm.stack, U256(0))
+    else:
+        call_data = memory_read_bytes(
+            evm.memory, memory_input_start_position, memory_input_size
+        )
+        code = get_account(evm.env.state, code_address).code
+        child_message = Message(
+            caller=caller,
+            target=to,
+            gas=U256(gas),
+            value=value,
+            data=call_data,
+            code=code,
+            current_target=to,
+            depth=evm.message.depth + 1,
+            code_address=code_address,
+            should_transfer_value=should_transfer_value,
+        )
+        child_evm = process_message(child_message, evm.env)
+        evm.children.append(child_evm)
+
+        if child_evm.has_erred:
+            push(evm.stack, U256(0))
+        else:
+            evm.logs += child_evm.logs
+            push(evm.stack, U256(1))
+
+        actual_output_size = min(
+            memory_output_size, U256(len(child_evm.output))
+        )
+        memory_write(
+            evm.memory,
+            memory_output_start_position,
+            child_evm.output[:actual_output_size],
+        )
+        evm.gas_left += child_evm.gas_left
+        child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -159,91 +215,56 @@ def call(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     to = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
-
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
     _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = U256(0) if _account_exists else GAS_NEW_ACCOUNT
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = u256_safe_add(
-        create_gas_cost,
-        transfer_gas_cost,
-        exception_type=OutOfGasError,
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
+    charge_gas(evm, call_gas_fee)
 
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, to).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=to,
-        should_transfer_value=True,
-    )
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            to,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
 
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def callcode(evm: Evm) -> None:
@@ -255,86 +276,58 @@ def callcode(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
     value = pop(evm.stack)
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
+
+    # GAS
     to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    _account_exists = account_exists(evm.env.state, to)
+    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    call_gas_fee = calculate_call_gas_cost(
+        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
+    message_call_gas = calculate_message_call_gas_stipend(
+        value,
+        gas,
+        Uint(evm.gas_left),
+        GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    transfer_gas_cost = U256(0) if value == 0 else GAS_CALL_VALUE
-    extra_gas = transfer_gas_cost
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
+    # OPERATION
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-
-    evm.pc += 1
-
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.current_target,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=True,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        evm.gas_left += message_call_gas
     else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
-        memory_output_start_position,
-        child_evm.output[:actual_output_size],
-    )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+        do_call(
+            evm,
+            message_call_gas,
+            value,
+            evm.message.current_target,
+            to,
+            code_address,
+            True,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+        )
+
+    # PROGRAM COUNTER
+    evm.pc += 1
 
 
 def selfdestruct(evm: Evm) -> None:
@@ -346,14 +339,16 @@ def selfdestruct(evm: Evm) -> None:
     evm :
         The current EVM frame.
     """
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_SELF_DESTRUCT)
+    # STACK
     beneficiary = to_address(pop(evm.stack))
 
-    if not account_exists(evm.env.state, beneficiary):
-        evm.gas_left = subtract_gas(
-            evm.gas_left, GAS_SELF_DESTRUCT_NEW_ACCOUNT
-        )
+    # GAS
+    if account_exists(evm.env.state, beneficiary):
+        charge_gas(evm, GAS_SELF_DESTRUCT)
+    else:
+        charge_gas(evm, GAS_SELF_DESTRUCT + GAS_SELF_DESTRUCT_NEW_ACCOUNT)
 
+    # OPERATION
     originator = evm.message.current_target
     beneficiary_balance = get_account(evm.env.state, beneficiary).balance
     originator_balance = get_account(evm.env.state, originator).balance
@@ -373,85 +368,50 @@ def selfdestruct(evm: Evm) -> None:
     # HALT the execution
     evm.running = False
 
+    # PROGRAM COUNTER
+    pass
+
 
 def delegatecall(evm: Evm) -> None:
     """
-    Message-call into this account with an alternative account’s code,
-    but persisting the current values for sender.
+    Message-call into an account.
 
     Parameters
     ----------
     evm :
         The current EVM frame.
     """
-    from ...vm.interpreter import STACK_DEPTH_LIMIT, process_message
-
-    evm.gas_left = subtract_gas(evm.gas_left, GAS_CALL)
-
-    gas = pop(evm.stack)
+    # STACK
+    gas = Uint(pop(evm.stack))
     code_address = to_address(pop(evm.stack))
-    memory_input_start_position = Uint(pop(evm.stack))
+    memory_input_start_position = pop(evm.stack)
     memory_input_size = pop(evm.stack)
-    memory_output_start_position = Uint(pop(evm.stack))
+    memory_output_start_position = pop(evm.stack)
     memory_output_size = pop(evm.stack)
-    value = evm.message.value
-    to = evm.message.current_target
 
-    gas_input_memory = calculate_gas_extend_memory(
-        evm.memory, memory_input_start_position, memory_input_size
+    # GAS
+    extend_memory(evm, memory_input_start_position, memory_input_size)
+    extend_memory(evm, memory_output_start_position, memory_output_size)
+    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
+    message_call_gas = calculate_message_call_gas_stipend(
+        U256(0), gas, Uint(evm.gas_left), GAS_CALL
     )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_input_memory)
-    extend_memory(evm.memory, memory_input_start_position, memory_input_size)
-    gas_output_memory = calculate_gas_extend_memory(
-        evm.memory, memory_output_start_position, memory_output_size
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, gas_output_memory)
-    extend_memory(evm.memory, memory_output_start_position, memory_output_size)
-    call_data = memory_read_bytes(
-        evm.memory, memory_input_start_position, memory_input_size
-    )
+    charge_gas(evm, call_gas_fee)
 
-    extra_gas = U256(0)
-    call_gas_fee = calculate_call_gas_cost(gas, evm.gas_left, extra_gas)
-    message_call_gas_fee = calculate_message_call_gas_stipend(
-        value, gas, evm.gas_left, extra_gas, call_stipend=U256(0)
-    )
-
-    evm.gas_left = subtract_gas(evm.gas_left, call_gas_fee)
-
-    evm.pc += 1
-
-    if evm.message.depth + 1 > STACK_DEPTH_LIMIT:
-        push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas_fee
-        return None
-
-    code = get_account(evm.env.state, code_address).code
-    child_message = Message(
-        caller=evm.message.caller,
-        target=to,
-        gas=message_call_gas_fee,
-        value=value,
-        data=call_data,
-        code=code,
-        current_target=to,
-        depth=evm.message.depth + 1,
-        code_address=code_address,
-        should_transfer_value=False,
-    )
-
-    child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
-    if child_evm.has_erred:
-        push(evm.stack, U256(0))
-    else:
-        evm.logs += child_evm.logs
-        push(evm.stack, U256(1))
-    actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
-    memory_write(
-        evm.memory,
+    # OPERATION
+    do_call(
+        evm,
+        message_call_gas,
+        evm.message.value,
+        evm.message.caller,
+        evm.message.current_target,
+        code_address,
+        False,
+        memory_input_start_position,
+        memory_input_size,
         memory_output_start_position,
-        child_evm.output[:actual_output_size],
+        memory_output_size,
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+
+    # PROGRAM COUNTER
+    evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -289,17 +289,15 @@ def callcode(evm: Evm) -> None:
 
     extend_memory(evm, memory_input_start_position, memory_input_size)
     extend_memory(evm, memory_output_start_position, memory_output_size)
-    _account_exists = account_exists(evm.env.state, to)
-    create_gas_cost = Uint(0) if _account_exists else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
     call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
+        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
     )
     message_call_gas = calculate_message_call_gas_stipend(
         value,
         gas,
         Uint(evm.gas_left),
-        GAS_CALL + create_gas_cost + transfer_gas_cost,
+        GAS_CALL + transfer_gas_cost,
     )
     charge_gas(evm, call_gas_fee)
 

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -30,7 +30,7 @@ from ..state import (
     touch_account,
 )
 from ..vm import Message
-from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, subtract_gas
+from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
@@ -136,7 +136,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
-            evm.gas_left = subtract_gas(evm.gas_left, contract_code_gas)
+            charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
             evm.gas_left = U256(0)

--- a/src/ethereum/tangerine_whistle/vm/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/memory.py
@@ -11,38 +11,44 @@ Introduction
 
 EVM memory operations.
 """
+from ethereum.utils.byte import right_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
+from . import Evm
+from .gas import calculate_gas_extend_memory, charge_gas
 
 
-def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
+def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    memory :
-        Memory contents of the EVM.
+    evm :
+        The current Evm.
     start_position :
         Starting pointer to the memory.
     size :
         Amount of bytes by which the memory needs to be extended.
     """
+    charge_gas(
+        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
+    )
     if size == 0:
-        return None
-    memory_size = Uint(len(memory))
+        return
+    memory_size = Uint(len(evm.memory))
     before_size = ceil32(memory_size)
-    after_size = ceil32(start_position + size)
+    after_size = ceil32(Uint(start_position) + Uint(size))
     if after_size <= before_size:
-        return None
+        return
     size_to_extend = after_size - memory_size
-    memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(
-    memory: bytearray, start_position: Uint, value: Bytes
+    memory: bytearray, start_position: U256, value: Bytes
 ) -> None:
     """
     Writes to memory.
@@ -56,12 +62,11 @@ def memory_write(
     value :
         Data to write to memory.
     """
-    for idx, byte in enumerate(value):
-        memory[start_position + idx] = byte
+    memory[start_position : Uint(start_position) + len(value)] = value
 
 
 def memory_read_bytes(
-    memory: bytearray, start_position: Uint, size: U256
+    memory: bytearray, start_position: U256, size: U256
 ) -> bytearray:
     """
     Read bytes from memory.
@@ -80,4 +85,27 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : start_position + size]
+    return memory[start_position : Uint(start_position) + Uint(size)]
+
+
+def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
+    """
+    Read bytes from a buffer. Padding with zeros if neccesary.
+
+    Parameters
+    ----------
+    buffer :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return right_pad_zero_bytes(
+        buffer[start_position : Uint(start_position) + Uint(size)], size
+    )

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
@@ -16,11 +16,9 @@ import hashlib
 from ethereum.base_types import Uint
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_RIPEMD160, GAS_RIPEMD160_WORD, charge_gas
 
 
 def ripemd160(evm: Evm) -> None:
@@ -33,18 +31,12 @@ def ripemd160(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_RIPEMD160_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_RIPEMD160,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_RIPEMD160 + GAS_RIPEMD160_WORD * word_count)
+
+    # OPERATION
     hash_bytes = hashlib.new("ripemd160", data).digest()
     padded_hash = left_pad_zero_bytes(hash_bytes, 32)
     evm.output = padded_hash

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/sha256.py
@@ -15,11 +15,9 @@ import hashlib
 
 from ethereum.base_types import Uint
 from ethereum.utils.numeric import ceil32
-from ethereum.utils.safe_arithmetic import u256_safe_add, u256_safe_multiply
 
 from ...vm import Evm
-from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, subtract_gas
-from ..exceptions import OutOfGasError
+from ...vm.gas import GAS_SHA256, GAS_SHA256_WORD, charge_gas
 
 
 def sha256(evm: Evm) -> None:
@@ -32,16 +30,10 @@ def sha256(evm: Evm) -> None:
         The current EVM frame.
     """
     data = evm.message.data
+
+    # GAS
     word_count = ceil32(Uint(len(data))) // 32
-    word_count_gas_cost = u256_safe_multiply(
-        word_count,
-        GAS_SHA256_WORD,
-        exception_type=OutOfGasError,
-    )
-    total_gas_cost = u256_safe_add(
-        GAS_SHA256,
-        word_count_gas_cost,
-        exception_type=OutOfGasError,
-    )
-    evm.gas_left = subtract_gas(evm.gas_left, total_gas_cost)
+    charge_gas(evm, GAS_SHA256 + GAS_SHA256_WORD * word_count)
+
+    # OPERATION
     evm.output = hashlib.sha256(data).digest()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -358,3 +358,4 @@ Downloader
 sublist
 
 x00
+codehash

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -356,3 +356,5 @@ Transaction2930
 downloader
 Downloader
 sublist
+
+x00


### PR DESCRIPTION
This PR refactors EVM opcodes, they are now all divided into 4 clearly demarcated sections (`STACK`, `GAS`, `OPERATION`, `PROGRAM COUNTER`). `subtract_gas()` has been replaced by `charge_gas()`, which is less verbose. `extend_memory()` now handles gas charges for memory expansion. Finally common logic between `CALL` and `CALLCODE` has been merged into a single `do_call()` function.

Overall these changes should make the EVM code less verbose and clearer.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i0.wp.com/luvthat.com/wp-content/uploads/2018/06/cute_puffer_fish_.jpg)
