### PR TITLE
decode blocks from `rlp`

### DIFF
--- a/src/ethereum/rlp.py
+++ b/src/ethereum/rlp.py
@@ -282,7 +282,7 @@ def _decode_to(cls: Type[T], raw_rlp: RLP) -> T:
         ensure(type(raw_rlp) == list, RLPDecodingError)
         assert isinstance(raw_rlp, list)
         args = []
-        # FIXME: Add length check
+        ensure(len(fields(cls)) == len(raw_rlp), RLPDecodingError)
         for (field, rlp_item) in zip(fields(cls), raw_rlp):
             args.append(_decode_to(field.type, rlp_item))
         return cls(*args)

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -295,8 +295,8 @@ class Load(BaseLoad):
         block_rlps = []
 
         for json_block in json_blocks:
-            if "blockHeader" not in json_block and "rlp" in json_block:
-                # Some blocks are represented by only the RLP and not the block details
+            if "rlp" in json_block:
+                # Always decode from rlp
                 block_rlp = hex_to_bytes(json_block["rlp"])
                 block = rlp.decode_to(self.Block, block_rlp)
                 blocks.append(block)


### PR DESCRIPTION
(closes #690 )

### What was wrong?
Blocks for tests are read from json instead of rlp.

Related to Issue #690 

### How was it fixed?
decode from rlp whenever it is available.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/0/09/TheCheethcat.jpg)
