### PR TITLE
don't read test data during collection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [3.8, pypy-3.8]

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -359,7 +359,13 @@ class Load(BaseLoad):
 
 def load_test(test_case: Dict, load: BaseLoad) -> Dict:
 
-    json_data = test_case["test_data"]
+    test_file = test_case["test_file"]
+    test_key = test_case["test_key"]
+
+    with open(test_file, "r") as fp:
+        data = json.load(fp)
+
+    json_data = data[test_key]
 
     blocks, block_header_hashes, block_rlps = load.json_to_blocks(
         json_data["blocks"]
@@ -470,7 +476,6 @@ def load_json_fixture(test_file: str, network: str) -> Generator:
             yield {
                 "test_file": test_file,
                 "test_key": _key,
-                "test_data": data[_key],
             }
 
 


### PR DESCRIPTION
### What was wrong?
The current test collection function collects all the test data from the json and loads it into memory which leads to resource limits especially on the Github Actions workers.

Related to Issue #

### How was it fixed?
Move the json data read to the test run phase instead of the test collection phase

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/d/db/HandheldHedgeHog.png)
