### PR TITLE
Fix handling of minimum difficulty

### DIFF
--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -65,7 +65,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(2 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 9000000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -1004,8 +1004,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -1002,15 +1002,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
+    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -1002,7 +1002,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
+    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -59,7 +59,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(3 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 3000000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -934,8 +934,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -932,7 +932,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
+    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -932,15 +932,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
+    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -921,7 +921,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
+    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -921,15 +921,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
+    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -59,7 +59,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(2 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 5000000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -923,8 +923,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -897,15 +897,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) // 100000) - 2
+    num_bomb_periods = int(block_number) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -897,7 +897,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = int(block_number) // 100000 - 2
+    num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -61,7 +61,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(5 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 
 
@@ -899,8 +899,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -900,11 +900,7 @@ def calculate_block_difficulty(
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return max(difficulty, MINIMUM_DIFFICULTY)

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -896,7 +896,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = int(block_number) // 100000 - 2
+    num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -877,7 +877,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = int(block_number) // 100000 - 2
+    num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -57,7 +57,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(5 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 
 
@@ -879,8 +879,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -877,15 +877,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) // 100000) - 2
+    num_bomb_periods = int(block_number) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -933,15 +933,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
+    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -59,7 +59,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(2 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 5000000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -935,8 +935,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -933,7 +933,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
+    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -933,15 +933,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
+    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -59,7 +59,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(2 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 9000000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -935,8 +935,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -933,7 +933,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) - BOMB_DELAY_BLOCKS) // 100000 - 2
+    num_bomb_periods = ((int(block_number) - BOMB_DELAY_BLOCKS) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/spurious_dragon/spec.py
+++ b/src/ethereum/spurious_dragon/spec.py
@@ -921,7 +921,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = int(block_number) // 100000 - 2
+    num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/spurious_dragon/spec.py
+++ b/src/ethereum/spurious_dragon/spec.py
@@ -921,15 +921,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) // 100000) - 2
+    num_bomb_periods = int(block_number) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -877,7 +877,7 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = int(block_number) // 100000 - 2
+    num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -57,7 +57,7 @@ from .vm.interpreter import process_message_call
 BLOCK_REWARD = U256(5 * 10**18)
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
-GENESIS_DIFFICULTY = Uint(131072)
+MINIMUM_DIFFICULTY = Uint(131072)
 MAX_OMMER_DEPTH = 6
 
 
@@ -879,8 +879,13 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
-        return Uint(
-            max(difficulty + 2**num_bomb_periods, GENESIS_DIFFICULTY)
-        )
-    else:
-        return Uint(max(difficulty, GENESIS_DIFFICULTY))
+        difficulty += 2**num_bomb_periods
+
+    # The Ethereum specification does not permit the difficulty to fall below
+    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
+    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
+    # after the bomb.
+    # In practice the question is moot. On Mainnet, it is impossible to reach
+    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
+    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -877,15 +877,11 @@ def calculate_block_difficulty(
     # bomb has no effect prior to block 200000 we pretend it existed from
     # genesis.
     # See https://github.com/ethereum/go-ethereum/pull/1588
-    num_bomb_periods = (int(block_number) // 100000) - 2
+    num_bomb_periods = int(block_number) // 100000 - 2
     if num_bomb_periods >= 0:
         difficulty += 2**num_bomb_periods
 
-    # The Ethereum specification does not permit the difficulty to fall below
-    # `MINIMUM_DIFFICULTY`. Unfortunately, there is no consistency about
-    # whether the difficulty is raised back to `MINIMUM_DIFFICULTY` before or
-    # after the bomb.
-    # In practice the question is moot. On Mainnet, it is impossible to reach
-    # `MINIMUM_DIFFICULTY` after block 800,000 due to the bomb itself. On
-    # testnets the bomb doesn't exist, so the issue doesn't arise.
+    # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
+    # the bomb. This bug does not matter because the difficulty is always much
+    # greater than `MINIMUM_DIFFICULTY` on Mainnet.
     return Uint(max(difficulty, MINIMUM_DIFFICULTY))

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -356,3 +356,5 @@ Transaction2930
 downloader
 Downloader
 sublist
+
+testnets

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -356,5 +356,3 @@ Transaction2930
 downloader
 Downloader
 sublist
-
-testnets


### PR DESCRIPTION
### What was wrong?

The `GENESIS_DIFFICULTY` was misnamed as it is not the difficulty at genesis, but instead the minimum difficulty allowed. Additionally there is inconsistently about whether the difficulty is raised to the minimum first or the difficulty bomb is applied first. The Yellow Paper, Nethermind and Akula apply the difficulty bomb first, whereas Geth, Erigon, Besu raise the difficulty to the minimum first. The situation is entirely moot because the minimum difficulty is not reached outside the testsuite.

### How was it fixed?

* Renamed `GENESIS_DIFFICULTY` to `MINIMUM_DIFFICULTY`.
* Arbitrarily implement the Yellow Paper/Nethermind/Akula approach, with an explanatory comment.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/55g342da3dl91.jpg)
