### PR TITLE
minor test bug fixes

### DIFF
--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -443,7 +443,7 @@ def load_json_fixture(test_file: str, network: str) -> Generator:
         # Some newer test files have patterns like _d0g0v0_
         # between test_name and network
         keys_to_search = re.compile(
-            f"{re.escape(test_name)}.*{re.escape(network)}"
+            f"^{re.escape(test_name)}.*{re.escape(network)}$"
         )
         found_keys = list(filter(keys_to_search.match, data.keys()))
 
@@ -520,6 +520,7 @@ def fetch_state_test_files(
 
 # Test case Identifier
 def idfn(test_case: Dict) -> str:
-    folder_name = test_case["test_file"].split("/")[-2]
-    # Assign Folder name and test_key to identify tests in output
-    return folder_name + " - " + test_case["test_key"]
+    if isinstance(test_case, dict):
+        folder_name = test_case["test_file"].split("/")[-2]
+        # Assign Folder name and test_key to identify tests in output
+        return folder_name + " - " + test_case["test_key"]


### PR DESCRIPTION
### What was wrong?
1. If `pytest.mark.parametrize` receives an empty list, it passes `NonSetType` to the `ids` function which results in error and crash. This scenario needs to be handled gracefully
2. In the latest release of the test suite, the tests for `Shanghai` have the identifier `test_*_Merge+EIP-XXXX`. The tests for Paris had `test_*_Merge`. The current [test selection logic](https://github.com/ethereum/execution-specs/blob/79db92bd4c49bdf5f559fdebea5a9a3a2bf3fb83/tests/helpers/load_state_tests.py#L446) assumes the `Shanghai` tests are meant to be for `Paris` and fails. Although the Shanghai tests might be re-named in the future, this scenario is avoidable.


### How was it fixed?
1. Type check the `test_case` before assigning an id
2. Make the test selection regex more stringent.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://paradepets.com/.image/c_limit%2Ccs_srgb%2Cq_auto:good%2Cw_724/MTkxMzY1Nzg4NjczMDU4NDAy/a-wild-weasel-pictured-in-japan.webp)
