### PR TITLE
Implement EIP-3607

### DIFF
--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -541,6 +541,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -526,6 +526,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -526,6 +526,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -527,6 +527,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -547,6 +547,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -516,6 +516,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -527,6 +527,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -527,6 +527,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/spurious_dragon/spec.py
+++ b/src/ethereum/spurious_dragon/spec.py
@@ -522,6 +522,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -516,6 +516,7 @@ def process_transaction(
     gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee, InvalidBlock)
+    ensure(sender_account.code == bytearray(), InvalidBlock)
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)


### PR DESCRIPTION
(closes #583)

### What was wrong?
EIP-3607 checks were not implemented

Related to Issue #583 

### How was it fixed?
Added checks for `sender.code` starting at genesis.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/d/d8/Tunnel_of_ducks.jpg)
