### PR TITLE
Create diffs by names

### DIFF
--- a/src/ethereum_spec_tools/diff.py
+++ b/src/ethereum_spec_tools/diff.py
@@ -60,6 +60,7 @@ def meaningful_diffs(
 
 def _diff(
     trivial_changes: List[Tuple[str, str, re.RegexFlag]],
+    ignore_in_name: List[str],
     old_path: str,
     new_path: str,
     diff_path: str,
@@ -119,6 +120,7 @@ def _diff(
     pub.set_destination(destination_path=diff_pickle_path)
     pub.set_reader("standalone", None, "restructuredtext")
     pub.settings.language_code = "en"  # TODO
+    pub.settings.ignore_in_section_name = ignore_in_name
 
     old_doc.settings = pub.settings
     old_doc.reporter = new_reporter("RSTDIFF", pub.settings)
@@ -155,6 +157,8 @@ def diff(
         ),
     ]
 
+    ignore_in_name = old.short_name.split("_") + new.short_name.split("_")
+
     old_path = old.name.replace(".", os.sep)
     old_path = os.path.join(input_path, old_path)
 
@@ -183,6 +187,7 @@ def diff(
         args = (
             (
                 trivial_changes,
+                ignore_in_name,
                 old_path,
                 new_path,
                 diff_path,

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,7 @@ commands =
 
     ethereum-spec-diff \
         "{toxworkdir}/docs/stage0_out/autoapi/" \
-        "doc/diffs" \
-        --compare-sections-normally
+        "doc/diffs"
 
     sphinx-build \
         -j auto \


### PR DESCRIPTION
(closes #591 )

### What was wrong?
The current method of comparing rst file normally leads to illegible diff rendering when there are changes in consecutive elements.

Related to Issue #591 

### How was it fixed?
Compare by section names instead. However, to avoid volatility due to the presence of hard fork names in the names, `rstdiff` was updated to be able to ignore junk words.

[This](https://gurukamath.github.io/execution-specs/diffs/tangerine_whistle_spurious_dragon/vm/interpreter/index.html#process-create-message) is what the final rendering is going to look like. The diffs are much cleaner.

[These](https://github.com/gurukamath/execution-specs/commit/bc9212c1f754589d3e24ed8efed99e34abe517ed#diff-9724f244c0b7026a0f4ca8e1849bf6c1f36b14aac84ba03eb0c4cfcfb9920741) are the changes in the html files expected post this PR. All the changes are as expected.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/6/6e/Passer_domesticus_male_%2815%29.jpg)
