### PR TITLE
single source precompile address

### DIFF
--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -21,11 +21,9 @@ from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
 from ..state import State, account_exists_and_is_empty
-from ..utils.address import to_address
+from .precompiled_contracts import RIPEMD160_ADDRESS
 
 __all__ = ("Environment", "Evm", "Message")
-
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/arrow_glacier/vm/precompiled_contracts/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/precompiled_contracts/__init__.py
@@ -12,3 +12,15 @@ Introduction
 Addresses of precompiled contracts and mappings to their
 implementations.
 """
+
+from ...utils.hexadecimal import hex_to_address
+
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")

--- a/src/ethereum/arrow_glacier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/arrow_glacier/vm/precompiled_contracts/mapping.py
@@ -14,7 +14,17 @@ Mapping of precompiled contracts their implementations.
 from typing import Callable, Dict
 
 from ...eth_types import Address
-from ...utils.hexadecimal import hex_to_address
+from . import (
+    ALT_BN128_ADD_ADDRESS,
+    ALT_BN128_MUL_ADDRESS,
+    ALT_BN128_PAIRING_CHECK_ADDRESS,
+    BLAKE2F_ADDRESS,
+    ECRECOVER_ADDRESS,
+    IDENTITY_ADDRESS,
+    MODEXP_ADDRESS,
+    RIPEMD160_ADDRESS,
+    SHA256_ADDRESS,
+)
 from .alt_bn128 import alt_bn128_add, alt_bn128_mul, alt_bn128_pairing_check
 from .blake2f import blake2f
 from .ecrecover import ecrecover
@@ -22,16 +32,6 @@ from .identity import identity
 from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
-
-ECRECOVER_ADDRESS = hex_to_address("0x01")
-SHA256_ADDRESS = hex_to_address("0x02")
-RIPEMD160_ADDRESS = hex_to_address("0x03")
-IDENTITY_ADDRESS = hex_to_address("0x04")
-MODEXP_ADDRESS = hex_to_address("0x05")
-ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
-ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
-ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
-BLAKE2F_ADDRESS = hex_to_address("0x09")
 
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
     ECRECOVER_ADDRESS: ecrecover,

--- a/src/ethereum/frontier/vm/precompiled_contracts/__init__.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/__init__.py
@@ -12,3 +12,10 @@ Introduction
 Addresses of precompiled contracts and mappings to their
 implementations.
 """
+
+from ...utils.hexadecimal import hex_to_address
+
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")

--- a/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/mapping.py
@@ -14,16 +14,16 @@ Mapping of precompiled contracts their implementations.
 from typing import Callable, Dict
 
 from ...eth_types import Address
-from ...utils.hexadecimal import hex_to_address
+from . import (
+    ECRECOVER_ADDRESS,
+    IDENTITY_ADDRESS,
+    RIPEMD160_ADDRESS,
+    SHA256_ADDRESS,
+)
 from .ecrecover import ecrecover
 from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
-
-ECRECOVER_ADDRESS = hex_to_address("0x01")
-SHA256_ADDRESS = hex_to_address("0x02")
-RIPEMD160_ADDRESS = hex_to_address("0x03")
-IDENTITY_ADDRESS = hex_to_address("0x04")
 
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
     ECRECOVER_ADDRESS: ecrecover,

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -21,11 +21,9 @@ from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
 from ..state import State, account_exists_and_is_empty
-from ..utils.address import to_address
+from .precompiled_contracts import RIPEMD160_ADDRESS
 
 __all__ = ("Environment", "Evm", "Message")
-
-RIPEMD160_ADDRESS = to_address(Uint(3))
 
 
 @dataclass

--- a/src/ethereum/gray_glacier/vm/precompiled_contracts/__init__.py
+++ b/src/ethereum/gray_glacier/vm/precompiled_contracts/__init__.py
@@ -12,3 +12,15 @@ Introduction
 Addresses of precompiled contracts and mappings to their
 implementations.
 """
+
+from ...utils.hexadecimal import hex_to_address
+
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")
+MODEXP_ADDRESS = hex_to_address("0x05")
+ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
+ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
+ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
+BLAKE2F_ADDRESS = hex_to_address("0x09")

--- a/src/ethereum/gray_glacier/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/gray_glacier/vm/precompiled_contracts/mapping.py
@@ -14,7 +14,17 @@ Mapping of precompiled contracts their implementations.
 from typing import Callable, Dict
 
 from ...eth_types import Address
-from ...utils.hexadecimal import hex_to_address
+from . import (
+    ALT_BN128_ADD_ADDRESS,
+    ALT_BN128_MUL_ADDRESS,
+    ALT_BN128_PAIRING_CHECK_ADDRESS,
+    BLAKE2F_ADDRESS,
+    ECRECOVER_ADDRESS,
+    IDENTITY_ADDRESS,
+    MODEXP_ADDRESS,
+    RIPEMD160_ADDRESS,
+    SHA256_ADDRESS,
+)
 from .alt_bn128 import alt_bn128_add, alt_bn128_mul, alt_bn128_pairing_check
 from .blake2f import blake2f
 from .ecrecover import ecrecover
@@ -22,16 +32,6 @@ from .identity import identity
 from .modexp import modexp
 from .ripemd160 import ripemd160
 from .sha256 import sha256
-
-ECRECOVER_ADDRESS = hex_to_address("0x01")
-SHA256_ADDRESS = hex_to_address("0x02")
-RIPEMD160_ADDRESS = hex_to_address("0x03")
-IDENTITY_ADDRESS = hex_to_address("0x04")
-MODEXP_ADDRESS = hex_to_address("0x05")
-ALT_BN128_ADD_ADDRESS = hex_to_address("0x06")
-ALT_BN128_MUL_ADDRESS = hex_to_address("0x07")
-ALT_BN128_PAIRING_CHECK_ADDRESS = hex_to_address("0x08")
-BLAKE2F_ADDRESS = hex_to_address("0x09")
 
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
     ECRECOVER_ADDRESS: ecrecover,

--- a/src/ethereum/homestead/vm/precompiled_contracts/__init__.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/__init__.py
@@ -12,3 +12,10 @@ Introduction
 Addresses of precompiled contracts and mappings to their
 implementations.
 """
+
+from ...utils.hexadecimal import hex_to_address
+
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")

--- a/src/ethereum/homestead/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/mapping.py
@@ -14,16 +14,16 @@ Mapping of precompiled contracts their implementations.
 from typing import Callable, Dict
 
 from ...eth_types import Address
-from ...utils.hexadecimal import hex_to_address
+from . import (
+    ECRECOVER_ADDRESS,
+    IDENTITY_ADDRESS,
+    RIPEMD160_ADDRESS,
+    SHA256_ADDRESS,
+)
 from .ecrecover import ecrecover
 from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
-
-ECRECOVER_ADDRESS = hex_to_address("0x01")
-SHA256_ADDRESS = hex_to_address("0x02")
-RIPEMD160_ADDRESS = hex_to_address("0x03")
-IDENTITY_ADDRESS = hex_to_address("0x04")
 
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
     ECRECOVER_ADDRESS: ecrecover,

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/__init__.py
@@ -12,3 +12,10 @@ Introduction
 Addresses of precompiled contracts and mappings to their
 implementations.
 """
+
+from ...utils.hexadecimal import hex_to_address
+
+ECRECOVER_ADDRESS = hex_to_address("0x01")
+SHA256_ADDRESS = hex_to_address("0x02")
+RIPEMD160_ADDRESS = hex_to_address("0x03")
+IDENTITY_ADDRESS = hex_to_address("0x04")

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/mapping.py
@@ -14,16 +14,16 @@ Mapping of precompiled contracts their implementations.
 from typing import Callable, Dict
 
 from ...eth_types import Address
-from ...utils.hexadecimal import hex_to_address
+from . import (
+    ECRECOVER_ADDRESS,
+    IDENTITY_ADDRESS,
+    RIPEMD160_ADDRESS,
+    SHA256_ADDRESS,
+)
 from .ecrecover import ecrecover
 from .identity import identity
 from .ripemd160 import ripemd160
 from .sha256 import sha256
-
-ECRECOVER_ADDRESS = hex_to_address("0x01")
-SHA256_ADDRESS = hex_to_address("0x02")
-RIPEMD160_ADDRESS = hex_to_address("0x03")
-IDENTITY_ADDRESS = hex_to_address("0x04")
 
 PRE_COMPILED_CONTRACTS: Dict[Address, Callable] = {
     ECRECOVER_ADDRESS: ecrecover,


### PR DESCRIPTION
### What was wrong?

The pre-compile addresses for some of the pre-compiles were moved to `precompiles/__init__.py`  as a part of #680 but some were missed


### How was it fixed?

Moved addresses to the relevant module
#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
