### PR TITLE
update paris big memory tests

### DIFF
--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -61,6 +61,8 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "/stRandom/",
     "/stSpecialTest/",
     "stTimeConsuming/",
+    "stBadOpcode/",
+    "stStaticCall/",
 )
 
 


### PR DESCRIPTION
### What was wrong?
There are some additional tests in `Paris` which need to be marked as `big_memory` but aren't

### How was it fixed?
Add the tests to the list


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.animalsaroundtheglobe.com/wp-content/uploads/2021/05/fennec-fox-5148309_960_720.jpg)
