### PR TITLE
Single-source precompile addresses

### DIFF
--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -49,7 +51,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/arrow_glacier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/arrow_glacier/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -48,7 +50,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/berlin/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -30,10 +30,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -47,7 +49,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/byzantium/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/mapping.py
@@ -22,13 +22,22 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
 }

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -48,7 +50,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/constantinople/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/mapping.py
@@ -22,13 +22,22 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
 }

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/mapping.py
@@ -20,9 +20,14 @@ from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
 }

--- a/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
@@ -20,9 +20,14 @@ from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
 }

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -49,7 +51,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/gray_glacier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/gray_glacier/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/homestead/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/mapping.py
@@ -20,9 +20,14 @@ from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
 }

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -48,7 +50,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/istanbul/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -49,7 +51,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/london/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/london/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -48,7 +50,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -31,10 +31,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -49,7 +51,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/paris/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/paris/vm/precompiled_contracts/mapping.py
@@ -23,14 +23,24 @@ from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
-    hex_to_address("0x05"): modexp,
-    hex_to_address("0x06"): alt_bn128_add,
-    hex_to_address("0x07"): alt_bn128_mul,
-    hex_to_address("0x08"): alt_bn128_pairing_check,
-    hex_to_address("0x09"): blake2f,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
+    MODEXP_ADDRESS: modexp,
+    ALT_BN128_ADD_ADDRESS: alt_bn128_add,
+    ALT_BN128_MUL_ADDRESS: alt_bn128_mul,
+    ALT_BN128_PAIRING_CHECK_ADDRESS: alt_bn128_pairing_check,
+    BLAKE2F_ADDRESS: blake2f,
 }

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -30,10 +30,12 @@ from ..state import (
     set_code,
     touch_account,
 )
-from ..utils.address import to_address
 from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, REFUND_SELF_DESTRUCT, charge_gas
-from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
+from ..vm.precompiled_contracts.mapping import (
+    PRE_COMPILED_CONTRACTS,
+    RIPEMD160_ADDRESS,
+)
 from . import Environment, Evm
 from .exceptions import (
     ExceptionalHalt,
@@ -46,7 +48,6 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = U256(1024)
 MAX_CODE_SIZE = 0x6000
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/mapping.py
@@ -20,9 +20,14 @@ from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
 }

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/mapping.py
@@ -20,9 +20,14 @@ from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
 
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
-    hex_to_address("0x01"): ecrecover,
-    hex_to_address("0x02"): sha256,
-    hex_to_address("0x03"): ripemd160,
-    hex_to_address("0x04"): identity,
+    ECRECOVER_ADDRESS: ecrecover,
+    SHA256_ADDRESS: sha256,
+    RIPEMD160_ADDRESS: ripemd160,
+    IDENTITY_ADDRESS: identity,
 }


### PR DESCRIPTION
(closes #643 )

### What was wrong?
Some precompile addresses were defined in multiple locations

Related to Issue #643 

### How was it fixed?
Define the addresses under `mapping.py` and import it for every other location

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.buzzfeed.com/buzzfeed-static/static/2022-11/14/20/asset/32f84f2e101a/sub-buzz-742-1668458911-28.jpg?downsize=600:*&output-format=auto&output-quality=auto)
