### PR TITLE
Consolidate test fixtures in a single directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,4 @@ pip-delete-this-directory.txt
 /doc/diffs
 /doc/autoapi
 
-tests/execution-spec-generated-tests
 tests/fixtures
-tests/t8n_testdata

--- a/tests/berlin/test_ethash.py
+++ b/tests/berlin/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -24,7 +25,9 @@ run_berlin_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/GeneralStateTests/"
+)
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/ValidBlocks/"
+)
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -115,7 +120,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/InvalidBlocks"
+)
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -9,7 +10,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_berlin_transaction = partial(load_test_transaction, network="Berlin")
 

--- a/tests/berlin/test_trie.py
+++ b/tests/berlin/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.berlin.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/byzantium/test_ethash.py
+++ b/tests/byzantium/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -24,9 +25,9 @@ run_byzantium_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 # These are tests that are considered to be incorrect,
@@ -67,8 +68,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -104,8 +106,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
@@ -138,7 +141,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_byzantium_transaction = partial(
     load_test_transaction, network="Byzantium"

--- a/tests/byzantium/test_trie.py
+++ b/tests/byzantium/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.byzantium.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/byzantium/vm/test_arithmetic_operations.py
+++ b/tests/byzantium/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_bitwise_logic_operations.py
+++ b/tests/byzantium/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_block_operations.py
+++ b/tests/byzantium/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_control_flow_operations.py
+++ b/tests/byzantium/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_environmental_operations.py
+++ b/tests/byzantium/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_keccak.py
+++ b/tests/byzantium/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_logging_operations.py
+++ b/tests/byzantium/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_memory_operations.py
+++ b/tests/byzantium/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_stack_operations.py
+++ b/tests/byzantium/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/byzantium/vm/test_storage_operations.py
+++ b/tests/byzantium/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/byzantium/vm/test_system_operations.py
+++ b/tests/byzantium/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,8 +109,10 @@ def pytest_sessionstart(session: Session) -> None:
 
     fixtures_location = "tests/fixtures"
 
-    if not os.path.exists(fixtures_location):
+    try:
         os.mkdir(fixtures_location)
+    except FileExistsError:
+        pass
 
     for idx, props in test_fixtures.items():
         fixture_path = f"{fixtures_location}/{idx}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,14 @@ from ethereum_spec_tools.evm_trace import evm_trace
 # Update the links and commit has in order to consume
 # newer/other tests
 test_fixtures = {
-    "execution-spec-generated-tests": {
+    "execution_spec_generated_tests": {
         "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v0.2.3/fixtures.tar.gz",
     },
     "t8n_testdata": {
         "url": "https://github.com/gurukamath/t8n_testdata.git",
         "commit_hash": "6b6a0fe",
     },
-    "fixtures": {
+    "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
         "commit_hash": "69c4c2a",
     },
@@ -107,10 +107,17 @@ def git_clone_fixtures(url: str, commit_hash: str, location: str) -> None:
 
 def pytest_sessionstart(session: Session) -> None:
 
-    fixtures_location = "tests"
+    fixtures_location = "tests/fixtures"
+
+    if not os.path.exists(fixtures_location):
+        os.mkdir(fixtures_location)
 
     for idx, props in test_fixtures.items():
         fixture_path = f"{fixtures_location}/{idx}"
+
+        # Set the path of the various downloaded fixtures
+        # as environment variables
+        os.environ[idx.upper()] = fixture_path
 
         if "commit_hash" in props:
             git_clone_fixtures(

--- a/tests/constantinople/test_ethash.py
+++ b/tests/constantinople/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -26,9 +27,9 @@ run_constantinople_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 
@@ -85,8 +86,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -122,8 +124,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
@@ -158,7 +161,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_constantinople_transaction = partial(
     load_test_transaction, network="ConstantinopleFix"

--- a/tests/constantinople/test_trie.py
+++ b/tests/constantinople/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.constantinople.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/constantinople/vm/test_arithmetic_operations.py
+++ b/tests/constantinople/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_bitwise_logic_operations.py
+++ b/tests/constantinople/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_block_operations.py
+++ b/tests/constantinople/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_control_flow_operations.py
+++ b/tests/constantinople/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_environmental_operations.py
+++ b/tests/constantinople/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_keccak.py
+++ b/tests/constantinople/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_logging_operations.py
+++ b/tests/constantinople/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_memory_operations.py
+++ b/tests/constantinople/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_stack_operations.py
+++ b/tests/constantinople/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/constantinople/vm/test_storage_operations.py
+++ b/tests/constantinople/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/constantinople/vm/test_system_operations.py
+++ b/tests/constantinople/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/frontier/test_ethash.py
+++ b/tests/frontier/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -25,9 +26,9 @@ run_frontier_blockchain_st_tests = partial(
 
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 GENERAL_STATE_BIG_MEMORY_TESTS = (
@@ -55,8 +56,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -85,8 +87,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
@@ -122,7 +125,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_frontier_transaction = partial(load_test_transaction, network="Frontier")
 

--- a/tests/frontier/test_trie.py
+++ b/tests/frontier/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.frontier.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_bitwise_logic_operations.py
+++ b/tests/frontier/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_block_operations.py
+++ b/tests/frontier/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_control_flow_operations.py
+++ b/tests/frontier/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_keccak.py
+++ b/tests/frontier/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_logging_operations.py
+++ b/tests/frontier/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_memory_operations.py
+++ b/tests/frontier/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_stack_operations.py
+++ b/tests/frontier/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/frontier/vm/test_storage_operations.py
+++ b/tests/frontier/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/frontier/vm/test_system_operations.py
+++ b/tests/frontier/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/homestead/test_ethash.py
+++ b/tests/homestead/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -25,9 +26,9 @@ run_homestead_blockchain_st_tests = partial(
 
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 # Every test below takes more than  60s to run and
@@ -141,8 +142,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -178,8 +180,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Homestead",)
@@ -212,7 +215,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_homestead_transaction = partial(
     load_test_transaction, network="Homestead"

--- a/tests/homestead/test_trie.py
+++ b/tests/homestead/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.homestead.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/homestead/vm/test_arithmetic_operations.py
+++ b/tests/homestead/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_bitwise_logic_operations.py
+++ b/tests/homestead/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_block_operations.py
+++ b/tests/homestead/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_control_flow_operations.py
+++ b/tests/homestead/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_environmental_operations.py
+++ b/tests/homestead/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_keccak.py
+++ b/tests/homestead/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_logging_operations.py
+++ b/tests/homestead/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_memory_operations.py
+++ b/tests/homestead/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_stack_operations.py
+++ b/tests/homestead/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/homestead/vm/test_storage_operations.py
+++ b/tests/homestead/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/homestead/vm/test_system_operations.py
+++ b/tests/homestead/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/istanbul/test_ethash.py
+++ b/tests/istanbul/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -24,7 +25,9 @@ run_istanbul_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/GeneralStateTests/"
+)
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/ValidBlocks/"
+)
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -115,7 +120,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/InvalidBlocks"
+)
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_istanbul_transaction = partial(load_test_transaction, network="Istanbul")
 

--- a/tests/istanbul/test_trie.py
+++ b/tests/istanbul/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.istanbul.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -24,7 +25,9 @@ run_london_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/GeneralStateTests/"
+)
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/ValidBlocks/"
+)
 
 only_in = (
     "bcUncleTest/oneUncle.json",
@@ -109,7 +114,9 @@ def test_uncles_correctness(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/InvalidBlocks"
+)
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -9,7 +10,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_london_transaction = partial(load_test_transaction, network="London")
 

--- a/tests/london/test_trie.py
+++ b/tests/london/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.london.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -24,7 +25,9 @@ run_paris_blockchain_st_tests = partial(
 )
 
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/GeneralStateTests/"
+)
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -85,10 +88,14 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/ValidBlocks/"
+)
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/InvalidBlocks"
+)
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/paris/test_trie.py
+++ b/tests/paris/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.paris.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/shanghai/test_state_transition.py
+++ b/tests/shanghai/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict, Tuple
 
@@ -33,7 +34,9 @@ def is_in_list(test_case: Dict, test_list: Tuple) -> bool:
 
 
 # Run EIP-4895 tests
-test_dir = "tests/fixtures/BlockchainTests/EIPTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"], "BlockchainTests/EIPTests/"
+)
 
 invalid_rlp_tests = (
     "bc4895-withdrawals/withdrawalsRLPlessElements.json",
@@ -79,8 +82,9 @@ def test_general_state_tests_4895(test_case: Dict) -> None:
 
 
 # Run EIP-3860 tests
-test_dir = (
-    "tests/fixtures/BlockchainTests/GeneralStateTests/EIPTests/stEIP3860"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/EIPTests/stEIP3860",
 )
 
 
@@ -98,7 +102,9 @@ def test_general_state_tests_3860(test_case: Dict) -> None:
 
 
 # Run execution-spec-generated-tests
-test_dir = "tests/execution-spec-generated-tests/fixtures/withdrawals"
+test_dir = os.path.join(
+    os.environ["EXECUTION_SPEC_GENERATED_TESTS"], "fixtures/withdrawals"
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/shanghai/test_trie.py
+++ b/tests/shanghai/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.shanghai.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/" + path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/spurious_dragon/test_ethash.py
+++ b/tests/spurious_dragon/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -25,9 +26,9 @@ run_spurious_dragon_blockchain_st_tests = partial(
 
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 GENERAL_STATE_BIG_MEMORY_TESTS = (
@@ -56,8 +57,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -90,8 +92,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
@@ -126,7 +129,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_spurious_dragon_transaction = partial(
     load_test_transaction, network="EIP158"

--- a/tests/spurious_dragon/test_trie.py
+++ b/tests/spurious_dragon/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.spurious_dragon.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/spurious_dragon/vm/test_arithmetic_operations.py
+++ b/tests/spurious_dragon/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_bitwise_logic_operations.py
+++ b/tests/spurious_dragon/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_block_operations.py
+++ b/tests/spurious_dragon/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_control_flow_operations.py
+++ b/tests/spurious_dragon/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_environmental_operations.py
+++ b/tests/spurious_dragon/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_keccak.py
+++ b/tests/spurious_dragon/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_logging_operations.py
+++ b/tests/spurious_dragon/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_memory_operations.py
+++ b/tests/spurious_dragon/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_stack_operations.py
+++ b/tests/spurious_dragon/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/spurious_dragon/vm/test_storage_operations.py
+++ b/tests/spurious_dragon/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/spurious_dragon/vm/test_system_operations.py
+++ b/tests/spurious_dragon/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/test_ethash.py
+++ b/tests/tangerine_whistle/test_ethash.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pkgutil
 from typing import Any, Dict, List, cast
 
@@ -59,7 +60,9 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        os.path.join(
+            os.environ["ETHEREUM_TESTS"], "PoWTests/ethash_tests.json"
+        )
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Dict
 
@@ -27,9 +28,9 @@ run_tangerine_whistle_blockchain_st_tests = partial(
 
 
 # Run legacy general state tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/GeneralStateTests/",
 )
 
 GENERAL_STATE_BIG_MEMORY_TESTS = (
@@ -58,8 +59,9 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/ValidBlocks/",
 )
 
 IGNORE_LIST = (
@@ -92,8 +94,9 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "LegacyTests/Constantinople/BlockchainTests/InvalidBlocks",
 )
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
@@ -129,7 +132,10 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = os.path.join(
+    os.environ["ETHEREUM_TESTS"],
+    "BlockchainTests/GeneralStateTests/",
+)
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -12,7 +13,7 @@ from ethereum.utils.hexadecimal import hex_to_uint
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+test_dir = os.path.join(os.environ["ETHEREUM_TESTS"], "TransactionTests")
 
 load_tangerine_whistle_transaction = partial(
     load_test_transaction, network="EIP150"

--- a/tests/tangerine_whistle/test_trie.py
+++ b/tests/tangerine_whistle/test_trie.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any
 
 from ethereum.tangerine_whistle.fork_types import Bytes
@@ -80,7 +81,9 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(
+        os.path.join(os.environ["ETHEREUM_TESTS"], "TrieTests/", path)
+    ) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/tangerine_whistle/vm/test_arithmetic_operations.py
+++ b/tests/tangerine_whistle/vm/test_arithmetic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_bitwise_logic_operations.py
+++ b/tests/tangerine_whistle/vm/test_bitwise_logic_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_block_operations.py
+++ b/tests/tangerine_whistle/vm/test_block_operations.py
@@ -1,10 +1,14 @@
+import os
 from functools import partial
 
 from ..vm.vm_test_helpers import run_test
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_control_flow_operations.py
+++ b/tests/tangerine_whistle/vm/test_control_flow_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from .vm_test_helpers import run_test
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_environmental_operations.py
+++ b/tests/tangerine_whistle/vm/test_environmental_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_keccak.py
+++ b/tests/tangerine_whistle/vm/test_keccak.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSha3Test",
+    ),
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_logging_operations.py
+++ b/tests/tangerine_whistle/vm/test_logging_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmLogTest",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_memory_operations.py
+++ b/tests/tangerine_whistle/vm/test_memory_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_stack_operations.py
+++ b/tests/tangerine_whistle/vm/test_stack_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,11 +7,17 @@ from ..vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    ),
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/tangerine_whistle/vm/test_storage_operations.py
+++ b/tests/tangerine_whistle/vm/test_storage_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,7 +7,10 @@ from ..vm.vm_test_helpers import run_test
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    ),
 )
 
 

--- a/tests/tangerine_whistle/vm/test_system_operations.py
+++ b/tests/tangerine_whistle/vm/test_system_operations.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 
 import pytest
@@ -6,12 +7,18 @@ from ..vm.vm_test_helpers import run_test
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    ),
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    os.path.join(
+        os.environ["ETHEREUM_TESTS"],
+        "LegacyTests/Constantinople/VMTests/vmTests",
+    ),
 )
 
 

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -357,7 +357,7 @@ def convert_to_rlp_native(
 def ethtest_fixtures_as_pytest_fixtures(
     *test_files: str,
 ) -> List[Tuple[RLP, Bytes]]:
-    base_path = "tests/fixtures/RLPTests/"
+    base_path = os.path.join(os.environ["ETHEREUM_TESTS"], "RLPTests/")
 
     test_data = dict()
     for test_file in test_files:

--- a/tests/test_t8n.py
+++ b/tests/test_t8n.py
@@ -15,7 +15,7 @@ from ethereum_spec_tools.evm_tools import parser, subparsers
 from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
 from ethereum_spec_tools.evm_tools.utils import FatalException
 
-testdata_dir = "tests/t8n_testdata"
+testdata_dir = os.environ["T8N_TESTDATA"]
 
 ignore_tests = [
     "fixtures/expected/26/Merge.json",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -23,7 +23,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]
@@ -71,5 +71,5 @@ extras =
     test
     optimized
 commands =
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
 


### PR DESCRIPTION
### What was wrong?
Currently, the test fixtures are downloaded or cloned into their own individual folders. The paths to these fixtures are also hard coded in the test source files.


### How was it fixed?
This commit consolidates all the fixtures into a single directory. Also, the paths to the fixtures are set as environment variables in `conftest.py` and used in the tesing source files

#### Cute Animal Picture

![Cute Animal](https://user-images.githubusercontent.com/48196632/227779455-3e885e8c-bdbe-4de2-affb-535421fc9fa9.jpg)
