### PR TITLE
Refactor apply_body()

### DIFF
--- a/src/ethereum/arrow_glacier/spec.py
+++ b/src/ethereum/arrow_glacier/spec.py
@@ -366,6 +366,97 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    base_fee_per_gas: Uint,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Tuple[Address, U256]:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    base_fee_per_gas :
+        The block base fee.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+    effective_gas_price :
+        The price to charge for gas when the transaction is executed.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    if isinstance(tx, FeeMarketTransaction):
+        ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+
+        priority_fee_per_gas = min(
+            tx.max_priority_fee_per_gas,
+            tx.max_fee_per_gas - base_fee_per_gas,
+        )
+        effective_gas_price = priority_fee_per_gas + base_fee_per_gas
+    else:
+        ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
+        effective_gas_price = tx.gas_price
+
+    return sender_address, effective_gas_price
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Union[Bytes, Receipt]:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    if isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(receipt)
+    if isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(receipt)
+    else:
+        return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -444,22 +535,9 @@ def apply_body(
             transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
         )
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
-
-        if isinstance(tx, FeeMarketTransaction):
-            ensure(
-                tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock
-            )
-
-            priority_fee_per_gas = min(
-                tx.max_priority_fee_per_gas,
-                tx.max_fee_per_gas - base_fee_per_gas,
-            )
-            effective_gas_price = priority_fee_per_gas + base_fee_per_gas
-        else:
-            ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
-            effective_gas_price = tx.gas_price
+        sender_address, effective_gas_price = check_transaction(
+            tx, base_fee_per_gas, gas_available, chain_id
+        )
 
         env = vm.Environment(
             caller=sender_address,
@@ -479,17 +557,9 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
-        receipt: Union[Bytes, Receipt] = Receipt(
-            succeeded=not has_erred,
-            cumulative_gas_used=(block_gas_limit - gas_available),
-            bloom=logs_bloom(logs),
-            logs=logs,
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
         )
-
-        if isinstance(tx, AccessListTransaction):
-            receipt = b"\x01" + rlp.encode(receipt)
-        if isinstance(tx, FeeMarketTransaction):
-            receipt = b"\x02" + rlp.encode(receipt)
 
         trie_set(
             receipts_trie,

--- a/src/ethereum/arrow_glacier/spec.py
+++ b/src/ethereum/arrow_glacier/spec.py
@@ -370,7 +370,7 @@ def check_transaction(
     tx: Transaction,
     base_fee_per_gas: Uint,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Address, U256]:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -316,7 +316,7 @@ def validate_proof_of_work(header: Header) -> None:
 def check_transaction(
     tx: Transaction,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Address:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -307,6 +307,75 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -380,8 +449,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
+        sender_address = check_transaction(tx, gas_available, chain_id)
 
         env = vm.Environment(
             caller=sender_address,
@@ -399,16 +467,16 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                succeeded=not has_erred,
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -310,7 +310,7 @@ def validate_proof_of_work(header: Header) -> None:
 def check_transaction(
     tx: Transaction,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Address:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -307,6 +307,75 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -380,8 +449,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
+        sender_address = check_transaction(tx, gas_available, chain_id)
 
         env = vm.Environment(
             caller=sender_address,
@@ -399,16 +467,16 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                succeeded=not has_erred,
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -310,7 +310,7 @@ def validate_proof_of_work(header: Header) -> None:
 def check_transaction(
     tx: Transaction,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Address:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -25,7 +25,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import MAINNET_FORK_BLOCK, vm
 from .bloom import logs_bloom
 from .dao import DAO_ACCOUNTS, DAO_RECOVERY
@@ -321,6 +321,72 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    post_state: Bytes32,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    post_state :
+        The state root immediately after this transaction.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        post_state=post_state,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -391,8 +457,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(tx)
+        sender_address = check_transaction(tx, gas_available)
 
         env = vm.Environment(
             caller=sender_address,
@@ -410,16 +475,16 @@ def apply_body(
         gas_used, logs = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, state_root(state), (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                post_state=state_root(state),
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -22,7 +22,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -332,6 +332,72 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    post_state: Bytes32,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    post_state :
+        The state root immediately after this transaction.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        post_state=post_state,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -402,8 +468,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(tx)
+        sender_address = check_transaction(tx, gas_available)
 
         env = vm.Environment(
             caller=sender_address,
@@ -421,16 +486,16 @@ def apply_body(
         gas_used, logs = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, state_root(state), (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                post_state=state_root(state),
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/gray_glacier/spec.py
+++ b/src/ethereum/gray_glacier/spec.py
@@ -366,6 +366,97 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    base_fee_per_gas: Uint,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Tuple[Address, U256]:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    base_fee_per_gas :
+        The block base fee.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+    effective_gas_price :
+        The price to charge for gas when the transaction is executed.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    if isinstance(tx, FeeMarketTransaction):
+        ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+
+        priority_fee_per_gas = min(
+            tx.max_priority_fee_per_gas,
+            tx.max_fee_per_gas - base_fee_per_gas,
+        )
+        effective_gas_price = priority_fee_per_gas + base_fee_per_gas
+    else:
+        ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
+        effective_gas_price = tx.gas_price
+
+    return sender_address, effective_gas_price
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Union[Bytes, Receipt]:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    if isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(receipt)
+    if isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(receipt)
+    else:
+        return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -444,22 +535,9 @@ def apply_body(
             transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
         )
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
-
-        if isinstance(tx, FeeMarketTransaction):
-            ensure(
-                tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock
-            )
-
-            priority_fee_per_gas = min(
-                tx.max_priority_fee_per_gas,
-                tx.max_fee_per_gas - base_fee_per_gas,
-            )
-            effective_gas_price = priority_fee_per_gas + base_fee_per_gas
-        else:
-            ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
-            effective_gas_price = tx.gas_price
+        sender_address, effective_gas_price = check_transaction(
+            tx, base_fee_per_gas, gas_available, chain_id
+        )
 
         env = vm.Environment(
             caller=sender_address,
@@ -479,17 +557,9 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
-        receipt: Union[Bytes, Receipt] = Receipt(
-            succeeded=not has_erred,
-            cumulative_gas_used=(block_gas_limit - gas_available),
-            bloom=logs_bloom(logs),
-            logs=logs,
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
         )
-
-        if isinstance(tx, AccessListTransaction):
-            receipt = b"\x01" + rlp.encode(receipt)
-        if isinstance(tx, FeeMarketTransaction):
-            receipt = b"\x02" + rlp.encode(receipt)
 
         trie_set(
             receipts_trie,

--- a/src/ethereum/gray_glacier/spec.py
+++ b/src/ethereum/gray_glacier/spec.py
@@ -370,7 +370,7 @@ def check_transaction(
     tx: Transaction,
     base_fee_per_gas: Uint,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Address, U256]:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -301,6 +301,72 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    post_state: Bytes32,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    post_state :
+        The state root immediately after this transaction.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        post_state=post_state,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -371,8 +437,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(tx)
+        sender_address = check_transaction(tx, gas_available)
 
         env = vm.Environment(
             caller=sender_address,
@@ -390,16 +455,16 @@ def apply_body(
         gas_used, logs = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, state_root(state), (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                post_state=state_root(state),
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -307,6 +307,75 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -380,8 +449,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
+        sender_address = check_transaction(tx, gas_available, chain_id)
 
         env = vm.Environment(
             caller=sender_address,
@@ -400,16 +468,16 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                succeeded=not has_erred,
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -310,7 +310,7 @@ def validate_proof_of_work(header: Header) -> None:
 def check_transaction(
     tx: Transaction,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Address:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/london/spec.py
+++ b/src/ethereum/london/spec.py
@@ -366,6 +366,97 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    base_fee_per_gas: Uint,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Tuple[Address, U256]:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    base_fee_per_gas :
+        The block base fee.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+    effective_gas_price :
+        The price to charge for gas when the transaction is executed.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    if isinstance(tx, FeeMarketTransaction):
+        ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+
+        priority_fee_per_gas = min(
+            tx.max_priority_fee_per_gas,
+            tx.max_fee_per_gas - base_fee_per_gas,
+        )
+        effective_gas_price = priority_fee_per_gas + base_fee_per_gas
+    else:
+        ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
+        effective_gas_price = tx.gas_price
+
+    return sender_address, effective_gas_price
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Union[Bytes, Receipt]:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    if isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(receipt)
+    if isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(receipt)
+    else:
+        return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -444,22 +535,9 @@ def apply_body(
             transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
         )
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
-
-        if isinstance(tx, FeeMarketTransaction):
-            ensure(
-                tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock
-            )
-
-            priority_fee_per_gas = min(
-                tx.max_priority_fee_per_gas,
-                tx.max_fee_per_gas - base_fee_per_gas,
-            )
-            effective_gas_price = priority_fee_per_gas + base_fee_per_gas
-        else:
-            ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
-            effective_gas_price = tx.gas_price
+        sender_address, effective_gas_price = check_transaction(
+            tx, base_fee_per_gas, gas_available, chain_id
+        )
 
         env = vm.Environment(
             caller=sender_address,
@@ -479,17 +557,9 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
-        receipt: Union[Bytes, Receipt] = Receipt(
-            succeeded=not has_erred,
-            cumulative_gas_used=(block_gas_limit - gas_available),
-            bloom=logs_bloom(logs),
-            logs=logs,
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
         )
-
-        if isinstance(tx, AccessListTransaction):
-            receipt = b"\x01" + rlp.encode(receipt)
-        if isinstance(tx, FeeMarketTransaction):
-            receipt = b"\x02" + rlp.encode(receipt)
 
         trie_set(
             receipts_trie,

--- a/src/ethereum/london/spec.py
+++ b/src/ethereum/london/spec.py
@@ -370,7 +370,7 @@ def check_transaction(
     tx: Transaction,
     base_fee_per_gas: Uint,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Address, U256]:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -307,6 +307,75 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -380,8 +449,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
+        sender_address = check_transaction(tx, gas_available, chain_id)
 
         env = vm.Environment(
             caller=sender_address,
@@ -400,16 +468,16 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                succeeded=not has_erred,
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -310,7 +310,7 @@ def validate_proof_of_work(header: Header) -> None:
 def check_transaction(
     tx: Transaction,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Address:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/paris/spec.py
+++ b/src/ethereum/paris/spec.py
@@ -271,6 +271,97 @@ def validate_header(header: Header, parent_header: Header) -> None:
     ensure(header.parent_hash == block_parent_hash, InvalidBlock)
 
 
+def check_transaction(
+    tx: Transaction,
+    base_fee_per_gas: Uint,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Tuple[Address, U256]:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    base_fee_per_gas :
+        The block base fee.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+    effective_gas_price :
+        The price to charge for gas when the transaction is executed.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    if isinstance(tx, FeeMarketTransaction):
+        ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+
+        priority_fee_per_gas = min(
+            tx.max_priority_fee_per_gas,
+            tx.max_fee_per_gas - base_fee_per_gas,
+        )
+        effective_gas_price = priority_fee_per_gas + base_fee_per_gas
+    else:
+        ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
+        effective_gas_price = tx.gas_price
+
+    return sender_address, effective_gas_price
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Union[Bytes, Receipt]:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    if isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(receipt)
+    if isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(receipt)
+    else:
+        return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -348,22 +439,9 @@ def apply_body(
             transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
         )
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
-
-        if isinstance(tx, FeeMarketTransaction):
-            ensure(
-                tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock
-            )
-
-            priority_fee_per_gas = min(
-                tx.max_priority_fee_per_gas,
-                tx.max_fee_per_gas - base_fee_per_gas,
-            )
-            effective_gas_price = priority_fee_per_gas + base_fee_per_gas
-        else:
-            ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
-            effective_gas_price = tx.gas_price
+        sender_address, effective_gas_price = check_transaction(
+            tx, base_fee_per_gas, gas_available, chain_id
+        )
 
         env = vm.Environment(
             caller=sender_address,
@@ -383,17 +461,9 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
-        receipt: Union[Bytes, Receipt] = Receipt(
-            succeeded=not has_erred,
-            cumulative_gas_used=(block_gas_limit - gas_available),
-            bloom=logs_bloom(logs),
-            logs=logs,
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
         )
-
-        if isinstance(tx, AccessListTransaction):
-            receipt = b"\x01" + rlp.encode(receipt)
-        if isinstance(tx, FeeMarketTransaction):
-            receipt = b"\x02" + rlp.encode(receipt)
 
         trie_set(
             receipts_trie,

--- a/src/ethereum/paris/spec.py
+++ b/src/ethereum/paris/spec.py
@@ -275,7 +275,7 @@ def check_transaction(
     tx: Transaction,
     base_fee_per_gas: Uint,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Address, U256]:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/shanghai/spec.py
+++ b/src/ethereum/shanghai/spec.py
@@ -281,7 +281,7 @@ def check_transaction(
     tx: Transaction,
     base_fee_per_gas: Uint,
     gas_available: Uint,
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Address, U256]:
     """
     Check if the transaction is includable in the block.

--- a/src/ethereum/shanghai/spec.py
+++ b/src/ethereum/shanghai/spec.py
@@ -277,6 +277,97 @@ def validate_header(header: Header, parent_header: Header) -> None:
     ensure(header.parent_hash == block_parent_hash, InvalidBlock)
 
 
+def check_transaction(
+    tx: Transaction,
+    base_fee_per_gas: Uint,
+    gas_available: Uint,
+    chain_id: Uint64,
+) -> Tuple[Address, U256]:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    base_fee_per_gas :
+        The block base fee.
+    gas_available :
+        The gas remaining in the block.
+    chain_id :
+        The ID of the current chain.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+    effective_gas_price :
+        The price to charge for gas when the transaction is executed.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(chain_id, tx)
+
+    if isinstance(tx, FeeMarketTransaction):
+        ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+
+        priority_fee_per_gas = min(
+            tx.max_priority_fee_per_gas,
+            tx.max_fee_per_gas - base_fee_per_gas,
+        )
+        effective_gas_price = priority_fee_per_gas + base_fee_per_gas
+    else:
+        ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
+        effective_gas_price = tx.gas_price
+
+    return sender_address, effective_gas_price
+
+
+def make_receipt(
+    tx: Transaction,
+    has_erred: bool,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Union[Bytes, Receipt]:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    has_erred :
+        Whether the top level frame of the transaction exited with an error.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        succeeded=not has_erred,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    if isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(receipt)
+    if isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(receipt)
+    else:
+        return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -360,22 +451,9 @@ def apply_body(
             transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
         )
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(chain_id, tx)
-
-        if isinstance(tx, FeeMarketTransaction):
-            ensure(
-                tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock
-            )
-
-            priority_fee_per_gas = min(
-                tx.max_priority_fee_per_gas,
-                tx.max_fee_per_gas - base_fee_per_gas,
-            )
-            effective_gas_price = priority_fee_per_gas + base_fee_per_gas
-        else:
-            ensure(tx.gas_price >= base_fee_per_gas, InvalidBlock)
-            effective_gas_price = tx.gas_price
+        sender_address, effective_gas_price = check_transaction(
+            tx, base_fee_per_gas, gas_available, chain_id
+        )
 
         env = vm.Environment(
             caller=sender_address,
@@ -395,17 +473,9 @@ def apply_body(
         gas_used, logs, has_erred = process_transaction(env, tx)
         gas_available -= gas_used
 
-        receipt: Union[Bytes, Receipt] = Receipt(
-            succeeded=not has_erred,
-            cumulative_gas_used=(block_gas_limit - gas_available),
-            bloom=logs_bloom(logs),
-            logs=logs,
+        receipt = make_receipt(
+            tx, has_erred, (block_gas_limit - gas_available), logs
         )
-
-        if isinstance(tx, AccessListTransaction):
-            receipt = b"\x01" + rlp.encode(receipt)
-        if isinstance(tx, FeeMarketTransaction):
-            receipt = b"\x02" + rlp.encode(receipt)
 
         trie_set(
             receipts_trie,

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -301,6 +301,72 @@ def validate_proof_of_work(header: Header) -> None:
     )
 
 
+def check_transaction(
+    tx: Transaction,
+    gas_available: Uint,
+) -> Address:
+    """
+    Check if the transaction is includable in the block.
+
+    Parameters
+    ----------
+    tx :
+        The transaction.
+    gas_available :
+        The gas remaining in the block.
+
+    Returns
+    -------
+    sender_address :
+        The sender of the transaction.
+
+    Raises
+    ------
+    InvalidBlock :
+        If the transaction is not includable.
+    """
+    ensure(tx.gas <= gas_available, InvalidBlock)
+    sender_address = recover_sender(tx)
+
+    return sender_address
+
+
+def make_receipt(
+    tx: Transaction,
+    post_state: Bytes32,
+    cumulative_gas_used: Uint,
+    logs: Tuple[Log, ...],
+) -> Receipt:
+    """
+    Make the receipt for a transaction that was executed.
+
+    Parameters
+    ----------
+    tx :
+        The executed transaction.
+    post_state :
+        The state root immediately after this transaction.
+    cumulative_gas_used :
+        The total gas used so far in the block after the transaction was
+        executed.
+    logs :
+        The logs produced by the transaction.
+
+    Returns
+    -------
+    receipt :
+        The receipt for the transaction.
+    """
+    receipt = Receipt(
+        post_state=post_state,
+        cumulative_gas_used=cumulative_gas_used,
+        bloom=logs_bloom(logs),
+        logs=logs,
+    )
+
+    return receipt
+
+
 def apply_body(
     state: State,
     block_hashes: List[Hash32],
@@ -371,8 +437,7 @@ def apply_body(
     for i, tx in enumerate(transactions):
         trie_set(transactions_trie, rlp.encode(Uint(i)), tx)
 
-        ensure(tx.gas <= gas_available, InvalidBlock)
-        sender_address = recover_sender(tx)
+        sender_address = check_transaction(tx, gas_available)
 
         env = vm.Environment(
             caller=sender_address,
@@ -390,16 +455,16 @@ def apply_body(
         gas_used, logs = process_transaction(env, tx)
         gas_available -= gas_used
 
+        receipt = make_receipt(
+            tx, state_root(state), (block_gas_limit - gas_available), logs
+        )
+
         trie_set(
             receipts_trie,
             rlp.encode(Uint(i)),
-            Receipt(
-                post_state=state_root(state),
-                cumulative_gas_used=(block_gas_limit - gas_available),
-                bloom=logs_bloom(logs),
-                logs=logs,
-            ),
+            receipt,
         )
+
         block_logs += logs
 
     pay_rewards(state, block_number, coinbase, ommers)


### PR DESCRIPTION
This PR refactors the `apply_body()` method, by moving the most of the fork specific rules into other functions. Many of the spec tools `t8n`, block building, basically boil down to re-implementing `apply_body()` and it would be easier to do this if `apply_body()` is as a generic as reasonably possible.

Paris only. Will require backporting prior to merge.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/z4kpz7ges81a1.jpg)
