### PR TITLE
ignore pow validation for tests post merge

### DIFF
--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -51,7 +51,7 @@ class BaseLoad(ABC):
 
     @property
     @abstractmethod
-    def pos_fork(self) -> bool:
+    def proof_of_stake(self) -> bool:
         pass
 
     @property
@@ -130,7 +130,7 @@ class Load(BaseLoad):
         return self._network
 
     @property
-    def pos_fork(self) -> bool:
+    def proof_of_stake(self) -> bool:
         forks = Hardfork.discover()
         merge_fork_found = False
         for fork in forks:
@@ -413,7 +413,7 @@ def run_blockchain_st_test(test_case: Dict, load: BaseLoad) -> None:
         chain_id=test_data["chain_id"],
     )
 
-    if not test_data["ignore_pow_validation"] or load.pos_fork:
+    if not test_data["ignore_pow_validation"] or load.proof_of_stake:
         add_blocks_to_chain(chain, test_data, load)
     else:
         with patch(


### PR DESCRIPTION
(closes #674 )

### What was wrong?
Currently, for post merge forks, tests need to be explicitly configured to ignore pow validation.

Related to Issue #674 

### How was it fixed?
Identify post merge forks and automatically ignore pow validation for them

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://paradepets.com/.image/c_limit%2Ccs_srgb%2Cq_auto:good%2Cw_724/MTkxMzY1Nzg4MTM3NjI5Mjgy/sea-otter-enhydra-lutris.webp)
