### PR TITLE
standardize integer types

### DIFF
--- a/src/ethereum/arrow_glacier/eth_types.py
+++ b/src/ethereum/arrow_glacier/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -69,7 +69,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256
@@ -89,7 +89,7 @@ class FeeMarketTransaction:
     The transaction type added in EIP-1559.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     max_priority_fee_per_gas: U256
     max_fee_per_gas: U256

--- a/src/ethereum/arrow_glacier/spec.py
+++ b/src/ethereum/arrow_glacier/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import MAINNET_FORK_BLOCK, vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -82,7 +82,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -377,7 +377,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -819,7 +819,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -43,7 +43,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -18,9 +18,9 @@ from dataclasses import replace
 from typing import Any, Callable, ClassVar, Optional, Tuple, Type, TypeVar
 
 U8_MAX_VALUE = (2**8) - 1
-UINT32_MAX_VALUE = (2**32) - 1
-UINT32_CEIL_VALUE = 2**32
-UINT64_MAX_VALUE = (2**64) - 1
+U32_MAX_VALUE = (2**32) - 1
+U32_CEIL_VALUE = 2**32
+U64_MAX_VALUE = (2**64) - 1
 U255_MAX_VALUE = (2**255) - 1
 U255_CEIL_VALUE = 2**255
 U256_MAX_VALUE = (2**256) - 1
@@ -734,18 +734,18 @@ U256.MAX_VALUE = int.__new__(U256, U256_MAX_VALUE)
 """autoapi_noindex"""
 
 
-class Uint32(FixedUInt):
+class U32(FixedUInt):
     """
     Unsigned positive integer, which can represent `0` to `2 ** 32 - 1`,
     inclusive.
     """
 
-    MAX_VALUE: ClassVar["Uint32"]
+    MAX_VALUE: ClassVar["U32"]
 
     __slots__ = ()
 
     @classmethod
-    def from_le_bytes(cls: Type, buffer: "Bytes") -> "Uint32":
+    def from_le_bytes(cls: Type, buffer: "Bytes") -> "U32":
         """
         Converts a sequence of bytes into an arbitrarily sized unsigned integer
         from its little endian representation.
@@ -782,22 +782,22 @@ class Uint32(FixedUInt):
         return self.to_bytes(byte_length, "little")
 
 
-Uint32.MAX_VALUE = int.__new__(Uint32, UINT32_MAX_VALUE)
+U32.MAX_VALUE = int.__new__(U32, U32_MAX_VALUE)
 """autoapi_noindex"""
 
 
-class Uint64(FixedUInt):
+class U64(FixedUInt):
     """
     Unsigned positive integer, which can represent `0` to `2 ** 64 - 1`,
     inclusive.
     """
 
-    MAX_VALUE: ClassVar["Uint64"]
+    MAX_VALUE: ClassVar["U64"]
 
     __slots__ = ()
 
     @classmethod
-    def from_le_bytes(cls: Type, buffer: "Bytes") -> "Uint64":
+    def from_le_bytes(cls: Type, buffer: "Bytes") -> "U64":
         """
         Converts a sequence of bytes into an arbitrarily sized unsigned integer
         from its little endian representation.
@@ -848,7 +848,7 @@ class Uint64(FixedUInt):
         return self.to_bytes(byte_length, "big")
 
     @classmethod
-    def from_be_bytes(cls: Type, buffer: "Bytes") -> "Uint64":
+    def from_be_bytes(cls: Type, buffer: "Bytes") -> "U64":
         """
         Converts a sequence of bytes into an unsigned 64 bit integer from its
         big endian representation.
@@ -859,7 +859,7 @@ class Uint64(FixedUInt):
             Bytes to decode.
         Returns
         -------
-        self : `Uint64`
+        self : `U64`
             Unsigned integer decoded from `buffer`.
         """
         if len(buffer) > 8:
@@ -868,7 +868,7 @@ class Uint64(FixedUInt):
         return cls(int.from_bytes(buffer, "big"))
 
 
-Uint64.MAX_VALUE = int.__new__(Uint64, UINT64_MAX_VALUE)
+U64.MAX_VALUE = int.__new__(U64, U64_MAX_VALUE)
 """autoapi_noindex"""
 
 

--- a/src/ethereum/berlin/eth_types.py
+++ b/src/ethereum/berlin/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -70,7 +70,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256

--- a/src/ethereum/berlin/spec.py
+++ b/src/ethereum/berlin/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -78,7 +78,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -323,7 +323,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -732,7 +732,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -42,7 +42,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/byzantium/spec.py
+++ b/src/ethereum/byzantium/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -72,7 +72,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -317,7 +317,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Transaction, ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -701,7 +701,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/constantinople/spec.py
+++ b/src/ethereum/constantinople/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -72,7 +72,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -317,7 +317,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Transaction, ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -701,7 +701,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/dao_fork/spec.py
+++ b/src/ethereum/dao_fork/spec.py
@@ -25,7 +25,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import MAINNET_FORK_BLOCK, vm
 from .bloom import logs_bloom
 from .dao import DAO_ACCOUNTS, DAO_RECOVERY
@@ -73,7 +73,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:

--- a/src/ethereum/frontier/genesis.py
+++ b/src/ethereum/frontier/genesis.py
@@ -18,11 +18,11 @@ from dataclasses import dataclass
 from typing import Dict, cast
 
 from ethereum.base_types import (
+    U64,
     U256,
     Bytes,
     Bytes8,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ethereum.utils.hexadecimal import (
@@ -46,7 +46,7 @@ class GenesisConfiguration:
     the fields of the genesis block.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     difficulty: Uint
     extra_data: Bytes
     gas_limit: Uint
@@ -84,7 +84,7 @@ def genesis_configuration(genesis_file: str) -> GenesisConfiguration:
     }
 
     return GenesisConfiguration(
-        chain_id=Uint64(genesis_data["config"]["chainId"]),
+        chain_id=U64(genesis_data["config"]["chainId"]),
         difficulty=hex_to_uint(genesis_data["difficulty"]),
         extra_data=hex_to_bytes(genesis_data["extraData"]),
         gas_limit=hex_to_uint(genesis_data["gasLimit"]),

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -22,7 +22,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -68,7 +68,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:

--- a/src/ethereum/gray_glacier/eth_types.py
+++ b/src/ethereum/gray_glacier/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -69,7 +69,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256
@@ -89,7 +89,7 @@ class FeeMarketTransaction:
     The transaction type added in EIP-1559.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     max_priority_fee_per_gas: U256
     max_fee_per_gas: U256

--- a/src/ethereum/gray_glacier/spec.py
+++ b/src/ethereum/gray_glacier/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import MAINNET_FORK_BLOCK, vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -82,7 +82,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -377,7 +377,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -819,7 +819,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -43,7 +43,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/homestead/spec.py
+++ b/src/ethereum/homestead/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -69,7 +69,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:

--- a/src/ethereum/istanbul/spec.py
+++ b/src/ethereum/istanbul/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -72,7 +72,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -317,7 +317,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Transaction, ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -702,7 +702,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -42,7 +42,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/london/eth_types.py
+++ b/src/ethereum/london/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -69,7 +69,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256
@@ -89,7 +89,7 @@ class FeeMarketTransaction:
     The transaction type added in EIP-1559.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     max_priority_fee_per_gas: U256
     max_fee_per_gas: U256

--- a/src/ethereum/london/spec.py
+++ b/src/ethereum/london/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import MAINNET_FORK_BLOCK, vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -82,7 +82,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -377,7 +377,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -819,7 +819,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -43,7 +43,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/muir_glacier/spec.py
+++ b/src/ethereum/muir_glacier/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -72,7 +72,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -317,7 +317,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Transaction, ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -702,7 +702,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -42,7 +42,7 @@ class Environment:
     time: U256
     difficulty: Uint
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/paris/eth_types.py
+++ b/src/ethereum/paris/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -69,7 +69,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256
@@ -89,7 +89,7 @@ class FeeMarketTransaction:
     The transaction type added in EIP-1559.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     max_priority_fee_per_gas: U256
     max_fee_per_gas: U256

--- a/src/ethereum/paris/spec.py
+++ b/src/ethereum/paris/spec.py
@@ -22,7 +22,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, Bytes, Uint, Uint64
+from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -75,7 +75,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -281,7 +281,7 @@ def apply_body(
     block_time: U256,
     prev_randao: Bytes32,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -600,7 +600,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -43,7 +43,7 @@ class Environment:
     time: U256
     prev_randao: Bytes32
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/rlp.py
+++ b/src/ethereum/rlp.py
@@ -23,7 +23,7 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import RLPDecodingError, RLPEncodingError
 from ethereum.utils.ensure import ensure
 
-from .base_types import U256, Bytes, Bytes0, Bytes20, Uint, Uint64
+from .base_types import U64, U256, Bytes, Bytes0, Bytes20, Uint
 
 RLP = Any
 
@@ -50,7 +50,7 @@ def encode(raw_data: RLP) -> Bytes:
     """
     if isinstance(raw_data, (bytearray, bytes)):
         return encode_bytes(raw_data)
-    elif isinstance(raw_data, (Uint, U256, Uint64)):
+    elif isinstance(raw_data, (Uint, U256, U64)):
         return encode(raw_data.to_be_bytes())
     elif isinstance(raw_data, str):
         return encode_bytes(raw_data.encode())
@@ -275,7 +275,7 @@ def _decode_to(cls: Type[T], raw_rlp: RLP) -> T:
     elif issubclass(cls, Bytes):
         ensure(type(raw_rlp) == Bytes, RLPDecodingError)
         return raw_rlp
-    elif issubclass(cls, (Uint, U256, Uint64)):
+    elif issubclass(cls, (Uint, U256, U64)):
         ensure(type(raw_rlp) == Bytes, RLPDecodingError)
         return cls.from_be_bytes(raw_rlp)  # type: ignore
     elif is_dataclass(cls):

--- a/src/ethereum/shanghai/eth_types.py
+++ b/src/ethereum/shanghai/eth_types.py
@@ -17,6 +17,7 @@ from typing import Tuple, Union
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes0,
@@ -25,7 +26,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
@@ -69,7 +69,7 @@ class AccessListTransaction:
     The transaction type added in EIP-2930 to support access lists.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     gas_price: U256
     gas: U256
@@ -89,7 +89,7 @@ class FeeMarketTransaction:
     The transaction type added in EIP-1559.
     """
 
-    chain_id: Uint64
+    chain_id: U64
     nonce: U256
     max_priority_fee_per_gas: U256
     max_fee_per_gas: U256
@@ -180,8 +180,8 @@ class Withdrawal:
     Withdrawals that have been validated on the consensus layer.
     """
 
-    index: Uint64
-    validator_index: Uint64
+    index: U64
+    validator_index: U64
     address: Address
     amount: U256
 

--- a/src/ethereum/shanghai/spec.py
+++ b/src/ethereum/shanghai/spec.py
@@ -22,7 +22,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, Bytes, Uint, Uint64
+from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -78,7 +78,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -287,7 +287,7 @@ def apply_body(
     block_time: U256,
     prev_randao: Bytes32,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
-    chain_id: Uint64,
+    chain_id: U64,
     withdrawals: Tuple[Withdrawal, ...],
 ) -> Tuple[Uint, Root, Root, Bloom, State, Root]:
     """
@@ -629,7 +629,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost + access_list_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -16,7 +16,7 @@ The abstract computer which runs the code stored in an
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
 from ..eth_types import Address, Log
@@ -43,7 +43,7 @@ class Environment:
     time: U256
     prev_randao: Bytes32
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 @dataclass

--- a/src/ethereum/spurious_dragon/spec.py
+++ b/src/ethereum/spurious_dragon/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -70,7 +70,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:
@@ -313,7 +313,7 @@ def apply_body(
     block_difficulty: Uint,
     transactions: Tuple[Transaction, ...],
     ommers: Tuple[Header, ...],
-    chain_id: Uint64,
+    chain_id: U64,
 ) -> Tuple[Uint, Root, Root, Bloom, State]:
     """
     Executes a block.
@@ -697,7 +697,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return Uint(TX_BASE_COST + data_cost + create_cost)
 
 
-def recover_sender(chain_id: Uint64, tx: Transaction) -> Address:
+def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     """
     Extracts the sender address from a transaction.
 

--- a/src/ethereum/tangerine_whistle/spec.py
+++ b/src/ethereum/tangerine_whistle/spec.py
@@ -23,7 +23,7 @@ from ethereum.exceptions import InvalidBlock
 from ethereum.utils.ensure import ensure
 
 from .. import rlp
-from ..base_types import U256, U256_CEIL_VALUE, Bytes, Uint, Uint64
+from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
 from .eth_types import (
@@ -69,7 +69,7 @@ class BlockChain:
 
     blocks: List[Block]
     state: State
-    chain_id: Uint64
+    chain_id: U64
 
 
 def apply_fork(old: BlockChain) -> BlockChain:

--- a/src/ethereum/utils/hexadecimal.py
+++ b/src/ethereum/utils/hexadecimal.py
@@ -12,13 +12,13 @@ Introduction
 Hexadecimal strings specific utility functions used in this specification.
 """
 from ethereum.base_types import (
+    U64,
     U256,
     Bytes,
     Bytes8,
     Bytes32,
     Bytes256,
     Uint,
-    Uint64,
 )
 from ethereum.crypto.hash import Hash32
 
@@ -165,9 +165,9 @@ def hex_to_uint(hex_string: str) -> Uint:
     return Uint(int(remove_hex_prefix(hex_string), 16))
 
 
-def hex_to_u64(hex_string: str) -> Uint64:
+def hex_to_u64(hex_string: str) -> U64:
     """
-    Convert hex string to Uint64.
+    Convert hex string to U64.
 
     Parameters
     ----------
@@ -176,10 +176,10 @@ def hex_to_u64(hex_string: str) -> Uint64:
 
     Returns
     -------
-    converted : `Uint64`
-        The Uint64 integer obtained from the given hexadecimal string.
+    converted : `U64`
+        The U64 integer obtained from the given hexadecimal string.
     """
-    return Uint64(int(remove_hex_prefix(hex_string), 16))
+    return U64(int(remove_hex_prefix(hex_string), 16))
 
 
 def hex_to_u256(hex_string: str) -> U256:

--- a/src/ethereum/utils/numeric.py
+++ b/src/ethereum/utils/numeric.py
@@ -13,7 +13,7 @@ Numeric operations specific utility functions used in this specification.
 """
 from typing import Sequence, Tuple
 
-from ethereum.base_types import Uint, Uint32
+from ethereum.base_types import U32, Uint
 
 
 def get_sign(value: int) -> int:
@@ -89,55 +89,55 @@ def is_prime(number: int) -> bool:
     return True
 
 
-def le_bytes_to_uint32_sequence(data: bytes) -> Tuple[Uint32, ...]:
+def le_bytes_to_uint32_sequence(data: bytes) -> Tuple[U32, ...]:
     """
-    Convert little endian byte stream `data` to a little endian Uint32
-    sequence i.e., the first Uint32 number of the sequence is the least
-    significant Uint32 number.
+    Convert little endian byte stream `data` to a little endian U32
+    sequence i.e., the first U32 number of the sequence is the least
+    significant U32 number.
 
     Parameters
     ----------
     data :
-        The byte stream (little endian) which is to be converted to a Uint32
+        The byte stream (little endian) which is to be converted to a U32
         stream.
 
     Returns
     -------
-    uint32_sequence : `Tuple[Uint32, ...]`
-        Sequence of Uint32 numbers obtained from the little endian byte
+    uint32_sequence : `Tuple[U32, ...]`
+        Sequence of U32 numbers obtained from the little endian byte
         stream.
     """
     sequence = []
     for i in range(0, len(data), 4):
-        sequence.append(Uint32.from_le_bytes(data[i : i + 4]))
+        sequence.append(U32.from_le_bytes(data[i : i + 4]))
 
     return tuple(sequence)
 
 
-def le_uint32_sequence_to_bytes(sequence: Sequence[Uint32]) -> bytes:
+def le_uint32_sequence_to_bytes(sequence: Sequence[U32]) -> bytes:
     r"""
-    Obtain little endian byte stream from a little endian Uint32 sequence
-    i.e., the first Uint32 number of the sequence is the least significant
-    Uint32 number.
+    Obtain little endian byte stream from a little endian U32 sequence
+    i.e., the first U32 number of the sequence is the least significant
+    U32 number.
 
     Note - In this conversion, the most significant byte (byte at the end of
     the little endian stream) may have leading zeroes. This function doesn't
     take care of removing these leading zeroes as shown in below example.
 
-    >>> le_uint32_sequence_to_bytes([Uint32(8)])
+    >>> le_uint32_sequence_to_bytes([U32(8)])
     b'\x08\x00\x00\x00'
 
 
     Parameters
     ----------
     sequence :
-        The Uint32 stream (little endian) which is to be converted to a
+        The U32 stream (little endian) which is to be converted to a
         little endian byte stream.
 
     Returns
     -------
     result : `bytes`
-        The byte stream obtained from the little endian Uint32 stream.
+        The byte stream obtained from the little endian U32 stream.
     """
     result_bytes = b""
     for item in sequence:
@@ -146,22 +146,22 @@ def le_uint32_sequence_to_bytes(sequence: Sequence[Uint32]) -> bytes:
     return result_bytes
 
 
-def le_uint32_sequence_to_uint(sequence: Sequence[Uint32]) -> Uint:
+def le_uint32_sequence_to_uint(sequence: Sequence[U32]) -> Uint:
     """
-    Obtain Uint from a Uint32 sequence assuming that this sequence is little
-    endian i.e., the first Uint32 number of the sequence is the least
-    significant Uint32 number.
+    Obtain Uint from a U32 sequence assuming that this sequence is little
+    endian i.e., the first U32 number of the sequence is the least
+    significant U32 number.
 
     Parameters
     ----------
     sequence :
-        The Uint32 stream (little endian) which is to be converted to a Uint.
+        The U32 stream (little endian) which is to be converted to a Uint.
 
     Returns
     -------
     value : `Uint`
         The Uint number obtained from the conversion of the little endian
-        Uint32 stream.
+        U32 stream.
     """
     sequence_as_bytes = le_uint32_sequence_to_bytes(sequence)
     return Uint.from_le_bytes(sequence_as_bytes)

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, TypeVar, Union
 from urllib import request
 
 from ethereum import rlp
-from ethereum.base_types import Bytes0, Bytes256, Uint64
+from ethereum.base_types import U64, Bytes0, Bytes256
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,
@@ -257,7 +257,7 @@ class BlockDownloader(ForkTracking):
                     )
                 return b"\x01" + rlp.encode(
                     self.module("eth_types").AccessListTransaction(
-                        Uint64(1),
+                        U64(1),
                         hex_to_u256(t["nonce"]),
                         hex_to_u256(t["gasPrice"]),
                         hex_to_u256(t["gas"]),
@@ -475,7 +475,7 @@ class BlockDownloader(ForkTracking):
             hex_to_bytes8(json["nonce"]),
         )
 
-    def download_chain_id(self) -> Uint64:
+    def download_chain_id(self) -> U64:
         """
         Fetch the chain id of the executing chain from the rpc provider.
         """
@@ -501,7 +501,7 @@ class BlockDownloader(ForkTracking):
         with request.urlopen(post) as response:
             reply = json.load(response)[0]
             assert reply["id"] == hex(2)
-            chain_id = Uint64(int(reply["result"], 16))
+            chain_id = U64(int(reply["result"], 16))
 
         return chain_id
 
@@ -694,7 +694,7 @@ class Sync(ForkTracking):
             end - start,
         )
 
-    def fetch_chain_id(self, state: Any) -> Uint64:
+    def fetch_chain_id(self, state: Any) -> U64:
         """
         Fetch the persisted chain id from the database.
         """
@@ -703,7 +703,7 @@ class Sync(ForkTracking):
         )
 
         if chain_id is not None:
-            chain_id = Uint64(int(chain_id))
+            chain_id = U64(int(chain_id))
 
         return chain_id
 

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ethereum.rlp as rlp
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.berlin.eth_types import (
     AccessListTransaction,
     Block,
@@ -54,7 +54,7 @@ legacy_transaction = LegacyTransaction(
 )
 
 access_list_transaction = AccessListTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(2),
     U256(3),

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -12,7 +12,7 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 from ethereum import rlp
-from ethereum.base_types import U256, Bytes0, Uint64
+from ethereum.base_types import U64, U256, Bytes0
 from ethereum.crypto.hash import Hash32
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
@@ -260,7 +260,7 @@ class Load(BaseLoad):
 
         # London and beyond
         if "maxFeePerGas" in raw and "maxPriorityFeePerGas" in raw:
-            parameters.insert(0, Uint64(1))
+            parameters.insert(0, U64(1))
             parameters.insert(2, hex_to_u256(raw.get("maxPriorityFeePerGas")))
             parameters.insert(3, hex_to_u256(raw.get("maxFeePerGas")))
             parameters.insert(
@@ -273,7 +273,7 @@ class Load(BaseLoad):
         parameters.insert(1, hex_to_u256(raw.get("gasPrice")))
         # Access List Transaction
         if "accessList" in raw:
-            parameters.insert(0, Uint64(1))
+            parameters.insert(0, U64(1))
             parameters.insert(
                 7, self.json_to_access_list(raw.get("accessList"))
             )
@@ -410,7 +410,7 @@ def load_test(test_case: Dict, load: BaseLoad) -> Dict:
         "test_file": test_case["test_file"],
         "test_key": test_case["test_key"],
         "genesis_header": load.json_to_header(json_data["genesisBlockHeader"]),
-        "chain_id": Uint64(json_data["genesisBlockHeader"].get("chainId", 1)),
+        "chain_id": U64(json_data["genesisBlockHeader"].get("chainId", 1)),
         "genesis_header_hash": hex_to_bytes(
             json_data["genesisBlockHeader"]["hash"]
         ),

--- a/tests/helpers/load_vm_tests.py
+++ b/tests/helpers/load_vm_tests.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from typing import Any, List, TypeVar
 
 from ethereum import rlp
-from ethereum.base_types import U256, Uint, Uint64
+from ethereum.base_types import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
@@ -137,7 +137,7 @@ class VmTestLoader:
         chain = self.BlockChain(
             blocks=[],
             state=current_state,
-            chain_id=Uint64(1),
+            chain_id=U64(1),
         )
 
         return self.Environment(

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ethereum.rlp as rlp
-from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint, Uint64
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.london.eth_types import (
     AccessListTransaction,
@@ -55,7 +55,7 @@ legacy_transaction = LegacyTransaction(
 )
 
 access_list_transaction = AccessListTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(2),
     U256(3),
@@ -69,7 +69,7 @@ access_list_transaction = AccessListTransaction(
 )
 
 transaction_1559 = FeeMarketTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(7),
     U256(2),

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -1,15 +1,7 @@
 import pytest
 
 import ethereum.rlp as rlp
-from ethereum.base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes32,
-    Uint,
-    Uint64,
-)
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.paris.eth_types import (
     AccessListTransaction,
@@ -63,7 +55,7 @@ legacy_transaction = LegacyTransaction(
 )
 
 access_list_transaction = AccessListTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(2),
     U256(3),
@@ -77,7 +69,7 @@ access_list_transaction = AccessListTransaction(
 )
 
 transaction_1559 = FeeMarketTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(7),
     U256(2),

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -1,15 +1,7 @@
 import pytest
 
 import ethereum.rlp as rlp
-from ethereum.base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes32,
-    Uint,
-    Uint64,
-)
+from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.shanghai.eth_types import (
     AccessListTransaction,
@@ -64,7 +56,7 @@ legacy_transaction = LegacyTransaction(
 )
 
 access_list_transaction = AccessListTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(2),
     U256(3),
@@ -78,7 +70,7 @@ access_list_transaction = AccessListTransaction(
 )
 
 transaction_1559 = FeeMarketTransaction(
-    Uint64(1),
+    U64(1),
     U256(1),
     U256(7),
     U256(2),
@@ -92,7 +84,7 @@ transaction_1559 = FeeMarketTransaction(
     U256(6),
 )
 
-withdrawal = Withdrawal(Uint64(0), Uint64(1), address1, U256(2))
+withdrawal = Withdrawal(U64(0), U64(1), address1, U256(2))
 
 
 header = Header(

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -55,6 +55,7 @@ typeshed
 U256
 U255
 U64
+U32
 U8
 secp256k1
 secp256k1n


### PR DESCRIPTION
(closes #713 )

### What was wrong?
The different integer types currently have non-standard naming conventions. For example 256 bit integer is named U256 whereas 32 and 64 bit integers are names Uint32 and Uint64 respectively

Related to Issue #713 

### How was it fixed?
Uint32 has been renamed U32 and Uint64 has been renamed U64

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/7/72/Igel.JPG)
