### PR TITLE
Run all available `ValidBlock` tests

### DIFF
--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -74,42 +74,12 @@ def test_general_state_tests(test_case: Dict) -> None:
 # Run legacy valid block tests
 test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/CallContractFromNotBestBlock.json",
-    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
-    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
-    "bcMultiChainTest/ChainAtoChainB.json",
-    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
-    "bcTotalDifficultyTest/lotsOfLeafs.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
-    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_berlin_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-    ),
-    ids=idfn,
-)
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_berlin_blockchain_st_tests(test_case)
-
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -120,12 +90,12 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
     "test_case",
     fetch_berlin_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_berlin_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -74,27 +74,63 @@ def test_general_state_tests(test_case: Dict) -> None:
 # Run legacy valid block tests
 test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
-    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
+only_in_incorrect = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/CallContractFromNotBestBlock.json",
+    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
+    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
+    "bcMultiChainTest/ChainAtoChainB.json",
+    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
+    "bcTotalDifficultyTest/lotsOfLeafs.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
+    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_berlin_tests(test_dir, only_in=only_in),
+    fetch_berlin_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_berlin_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_berlin_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_berlin_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_berlin_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -24,7 +24,7 @@ test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
+GENERAL_STATE_SLOW_TESTS = (
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -58,7 +58,7 @@ BIG_MEMORY_TESTS = ("50000_",)
     fetch_berlin_tests(
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=SLOW_TESTS,
+        slow_list=GENERAL_STATE_SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
@@ -83,7 +83,7 @@ IGNORE_LIST = (
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
     fetch_berlin_tests(
         test_dir,
         ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
+        slow_list=VALID_BLOCKS_SLOW_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -60,36 +60,16 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_byzantium_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-        slow_list=SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_byzantium_blockchain_st_tests(test_case)
-
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
@@ -98,13 +78,13 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
     "test_case",
     fetch_byzantium_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_byzantium_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -78,57 +78,16 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/CallContractFromNotBestBlock.json",
-    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
-    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
-    "bcMultiChainTest/ChainAtoChainB.json",
-    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
-    "bcTotalDifficultyTest/lotsOfLeafs.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
-    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_constantinople_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-        slow_list=SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_constantinople_blockchain_st_tests(test_case)
-
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
@@ -137,13 +96,13 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
     "test_case",
     fetch_constantinople_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_constantinople_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -78,24 +78,77 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
+only_in_incorrect = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/CallContractFromNotBestBlock.json",
+    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
+    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
+    "bcMultiChainTest/ChainAtoChainB.json",
+    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
+    "bcTotalDifficultyTest/lotsOfLeafs.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
+    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+)
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_constantinople_tests(test_dir, only_in=only_in),
+    fetch_constantinople_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_constantinople_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_constantinople_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+
+BIG_MEMORY_TESTS = ("randomStatetest94_",)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_constantinople_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+        big_memory_list=BIG_MEMORY_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_constantinople_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -45,38 +45,11 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/CallContractFromNotBestBlock.json",
-    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
-    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
-    "bcMultiChainTest/ChainAtoChainB.json",
-    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
-    "bcTotalDifficultyTest/lotsOfLeafs.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
-    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+    "bcMultiChainTest/",
+    "bcTotalDifficultyTest/",
 )
 
 
@@ -84,25 +57,11 @@ SLOW_TESTS = (
     "test_case",
     fetch_frontier_tests(
         test_dir,
-        only_in=only_in_incorrect,
-        slow_list=SLOW_TESTS,
+        ignore_list=IGNORE_LIST,
     ),
     ids=idfn,
 )
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_frontier_blockchain_st_tests(test_case)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_frontier_tests(
-        test_dir,
-        ignore_list=only_in_incorrect,
-    ),
-    ids=idfn,
-)
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_frontier_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -45,27 +45,69 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
-    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
+only_in_incorrect = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/CallContractFromNotBestBlock.json",
+    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
+    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
+    "bcMultiChainTest/ChainAtoChainB.json",
+    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
+    "bcTotalDifficultyTest/lotsOfLeafs.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
+    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+)
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(test_dir, only_in=only_in),
+    fetch_frontier_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_frontier_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_frontier_blockchain_st_tests(test_case)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_frontier_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_frontier_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -129,26 +129,12 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = ("bcGasPricerTest/RPC_API_Test.json",)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcGasPricerTest/RPC_API_Test.json",)  # type: ignore
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_homestead_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-        slow_list=SLOW_TESTS,
-    ),
-    ids=idfn,
+IGNORE_LIST = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/",
+    "bcTotalDifficultyTest/",
 )
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_homestead_blockchain_st_tests(test_case)
-
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -161,13 +147,13 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
     "test_case",
     fetch_homestead_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_homestead_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -129,26 +129,50 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
-)
+only_in_incorrect = ("bcGasPricerTest/RPC_API_Test.json",)
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcGasPricerTest/RPC_API_Test.json",)  # type: ignore
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(test_dir, only_in=only_in),
+    fetch_homestead_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_homestead_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_homestead_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+
+BIG_MEMORY_TESTS = ("randomStatetest94_",)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_homestead_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+        big_memory_list=BIG_MEMORY_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_homestead_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -28,7 +28,7 @@ test_dir = (
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
+GENERAL_STATE_SLOW_TESTS = (
     "stRandom/randomStatetest177_d0g0v0.json",
     "stQuadraticComplexityTest/Call50000_d0g1v0.json",
     "stQuadraticComplexityTest/Call50000_sha256_d0g1v0.json",
@@ -113,7 +113,7 @@ INCORRECT_UPSTREAM_STATE_TESTS = ()
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(test_dir, slow_list=SLOW_TESTS),
+    fetch_homestead_tests(test_dir, slow_list=GENERAL_STATE_SLOW_TESTS),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:
@@ -138,7 +138,7 @@ IGNORE_LIST = (
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
@@ -148,7 +148,7 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
     fetch_homestead_tests(
         test_dir,
         ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
+        slow_list=VALID_BLOCKS_SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -74,42 +74,12 @@ def test_general_state_tests(test_case: Dict) -> None:
 # Run legacy valid block tests
 test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/CallContractFromNotBestBlock.json",
-    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
-    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
-    "bcMultiChainTest/ChainAtoChainB.json",
-    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
-    "bcTotalDifficultyTest/lotsOfLeafs.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
-    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_istanbul_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-    ),
-    ids=idfn,
-)
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_istanbul_blockchain_st_tests(test_case)
-
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -120,12 +90,12 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
     "test_case",
     fetch_istanbul_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_istanbul_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -24,7 +24,7 @@ test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
+GENERAL_STATE_SLOW_TESTS = (
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -58,7 +58,7 @@ BIG_MEMORY_TESTS = ("50000_",)
     fetch_istanbul_tests(
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=SLOW_TESTS,
+        slow_list=GENERAL_STATE_SLOW_TESTS,
         big_memory_list=BIG_MEMORY_TESTS,
     ),
     ids=idfn,
@@ -83,7 +83,7 @@ IGNORE_LIST = (
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
     fetch_istanbul_tests(
         test_dir,
         ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
+        slow_list=VALID_BLOCKS_SLOW_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -74,27 +74,63 @@ def test_general_state_tests(test_case: Dict) -> None:
 # Run legacy valid block tests
 test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
-    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
+only_in_incorrect = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/CallContractFromNotBestBlock.json",
+    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
+    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
+    "bcMultiChainTest/ChainAtoChainB.json",
+    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
+    "bcTotalDifficultyTest/lotsOfLeafs.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
+    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_istanbul_tests(test_dir, only_in=only_in),
+    fetch_istanbul_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_istanbul_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_istanbul_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_istanbul_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_istanbul_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -45,26 +45,12 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = ("bcGasPricerTest/RPC_API_Test.json",)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcGasPricerTest/RPC_API_Test.json",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_spurious_dragon_tests(
-        test_dir,
-        only_in=only_in_incorrect,
-        slow_list=SLOW_TESTS,
-    ),
-    ids=idfn,
+IGNORE_LIST = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_spurious_dragon_blockchain_st_tests(test_case)
-
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -75,12 +61,12 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
     "test_case",
     fetch_spurious_dragon_tests(
         test_dir,
-        ignore_list=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_spurious_dragon_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -45,27 +45,47 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
-    "bcUncleSpecialTests/futureUncleTimestampDifficultyDrop.json",
-)
+only_in_incorrect = ("bcGasPricerTest/RPC_API_Test.json",)
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcGasPricerTest/RPC_API_Test.json",)
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(test_dir, only_in=only_in),
+    fetch_spurious_dragon_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_spurious_dragon_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_spurious_dragon_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_spurious_dragon_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_spurious_dragon_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -47,69 +47,28 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in_incorrect = (
+IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/CallContractFromNotBestBlock.json",
-    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
-    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
-    "bcMultiChainTest/ChainAtoChainB.json",
-    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
-    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
-    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
-    "bcTotalDifficultyTest/lotsOfLeafs.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
-    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
-    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
-    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
 )
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-SLOW_TESTS = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcTotalDifficultyTest/newChainFrom4Block.json",
-    "bcTotalDifficultyTest/newChainFrom5Block.json",
-    "bcTotalDifficultyTest/newChainFrom6Block.json",
-)
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
 
 @pytest.mark.parametrize(
     "test_case",
     fetch_tangerine_whistle_tests(
         test_dir,
-        only_in=only_in_incorrect,
+        ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
     ),
     ids=idfn,
 )
-def test_valid_block_incorrect(test_case: Dict) -> None:
-    with pytest.raises(InvalidBlock):
-        run_tangerine_whistle_blockchain_st_tests(test_case)
-
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_tangerine_whistle_tests(
-        test_dir,
-        ignore_list=only_in_incorrect,
-        slow_list=SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_correct(test_case: Dict) -> None:
+def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_tangerine_whistle_blockchain_st_tests(test_case)
     except KeyError:

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -47,26 +47,74 @@ test_dir = (
     "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 )
 
-only_in = (
-    "bcUncleTest/oneUncle.json",
-    "bcUncleTest/oneUncleGeneration2.json",
-    "bcUncleTest/oneUncleGeneration3.json",
-    "bcUncleTest/oneUncleGeneration4.json",
-    "bcUncleTest/oneUncleGeneration5.json",
-    "bcUncleTest/oneUncleGeneration6.json",
-    "bcUncleTest/twoUncle.json",
-    "bcUncleTest/uncleHeaderAtBlock2.json",
-    "bcUncleSpecialTests/uncleBloomNot0.json",
+only_in_incorrect = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/CallContractFromNotBestBlock.json",
+    "bcMultiChainTest/ChainAtoChainB_BlockHash.json",
+    "bcMultiChainTest/ChainAtoChainB_difficultyB.json",
+    "bcMultiChainTest/ChainAtoChainB.json",
+    "bcMultiChainTest/ChainAtoChainBCallContractFormA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainA.json",
+    "bcMultiChainTest/ChainAtoChainBtoChainAtoChainB.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheEnd.json",
+    "bcTotalDifficultyTest/lotsOfBranchesOverrideAtTheMiddle.json",
+    "bcTotalDifficultyTest/lotsOfLeafs.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions.json",
+    "bcTotalDifficultyTest/sideChainWithMoreTransactions2.json",
+    "bcTotalDifficultyTest/sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3AfterBlock3.json",
+    "bcTotalDifficultyTest/uncleBlockAtBlock3afterBlock4.json",
+)
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = (
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcTotalDifficultyTest/newChainFrom4Block.json",
+    "bcTotalDifficultyTest/newChainFrom5Block.json",
+    "bcTotalDifficultyTest/newChainFrom6Block.json",
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(test_dir, only_in=only_in),
+    fetch_tangerine_whistle_tests(
+        test_dir,
+        only_in=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
     ids=idfn,
 )
-def test_uncles_correctness(test_case: Dict) -> None:
-    run_tangerine_whistle_blockchain_st_tests(test_case)
+def test_valid_block_incorrect(test_case: Dict) -> None:
+    with pytest.raises(InvalidBlock):
+        run_tangerine_whistle_blockchain_st_tests(test_case)
+
+
+# Every test below takes more than  60s to run and
+# hence they've been marked as slow
+SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_tangerine_whistle_tests(
+        test_dir,
+        ignore_list=only_in_incorrect,
+        slow_list=SLOW_TESTS,
+    ),
+    ids=idfn,
+)
+def test_valid_block_correct(test_case: Dict) -> None:
+    try:
+        run_tangerine_whistle_blockchain_st_tests(test_case)
+    except KeyError:
+        # FIXME: Handle tests that don't have post state
+        pytest.xfail(f"{test_case} doesn't have post state")
 
 
 # Run legacy invalid block tests


### PR DESCRIPTION
(closes #594 )

### What was wrong?
Only a small sub-set of the `ValidBlock` test is currently being run

Related to Issue #594 

### How was it fixed?
Some of the `ValidBlock` have Invalid blocks in them. For each hard fork, the following steps were done

1. Independently identify which tests have Invalid Blocks in them. This was done by using `geth`. A test for which `geth` was unable to generate a valid evm trace is assumed to have an invalid block

2. Run separate category of tests - `test_valid_block_incorrect` for tests with invalid blocks and `test_valid_block_correct` for ones with only valid blocks.

3. Identify and mark tests that are slow or use large memory. 


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/5/5f/Rose-ringed_Parakeet_%28Psittacula_krameri%29_-blue_mutation_on_perch.jpg)
