### PR TITLE
Add client release of geth mainnet

### DIFF
--- a/network-upgrades/mainnet-upgrades/paris.md
+++ b/network-upgrades/mainnet-upgrades/paris.md
@@ -90,3 +90,4 @@ See https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md
     - [Nethermind](https://github.com/NethermindEth/nethermind/releases/tag/1.13.4)
 - Goerli
 - Mainnet 
+    - [go-ethereum (geth)](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.22)

--- a/network-upgrades/mainnet-upgrades/paris.md
+++ b/network-upgrades/mainnet-upgrades/paris.md
@@ -90,4 +90,4 @@ See https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md
     - [Nethermind](https://github.com/NethermindEth/nethermind/releases/tag/1.13.4)
 - Goerli
 - Mainnet 
-    - [go-ethereum (geth)](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.22)
+    - [go-ethereum (geth)](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.23)


### PR DESCRIPTION
### What was wrong?

Geth released the [mainnet version](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.22) of post-merge

### How was it fixed?

Add new link

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/70309026/188352701-9cfb6364-5abb-4cbc-b3ac-f6dfbd946fb7.png)
