### PR TITLE
check word boundaries before replace

### DIFF
--- a/src/ethereum_spec_tools/new_fork.py
+++ b/src/ethereum_spec_tools/new_fork.py
@@ -59,7 +59,7 @@ def find_replace(dir: str, find: str, replace: str, file_pattern: str) -> None:
             file_path = os.path.join(path, filename)
             with open(file_path, "r+b") as f:
                 s = f.read()
-                find_pattern = (r"\b" + find + r"\b").encode()
+                find_pattern = (r"\b" + re.escape(find) + r"\b").encode()
                 s = re.sub(find_pattern, replace.encode(), s)
                 f.seek(0)
                 f.write(s)

--- a/src/ethereum_spec_tools/new_fork.py
+++ b/src/ethereum_spec_tools/new_fork.py
@@ -5,6 +5,7 @@ Tool to create a new fork using the latest fork
 import argparse
 import fnmatch
 import os
+import re
 from shutil import copytree
 from typing import Tuple
 
@@ -58,7 +59,8 @@ def find_replace(dir: str, find: str, replace: str, file_pattern: str) -> None:
             file_path = os.path.join(path, filename)
             with open(file_path, "r+b") as f:
                 s = f.read()
-                s = s.replace(find.encode(), replace.encode())
+                find_pattern = (r"\b" + find + r"\b").encode()
+                s = re.sub(find_pattern, replace.encode(), s)
                 f.seek(0)
                 f.write(s)
                 f.truncate()


### PR DESCRIPTION
(closes #687 )

### What was wrong?
While creating a new fork for Shanghai using Paris, the new fork tool replaces paris in the word Comparison with shanghai. This should not happen.

Related to Issue #687 

### How was it fixed?
Check word boundaries before replace
