### PR TITLE
Replace references to hardforks with specific EIPs

### DIFF
--- a/src/ethereum/berlin/eth_types.py
+++ b/src/ethereum/berlin/eth_types.py
@@ -67,7 +67,7 @@ class LegacyTransaction:
 @dataclass
 class AccessListTransaction:
     """
-    The transaction type added in the Berlin hardfork to support access lists.
+    The transaction type added in EIP-2930 to support access lists.
     """
 
     chain_id: Uint64

--- a/src/ethereum/london/eth_types.py
+++ b/src/ethereum/london/eth_types.py
@@ -66,7 +66,7 @@ class LegacyTransaction:
 @dataclass
 class AccessListTransaction:
     """
-    The transaction type added in the London hardfork to support access lists.
+    The transaction type added in EIP-2930 to support access lists.
     """
 
     chain_id: Uint64
@@ -86,7 +86,7 @@ class AccessListTransaction:
 @dataclass
 class FeeMarketTransaction:
     """
-    The transaction type added in the London hardfork.
+    The transaction type added in EIP-1559.
     """
 
     chain_id: Uint64


### PR DESCRIPTION
### What was wrong?
Some docs strings in Berlin had reference to the hard fork name which was replaced by `London` in the London hard fork due to the new fork tool. 


### How was it fixed?
Corrected the docstrings to refer to the specific EIP instead.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.animalsaroundtheglobe.com/wp-content/uploads/2021/05/meerkat-255564_960_720.jpg)
