### PR TITLE
Update Erigon Shanghai status

### DIFF
--- a/network-upgrades/mainnet-upgrades/shanghai.md
+++ b/network-upgrades/mainnet-upgrades/shanghai.md
@@ -19,14 +19,13 @@ Specifies changes potentially included in the Network Upgrade, pending successfu
 
 Code merged into Participating Clients:
 
-| EIP | [EIP-3540](https://eips.ethereum.org/EIPS/eip-3540) | [EIP-3670](https://eips.ethereum.org/EIPS/eip-3670) | [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) | [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) |
-|------------------|------|------|------|------|
-| **Geth**         | [Not merged](https://github.com/ethereum/go-ethereum/pull/22958) | [Not merged](https://github.com/ethereum/go-ethereum/pull/24090) | [Merged](https://github.com/ethereum/go-ethereum/pull/24039) | [Not merged](https://github.com/ethereum/go-ethereum/pull/23847) |
-| **Besu**         | | | | |
-| **Nethermind**   | | | | |
-| **OpenEthereum** | | | | |
-| **Erigon**    | | | | |
-| **EthereumJS**   | | | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1616) | [Not merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1619) |
+| EIP | [EIP-3540](https://eips.ethereum.org/EIPS/eip-3540) | [EIP-3651](https://eips.ethereum.org/EIPS/eip-3651) | [EIP-3670](https://eips.ethereum.org/EIPS/eip-3670) | [EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) | [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) | [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) |
+|------------------|------|------|------|------|------|------|
+| **Geth**         | [Not merged](https://github.com/ethereum/go-ethereum/pull/22958) | | [Not merged](https://github.com/ethereum/go-ethereum/pull/24090) | [Merged](https://github.com/ethereum/go-ethereum/pull/24039) | [Not merged](https://github.com/ethereum/go-ethereum/pull/23847) | |
+| **Besu**         | | | | | | |
+| **Nethermind**   | | | | | | |
+| **Erigon**    | | | | [Merged](https://github.com/ledgerwatch/erigon/pull/5256) | | |
+| **EthereumJS**   | | | | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1616) | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1619) | |
 
  Tasks
 - [ ] Client Integration Testing


### PR DESCRIPTION
- Add EIP-3651 & EIP-4895 columns to the implementation table.
- EIP-3855 [PR](https://github.com/ledgerwatch/erigon/pull/5256) has been merged in Erigon.
- Remove OpenEthereum from the list of Shanghai clients.
- EIP-3860 [PR](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1619) has been merged in EthereumJS.