### PR TITLE
Refactor account deletion and clearing

### DIFF
--- a/src/ethereum/london/spec.py
+++ b/src/ethereum/london/spec.py
@@ -50,12 +50,11 @@ from .eth_types import (
 )
 from .state import (
     State,
-    account_exists,
+    account_exists_and_is_empty,
     create_ether,
     destroy_account,
     get_account,
     increment_nonce,
-    is_account_empty,
     set_account_balance,
     state_root,
 )
@@ -738,10 +737,7 @@ def process_transaction(
         destroy_account(env.state, address)
 
     for address in output.touched_accounts:
-        should_delete = account_exists(
-            env.state, address
-        ) and is_account_empty(env.state, address)
-        if should_delete:
+        if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
     return total_gas_used, output.logs, output.has_erred

--- a/src/ethereum/london/state.py
+++ b/src/ethereum/london/state.py
@@ -369,6 +369,35 @@ def is_account_empty(state: State, address: Address) -> bool:
     )
 
 
+def account_exists_and_is_empty(state: State, address: Address) -> bool:
+    """
+    Checks if an account exists and has zero nonce, empty code and zero
+    balance.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    exists_and_is_empty : `bool`
+        True if an account exists and has zero nonce, empty code and zero
+        balance, False otherwise.
+    """
+    account = get_account_optional(state, address)
+    if account is None:
+        return False
+    else:
+        return (
+            account.nonce == Uint(0)
+            and account.code == b""
+            and account.balance == 0
+        )
+
+
 def is_account_alive(state: State, address: Address) -> bool:
     """
     Check whether is an account is both in the state and non empty.

--- a/src/ethereum/london/state.py
+++ b/src/ethereum/london/state.py
@@ -388,14 +388,12 @@ def account_exists_and_is_empty(state: State, address: Address) -> bool:
         balance, False otherwise.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+    return (
+        account is not None
+        and account.nonce == Uint(0)
+        and account.code == b""
+        and account.balance == 0
+    )
 
 
 def is_account_alive(state: State, address: Address) -> bool:

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -14,15 +14,18 @@ The abstract computer which runs the code stored in an
 """
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
-from ..state import State
+from ..state import State, account_exists_and_is_empty
+from ..utils.address import to_address
 
 __all__ = ("Environment", "Evm", "Message")
+
+RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass
@@ -82,10 +85,64 @@ class Evm:
     running: bool
     message: Message
     output: Bytes
-    accounts_to_delete: Dict[Address, Address]
+    accounts_to_delete: Set[Address]
+    touched_accounts: Set[Address]
     has_erred: bool
-    children: List["Evm"]
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
+
+
+def incorporate_child_evm_successful(evm: Evm, child_evm: Evm) -> None:
+    """
+    Incorporate the state of a successful `child_evm` into the parent `evm`.
+
+    Parameters
+    ----------
+    evm :
+        The parent `EVM`.
+    child_evm :
+        The child evm to incorporate.
+    """
+    evm.gas_left += child_evm.gas_left
+    evm.logs += child_evm.logs
+    evm.refund_counter += child_evm.refund_counter
+    evm.accounts_to_delete.update(child_evm.accounts_to_delete)
+    evm.touched_accounts.update(child_evm.touched_accounts)
+    if account_exists_and_is_empty(
+        evm.env.state, child_evm.message.current_target
+    ):
+        evm.touched_accounts.add(child_evm.message.current_target)
+    evm.accessed_addresses.update(child_evm.accessed_addresses)
+    evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
+
+
+def incorporate_child_evm_error(evm: Evm, child_evm: Evm) -> None:
+    """
+    Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
+
+    Parameters
+    ----------
+    evm :
+        The parent `EVM`.
+    child_evm :
+        The child evm to incorporate.
+    """
+    # In block 2675119, the empty account at 0x2 (the RIPEMD160 precompile) was
+    # cleared despite running out of gas. This is an obscure edge case that can
+    # only happen to a precompile.
+    # According to the general rules governing clearing of empty accounts, the
+    # touch should have been reverted. Due to client bugs, this event went
+    # unnoticed and 0x2 has been exempted from the rule that touches are
+    # reverted in order to preserve this historical behaviour.
+    if RIPEMD160_ADDRESS in child_evm.touched_accounts:
+        evm.touched_accounts.add(RIPEMD160_ADDRESS)
+    if (
+        child_evm.message.current_target == RIPEMD160_ADDRESS
+        and account_exists_and_is_empty(
+            evm.env.state, child_evm.message.current_target
+        )
+    ):
+        evm.touched_accounts.add(RIPEMD160_ADDRESS)
+    evm.gas_left += child_evm.gas_left

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -94,7 +94,7 @@ class Evm:
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 
 
-def incorporate_child_evm_successful(evm: Evm, child_evm: Evm) -> None:
+def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     """
     Incorporate the state of a successful `child_evm` into the parent `evm`.
 
@@ -118,7 +118,7 @@ def incorporate_child_evm_successful(evm: Evm, child_evm: Evm) -> None:
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
 
 
-def incorporate_child_evm_error(evm: Evm, child_evm: Evm) -> None:
+def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
     """
     Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
 
@@ -138,11 +138,9 @@ def incorporate_child_evm_error(evm: Evm, child_evm: Evm) -> None:
     # reverted in order to preserve this historical behaviour.
     if RIPEMD160_ADDRESS in child_evm.touched_accounts:
         evm.touched_accounts.add(RIPEMD160_ADDRESS)
-    if (
-        child_evm.message.current_target == RIPEMD160_ADDRESS
-        and account_exists_and_is_empty(
+    if child_evm.message.current_target == RIPEMD160_ADDRESS:
+        if account_exists_and_is_empty(
             evm.env.state, child_evm.message.current_target
-        )
-    ):
-        evm.touched_accounts.add(RIPEMD160_ADDRESS)
+        ):
+            evm.touched_accounts.add(RIPEMD160_ADDRESS)
     evm.gas_left += child_evm.gas_left

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -17,6 +17,7 @@ from ethereum.utils.numeric import ceil32
 
 from ...eth_types import Address
 from ...state import (
+    account_exists_and_is_empty,
     account_has_code_or_nonce,
     get_account,
     increment_nonce,
@@ -28,7 +29,12 @@ from ...utils.address import (
     compute_create2_contract_address,
     to_address,
 )
-from .. import Evm, Message
+from .. import (
+    Evm,
+    Message,
+    incorporate_child_evm_error,
+    incorporate_child_evm_successful,
+)
 from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
     GAS_CALL_VALUE,
@@ -110,17 +116,15 @@ def generic_create(
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
     )
     child_evm = process_create_message(child_message, evm.env)
-    evm.children.append(child_evm)
+
     if child_evm.has_erred:
-        push(evm.stack, U256(0))
+        incorporate_child_evm_error(evm, child_evm)
         evm.return_data = child_evm.output
+        push(evm.stack, U256(0))
     else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
+        incorporate_child_evm_successful(evm, child_evm)
+        evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
 
 
 def create(evm: Evm) -> None:
@@ -267,18 +271,15 @@ def generic_call(
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
     )
     child_evm = process_message(child_message, evm.env)
-    evm.children.append(child_evm)
 
     if child_evm.has_erred:
-        push(evm.stack, U256(0))
-        if isinstance(child_evm.error, Revert):
-            evm.return_data = child_evm.output
-    else:
-        evm.logs += child_evm.logs
-        evm.accessed_addresses = child_evm.accessed_addresses
-        evm.accessed_storage_keys = child_evm.accessed_storage_keys
-        push(evm.stack, U256(1))
+        incorporate_child_evm_error(evm, child_evm)
         evm.return_data = child_evm.output
+        push(evm.stack, U256(0))
+    else:
+        incorporate_child_evm_successful(evm, child_evm)
+        evm.return_data = child_evm.output
+        push(evm.stack, U256(1))
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -286,8 +287,6 @@ def generic_call(
         memory_output_start_position,
         child_evm.output[:actual_output_size],
     )
-    evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
 
 
 def call(evm: Evm) -> None:
@@ -480,7 +479,11 @@ def selfdestruct(evm: Evm) -> None:
     set_account_balance(evm.env.state, originator, U256(0))
 
     # register account for deletion
-    evm.accounts_to_delete[originator] = beneficiary
+    evm.accounts_to_delete.add(originator)
+
+    # mark beneficiary as touched
+    if account_exists_and_is_empty(evm.env.state, beneficiary):
+        evm.touched_accounts.add(beneficiary)
 
     # HALT the execution
     evm.running = False

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -32,8 +32,8 @@ from ...utils.address import (
 from .. import (
     Evm,
     Message,
-    incorporate_child_evm_error,
-    incorporate_child_evm_successful,
+    incorporate_child_on_error,
+    incorporate_child_on_success,
 )
 from ..exceptions import Revert, WriteInStaticContext
 from ..gas import (
@@ -118,11 +118,11 @@ def generic_create(
     child_evm = process_create_message(child_message, evm.env)
 
     if child_evm.has_erred:
-        incorporate_child_evm_error(evm, child_evm)
+        incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
-        incorporate_child_evm_successful(evm, child_evm)
+        incorporate_child_on_success(evm, child_evm)
         evm.return_data = b""
         push(evm.stack, U256.from_be_bytes(child_evm.message.current_target))
 
@@ -273,11 +273,11 @@ def generic_call(
     child_evm = process_message(child_message, evm.env)
 
     if child_evm.has_erred:
-        incorporate_child_evm_error(evm, child_evm)
+        incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
-        incorporate_child_evm_successful(evm, child_evm)
+        incorporate_child_on_success(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
 

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -12,7 +12,6 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from itertools import chain
 from typing import Iterable, Set, Tuple, Union
 
 from ethereum import evm_trace
@@ -21,6 +20,7 @@ from ethereum.utils.ensure import ensure
 
 from ..eth_types import Address, Log
 from ..state import (
+    account_exists_and_is_empty,
     account_has_code_or_nonce,
     begin_transaction,
     commit_transaction,
@@ -31,7 +31,6 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
@@ -49,7 +48,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass
@@ -107,16 +105,19 @@ def process_message_call(
             evm = process_create_message(message, env)
     else:
         evm = process_message(message, env)
-
-    accounts_to_delete = collect_accounts_to_delete(evm)
-    refund_counter = U256(calculate_gas_refund(evm))
+        if account_exists_and_is_empty(env.state, Address(message.target)):
+            evm.touched_accounts.add(Address(message.target))
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
-        refund_counter=refund_counter,
+        refund_counter=U256(evm.refund_counter)
+        if not evm.has_erred
+        else U256(0),
         logs=evm.logs if not evm.has_erred else (),
-        accounts_to_delete=accounts_to_delete,
-        touched_accounts=collect_touched_accounts(evm),
+        accounts_to_delete=evm.accounts_to_delete
+        if not evm.has_erred
+        else set(),
+        touched_accounts=evm.touched_accounts if not evm.has_erred else set(),
         has_erred=evm.has_erred,
     )
 
@@ -238,9 +239,9 @@ def execute_code(message: Message, env: Environment) -> Evm:
         running=True,
         message=message,
         output=b"",
-        accounts_to_delete=dict(),
+        accounts_to_delete=set(),
+        touched_accounts=set(),
         has_erred=False,
-        children=[],
         return_data=b"",
         error=None,
         accessed_addresses=message.accessed_addresses,
@@ -270,109 +271,3 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.error = e
         evm.has_erred = True
     return evm
-
-
-def collect_touched_accounts(
-    evm: Evm, ancestor_had_error: bool = False
-) -> Iterable[Address]:
-    """
-    Collect all of the accounts that *may* need to be deleted based on
-    `EIP-161 <https://eips.ethereum.org/EIPS/eip-161>`_.
-    Checking whether they *do* need to be deleted happens in the caller.
-    See also: https://github.com/ethereum/EIPs/issues/716
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-    ancestor_had_error :
-        True if the ancestors of the evm object erred else False
-
-    Returns
-    -------
-    touched_accounts: `typing.Iterable`
-        returns all the accounts that were touched and may need to be deleted.
-    """
-    # collect the coinbase account if it was touched via zero-fee transfer
-    if (evm.message.caller == evm.env.origin) and evm.env.gas_price == 0:
-        yield evm.env.coinbase
-
-    # collect those explicitly marked for deletion
-    # ("beneficiary" is of SELFDESTRUCT)
-    for beneficiary in sorted(set(evm.accounts_to_delete.values())):
-        if evm.has_erred or ancestor_had_error:
-            # Special case to account for geth+parity bug
-            # https://github.com/ethereum/EIPs/issues/716
-            if beneficiary == RIPEMD160_ADDRESS:
-                yield beneficiary
-            continue
-        else:
-            yield beneficiary
-
-    # collect account directly addressed
-    if not isinstance(evm.message.target, Bytes0):
-        if evm.has_erred or ancestor_had_error:
-            # collect RIPEMD160 precompile even if ancestor evm had error.
-            # otherwise, skip collection from children of erred-out evm objects
-            if evm.message.target == RIPEMD160_ADDRESS:
-                yield evm.message.target
-        else:
-            yield evm.message.target
-
-    # recurse into nested computations
-    # (even erred ones, since looking for RIPEMD160)
-    for child in evm.children:
-        yield from collect_touched_accounts(
-            child, ancestor_had_error=(evm.has_erred or ancestor_had_error)
-        )
-
-
-def collect_accounts_to_delete(evm: Evm) -> Set[Address]:
-    """
-    Collects all the accounts that were marked for deletion by the
-    `SELFDESTRUCT` opcode.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    accounts_to_delete: `set`
-        returns all the accounts need marked for deletion by the
-        `SELFDESTRUCT` opcode.
-    """
-    if evm.has_erred:
-        return set()
-    else:
-        return set(
-            chain(
-                evm.accounts_to_delete.keys(),
-                *(collect_accounts_to_delete(child) for child in evm.children),
-            )
-        )
-
-
-def calculate_gas_refund(evm: Evm) -> int:
-    """
-    Adds up the gas that was refunded in each execution frame during the
-    message call.
-
-    Parameters
-    ----------
-    evm :
-        The current EVM frame.
-
-    Returns
-    -------
-    gas_refund: `ethereum.base_types.U256`
-        returns the total gas that needs to be refunded after executing the
-        message call.
-    """
-    if evm.has_erred:
-        return 0
-    else:
-        return evm.refund_counter + sum(
-            calculate_gas_refund(child_evm) for child_evm in evm.children
-        )

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -108,16 +108,21 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
+    if evm.has_erred:
+        logs = set()
+        accounts_to_delete = set()
+        touched_accounts = set()
+    else:
+        logs = evm.logs
+        accounts_to_delete = evm.accounts_to_delete
+        touched_accounts = evm.touched_accounts
+
     return MessageCallOutput(
         gas_left=evm.gas_left,
-        refund_counter=U256(evm.refund_counter)
-        if not evm.has_erred
-        else U256(0),
-        logs=evm.logs if not evm.has_erred else (),
-        accounts_to_delete=evm.accounts_to_delete
-        if not evm.has_erred
-        else set(),
-        touched_accounts=evm.touched_accounts if not evm.has_erred else set(),
+        refund_counter=U256(evm.refund_counter),
+        logs=logs,
+        accounts_to_delete=accounts_to_delete,
+        touched_accounts=touched_accounts,
         has_erred=evm.has_erred,
     )
 


### PR DESCRIPTION
This removes the preservation of stack frames of the course of execution through the `children` element of `EVM` and instead switches to a model where `child_evm` s are incorporated into their parents. This substantially reduces the memory usage of the test suite and gives the specs semantics that better match real clients.

This only implements the changes for `london`, backporting to other hardforks will be required before merging.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://web.archive.org/web/20221109180112/https://i.redd.it/ynd61gc9fqy91.jpg?ref=upstract.com)
