### PR TITLE
separate doc build CI process

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,10 +1,6 @@
 name: GitHub Pages
 
-on:
-  push:
-    branches:
-      - master
-      - pyspec
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-and-deploy:
@@ -25,6 +21,7 @@ jobs:
         run: tox -e doc
 
       - name: Deploy
+        if: ${{ github.event_name == 'push' && ( github.ref == 'refs/heads/master' ||  github.ref == 'refs/heads/pyspec') }}
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,6 @@ jobs:
         with:
           files: .tox/coverage.xml
           flags: unittests
-      - name: Build docs
-        if: ${{ matrix.python != 'pypy-3.8' }}
-        run: tox -e doc
       - name: Run Tox (optimized state/ethash)
         if: ${{ matrix.python != 'pypy-3.8' }}
         run: tox -e optimized


### PR DESCRIPTION
### What was wrong?

Currently, the doc-build is part of the `py-3.8` CI process but it can (should) be run independently. Also, it runs twice when a `push` event is triggered on the `master` or the `pyspec` branches

### How was it fixed?
Run the `doc-build` as a separate CI process. This allows the `py-3.8` CI to finish sooner since it no longer depends on the `doc-build`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/82/Giant_Panda_Tai_Shan.JPG)
