### PR TITLE
remove `Raises` from docstrings in `Paris`

### DIFF
--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -70,10 +70,6 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
     amount :
         The amount of gas the current operation requires.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `gas_left` is less than `amount`.
     """
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/paris/vm/instructions/arithmetic.py
+++ b/src/ethereum/paris/vm/instructions/arithmetic.py
@@ -37,12 +37,6 @@ def add(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -70,12 +64,6 @@ def sub(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     x = pop(evm.stack)
@@ -103,12 +91,6 @@ def mul(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -136,12 +118,6 @@ def div(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack)
@@ -172,12 +148,6 @@ def sdiv(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     dividend = pop(evm.stack).to_signed()
@@ -211,12 +181,6 @@ def mod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack)
@@ -247,12 +211,6 @@ def smod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     x = pop(evm.stack).to_signed()
@@ -283,12 +241,6 @@ def addmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -320,12 +272,6 @@ def mulmod(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     x = Uint(pop(evm.stack))
@@ -357,10 +303,6 @@ def exp(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     base = Uint(pop(evm.stack))
@@ -394,12 +336,6 @@ def signextend(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `5`.
     """
     # STACK
     byte_num = pop(evm.stack)

--- a/src/ethereum/paris/vm/instructions/bitwise.py
+++ b/src/ethereum/paris/vm/instructions/bitwise.py
@@ -29,12 +29,6 @@ def bitwise_and(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -60,12 +54,6 @@ def bitwise_or(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -91,12 +79,6 @@ def bitwise_xor(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -122,12 +104,6 @@ def bitwise_not(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)
@@ -153,12 +129,6 @@ def get_byte(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     byte_index = pop(evm.stack)

--- a/src/ethereum/paris/vm/instructions/comparison.py
+++ b/src/ethereum/paris/vm/instructions/comparison.py
@@ -29,12 +29,6 @@ def less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -61,12 +55,6 @@ def signed_less_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -94,12 +82,6 @@ def greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -126,12 +108,6 @@ def signed_greater_than(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack).to_signed()
@@ -159,12 +135,6 @@ def equal(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     left = pop(evm.stack)
@@ -192,12 +162,6 @@ def is_zero(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `GAS_VERY_LOW`.
     """
     # STACK
     x = pop(evm.stack)

--- a/src/ethereum/paris/vm/instructions/control_flow.py
+++ b/src/ethereum/paris/vm/instructions/control_flow.py
@@ -52,18 +52,6 @@ def jump(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `8`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -90,18 +78,6 @@ def jumpi(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.InvalidJumpDestError`
-        If the jump destination doesn't meet any of the following criteria:
-            * The jump destination is less than the length of the code.
-            * The jump destination should have the `JUMPDEST` opcode (0x5B).
-            * The jump destination shouldn't be part of the data corresponding
-            to `PUSH-N` opcodes.
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `10`.
     """
     # STACK
     jump_dest = Uint(pop(evm.stack))
@@ -132,12 +108,6 @@ def pc(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -162,12 +132,6 @@ def gas_left(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackOverflowError`
-        If `len(stack)` is more than `1023`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -193,10 +157,6 @@ def jumpdest(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `1`.
     """
     # STACK
     pass

--- a/src/ethereum/paris/vm/instructions/environment.py
+++ b/src/ethereum/paris/vm/instructions/environment.py
@@ -45,10 +45,6 @@ def address(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -72,12 +68,6 @@ def balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -109,10 +99,6 @@ def origin(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -136,10 +122,6 @@ def caller(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -163,10 +145,6 @@ def callvalue(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -191,12 +169,6 @@ def calldataload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     start_index = pop(evm.stack)
@@ -222,10 +194,6 @@ def calldatasize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -252,10 +220,6 @@ def calldatacopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -285,10 +249,6 @@ def codesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -315,10 +275,6 @@ def codecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `3`.
     """
     # STACK
     memory_start_index = pop(evm.stack)
@@ -348,10 +304,6 @@ def gasprice(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     pass
@@ -375,12 +327,6 @@ def extcodesize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -411,10 +357,6 @@ def extcodecopy(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `4`.
     """
     # STACK
     address = to_address(pop(evm.stack))
@@ -540,12 +482,6 @@ def self_balance(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20`.
     """
     # STACK
     pass
@@ -572,10 +508,6 @@ def base_fee(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than GAS_BASE.
     """
     # STACK
     pass

--- a/src/ethereum/paris/vm/instructions/keccak.py
+++ b/src/ethereum/paris/vm/instructions/keccak.py
@@ -34,10 +34,6 @@ def keccak(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/paris/vm/instructions/log.py
+++ b/src/ethereum/paris/vm/instructions/log.py
@@ -38,10 +38,6 @@ def log_n(evm: Evm, num_topics: U256) -> None:
     num_topics :
         The number of topics to be included in the log entry.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2 + num_topics`.
     """
     # STACK
     memory_start_index = pop(evm.stack)

--- a/src/ethereum/paris/vm/instructions/memory.py
+++ b/src/ethereum/paris/vm/instructions/memory.py
@@ -30,13 +30,6 @@ def mstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memeory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -64,13 +57,6 @@ def mstore8(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -97,13 +83,6 @@ def mload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than
-        `3` + gas needed to extend memory.
     """
     # STACK
     start_position = pop(evm.stack)
@@ -131,10 +110,6 @@ def msize(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`
     """
     # STACK
     pass

--- a/src/ethereum/paris/vm/instructions/stack.py
+++ b/src/ethereum/paris/vm/instructions/stack.py
@@ -32,12 +32,6 @@ def pop(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `2`.
     """
     # STACK
     stack.pop(evm.stack)
@@ -65,12 +59,6 @@ def push_n(evm: Evm, num_bytes: int) -> None:
         The number of immediate bytes to be read from the code and pushed to
         the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackOverflowError`
-        If `len(stack)` is equals `1024`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -101,10 +89,6 @@ def dup_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be duplicated
         to the top of stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass
@@ -138,10 +122,6 @@ def swap_n(evm: Evm, item_number: int) -> None:
         The stack item number (0-indexed from top of stack) to be swapped
         with the top of stack element.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `3`.
     """
     # STACK
     pass

--- a/src/ethereum/paris/vm/instructions/storage.py
+++ b/src/ethereum/paris/vm/instructions/storage.py
@@ -39,12 +39,6 @@ def sload(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `1`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `50`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()
@@ -74,12 +68,6 @@ def sstore(evm: Evm) -> None:
     evm :
         The current EVM frame.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `len(stack)` is less than `2`.
-    :py:class:`~ethereum.paris.vm.exceptions.OutOfGasError`
-        If `evm.gas_left` is less than `20000`.
     """
     # STACK
     key = pop(evm.stack).to_be_bytes32()

--- a/src/ethereum/paris/vm/stack.py
+++ b/src/ethereum/paris/vm/stack.py
@@ -33,10 +33,6 @@ def pop(stack: List[U256]) -> U256:
     value : `U256`
         The top element on the stack.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackUnderflowError`
-        If `stack` is empty.
     """
     if len(stack) == 0:
         raise StackUnderflowError
@@ -56,10 +52,6 @@ def push(stack: List[U256], value: U256) -> None:
     value :
         Item to be pushed onto `stack`.
 
-    Raises
-    ------
-    :py:class:`~ethereum.paris.vm.exceptions.StackOverflowError`
-        If `len(stack)` is `1024`.
     """
     if len(stack) == 1024:
         raise StackOverflowError


### PR DESCRIPTION
(closes #652 )

### What was wrong?
All `Raises` were removed from the docstrings in #622. However, they have been included in `Paris`. This causes the rendered docs to render diffs where none exist

Related to Issue #652 

### How was it fixed?
Remove `Raises` from `Paris`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.animalsaroundtheglobe.com/wp-content/uploads/2021/05/photo-1516703995331-215d1188db0c.jpg)
