### PR TITLE
Memory `extend_memory` re-factor

### DIFF
--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -59,6 +62,38 @@ GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
 GAS_WARM_ACCESS = Uint(100)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -104,8 +139,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -113,70 +148,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -186,6 +197,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -195,15 +208,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/arrow_glacier/vm/instructions/environment.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -31,6 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -229,10 +230,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -284,10 +288,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -367,15 +374,20 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
 
     if address in evm.accessed_addresses:
-        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost + extend_memory.cost)
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
+        charge_gas(
+            evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost + extend_memory.cost
+        )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -423,8 +435,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -432,6 +446,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/arrow_glacier/vm/instructions/log.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -40,12 +40,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_WARM_ACCESS,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -138,10 +138,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -174,11 +178,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -207,10 +217,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -309,8 +323,13 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -324,32 +343,29 @@ def call(evm: Evm) -> None:
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -387,8 +403,13 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -397,31 +418,28 @@ def callcode(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -507,8 +525,13 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -516,18 +539,16 @@ def delegatecall(evm: Evm) -> None:
         evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), access_gas_cost
-    )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -562,8 +583,13 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -571,21 +597,20 @@ def staticcall(evm: Evm) -> None:
         evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -616,9 +641,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/arrow_glacier/vm/memory.py
+++ b/src/ethereum/arrow_glacier/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -60,6 +63,38 @@ GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
 GAS_WARM_ACCESS = Uint(100)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -105,8 +140,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -114,70 +149,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -187,6 +198,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -196,15 +209,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -31,6 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -229,10 +230,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -284,10 +288,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -367,15 +374,20 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
 
     if address in evm.accessed_addresses:
-        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost + extend_memory.cost)
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
+        charge_gas(
+            evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost + extend_memory.cost
+        )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -423,8 +435,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -432,6 +446,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/berlin/vm/instructions/log.py
+++ b/src/ethereum/berlin/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -40,12 +40,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_WARM_ACCESS,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -138,10 +138,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -174,11 +178,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -207,10 +217,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -309,8 +323,13 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -324,32 +343,29 @@ def call(evm: Evm) -> None:
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -387,8 +403,13 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -397,31 +418,28 @@ def callcode(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -507,8 +525,13 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -516,18 +539,16 @@ def delegatecall(evm: Evm) -> None:
         evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), access_gas_cost
-    )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -562,8 +583,13 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -571,21 +597,20 @@ def staticcall(evm: Evm) -> None:
         evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -616,9 +641,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/berlin/vm/memory.py
+++ b/src/ethereum/berlin/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -18,7 +18,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -28,6 +28,7 @@ from ..gas import (
     GAS_EXTERNAL,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -222,10 +223,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -277,10 +281,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -356,10 +363,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -407,8 +417,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -416,6 +428,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -33,12 +33,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT,
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -61,14 +61,18 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= U256(create_message_gas)
 
     # OPERATION
     ensure(not evm.message.is_static, WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.return_data = b""
 
     sender_address = evm.message.current_target
@@ -140,10 +144,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -238,38 +246,42 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
     create_gas_cost = (
         Uint(0)
         if value == 0 or is_account_alive(evm.env.state, to)
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -307,32 +319,36 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    message_call_gas = calculate_message_call_gas_stipend(
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -414,18 +430,23 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), GAS_CALL
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    charge_gas(evm, call_gas_fee)
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, GAS_CALL
+    )
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -460,21 +481,27 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -505,9 +532,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/byzantium/vm/memory.py
+++ b/src/ethereum/byzantium/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -60,6 +63,38 @@ GAS_RETURN_DATA_COPY = Uint(3)
 GAS_CODE_HASH = Uint(400)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -105,8 +140,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -114,70 +149,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -187,6 +198,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -196,15 +209,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/constantinople/vm/instructions/log.py
+++ b/src/ethereum/constantinople/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -39,12 +39,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT,
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -131,10 +131,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -167,11 +171,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -200,10 +210,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -298,38 +312,42 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
     create_gas_cost = (
         Uint(0)
         if value == 0 or is_account_alive(evm.env.state, to)
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -367,32 +385,36 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    message_call_gas = calculate_message_call_gas_stipend(
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -474,18 +496,23 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), GAS_CALL
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    charge_gas(evm, call_gas_fee)
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, GAS_CALL
+    )
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -520,21 +547,27 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -565,9 +598,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/constantinople/vm/memory.py
+++ b/src/ethereum/constantinople/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -58,6 +61,38 @@ GAS_IDENTITY = Uint(15)
 GAS_IDENTITY_WORD = Uint(3)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -103,8 +138,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -112,34 +147,38 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
+def calculate_message_call_gas(
     state: State, gas: Uint, to: Address, value: U256
-) -> Uint:
+) -> MessageCallGas:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -156,26 +195,10 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
+    message_call_gas: `MessageCallGas`
     """
     create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
-
-
-def calculate_message_call_gas_stipend(value: U256) -> Uint:
-    """
-    Calculates the gas stipend for making the message call
-    with the given value.
-
-    Parameters
-    ----------
-    value:
-        The amount of `ETH` that needs to be transferred.
-    Returns
-    -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
-    """
-    return Uint(0) if value == 0 else GAS_CALL_STIPEND
+    cost = GAS_CALL + gas + create_gas_cost + transfer_gas_cost
+    stipend = gas if value == 0 else GAS_CALL_STIPEND + gas
+    return MessageCallGas(cost, stipend)

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -17,7 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BALANCE,
@@ -25,6 +25,7 @@ from ..gas import (
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -219,10 +220,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -274,10 +278,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -353,10 +360,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -63,7 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         + GAS_LOG_TOPIC * num_topics
         + extend_memory.cost,
     )
-  
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -17,8 +17,14 @@ from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -47,10 +53,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
-
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
+  
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -26,11 +26,11 @@ from ..gas import (
     GAS_CALL,
     GAS_CREATE,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -53,13 +53,17 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
     evm.gas_left = U256(0)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -127,10 +131,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -218,23 +226,28 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -271,23 +284,28 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -360,11 +378,17 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    charge_gas(evm, GAS_CALL + gas)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    charge_gas(evm, GAS_CALL + gas + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
         gas,

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -233,7 +233,9 @@ def call(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
@@ -291,7 +293,9 @@ def callcode(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION

--- a/src/ethereum/dao_fork/vm/memory.py
+++ b/src/ethereum/dao_fork/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -58,6 +61,38 @@ GAS_IDENTITY = Uint(15)
 GAS_IDENTITY_WORD = Uint(3)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -103,8 +138,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -112,34 +147,38 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
+def calculate_message_call_gas(
     state: State, gas: Uint, to: Address, value: U256
-) -> Uint:
+) -> MessageCallGas:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -156,26 +195,10 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
+    message_call_gas: `MessageCallGas`
     """
     create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
-
-
-def calculate_message_call_gas_stipend(value: U256) -> Uint:
-    """
-    Calculates the gas stipend for making the message call
-    with the given value.
-
-    Parameters
-    ----------
-    value:
-        The amount of `ETH` that needs to be transferred.
-    Returns
-    -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
-    """
-    return Uint(0) if value == 0 else GAS_CALL_STIPEND
+    cost = GAS_CALL + gas + create_gas_cost + transfer_gas_cost
+    stipend = gas if value == 0 else GAS_CALL_STIPEND + gas
+    return MessageCallGas(cost, stipend)

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -17,7 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BALANCE,
@@ -25,6 +25,7 @@ from ..gas import (
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -219,10 +220,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -274,10 +278,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -353,10 +360,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -63,7 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         + GAS_LOG_TOPIC * num_topics
         + extend_memory.cost,
     )
-  
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -17,8 +17,14 @@ from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -47,10 +53,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
-
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
+  
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -25,11 +25,11 @@ from .. import Evm, Message
 from ..gas import (
     GAS_CREATE,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -52,13 +52,17 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
     evm.gas_left = U256(0)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -125,10 +129,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -214,23 +222,28 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -266,23 +279,28 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -229,7 +229,9 @@ def call(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
@@ -286,7 +288,9 @@ def callcode(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -59,6 +62,38 @@ GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
 GAS_WARM_ACCESS = Uint(100)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -104,8 +139,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -113,70 +148,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -186,6 +197,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -195,15 +208,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/gray_glacier/vm/instructions/environment.py
+++ b/src/ethereum/gray_glacier/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -31,6 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -229,10 +230,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -284,10 +288,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -367,15 +374,20 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
 
     if address in evm.accessed_addresses:
-        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost + extend_memory.cost)
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
+        charge_gas(
+            evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost + extend_memory.cost
+        )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -423,8 +435,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -432,6 +446,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/gray_glacier/vm/instructions/log.py
+++ b/src/ethereum/gray_glacier/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -40,12 +40,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_WARM_ACCESS,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -138,10 +138,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -174,11 +178,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -207,10 +217,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -309,8 +323,13 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -324,32 +343,29 @@ def call(evm: Evm) -> None:
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -387,8 +403,13 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -397,31 +418,28 @@ def callcode(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -507,8 +525,13 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -516,18 +539,16 @@ def delegatecall(evm: Evm) -> None:
         evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), access_gas_cost
-    )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -562,8 +583,13 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -571,21 +597,20 @@ def staticcall(evm: Evm) -> None:
         evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -616,9 +641,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/gray_glacier/vm/memory.py
+++ b/src/ethereum/gray_glacier/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -58,6 +61,38 @@ GAS_IDENTITY = Uint(15)
 GAS_IDENTITY_WORD = Uint(3)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -103,8 +138,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -112,34 +147,38 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
+def calculate_message_call_gas(
     state: State, gas: Uint, to: Address, value: U256
-) -> Uint:
+) -> MessageCallGas:
     """
     Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
 
@@ -156,26 +195,10 @@ def calculate_call_gas_cost(
 
     Returns
     -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
+    message_call_gas: `MessageCallGas`
     """
     create_gas_cost = Uint(0) if account_exists(state, to) else GAS_NEW_ACCOUNT
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    return GAS_CALL + gas + create_gas_cost + transfer_gas_cost
-
-
-def calculate_message_call_gas_stipend(value: U256) -> Uint:
-    """
-    Calculates the gas stipend for making the message call
-    with the given value.
-
-    Parameters
-    ----------
-    value:
-        The amount of `ETH` that needs to be transferred.
-    Returns
-    -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
-    """
-    return Uint(0) if value == 0 else GAS_CALL_STIPEND
+    cost = GAS_CALL + gas + create_gas_cost + transfer_gas_cost
+    stipend = gas if value == 0 else GAS_CALL_STIPEND + gas
+    return MessageCallGas(cost, stipend)

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -17,7 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BALANCE,
@@ -25,6 +25,7 @@ from ..gas import (
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -219,10 +220,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -274,10 +278,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -353,10 +360,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -63,7 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         + GAS_LOG_TOPIC * num_topics
         + extend_memory.cost,
     )
-  
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -17,8 +17,14 @@ from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -47,10 +53,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
-
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
+  
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -26,11 +26,11 @@ from ..gas import (
     GAS_CALL,
     GAS_CREATE,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -53,13 +53,17 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
     evm.gas_left = U256(0)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -127,10 +131,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -218,23 +226,28 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -271,23 +284,28 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(evm.env.state, gas, to, value)
-    charge_gas(evm, call_gas_fee)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
-    message_call_gas = gas + calculate_message_call_gas_stipend(value)
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -360,11 +378,17 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    charge_gas(evm, GAS_CALL + gas)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    charge_gas(evm, GAS_CALL + gas + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
         gas,

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -233,7 +233,9 @@ def call(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
@@ -291,7 +293,9 @@ def callcode(evm: Evm) -> None:
             (memory_output_start_position, memory_output_size),
         ],
     )
-    message_call_gas = calculate_message_call_gas(evm.env.state, gas, to, value)
+    message_call_gas = calculate_message_call_gas(
+        evm.env.state, gas, to, value
+    )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION

--- a/src/ethereum/homestead/vm/memory.py
+++ b/src/ethereum/homestead/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -62,6 +65,38 @@ GAS_FAST_STEP = Uint(5)
 GAS_BLAKE2_PER_ROUND = Uint(1)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -107,8 +142,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -116,70 +151,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -189,6 +200,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -198,15 +211,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -32,6 +32,7 @@ from ..gas import (
     GAS_FAST_STEP,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -226,10 +227,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -281,10 +285,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -360,10 +367,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -411,8 +421,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -420,6 +432,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/istanbul/vm/instructions/log.py
+++ b/src/ethereum/istanbul/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -39,12 +39,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT,
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -131,10 +131,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -167,11 +171,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -200,10 +210,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -298,38 +312,42 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
     create_gas_cost = (
         Uint(0)
         if value == 0 or is_account_alive(evm.env.state, to)
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -367,32 +385,36 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    message_call_gas = calculate_message_call_gas_stipend(
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -474,18 +496,23 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), GAS_CALL
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    charge_gas(evm, call_gas_fee)
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, GAS_CALL
+    )
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -520,21 +547,27 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -565,9 +598,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/istanbul/vm/memory.py
+++ b/src/ethereum/istanbul/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -69,12 +69,12 @@ class ExtendMemory:
 
     `cost`: `ethereum.base_types.Uint`
         The gas required to perform the extension
-    `size`: `ethereum.base_types.Uint`
+    `expand_by`: `ethereum.base_types.Uint`
         The size by which the memory will be extended
     """
 
     cost: Uint
-    size: Uint
+    expand_by: Uint
 
 
 @dataclass
@@ -83,9 +83,11 @@ class MessageCallGas:
     Define the gas cost and stipend for executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas amount for executing the Opcodes.
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
     `stipend`: `ethereum.base_types.Uint`
-        The gas stipend for executing the Opcodes.
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
     """
 
     cost: Uint

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -11,6 +11,7 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
 from typing import List, Tuple
 
 from ethereum.base_types import U256, Uint
@@ -61,6 +62,21 @@ GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
 GAS_WARM_ACCESS = Uint(100)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `size`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    size: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -107,7 +123,7 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 def calculate_gas_extend_memory(
     memory: bytearray, extensions: List[Tuple[U256, U256]]
-) -> Tuple[Uint, Uint]:
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -121,14 +137,7 @@ def calculate_gas_extend_memory(
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
-    size_to_extend : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the size to be extended.
+    extend_memory: `ExtendMemory`
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
@@ -148,7 +157,7 @@ def calculate_gas_extend_memory(
 
         current_size = after_size
 
-    return to_be_paid, size_to_extend
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
 def calculate_call_gas_cost(

--- a/src/ethereum/london/vm/instructions/environment.py
+++ b/src/ethereum/london/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -31,6 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -229,10 +230,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -284,10 +288,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -367,15 +374,18 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
 
     if address in evm.accessed_addresses:
-        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost + memory_cost)
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -423,8 +433,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + memory_cost)
 
     # OPERATION
     ensure(
@@ -432,6 +444,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * size_to_extend
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/london/vm/instructions/environment.py
+++ b/src/ethereum/london/vm/instructions/environment.py
@@ -236,7 +236,7 @@ def calldatacopy(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -294,7 +294,7 @@ def codecopy(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -387,7 +387,7 @@ def extcodecopy(evm: Evm) -> None:
         )
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -446,7 +446,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/london/vm/instructions/keccak.py
+++ b/src/ethereum/london/vm/instructions/keccak.py
@@ -53,7 +53,7 @@ def keccak(evm: Evm) -> None:
     charge_gas(evm, GAS_KECCAK256 + word_gas_cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 

--- a/src/ethereum/london/vm/instructions/keccak.py
+++ b/src/ethereum/london/vm/instructions/keccak.py
@@ -47,13 +47,13 @@ def keccak(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     word_gas_cost = GAS_KECCAK256_WORD * words
-    memory_cost, size_to_extend = calculate_gas_extend_memory(
+    extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )
-    charge_gas(evm, GAS_KECCAK256 + word_gas_cost + memory_cost)
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * extend_memory.size
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 

--- a/src/ethereum/london/vm/instructions/keccak.py
+++ b/src/ethereum/london/vm/instructions/keccak.py
@@ -17,8 +17,13 @@ from ethereum.crypto.hash import keccak256
 from ethereum.utils.numeric import ceil32
 
 from .. import Evm
-from ..gas import GAS_KECCAK256, GAS_KECCAK256_WORD, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_KECCAK256,
+    GAS_KECCAK256_WORD,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop, push
 
 
@@ -42,10 +47,13 @@ def keccak(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     word_gas_cost = GAS_KECCAK256_WORD * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_KECCAK256 + word_gas_cost)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_KECCAK256 + word_gas_cost + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     data = memory_read_bytes(evm.memory, memory_start_index, size)
     hash = keccak256(data)
 

--- a/src/ethereum/london/vm/instructions/log.py
+++ b/src/ethereum/london/vm/instructions/log.py
@@ -67,7 +67,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     )
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/london/vm/instructions/log.py
+++ b/src/ethereum/london/vm/instructions/log.py
@@ -55,7 +55,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    memory_cost, size_to_extend = calculate_gas_extend_memory(
+    extend_memory = calculate_gas_extend_memory(
         evm.memory, [(memory_start_index, size)]
     )
     charge_gas(
@@ -63,11 +63,11 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         GAS_LOG
         + GAS_LOG_DATA * size
         + GAS_LOG_TOPIC * num_topics
-        + memory_cost,
+        + extend_memory.cost,
     )
 
     # OPERATION
-    evm.memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * extend_memory.size
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/london/vm/instructions/memory.py
+++ b/src/ethereum/london/vm/instructions/memory.py
@@ -41,14 +41,14 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    memory_cost, size_to_extend = calculate_gas_extend_memory(
+    extend_memory = calculate_gas_extend_memory(
         evm.memory, [(start_position, U256(len(value)))]
     )
 
-    charge_gas(evm, GAS_VERY_LOW + memory_cost)
+    charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * extend_memory.size
     memory_write(evm.memory, start_position, value)
 
     # PROGRAM COUNTER
@@ -72,14 +72,14 @@ def mstore8(evm: Evm) -> None:
     value = pop(evm.stack)
 
     # GAS
-    memory_cost, size_to_extend = calculate_gas_extend_memory(
+    extend_memory = calculate_gas_extend_memory(
         evm.memory, [(start_position, U256(1))]
     )
 
-    charge_gas(evm, GAS_VERY_LOW + memory_cost)
+    charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * extend_memory.size
     normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
@@ -101,13 +101,13 @@ def mload(evm: Evm) -> None:
     start_position = pop(evm.stack)
 
     # GAS
-    memory_cost, size_to_extend = calculate_gas_extend_memory(
+    extend_memory = calculate_gas_extend_memory(
         evm.memory, [(start_position, U256(32))]
     )
-    charge_gas(evm, GAS_VERY_LOW + memory_cost)
+    charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * size_to_extend
+    evm.memory += b"\x00" * extend_memory.size
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )

--- a/src/ethereum/london/vm/instructions/memory.py
+++ b/src/ethereum/london/vm/instructions/memory.py
@@ -14,8 +14,13 @@ Implementations of the EVM Memory instructions.
 from ethereum.base_types import U8_MAX_VALUE, U256, Bytes
 
 from .. import Evm
-from ..gas import GAS_BASE, GAS_VERY_LOW, charge_gas
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..gas import (
+    GAS_BASE,
+    GAS_VERY_LOW,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -36,10 +41,14 @@ def mstore(evm: Evm) -> None:
     value = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, start_position, U256(len(value)))
-    charge_gas(evm, GAS_VERY_LOW)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(start_position, U256(len(value)))]
+    )
+
+    charge_gas(evm, GAS_VERY_LOW + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     memory_write(evm.memory, start_position, value)
 
     # PROGRAM COUNTER
@@ -63,10 +72,14 @@ def mstore8(evm: Evm) -> None:
     value = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, start_position, U256(1))
-    charge_gas(evm, GAS_VERY_LOW)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(start_position, U256(1))]
+    )
+
+    charge_gas(evm, GAS_VERY_LOW + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
@@ -88,10 +101,13 @@ def mload(evm: Evm) -> None:
     start_position = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, start_position, U256(32))
-    charge_gas(evm, GAS_VERY_LOW)
+    memory_cost, size_to_extend = calculate_gas_extend_memory(
+        evm.memory, [(start_position, U256(32))]
+    )
+    charge_gas(evm, GAS_VERY_LOW + memory_cost)
 
     # OPERATION
+    evm.memory += b"\x00" * size_to_extend
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )

--- a/src/ethereum/london/vm/instructions/memory.py
+++ b/src/ethereum/london/vm/instructions/memory.py
@@ -48,7 +48,7 @@ def mstore(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     memory_write(evm.memory, start_position, value)
 
     # PROGRAM COUNTER
@@ -79,7 +79,7 @@ def mstore8(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     normalized_bytes_value = Bytes([value & U8_MAX_VALUE])
     memory_write(evm.memory, start_position, normalized_bytes_value)
 
@@ -107,7 +107,7 @@ def mload(evm: Evm) -> None:
     charge_gas(evm, GAS_VERY_LOW + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = U256.from_be_bytes(
         memory_read_bytes(evm.memory, start_position, U256(32))
     )

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -149,7 +149,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -192,7 +192,7 @@ def create2(evm: Evm) -> None:
     )
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -228,7 +228,7 @@ def return_(evm: Evm) -> None:
     charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -353,7 +353,7 @@ def call(evm: Evm) -> None:
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -427,7 +427,7 @@ def callcode(evm: Evm) -> None:
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
@@ -548,7 +548,7 @@ def delegatecall(evm: Evm) -> None:
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
         message_call_gas.stipend,
@@ -610,7 +610,7 @@ def staticcall(evm: Evm) -> None:
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
         message_call_gas.stipend,
@@ -651,7 +651,7 @@ def revert(evm: Evm) -> None:
     charge_gas(evm, extend_memory.cost)
 
     # OPERATION
-    evm.memory += b"\x00" * extend_memory.size
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/london/vm/memory.py
+++ b/src/ethereum/london/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -62,6 +65,38 @@ GAS_FAST_STEP = Uint(5)
 GAS_BLAKE2_PER_ROUND = Uint(1)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -107,8 +142,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -116,70 +151,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -189,6 +200,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -198,15 +211,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -32,6 +32,7 @@ from ..gas import (
     GAS_FAST_STEP,
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -226,10 +227,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -281,10 +285,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -360,10 +367,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -411,8 +421,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -420,6 +432,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/muir_glacier/vm/instructions/log.py
+++ b/src/ethereum/muir_glacier/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -39,12 +39,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT,
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -131,10 +131,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -167,11 +171,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -200,10 +210,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -298,38 +312,42 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
     create_gas_cost = (
         Uint(0)
         if value == 0 or is_account_alive(evm.env.state, to)
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -367,32 +385,36 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    message_call_gas = calculate_message_call_gas_stipend(
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -474,18 +496,23 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), GAS_CALL
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    charge_gas(evm, call_gas_fee)
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, GAS_CALL
+    )
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -520,21 +547,27 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -565,9 +598,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/muir_glacier/vm/memory.py
+++ b/src/ethereum/muir_glacier/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -59,6 +62,38 @@ GAS_COLD_ACCOUNT_ACCESS = Uint(2600)
 GAS_WARM_ACCESS = Uint(100)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -104,8 +139,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -113,70 +148,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -186,6 +197,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -195,15 +208,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/paris/vm/instructions/environment.py
+++ b/src/ethereum/paris/vm/instructions/environment.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32
 from ...eth_types import EMPTY_ACCOUNT
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..exceptions import OutOfBoundsRead
 from ..gas import (
@@ -31,6 +31,7 @@ from ..gas import (
     GAS_RETURN_DATA_COPY,
     GAS_VERY_LOW,
     GAS_WARM_ACCESS,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -229,10 +230,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -284,10 +288,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -367,15 +374,20 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
 
     if address in evm.accessed_addresses:
-        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost)
+        charge_gas(evm, GAS_WARM_ACCESS + copy_gas_cost + extend_memory.cost)
     else:
         evm.accessed_addresses.add(address)
-        charge_gas(evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost)
+        charge_gas(
+            evm, GAS_COLD_ACCOUNT_ACCESS + copy_gas_cost + extend_memory.cost
+        )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -423,8 +435,10 @@ def returndatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_RETURN_DATA_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
     ensure(
@@ -432,6 +446,7 @@ def returndatacopy(evm: Evm) -> None:
         OutOfBoundsRead,
     )
 
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = evm.return_data[
         return_data_start_position : return_data_start_position + size
     ]

--- a/src/ethereum/paris/vm/instructions/log.py
+++ b/src/ethereum/paris/vm/instructions/log.py
@@ -19,8 +19,14 @@ from ethereum.utils.ensure import ensure
 from ...eth_types import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -49,10 +55,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     ensure(not evm.message.is_static, WriteInStaticContext)
     log_entry = Log(
         address=evm.message.current_target,

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -40,12 +40,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_WARM_ACCESS,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -138,10 +138,14 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(evm.env.state, evm.message.current_target).nonce,
@@ -174,11 +178,17 @@ def create2(evm: Evm) -> None:
     salt = pop(evm.stack).to_be_bytes32()
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
     call_data_words = ceil32(Uint(memory_size)) // 32
-    charge_gas(evm, GAS_CREATE + GAS_KECCAK256_WORD * call_data_words)
+    charge_gas(
+        evm,
+        GAS_CREATE + GAS_KECCAK256_WORD * call_data_words + extend_memory.cost,
+    )
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_create2_contract_address(
         evm.message.current_target,
         salt,
@@ -207,10 +217,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -309,8 +323,13 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -324,32 +343,29 @@ def call(evm: Evm) -> None:
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
     ensure(not evm.message.is_static or value == U256(0), WriteInStaticContext)
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -387,8 +403,13 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -397,31 +418,28 @@ def callcode(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas,
-        Uint(evm.gas_left),
-        access_gas_cost + transfer_gas_cost,
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -507,8 +525,13 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -516,18 +539,16 @@ def delegatecall(evm: Evm) -> None:
         evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), access_gas_cost
-    )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -562,8 +583,13 @@ def staticcall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
 
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -571,21 +597,20 @@ def staticcall(evm: Evm) -> None:
         evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), access_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         access_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         U256(0),
         evm.message.current_target,
         to,
@@ -616,9 +641,14 @@ def revert(evm: Evm) -> None:
     size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+
+    charge_gas(evm, extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
     evm.output = bytes(output)
     raise Revert

--- a/src/ethereum/paris/vm/memory.py
+++ b/src/ethereum/paris/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -58,6 +61,38 @@ GAS_IDENTITY = Uint(15)
 GAS_IDENTITY_WORD = Uint(3)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -103,8 +138,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -112,70 +147,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -185,6 +196,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -194,15 +207,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/spurious_dragon/vm/instructions/environment.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/environment.py
@@ -17,7 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BALANCE,
@@ -25,6 +25,7 @@ from ..gas import (
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -219,10 +220,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -274,10 +278,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -353,10 +360,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -63,7 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         + GAS_LOG_TOPIC * num_topics
         + extend_memory.cost,
     )
-  
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -17,8 +17,14 @@ from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -47,10 +53,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
-
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
+  
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -31,12 +31,12 @@ from ..gas import (
     GAS_SELF_DESTRUCT,
     GAS_SELF_DESTRUCT_NEW_ACCOUNT,
     GAS_ZERO,
-    calculate_call_gas_cost,
-    calculate_message_call_gas_stipend,
+    calculate_gas_extend_memory,
+    calculate_message_call_gas,
     charge_gas,
     max_message_call_gas,
 )
-from ..memory import extend_memory, memory_read_bytes, memory_write
+from ..memory import memory_read_bytes, memory_write
 from ..stack import pop, push
 
 
@@ -59,13 +59,17 @@ def create(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_CREATE)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= U256(create_message_gas)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_address = evm.message.current_target
     sender = get_account(evm.env.state, sender_address)
 
@@ -133,10 +137,14 @@ def return_(evm: Evm) -> None:
     memory_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_start_position, memory_size)
-    charge_gas(evm, GAS_ZERO)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_position, memory_size)]
+    )
+
+    charge_gas(evm, GAS_ZERO + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     evm.output = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
@@ -224,36 +232,40 @@ def call(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
+    )
     create_gas_cost = (
         Uint(0)
         if value == 0 or is_account_alive(evm.env.state, to)
         else GAS_NEW_ACCOUNT
     )
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + create_gas_cost + transfer_gas_cost
-    )
-    message_call_gas = calculate_message_call_gas_stipend(
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -290,31 +302,35 @@ def callcode(evm: Evm) -> None:
     # GAS
     to = evm.message.current_target
 
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
-    call_gas_fee = calculate_call_gas_cost(
-        gas, Uint(evm.gas_left), GAS_CALL + transfer_gas_cost
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    message_call_gas = calculate_message_call_gas_stipend(
+    transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+    message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
+        extend_memory.cost,
         GAS_CALL + transfer_gas_cost,
     )
-    charge_gas(evm, call_gas_fee)
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
         evm.env.state, evm.message.current_target
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas
+        evm.gas_left += message_call_gas.stipend
     else:
         generic_call(
             evm,
-            message_call_gas,
+            message_call_gas.stipend,
             value,
             evm.message.current_target,
             to,
@@ -393,18 +409,23 @@ def delegatecall(evm: Evm) -> None:
     memory_output_size = pop(evm.stack)
 
     # GAS
-    extend_memory(evm, memory_input_start_position, memory_input_size)
-    extend_memory(evm, memory_output_start_position, memory_output_size)
-    call_gas_fee = calculate_call_gas_cost(gas, Uint(evm.gas_left), GAS_CALL)
-    message_call_gas = calculate_message_call_gas_stipend(
-        U256(0), gas, Uint(evm.gas_left), GAS_CALL
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory,
+        [
+            (memory_input_start_position, memory_input_size),
+            (memory_output_start_position, memory_output_size),
+        ],
     )
-    charge_gas(evm, call_gas_fee)
+    message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, GAS_CALL
+    )
+    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas,
+        message_call_gas.stipend,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,

--- a/src/ethereum/spurious_dragon/vm/memory.py
+++ b/src/ethereum/spurious_dragon/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -11,6 +11,9 @@ Introduction
 
 EVM gas constants and calculators.
 """
+from dataclasses import dataclass
+from typing import List, Tuple
+
 from ethereum.base_types import U256, Uint
 from ethereum.utils.numeric import ceil32
 
@@ -58,6 +61,38 @@ GAS_IDENTITY = Uint(15)
 GAS_IDENTITY_WORD = Uint(3)
 
 
+@dataclass
+class ExtendMemory:
+    """
+    Define the parameters for memory extension in opcodes
+
+    `cost`: `ethereum.base_types.Uint`
+        The gas required to perform the extension
+    `expand_by`: `ethereum.base_types.Uint`
+        The size by which the memory will be extended
+    """
+
+    cost: Uint
+    expand_by: Uint
+
+
+@dataclass
+class MessageCallGas:
+    """
+    Define the gas cost and stipend for executing the call opcodes.
+
+    `cost`: `ethereum.base_types.Uint`
+        The non-refundable portion of gas reserved for executing the
+        call opcode.
+    `stipend`: `ethereum.base_types.Uint`
+        The portion of gas available to sub-calls that is refundable
+        if not consumed
+    """
+
+    cost: Uint
+    stipend: Uint
+
+
 def charge_gas(evm: Evm, amount: Uint) -> None:
     """
     Subtracts `amount` from `evm.gas_left`.
@@ -103,8 +138,8 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> Uint:
 
 
 def calculate_gas_extend_memory(
-    memory: bytearray, start_position: U256, size: U256
-) -> Uint:
+    memory: bytearray, extensions: List[Tuple[U256, U256]]
+) -> ExtendMemory:
     """
     Calculates the gas amount to extend memory
 
@@ -112,70 +147,46 @@ def calculate_gas_extend_memory(
     ----------
     memory :
         Memory contents of the EVM.
-    start_position :
-        Starting pointer to the memory.
-    size:
-        Amount of bytes by which the memory needs to be extended.
+    extensions:
+        List of extensions to be made to the memory.
+        Consists of a tuple of start position and size.
 
     Returns
     -------
-    to_be_paid : `ethereum.base_types.Uint`
-        returns `0` if size=0 or if the
-        size after extending memory is less than the size before extending
-        else it returns the amount that needs to be paid for extendinng memory.
+    extend_memory: `ExtendMemory`
     """
-    if size == 0:
-        return Uint(0)
-    memory_size = Uint(len(memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return Uint(0)
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    return to_be_paid
+    size_to_extend = Uint(0)
+    to_be_paid = Uint(0)
+    current_size = Uint(len(memory))
+    for start_position, size in extensions:
+        if size == 0:
+            continue
+        before_size = ceil32(current_size)
+        after_size = ceil32(Uint(start_position) + Uint(size))
+        if after_size <= before_size:
+            continue
+
+        size_to_extend += after_size - before_size
+        already_paid = calculate_memory_gas_cost(before_size)
+        total_cost = calculate_memory_gas_cost(after_size)
+        to_be_paid += total_cost - already_paid
+
+        current_size = after_size
+
+    return ExtendMemory(to_be_paid, size_to_extend)
 
 
-def calculate_call_gas_cost(
-    gas: Uint, gas_left: Uint, extra_gas: Uint
-) -> Uint:
-    """
-    Calculates the gas amount for executing Opcodes `CALL` and `CALLCODE`.
-
-    Parameters
-    ----------
-    gas :
-        The amount of gas provided to the message-call.
-    gas_left :
-        The amount of gas left in the current frame.
-    extra_gas :
-        The amount of gas needed for transferring value + creating a new
-        account inside a message call.
-
-    Returns
-    -------
-    call_gas_cost: `ethereum.base_types.Uint`
-        The total gas amount for executing Opcodes `CALL` and `CALLCODE`.
-    """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
-
-    return gas + extra_gas
-
-
-def calculate_message_call_gas_stipend(
+def calculate_message_call_gas(
     value: U256,
     gas: Uint,
     gas_left: Uint,
+    memory_cost: Uint,
     extra_gas: Uint,
     call_stipend: Uint = GAS_CALL_STIPEND,
-) -> Uint:
+) -> MessageCallGas:
     """
-    Calculates the gas stipend for making the message call
-    with the given value.
+    Calculates the MessageCallGas (cost and stipend) for
+    executing call Opcodes.
 
     Parameters
     ----------
@@ -185,6 +196,8 @@ def calculate_message_call_gas_stipend(
         The amount of gas provided to the message-call.
     gas_left :
         The amount of gas left in the current frame.
+    memory_cost :
+        The amount needed to extend the memory in the current frame.
     extra_gas :
         The amount of gas needed for transferring value + creating a new
         account inside a message call.
@@ -194,15 +207,15 @@ def calculate_message_call_gas_stipend(
 
     Returns
     -------
-    message_call_gas_stipend : `ethereum.base_types.Uint`
-        The gas stipend for making the message-call.
+    message_call_gas: `MessageCallGas`
     """
-    if gas_left < extra_gas:
-        raise OutOfGasError
-
-    gas = min(gas, max_message_call_gas(gas_left - extra_gas))
     call_stipend = Uint(0) if value == 0 else call_stipend
-    return gas + call_stipend
+    if gas_left < extra_gas + memory_cost:
+        return MessageCallGas(gas + extra_gas, gas + call_stipend)
+
+    gas = min(gas, max_message_call_gas(gas_left - memory_cost - extra_gas))
+
+    return MessageCallGas(gas + extra_gas, gas + call_stipend)
 
 
 def max_message_call_gas(gas: Uint) -> Uint:

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -17,7 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...state import get_account
 from ...utils.address import to_address
-from ...vm.memory import buffer_read, extend_memory, memory_write
+from ...vm.memory import buffer_read, memory_write
 from .. import Evm
 from ..gas import (
     GAS_BALANCE,
@@ -25,6 +25,7 @@ from ..gas import (
     GAS_COPY,
     GAS_EXTERNAL,
     GAS_VERY_LOW,
+    calculate_gas_extend_memory,
     charge_gas,
 )
 from ..stack import pop, push
@@ -219,10 +220,13 @@ def calldatacopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.message.data, data_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -274,10 +278,13 @@ def codecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_VERY_LOW + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     value = buffer_read(evm.code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
 
@@ -353,10 +360,13 @@ def extcodecopy(evm: Evm) -> None:
     # GAS
     words = ceil32(Uint(size)) // 32
     copy_gas_cost = GAS_COPY * words
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost)
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(evm, GAS_EXTERNAL + copy_gas_cost + extend_memory.cost)
 
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     code = get_account(evm.env.state, address).code
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -63,7 +63,7 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         + GAS_LOG_TOPIC * num_topics
         + extend_memory.cost,
     )
-  
+
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -17,8 +17,14 @@ from ethereum.base_types import U256
 
 from ...eth_types import Log
 from .. import Evm
-from ..gas import GAS_LOG, GAS_LOG_DATA, GAS_LOG_TOPIC, charge_gas
-from ..memory import extend_memory, memory_read_bytes
+from ..gas import (
+    GAS_LOG,
+    GAS_LOG_DATA,
+    GAS_LOG_TOPIC,
+    calculate_gas_extend_memory,
+    charge_gas,
+)
+from ..memory import memory_read_bytes
 from ..stack import pop
 
 
@@ -47,10 +53,19 @@ def log_n(evm: Evm, num_topics: U256) -> None:
         topics.append(topic)
 
     # GAS
-    extend_memory(evm, memory_start_index, size)
-    charge_gas(evm, GAS_LOG + GAS_LOG_DATA * size + GAS_LOG_TOPIC * num_topics)
-
+    extend_memory = calculate_gas_extend_memory(
+        evm.memory, [(memory_start_index, size)]
+    )
+    charge_gas(
+        evm,
+        GAS_LOG
+        + GAS_LOG_DATA * size
+        + GAS_LOG_TOPIC * num_topics
+        + extend_memory.cost,
+    )
+  
     # OPERATION
+    evm.memory += b"\x00" * extend_memory.expand_by
     log_entry = Log(
         address=evm.message.current_target,
         topics=tuple(topics),

--- a/src/ethereum/tangerine_whistle/vm/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/memory.py
@@ -12,39 +12,8 @@ Introduction
 EVM memory operations.
 """
 from ethereum.utils.byte import right_pad_zero_bytes
-from ethereum.utils.numeric import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from . import Evm
-from .gas import calculate_gas_extend_memory, charge_gas
-
-
-def extend_memory(evm: Evm, start_position: U256, size: U256) -> None:
-    """
-    Extends the size of the memory and
-    substracts the gas amount to extend memory.
-
-    Parameters
-    ----------
-    evm :
-        The current Evm.
-    start_position :
-        Starting pointer to the memory.
-    size :
-        Amount of bytes by which the memory needs to be extended.
-    """
-    charge_gas(
-        evm, calculate_gas_extend_memory(evm.memory, start_position, size)
-    )
-    if size == 0:
-        return
-    memory_size = Uint(len(evm.memory))
-    before_size = ceil32(memory_size)
-    after_size = ceil32(Uint(start_position) + Uint(size))
-    if after_size <= before_size:
-        return
-    size_to_extend = after_size - memory_size
-    evm.memory += b"\x00" * size_to_extend
 
 
 def memory_write(


### PR DESCRIPTION
The changes have only been implemented in Frontier. Will be applied to the other forks post feedback.

### What was wrong?
1.  The `extend_memory` function and the `calculate_gas_extend_memory` function perform mostly the same calculations.
2. The `extend_memory` gas is charged separately from the other gas charges involved. It is better to calculate the overall gas costs and then deduct it in one go (which also makes it easier to implement an EVM Trace see #624 )

### How was it fixed?
Remove the `extend_memory` function and allow the `calculate_gas_extend_memory` function to return the gas_cost as well as the size to be extended

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-4.jpg)
