### PR TITLE
Decode blocks from RLP

### DIFF
--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -12,7 +12,7 @@ import pytest
 from _pytest.mark.structures import ParameterSet
 
 from ethereum import rlp
-from ethereum.base_types import U256, Uint64
+from ethereum.base_types import U64, U256
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,
@@ -300,7 +300,7 @@ def load_test(test_case: Dict, load: BaseLoad) -> Dict:
     return {
         "test_file": test_case["test_file"],
         "test_key": test_case["test_key"],
-        "chain_id": Uint64(json_data["genesisBlockHeader"].get("chainId", 1)),
+        "chain_id": U64(json_data["genesisBlockHeader"].get("chainId", 1)),
         "genesis_block": genesis_block,
         "pre_state": load.json_to_state(json_data["pre"]),
         "blocks": blocks,


### PR DESCRIPTION
### What was wrong?
Currently the testing framework creates the Block and Genesis Block datatypes  from the various fields available in the fixture json files. There are a couple of problems with this approach

1. The ethereum tests repository looks upon a lot of these json fields as an aid for human readability and looks at the rlp fields as the primary source of the data.
2. If new fields are added to the Block, Header, Transaction and Withdrawal datatypes,  patches will have to be added to fix the testing logic

### How was it fixed?
The specs need to derive the data structures for testing by decoding the rlp instead of using the json fields. This will also serve as an additional layer of testing for the rlp decode logic within the specs. The current commit makes that change and also re-factors some of the code in the state test helper.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/8/8b/Two-toed_sloth_Costa_Rica_-_cropped.jpg)
