### PR TITLE
Hide submodules and subpackages in diffs

### DIFF
--- a/doc/_templates/autoapi/python/module.rst
+++ b/doc/_templates/autoapi/python/module.rst
@@ -12,38 +12,40 @@
 {{ obj.docstring|prepare_docstring }}
 {% endif %}
 
-{% block subpackages %}
-{% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
-{% if visible_subpackages %}
-Subpackages
------------
-.. toctree::
-   :titlesonly:
-   :maxdepth: 3
+.. only:: stage1
 
-{% for subpackage in visible_subpackages %}
-   {{ subpackage.short_name }}/index.rst
-{% endfor %}
+   {% block subpackages %}
+   {% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
+   {% if visible_subpackages %}
+   Subpackages
+   -----------
+   .. toctree::
+      :titlesonly:
+      :maxdepth: 3
 
-
-{% endif %}
-{% endblock %}
-{% block submodules %}
-{% set visible_submodules = obj.submodules|selectattr("display")|list %}
-{% if visible_submodules %}
-Submodules
-----------
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-{% for submodule in visible_submodules %}
-   {{ submodule.short_name }}/index.rst
-{% endfor %}
+   {% for subpackage in visible_subpackages %}
+      {{ subpackage.short_name }}/index.rst
+   {% endfor %}
 
 
-{% endif %}
-{% endblock %}
+   {% endif %}
+   {% endblock %}
+   {% block submodules %}
+   {% set visible_submodules = obj.submodules|selectattr("display")|list %}
+   {% if visible_submodules %}
+   Submodules
+   ----------
+   .. toctree::
+      :titlesonly:
+      :maxdepth: 1
+
+   {% for submodule in visible_submodules %}
+      {{ submodule.short_name }}/index.rst
+   {% endfor %}
+
+
+   {% endif %}
+   {% endblock %}
 {% block content %}
 {% if obj.all is not none %}
 {% set visible_children = obj.children|selectattr("short_name", "in", obj.all)|list %}


### PR DESCRIPTION
(closes #636 )

### What was wrong?
Currently, the rendered docs have links to sub-packages and sub-modules in the diffs which are linked to the pickle files instead of html. It is not sensible to have these links in the first place because not all sub-packages might have diffs.

Related to Issue #636 

### How was it fixed?
Hide the relevant sections upon rendering the page.

[This](https://gurukamath.github.io/execution-specs/diffs/frontier_homestead/index.html) is what the rendered docs will look like after this PR.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://assets3.thrillist.com/v1/image/3010676/1440x1920/scale;webp=auto;jpeg_quality=60.jpg)
