### PR TITLE
Improve bad RLP handling

### DIFF
--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -640,6 +640,20 @@ class FixedUInt(int):
             return NotImplemented
         return int.__new__(self.__class__, int.__rshift__(self, shift_by))
 
+    def to_be_bytes(self) -> "Bytes":
+        """
+        Converts this unsigned integer into its big endian representation,
+        omitting leading zero bytes.
+
+        Returns
+        -------
+        big_endian : `Bytes`
+            Big endian (most significant bits first) representation.
+        """
+        bit_length = self.bit_length()
+        byte_length = (bit_length + 7) // 8
+        return self.to_bytes(byte_length, "big")
+
     # TODO: Implement neg, pos, abs ...
 
 
@@ -700,19 +714,6 @@ class U256(FixedUInt):
             Big endian (most significant bits first) representation.
         """
         return Bytes32(self.to_bytes(32, "big"))
-
-    def to_be_bytes(self) -> "Bytes":
-        """
-        Converts this 256-bit unsigned integer into its big endian
-        representation, omitting leading zero bytes.
-        Returns
-        -------
-        big_endian : `Bytes`
-            Big endian (most significant bits first) representation.
-        """
-        bit_length = self.bit_length()
-        byte_length = (bit_length + 7) // 8
-        return self.to_bytes(byte_length, "big")
 
     def to_signed(self) -> int:
         """
@@ -832,20 +833,6 @@ class U64(FixedUInt):
         bit_length = self.bit_length()
         byte_length = (bit_length + 7) // 8
         return self.to_bytes(byte_length, "little")
-
-    def to_be_bytes(self) -> "Bytes":
-        """
-        Converts this unsigned 64 bit integer into its big endian
-        representation.
-
-        Returns
-        -------
-        big_endian : `Bytes`
-            Big endian (most significant bits first) representation.
-        """
-        bit_length = self.bit_length()
-        byte_length = (bit_length + 7) // 8
-        return self.to_bytes(byte_length, "big")
 
     @classmethod
     def from_be_bytes(cls: Type, buffer: "Bytes") -> "U64":

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -26,7 +26,7 @@ class InvalidBlock(EthereumException):
     """
 
 
-class RLPDecodingError(EthereumException):
+class RLPDecodingError(InvalidBlock):
     """
     Indicates that RLP decoding failed.
     """

--- a/src/ethereum/rlp.py
+++ b/src/ethereum/rlp.py
@@ -51,7 +51,7 @@ def encode(raw_data: RLP) -> Bytes:
     if isinstance(raw_data, (bytearray, bytes)):
         return encode_bytes(raw_data)
     elif isinstance(raw_data, (Uint, FixedUInt)):
-        return encode(raw_data.to_be_bytes())  # type: ignore
+        return encode(raw_data.to_be_bytes())
     elif isinstance(raw_data, str):
         return encode_bytes(raw_data.encode())
     elif isinstance(raw_data, bool):

--- a/tests/shanghai/test_state_transition.py
+++ b/tests/shanghai/test_state_transition.py
@@ -64,7 +64,7 @@ def test_general_state_tests_4895(test_case: Dict) -> None:
                 run_shanghai_blockchain_st_tests(test_case)
 
         elif is_in_list(test_case, invalid_bounds_tests):
-            with pytest.raises(ValueError):
+            with pytest.raises(InvalidBlock):
                 run_shanghai_blockchain_st_tests(test_case)
 
         elif is_in_list(test_case, invalid_block_tests):
@@ -120,20 +120,16 @@ invalid_block_spec_tests = ("withdrawals/withdrawals_use_value_in_tx.json",)
 def test_execution_specs_generated_tests(test_case: Dict) -> None:
     try:
         if is_in_list(test_case, invalid_rlp_spec_tests):
-            try:
-                run_shanghai_blockchain_st_tests(test_case)
-            except:
-                # FIXME: This should be changed once the issue is fixed
-                # https://github.com/ethereum/execution-spec-tests/issues/36
-                pytest.xfail(f"{test_case} currently has rlp issues")
-
-        elif is_in_list(test_case, invalid_bounds_spec_tests):
-            with pytest.raises(ValueError):
+            with pytest.raises(RLPDecodingError):
                 run_shanghai_blockchain_st_tests(test_case)
 
         elif is_in_list(test_case, invalid_block_spec_tests):
             with pytest.raises(InvalidBlock):
                 run_shanghai_blockchain_st_tests(test_case)
+
+        elif is_in_list(test_case, invalid_bounds_spec_tests):
+            # FIXME: This test has been removed upstream
+            pytest.xfail(f"{test_case} covers undefined behaviour")
 
         else:
             run_shanghai_blockchain_st_tests(test_case)


### PR DESCRIPTION
### What was wrong?

The spec was incorrectly handling block with bad RLP in them.

### How was it fixed?

* The RLP decoder now raises `RLPDecodingError` rather than attempting to create an invalid value for a type (e.g. out of bounds integers).
* `RLPDecodingError` is a subclass of `InvalidBlock`.

This should fix the current CI failure with `--optimized`. The tests no longer need to disguish between RLP issues and other types of invalid blocks, but that is not in this PR.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/q84obyruhjia1.jpg)
