### PR TITLE
Remove noise from `gh-pages` diff

### DIFF
--- a/src/ethereum_spec_tools/diff.py
+++ b/src/ethereum_spec_tools/diff.py
@@ -206,7 +206,7 @@ def diff(
         f.write(".. toctree::\n")
         f.write("   :maxdepth: 1\n\n")
 
-        for diff_file in find_pickles(diff_path, ".pickle64"):
+        for diff_file in sorted(list(find_pickles(diff_path, ".pickle64"))):
             f.write(
                 f"   {os.path.join(os.path.basename(diff_path), diff_file)}\n"
             )


### PR DESCRIPTION
### What was wrong?
Currently, the rendered documentation is deployed on the `gh-pages` branch and there is no CI process to ensure that only the intended changes are being deployed. One potential control could be the diff among the commits on `gh-pages`. However, there is currently a lot of noise on these diffs due to the fact that the the `Ethereum-spec-diff` tool processes (and writes) diffs in parallel. Thus multiple runs of the same code will potentially give different orders of the elements in the `toc tree` thus causing a noisy diff.
This PR intends to change this behaviour, whereby the processing of the files is still done in parallel but the writing to index files is done in a specific order. The benefits of parallelisation are thus retained without the randomness of output.

With this, looking at the `gh-pages` diff will give us a fair idea of whether an intended change is working as expected and not having any unintended side-effects.

### How was it fixed?
Keep the parallel processing of the files but write the `too tree` in a specific order

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2016/10/31/14/55/rottweiler-1785760_1280.jpg)
