### PR TITLE
update test collection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
     path = tests/fixtures
     url = https://github.com/ethereum/tests
     branch = develop
+[submodule "tests/execution-spec-generated-tests"]
+	path = tests/execution-spec-generated-tests
+	url = https://github.com/petertdavies/execution-spec-generated-tests.git

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -130,6 +130,9 @@ xfail_candidates = (
     ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Berlin"),
 )
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 def is_in_xfail(test_case: Dict) -> bool:
     for dir, test_key in xfail_candidates:
@@ -141,7 +144,7 @@ def is_in_xfail(test_case: Dict) -> bool:
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_berlin_tests(test_dir),
+    fetch_berlin_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -110,10 +110,13 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_byzantium_tests(test_dir),
+    fetch_byzantium_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -128,10 +128,15 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_constantinople_tests(test_dir),
+    fetch_constantinople_tests(
+        test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS
+    ),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -91,10 +91,16 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(test_dir),
+    fetch_frontier_tests(
+        test_dir,
+        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
+    ),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -462,12 +462,14 @@ def load_json_fixture(test_file: str, network: str) -> Generator:
     with open(test_file, "r") as fp:
         data = json.load(fp)
 
-        # Some newer test files have patterns like _d0g0v0_
-        # between test_name and network
-        keys_to_search = re.compile(
-            f"^{re.escape(test_name)}.*{re.escape(network)}$"
-        )
-        found_keys = list(filter(keys_to_search.match, data.keys()))
+        # Search tests by looking at the `network` attribute
+        found_keys = []
+        for key, test in data.items():
+            if "network" not in test:
+                continue
+
+            if test["network"] == network:
+                found_keys.append(key)
 
         if not any(found_keys):
             raise NoTestsFound

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -184,10 +184,13 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Homestead",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(test_dir),
+    fetch_homestead_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -130,6 +130,9 @@ xfail_candidates = (
     ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Istanbul"),
 )
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 def is_in_xfail(test_case: Dict) -> bool:
     for dir, test_key in xfail_candidates:
@@ -141,7 +144,10 @@ def is_in_xfail(test_case: Dict) -> bool:
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_istanbul_tests(test_dir),
+    fetch_istanbul_tests(
+        test_dir,
+        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
+    ),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -124,6 +124,9 @@ xfail_candidates = (
     ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_London"),
 )
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 def is_in_xfail(test_case: Dict) -> bool:
     for dir, test_key in xfail_candidates:
@@ -135,7 +138,7 @@ def is_in_xfail(test_case: Dict) -> bool:
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_london_tests(test_dir),
+    fetch_london_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -103,6 +103,9 @@ xfail_candidates = (
     ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Merge"),
 )
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 def is_in_xfail(test_case: Dict) -> bool:
     for dir, test_key in xfail_candidates:
@@ -114,7 +117,7 @@ def is_in_xfail(test_case: Dict) -> bool:
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_paris_tests(test_dir),
+    fetch_paris_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -96,10 +96,15 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(test_dir),
+    fetch_spurious_dragon_tests(
+        test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS
+    ),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -98,10 +98,16 @@ test_dir = (
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
 
+# FIXME: Check if these tests should in fact be ignored
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(test_dir),
+    fetch_tangerine_whistle_tests(
+        test_dir,
+        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
+    ),
     ids=idfn,
 )
 def test_invalid_block_tests(test_case: Dict) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow and not bigmem" -n 2 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
-    pytest -m bigmem --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --cov-append --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and not bigmem" -n 2 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
+    pytest -m bigmem --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --cov-append --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -24,8 +24,8 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
-    pytest -m bigmem --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
+    pytest -m bigmem --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]


### PR DESCRIPTION
This commit updates the test collection logic to collect the tests for a particular fork by looking at the  attribute instead of the test key. This collects some additional tests that werent being collected before. Some of these tests, specifically the  currently fail but have been added to the ignore list. This will need to be explored in depth in the future
