### PR TITLE
Switch to -n auto and stop running bigmem tests separately

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow and not bigmem" -n 2 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
-    pytest -m bigmem --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --cov-append --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -24,8 +23,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
-    pytest -m bigmem --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]
@@ -73,5 +71,5 @@ extras =
     test
     optimized
 commands =
-    pytest -m "not slow and not bigmem" -n 2 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --optimized
-    pytest -m bigmem --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --basetemp="{temp_dir}/pytest" --optimized
+


### PR DESCRIPTION
### What was wrong?

The memory issues that required distinguishing `bigmem` tests and limiting tests to 2 threads have been fixed.

### How was it fixed?

Switch to `-n auto` with `--maxprocesses 8`. Run `bigmem` together with the other tests. The `bigmem` flag has not been removed.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/uxqq9vgzbcea1.jpg)
