### PR TITLE
smoothen docstring diffs and comments

### DIFF
--- a/src/ethereum/arrow_glacier/__init__.py
+++ b/src/ethereum/arrow_glacier/__init__.py
@@ -2,7 +2,7 @@
 Ethereum Arrow Glacier Hardfork
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Eleventh Ethereum hardfork.
+The Twelfth Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 13773000

--- a/src/ethereum/arrow_glacier/bloom.py
+++ b/src/ethereum/arrow_glacier/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/berlin/bloom.py
+++ b/src/ethereum/berlin/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/byzantium/__init__.py
+++ b/src/ethereum/byzantium/__init__.py
@@ -2,7 +2,7 @@
 Ethereum Byzantium Hardfork
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The fifth Ethereum hardfork.
+The sixth Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 4370000

--- a/src/ethereum/byzantium/bloom.py
+++ b/src/ethereum/byzantium/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
@@ -22,7 +22,7 @@ GQUADDIVISOR = Uint(20)
 
 def modexp(evm: Evm) -> None:
     """
-    Calculates `(base ** exp) % modulus` for arbitary sized `base`, `exp` and.
+    Calculates `(base**exp) % modulus` for arbitary sized `base`, `exp` and.
     `modulus`. The return value is the same length as the modulus.
     """
     data = evm.message.data

--- a/src/ethereum/constantinople/bloom.py
+++ b/src/ethereum/constantinople/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -840,6 +840,17 @@ def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.
 
+    The bounds of the gas limit, ``max_adjustment_delta``, is set as the
+    quotient of the parent block's gas limit and the
+    ``GAS_LIMIT_ADJUSTMENT_FACTOR``. Therefore, if the gas limit that is
+    passed through as a parameter is greater than or equal to the *sum* of
+    the parent's gas and the adjustment delta then the limit for gas is too
+    high and fails this function's check. Similarly, if the limit is less
+    than or equal to the *difference* of the parent's gas and the adjustment
+    delta *or* the predefined ``GAS_LIMIT_MINIMUM`` then this function's
+    check fails because the gas limit doesn't allow for a sufficient or
+    reasonable amount of gas to be used on a block.
+
     Parameters
     ----------
     gas_limit :

--- a/src/ethereum/dao_fork/bloom.py
+++ b/src/ethereum/dao_fork/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/gray_glacier/__init__.py
+++ b/src/ethereum/gray_glacier/__init__.py
@@ -2,7 +2,7 @@
 Ethereum Gray Glacier Hardfork
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Eleventh Ethereum hardfork.
+The Thirteenth Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 15050000

--- a/src/ethereum/gray_glacier/bloom.py
+++ b/src/ethereum/gray_glacier/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/homestead/bloom.py
+++ b/src/ethereum/homestead/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -55,6 +59,8 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
 def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
+
+    The address and each topic of a log are added to the bloom filter.
 
     Parameters
     ----------

--- a/src/ethereum/istanbul/bloom.py
+++ b/src/ethereum/istanbul/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/london/bloom.py
+++ b/src/ethereum/london/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/muir_glacier/bloom.py
+++ b/src/ethereum/muir_glacier/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/paris/__init__.py
+++ b/src/ethereum/paris/__init__.py
@@ -2,7 +2,7 @@
 Ethereum Paris Hardfork
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The Eleventh Ethereum hardfork.
+The Fourteenth Ethereum hardfork.
 """
 
 MAINNET_FORK_BLOCK = 15537394

--- a/src/ethereum/paris/bloom.py
+++ b/src/ethereum/paris/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/spurious_dragon/bloom.py
+++ b/src/ethereum/spurious_dragon/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:

--- a/src/ethereum/tangerine_whistle/bloom.py
+++ b/src/ethereum/tangerine_whistle/bloom.py
@@ -28,6 +28,10 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 
+    The number of hash functions used is 3. They are calculated by taking the
+    least significant 11 bits from the first 3 16-bit words of the
+    `keccak_256()` hash of `bloom_entry`.
+
     Parameters
     ----------
     bloom :
@@ -35,7 +39,6 @@ def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
     bloom_entry :
         An entry which is to be added to bloom filter.
     """
-    # TODO: This functionality hasn't been tested rigorously yet.
     hash = keccak256(bloom_entry)
 
     for idx in (0, 2, 4):
@@ -57,6 +60,8 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
     """
     Obtain the logs bloom from a list of log entries.
 
+    The address and each topic of a log are added to the bloom filter.
+
     Parameters
     ----------
     logs :
@@ -68,8 +73,6 @@ def logs_bloom(logs: Tuple[Log, ...]) -> Bloom:
         The logs bloom obtained which is 256 bytes with some bits set as per
         the caller address and the log topics.
     """
-    # TODO: Logs bloom functionality hasn't been tested rigorously yet. The
-    # required test cases need `CALL` opcode to be implemented.
     bloom: bytearray = bytearray(b"\x00" * 256)
 
     for log in logs:


### PR DESCRIPTION
(closes #519 )

### What was wrong?
Some of the rendered diffs are plainly due to sporadic comments rather than any actual difference in the specifications

Related to Issue #519 

### How was it fixed?
Update the comments to be consistent across forks

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.animalsaroundtheglobe.com/wp-content/uploads/2021/05/istockphoto-1269174671-612x612-1.jpg)
