### PR TITLE
replace `pysha3` with `pycryptodome`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ package_dir =
 
 python_requires = >=3.8
 install_requires =
-    pysha3>=1,<2
+    pycryptodome>=3,<4
     coincurve>=17,<18
     typing_extensions>=4
 

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -12,7 +12,7 @@ Introduction
 Cryptographic hashing functions.
 """
 
-import sha3
+from Crypto.Hash import keccak
 
 from ..base_types import Bytes, Bytes32, Bytes64
 
@@ -34,7 +34,8 @@ def keccak256(buffer: Bytes) -> Hash32:
     hash : `ethereum.base_types.Hash32`
         Output of the hash function.
     """
-    return sha3.keccak_256(buffer).digest()
+    k = keccak.new(digest_bits=256)
+    return Hash32(k.update(buffer).digest())
 
 
 def keccak512(buffer: Bytes) -> Hash64:
@@ -51,4 +52,5 @@ def keccak512(buffer: Bytes) -> Hash64:
     hash : `ethereum.base_types.Hash32`
         Output of the hash function.
     """
-    return sha3.keccak_512(buffer).digest()
+    k = keccak.new(digest_bits=512)
+    return Hash64(k.update(buffer).digest())


### PR DESCRIPTION
(closes #726 )

### What was wrong?
`pysha3` is no longer being maintained

Related to Issue #726 

### How was it fixed?
Use `pycryptodome` instead.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://paradepets.com/.image/c_limit%2Ccs_srgb%2Cq_auto:good%2Cw_724/MTkxMzY1Nzg4MTM4NDE1NzE0/cute-animals-45-jpeg.webp)
