### PR TITLE
Rename `evm` command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -139,7 +139,7 @@ console_scripts =
     ethereum-spec-sync = ethereum_spec_tools.sync:main
     ethereum-spec-diff = ethereum_spec_tools.diff:main
     ethereum-spec-new-fork = ethereum_spec_tools.new_fork:main
-    evm = ethereum_spec_tools.evm_tools:main
+    ethereum-spec-evm = ethereum_spec_tools.evm_tools:main
 
 [options.extras_require]
 test =


### PR DESCRIPTION
### What was wrong?

The newly introduced `evm` command collides with go-ethereum's `evm`, and this caused an issue in https://github.com/ethereum/execution-spec-tests because this repo is listed as a dependency.

### How was it fixed?

Fix suggested in this PR is to simply rename the `evm` command to `ethereum-spec-evm`, which is more inline with the other existing console scripts.

Furthermore, this should make it easier for the `execution-spec-tests`' filler to select which implementation installed in the system to use to fill tests.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lollybrown.com/wp-content/uploads/2018/10/axolotl-cover2.jpg)
