### PR TITLE
Update tests - `NoPostState` and `bigmem`

### DIFF
--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -53,7 +53,14 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TESTS = ("50000_",)
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "50000_",
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
 
 
 @pytest.mark.parametrize(
@@ -62,7 +69,7 @@ BIG_MEMORY_TESTS = ("50000_",)
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
         slow_list=GENERAL_STATE_SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -76,7 +77,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_berlin_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -108,7 +109,7 @@ VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_berlin_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -154,7 +155,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_berlin_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -38,7 +38,14 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TESTS = ("50000_",)
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "50000_",
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
 
 
 @pytest.mark.parametrize(
@@ -46,7 +53,7 @@ BIG_MEMORY_TESTS = ("50000_",)
     fetch_byzantium_tests(
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )
@@ -74,7 +81,7 @@ IGNORE_LIST = (
 # hence they've been marked as slow
 SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
-BIG_MEMORY_TESTS = ("randomStatetest94_",)
+VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
 
 @pytest.mark.parametrize(
@@ -83,7 +90,7 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
         test_dir,
         ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -60,7 +61,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_byzantium_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -97,7 +98,7 @@ VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_byzantium_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -126,7 +127,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_byzantium_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -56,7 +56,14 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TESTS = ("50000_",)
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "50000_",
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
 
 
 @pytest.mark.parametrize(
@@ -64,7 +71,7 @@ BIG_MEMORY_TESTS = ("50000_",)
     fetch_constantinople_tests(
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )
@@ -92,7 +99,7 @@ IGNORE_LIST = (
 # hence they've been marked as slow
 SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
-BIG_MEMORY_TESTS = ("randomStatetest94_",)
+VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
 
 @pytest.mark.parametrize(
@@ -101,7 +108,7 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
         test_dir,
         ignore_list=IGNORE_LIST,
         slow_list=SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -78,7 +79,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_constantinople_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -115,7 +116,7 @@ VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_constantinople_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -144,7 +145,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_constantinople_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -29,10 +29,20 @@ test_dir = (
     "GeneralStateTests/"
 )
 
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(test_dir),
+    fetch_frontier_tests(
+        test_dir,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:
@@ -53,6 +63,7 @@ IGNORE_LIST = (
     "bcGasPricerTest/RPC_API_Test.json",
     "bcMultiChainTest/",
     "bcTotalDifficultyTest/",
+    "stTimeConsuming/",
 )
 
 

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -48,7 +49,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_frontier_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -78,7 +79,7 @@ IGNORE_LIST = (
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_frontier_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -107,7 +108,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_frontier_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -349,9 +349,10 @@ def load_test(test_case: Dict, load: BaseLoad) -> Dict:
     )
 
     try:
-        post_state = load.json_to_state(json_data["postState"])
+        raw_post_state = json_data["postState"]
     except KeyError:
         raise NoPostState
+    post_state = load.json_to_state(raw_post_state)
 
     return {
         "test_file": test_case["test_file"],

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -113,10 +113,22 @@ GENERAL_STATE_SLOW_TESTS = (
 # Please provide an explanation when adding entries
 INCORRECT_UPSTREAM_STATE_TESTS = ()
 
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(test_dir, slow_list=GENERAL_STATE_SLOW_TESTS),
+    fetch_homestead_tests(
+        test_dir,
+        slow_list=GENERAL_STATE_SLOW_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:
@@ -143,7 +155,7 @@ IGNORE_LIST = (
 # hence they've been marked as slow
 VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 
-BIG_MEMORY_TESTS = ("randomStatetest94_",)
+VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 
 
 @pytest.mark.parametrize(
@@ -152,7 +164,7 @@ BIG_MEMORY_TESTS = ("randomStatetest94_",)
         test_dir,
         ignore_list=IGNORE_LIST,
         slow_list=VALID_BLOCKS_SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -134,7 +135,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_homestead_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -171,7 +172,7 @@ VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_homestead_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -200,7 +201,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_homestead_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -53,7 +53,14 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TESTS = ("50000_",)
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "50000_",
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
 
 
 @pytest.mark.parametrize(
@@ -62,7 +69,7 @@ BIG_MEMORY_TESTS = ("50000_",)
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
         slow_list=GENERAL_STATE_SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -76,7 +77,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_istanbul_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -108,7 +109,7 @@ VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_istanbul_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -154,7 +155,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_istanbul_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -53,7 +53,14 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TESTS = ("50000_",)
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "50000_",
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
 
 
 @pytest.mark.parametrize(
@@ -62,7 +69,7 @@ BIG_MEMORY_TESTS = ("50000_",)
         test_dir,
         ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
         slow_list=SLOW_TESTS,
-        big_memory_list=BIG_MEMORY_TESTS,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
     ),
     ids=idfn,
 )

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -76,7 +77,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_london_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -148,7 +149,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_london_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -29,10 +29,21 @@ test_dir = (
     "GeneralStateTests/"
 )
 
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(test_dir),
+    fetch_spurious_dragon_tests(
+        test_dir,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -49,7 +50,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_spurious_dragon_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -83,7 +84,7 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_spurious_dragon_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -112,7 +113,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_spurious_dragon_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -31,10 +31,21 @@ test_dir = (
     "GeneralStateTests/"
 )
 
+GENERAL_STATE_BIG_MEMORY_TESTS = (
+    "/stQuadraticComplexityTest/",
+    "/stRandom2/",
+    "/stRandom/",
+    "/stSpecialTest/",
+    "stTimeConsuming/",
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(test_dir),
+    fetch_tangerine_whistle_tests(
+        test_dir,
+        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -9,6 +9,7 @@ from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
 from tests.helpers.load_state_tests import (
     Load,
+    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -51,7 +52,7 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
 def test_general_state_tests(test_case: Dict) -> None:
     try:
         run_tangerine_whistle_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -85,7 +86,7 @@ SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
 def test_valid_block_tests(test_case: Dict) -> None:
     try:
         run_tangerine_whistle_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(f"{test_case} doesn't have post state")
 
@@ -114,7 +115,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
         else:
             with pytest.raises(InvalidBlock):
                 run_tangerine_whistle_blockchain_st_tests(test_case)
-    except KeyError:
+    except NoPostState:
         # FIXME: Handle tests that don't have post state
         pytest.xfail(
             "{} doesn't have post state".format(test_case["test_key"])


### PR DESCRIPTION
(closes #619 )
(closes #617 )

### What was wrong?
This PR resolves the following issues related to tests
1. Some tests cause  the Github CI worker to crash. 
2. Currently, the tests are configured to `xfail` upon `KeyError` which could potentially hide actual `KeyError`

Related to Issue #617 #619

### How was it fixed?
1. Marked the responsible tests as `bigmem`
2. Raised a more specific error when the post state is missing


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.animalsaroundtheglobe.com/wp-content/uploads/2021/05/meerkat-255564_960_720.jpg)
