### PR TITLE
Remove all "Raises" sections from docstrings

### DIFF
--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -70,10 +70,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/arrow_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/arrow_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/arrow_glacier/vm/instructions/block.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/arrow_glacier/vm/instructions/comparison.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/arrow_glacier/vm/instructions/control_flow.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/arrow_glacier/vm/instructions/environment.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -109,10 +99,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -136,10 +122,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -163,10 +145,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -191,12 +169,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -222,10 +194,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -252,10 +220,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -285,10 +249,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -315,10 +275,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -348,10 +304,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -375,12 +327,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -411,10 +357,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -540,12 +482,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass
@@ -572,10 +508,6 @@ def base_fee(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_BASE.
     """
     # STACK
     pass

--- a/src/ethereum/arrow_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/arrow_glacier/vm/instructions/log.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/arrow_glacier/vm/instructions/memory.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/arrow_glacier/vm/instructions/stack.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/arrow_glacier/vm/instructions/storage.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/storage.py
@@ -39,12 +39,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -74,12 +68,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/arrow_glacier/vm/stack.py
+++ b/src/ethereum/arrow_glacier/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.arrow_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -71,10 +71,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/berlin/vm/instructions/arithmetic.py
+++ b/src/ethereum/berlin/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/berlin/vm/instructions/bitwise.py
+++ b/src/ethereum/berlin/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/berlin/vm/instructions/block.py
+++ b/src/ethereum/berlin/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/berlin/vm/instructions/comparison.py
+++ b/src/ethereum/berlin/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/berlin/vm/instructions/control_flow.py
+++ b/src/ethereum/berlin/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -109,10 +99,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -136,10 +122,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -163,10 +145,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -191,12 +169,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -222,10 +194,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -252,10 +220,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -285,10 +249,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -315,10 +275,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -348,10 +304,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -375,12 +327,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -411,10 +357,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -540,12 +482,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass

--- a/src/ethereum/berlin/vm/instructions/keccak.py
+++ b/src/ethereum/berlin/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/berlin/vm/instructions/log.py
+++ b/src/ethereum/berlin/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/berlin/vm/instructions/memory.py
+++ b/src/ethereum/berlin/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/berlin/vm/instructions/stack.py
+++ b/src/ethereum/berlin/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/berlin/vm/instructions/storage.py
+++ b/src/ethereum/berlin/vm/instructions/storage.py
@@ -39,12 +39,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -74,12 +68,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.berlin.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/berlin/vm/stack.py
+++ b/src/ethereum/berlin/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.berlin.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -70,10 +70,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/byzantium/vm/instructions/arithmetic.py
+++ b/src/ethereum/byzantium/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/bitwise.py
+++ b/src/ethereum/byzantium/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/block.py
+++ b/src/ethereum/byzantium/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/byzantium/vm/instructions/comparison.py
+++ b/src/ethereum/byzantium/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/control_flow.py
+++ b/src/ethereum/byzantium/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -42,10 +42,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -69,12 +65,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -102,10 +92,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -129,10 +115,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -156,10 +138,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -184,12 +162,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -215,10 +187,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -245,10 +213,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -278,10 +242,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -308,10 +268,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -341,10 +297,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -368,12 +320,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -400,10 +346,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/byzantium/vm/instructions/keccak.py
+++ b/src/ethereum/byzantium/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/byzantium/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/byzantium/vm/instructions/stack.py
+++ b/src/ethereum/byzantium/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/byzantium/vm/instructions/storage.py
+++ b/src/ethereum/byzantium/vm/instructions/storage.py
@@ -36,12 +36,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -67,12 +61,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.byzantium.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/byzantium/vm/stack.py
+++ b/src/ethereum/byzantium/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.byzantium.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -71,10 +71,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/constantinople/vm/instructions/arithmetic.py
+++ b/src/ethereum/constantinople/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/constantinople/vm/instructions/bitwise.py
+++ b/src/ethereum/constantinople/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/constantinople/vm/instructions/block.py
+++ b/src/ethereum/constantinople/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/constantinople/vm/instructions/comparison.py
+++ b/src/ethereum/constantinople/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/constantinople/vm/instructions/control_flow.py
+++ b/src/ethereum/constantinople/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/constantinople/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -105,10 +95,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -132,10 +118,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -159,10 +141,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -187,12 +165,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -218,10 +190,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -248,10 +216,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -281,10 +245,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -311,10 +271,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -344,10 +300,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -371,12 +323,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -403,10 +349,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/constantinople/vm/instructions/keccak.py
+++ b/src/ethereum/constantinople/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/constantinople/vm/instructions/log.py
+++ b/src/ethereum/constantinople/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/constantinople/vm/instructions/memory.py
+++ b/src/ethereum/constantinople/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/constantinople/vm/instructions/stack.py
+++ b/src/ethereum/constantinople/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/constantinople/vm/instructions/storage.py
+++ b/src/ethereum/constantinople/vm/instructions/storage.py
@@ -36,12 +36,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -67,12 +61,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.constantinople.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/constantinople/vm/stack.py
+++ b/src/ethereum/constantinople/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.constantinople.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -69,10 +69,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/dao_fork/vm/instructions/arithmetic.py
+++ b/src/ethereum/dao_fork/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/bitwise.py
+++ b/src/ethereum/dao_fork/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/block.py
+++ b/src/ethereum/dao_fork/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/dao_fork/vm/instructions/comparison.py
+++ b/src/ethereum/dao_fork/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/control_flow.py
+++ b/src/ethereum/dao_fork/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -39,10 +39,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -66,12 +62,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -99,10 +89,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -126,10 +112,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -153,10 +135,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -181,12 +159,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -212,10 +184,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -242,10 +210,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -275,10 +239,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -305,10 +265,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -338,10 +294,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -365,12 +317,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -397,10 +343,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/dao_fork/vm/instructions/keccak.py
+++ b/src/ethereum/dao_fork/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -36,10 +36,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/dao_fork/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/dao_fork/vm/instructions/stack.py
+++ b/src/ethereum/dao_fork/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/dao_fork/vm/instructions/storage.py
+++ b/src/ethereum/dao_fork/vm/instructions/storage.py
@@ -34,12 +34,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -65,12 +59,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.dao_fork.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/dao_fork/vm/stack.py
+++ b/src/ethereum/dao_fork/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.dao_fork.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -69,10 +69,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/frontier/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/bitwise.py
+++ b/src/ethereum/frontier/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/block.py
+++ b/src/ethereum/frontier/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/frontier/vm/instructions/comparison.py
+++ b/src/ethereum/frontier/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/control_flow.py
+++ b/src/ethereum/frontier/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -39,10 +39,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -66,12 +62,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -99,10 +89,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -126,10 +112,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -153,10 +135,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -181,12 +159,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -212,10 +184,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -242,10 +210,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -275,10 +239,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -305,10 +265,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -338,10 +294,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -365,12 +317,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -397,10 +343,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/frontier/vm/instructions/keccak.py
+++ b/src/ethereum/frontier/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -36,10 +36,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/frontier/vm/instructions/storage.py
+++ b/src/ethereum/frontier/vm/instructions/storage.py
@@ -34,12 +34,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~:py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError``
-        If `len(stack)` is less than `1`.
-    :py:class:`~:py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError``
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -65,12 +59,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.frontier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/frontier/vm/stack.py
+++ b/src/ethereum/frontier/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.frontier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -70,10 +70,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/gray_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/gray_glacier/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/gray_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/gray_glacier/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/gray_glacier/vm/instructions/block.py
+++ b/src/ethereum/gray_glacier/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/gray_glacier/vm/instructions/comparison.py
+++ b/src/ethereum/gray_glacier/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/gray_glacier/vm/instructions/control_flow.py
+++ b/src/ethereum/gray_glacier/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/gray_glacier/vm/instructions/environment.py
+++ b/src/ethereum/gray_glacier/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -109,10 +99,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -136,10 +122,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -163,10 +145,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -191,12 +169,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -222,10 +194,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -252,10 +220,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -285,10 +249,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -315,10 +275,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -348,10 +304,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -375,12 +327,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -411,10 +357,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -540,12 +482,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass
@@ -572,10 +508,6 @@ def base_fee(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_BASE.
     """
     # STACK
     pass

--- a/src/ethereum/gray_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/gray_glacier/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/gray_glacier/vm/instructions/log.py
+++ b/src/ethereum/gray_glacier/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/gray_glacier/vm/instructions/memory.py
+++ b/src/ethereum/gray_glacier/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/gray_glacier/vm/instructions/stack.py
+++ b/src/ethereum/gray_glacier/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/gray_glacier/vm/instructions/storage.py
+++ b/src/ethereum/gray_glacier/vm/instructions/storage.py
@@ -39,12 +39,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -74,12 +68,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/gray_glacier/vm/stack.py
+++ b/src/ethereum/gray_glacier/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.gray_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -69,10 +69,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/homestead/vm/instructions/arithmetic.py
+++ b/src/ethereum/homestead/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/bitwise.py
+++ b/src/ethereum/homestead/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/block.py
+++ b/src/ethereum/homestead/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/homestead/vm/instructions/comparison.py
+++ b/src/ethereum/homestead/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/control_flow.py
+++ b/src/ethereum/homestead/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -39,10 +39,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -66,12 +62,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -99,10 +89,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -126,10 +112,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -153,10 +135,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -181,12 +159,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -212,10 +184,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -242,10 +210,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -275,10 +239,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -305,10 +265,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -338,10 +294,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -365,12 +317,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -397,10 +343,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/homestead/vm/instructions/keccak.py
+++ b/src/ethereum/homestead/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -36,10 +36,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/homestead/vm/instructions/memory.py
+++ b/src/ethereum/homestead/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/homestead/vm/instructions/stack.py
+++ b/src/ethereum/homestead/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/homestead/vm/instructions/storage.py
+++ b/src/ethereum/homestead/vm/instructions/storage.py
@@ -34,12 +34,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~:py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError``
-        If `len(stack)` is less than `1`.
-    :py:class:`~:py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError``
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -65,12 +59,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.homestead.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/homestead/vm/stack.py
+++ b/src/ethereum/homestead/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.homestead.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -73,10 +73,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/istanbul/vm/instructions/arithmetic.py
+++ b/src/ethereum/istanbul/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/istanbul/vm/instructions/bitwise.py
+++ b/src/ethereum/istanbul/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/istanbul/vm/instructions/block.py
+++ b/src/ethereum/istanbul/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/istanbul/vm/instructions/comparison.py
+++ b/src/ethereum/istanbul/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/istanbul/vm/instructions/control_flow.py
+++ b/src/ethereum/istanbul/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -46,10 +46,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -73,12 +69,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -106,10 +96,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -133,10 +119,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -160,10 +142,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -188,12 +166,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -219,10 +191,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -249,10 +217,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -282,10 +246,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -312,10 +272,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -345,10 +301,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -372,12 +324,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -404,10 +350,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -524,12 +466,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass

--- a/src/ethereum/istanbul/vm/instructions/keccak.py
+++ b/src/ethereum/istanbul/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/istanbul/vm/instructions/log.py
+++ b/src/ethereum/istanbul/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/istanbul/vm/instructions/memory.py
+++ b/src/ethereum/istanbul/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/istanbul/vm/instructions/stack.py
+++ b/src/ethereum/istanbul/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/istanbul/vm/instructions/storage.py
+++ b/src/ethereum/istanbul/vm/instructions/storage.py
@@ -37,12 +37,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -68,12 +62,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.istanbul.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/istanbul/vm/stack.py
+++ b/src/ethereum/istanbul/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.istanbul.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -70,10 +70,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/london/vm/instructions/arithmetic.py
+++ b/src/ethereum/london/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/london/vm/instructions/bitwise.py
+++ b/src/ethereum/london/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/london/vm/instructions/block.py
+++ b/src/ethereum/london/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/london/vm/instructions/comparison.py
+++ b/src/ethereum/london/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/london/vm/instructions/control_flow.py
+++ b/src/ethereum/london/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/london/vm/instructions/environment.py
+++ b/src/ethereum/london/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -109,10 +99,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -136,10 +122,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -163,10 +145,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -191,12 +169,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -222,10 +194,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -252,10 +220,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -285,10 +249,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -315,10 +275,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -348,10 +304,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -375,12 +327,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -411,10 +357,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -540,12 +482,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass
@@ -572,10 +508,6 @@ def base_fee(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_BASE.
     """
     # STACK
     pass

--- a/src/ethereum/london/vm/instructions/keccak.py
+++ b/src/ethereum/london/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/london/vm/instructions/log.py
+++ b/src/ethereum/london/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/london/vm/instructions/memory.py
+++ b/src/ethereum/london/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/london/vm/instructions/stack.py
+++ b/src/ethereum/london/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/london/vm/instructions/storage.py
+++ b/src/ethereum/london/vm/instructions/storage.py
@@ -39,12 +39,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -74,12 +68,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.london.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/london/vm/stack.py
+++ b/src/ethereum/london/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.london.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -73,10 +73,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/muir_glacier/vm/instructions/bitwise.py
+++ b/src/ethereum/muir_glacier/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/muir_glacier/vm/instructions/block.py
+++ b/src/ethereum/muir_glacier/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -228,12 +192,6 @@ def chain_id(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/muir_glacier/vm/instructions/comparison.py
+++ b/src/ethereum/muir_glacier/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/muir_glacier/vm/instructions/control_flow.py
+++ b/src/ethereum/muir_glacier/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -46,10 +46,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -73,12 +69,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -106,10 +96,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -133,10 +119,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -160,10 +142,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -188,12 +166,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -219,10 +191,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -249,10 +217,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -282,10 +246,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -312,10 +272,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -345,10 +301,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -372,12 +324,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -404,10 +350,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -524,12 +466,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass

--- a/src/ethereum/muir_glacier/vm/instructions/keccak.py
+++ b/src/ethereum/muir_glacier/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/muir_glacier/vm/instructions/log.py
+++ b/src/ethereum/muir_glacier/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/muir_glacier/vm/instructions/memory.py
+++ b/src/ethereum/muir_glacier/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/muir_glacier/vm/instructions/stack.py
+++ b/src/ethereum/muir_glacier/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/muir_glacier/vm/instructions/storage.py
+++ b/src/ethereum/muir_glacier/vm/instructions/storage.py
@@ -37,12 +37,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -68,12 +62,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/muir_glacier/vm/stack.py
+++ b/src/ethereum/muir_glacier/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.muir_glacier.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -69,10 +69,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/block.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/spurious_dragon/vm/instructions/comparison.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/spurious_dragon/vm/instructions/environment.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/environment.py
@@ -39,10 +39,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -66,12 +62,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -99,10 +89,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -126,10 +112,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -153,10 +135,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -181,12 +159,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -212,10 +184,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -242,10 +210,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -275,10 +239,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -305,10 +265,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -338,10 +294,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -365,12 +317,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -397,10 +343,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/spurious_dragon/vm/instructions/keccak.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -36,10 +36,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/spurious_dragon/vm/instructions/stack.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/spurious_dragon/vm/instructions/storage.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/storage.py
@@ -34,12 +34,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -65,12 +59,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/spurious_dragon/vm/stack.py
+++ b/src/ethereum/spurious_dragon/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.spurious_dragon.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -69,10 +69,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/block.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/block.py
@@ -29,12 +29,6 @@ def block_hash(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     block_number = pop(evm.stack)
@@ -70,12 +64,6 @@ def coinbase(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -103,12 +91,6 @@ def timestamp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -135,12 +117,6 @@ def number(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -167,12 +143,6 @@ def difficulty(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -199,12 +169,6 @@ def gas_limit(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equal to `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass

--- a/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -39,10 +39,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -66,12 +62,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -99,10 +89,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -126,10 +112,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -153,10 +135,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -181,12 +159,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -212,10 +184,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -242,10 +210,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -275,10 +239,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -305,10 +265,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -338,10 +294,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -365,12 +317,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -397,10 +343,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))

--- a/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -36,10 +36,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/tangerine_whistle/vm/instructions/stack.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/tangerine_whistle/vm/instructions/storage.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/storage.py
@@ -34,12 +34,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -65,12 +59,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/tangerine_whistle/vm/stack.py
+++ b/src/ethereum/tangerine_whistle/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.tangerine_whistle.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError


### PR DESCRIPTION
As discussed on the call this PR removes all `Raises` sections from docstrings in `src/ethereum`.

Before I give @SamWilsn trauma flashbacks from the "Refactor Opcodes" PR, I will explain that this PR is merely the consequence of applying the awk script

```awk
$1 == "Raises" { raises = 1 }
$1 == "Returns" { raises = 0 }
$1 == "\"\"\"" { raises = 0 }
!raises { print }
```

with the command

```sh
gawk -i inplace -f prog.awk `find src | grep "src/ethereum/.*\.py$"`
```

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-preview.redd.it/b7DptgtoDr7s_Uzy_lBZ7JBi1-MGrwDm7hGfB8_uNp8.jpg?auto=webp&s=71aecc309c1c14d2b6896af499551ce1795aa940)
