### PR TITLE
update hardfork discover

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ ethereum-spec-new-fork --from_fork="Tangerine Whistle" --to_fork="Spurious Drago
 ```
 
 The following will have to however, be updated manually
- 1. The fork number and `MAINNET_FORK_BLOCK` in `__init__.py`
+ 1. The fork number and `MAINNET_FORK_BLOCK` in `__init__.py`. If you are proposing a new EIP, please set `MAINNET_FORK_BLOCK` to `None`.
  2. Any absolute package imports from other forks eg. in `trie.py`
  3. Package names under `setup.cfg`
  4. Add the new fork to the `monkey_patch()` function in `src/ethereum_optimized/__init__.py`

--- a/src/ethereum_spec_tools/new_fork.py
+++ b/src/ethereum_spec_tools/new_fork.py
@@ -184,7 +184,8 @@ def main() -> None:
 Fork `{fork}` has been successfully created.
 
 PLEASE REMEMBER TO UPDATE THE FOLLOWING MANUALLY:
-    1. The fork number and MAINNET_FORK_BLOCK in __init__.py
+    1. The fork number and MAINNET_FORK_BLOCK in __init__.py. \
+If you are proposing a new EIP, please set MAINNET_FORK_BLOCK to None.
     2. Any absolute package imports from other forks. Eg. in trie.py
     3. Package Names under setup.cfg
     4. Add the new fork to the monkey_patch() function in \


### PR DESCRIPTION
(closes #683 )

### What was wrong?
New EIP proposals will not have a `MAINNET_FORK_BLOCK`. The current hard fork discover logic is unable to handle this scenario.

Related to Issue #683 

### How was it fixed?
Update the current logic to handle `MAINNET_FORK_BLOCK is None` 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/07/Emperor_Penguin_Manchot_empereur.jpg)
