### PR TITLE
ignore bcMultiChainTest for invalid_block_tests

### DIFF
--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -131,7 +131,7 @@ xfail_candidates = (
 )
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 def is_in_xfail(test_case: Dict) -> bool:

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -111,7 +111,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -129,7 +129,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -92,7 +92,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -185,7 +185,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_Homestead",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -131,7 +131,7 @@ xfail_candidates = (
 )
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 def is_in_xfail(test_case: Dict) -> bool:

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -125,7 +125,7 @@ xfail_candidates = (
 )
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 def is_in_xfail(test_case: Dict) -> bool:

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -104,7 +104,7 @@ xfail_candidates = (
 )
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 def is_in_xfail(test_case: Dict) -> bool:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -97,7 +97,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -99,7 +99,7 @@ test_dir = (
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
 
 # FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest",)
+IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
The bcMultiChainTest are not relevant for the specs. Currently, those are ignored for the valid block tests but not for the invalid block tests.

### How was it fixed?
This commit ignores them for the invalid block tests as well

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/48196632/227555438-f7ce686c-ae35-457f-9b0d-8fc30603233e.jpg)
