### PR TITLE
Consolidate test fixtures in a single directory

### DIFF
--- a/tests/berlin/test_ethash.py
+++ b/tests/berlin/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,8 +24,10 @@ run_berlin_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -115,7 +118,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -6,10 +6,13 @@ from ethereum import rlp
 from ethereum.berlin.fork import calculate_intrinsic_cost, validate_transaction
 from ethereum.berlin.fork_types import LegacyTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_berlin_transaction = partial(load_test_transaction, network="Berlin")
 

--- a/tests/berlin/test_trie.py
+++ b/tests/berlin/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/byzantium/test_ethash.py
+++ b/tests/byzantium/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,9 +24,11 @@ run_byzantium_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -67,9 +70,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -104,9 +105,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
 
@@ -138,7 +137,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.byzantium.fork import (
 )
 from ethereum.byzantium.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_byzantium_transaction = partial(
     load_test_transaction, network="Byzantium"

--- a/tests/byzantium/test_trie.py
+++ b/tests/byzantium/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/byzantium/vm/test_arithmetic_operations.py
+++ b/tests/byzantium/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/byzantium/vm/test_bitwise_logic_operations.py
+++ b/tests/byzantium/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/byzantium/vm/test_block_operations.py
+++ b/tests/byzantium/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/byzantium/vm/test_control_flow_operations.py
+++ b/tests/byzantium/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/byzantium/vm/test_environmental_operations.py
+++ b/tests/byzantium/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/byzantium/vm/test_keccak.py
+++ b/tests/byzantium/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/byzantium/vm/test_logging_operations.py
+++ b/tests/byzantium/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/byzantium/vm/test_memory_operations.py
+++ b/tests/byzantium/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/byzantium/vm/test_stack_operations.py
+++ b/tests/byzantium/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/byzantium/vm/test_storage_operations.py
+++ b/tests/byzantium/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/byzantium/vm/test_system_operations.py
+++ b/tests/byzantium/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,22 +12,7 @@ from pytest import Session
 
 import ethereum
 from ethereum_spec_tools.evm_trace import evm_trace
-
-# Update the links and commit has in order to consume
-# newer/other tests
-test_fixtures = {
-    "execution-spec-generated-tests": {
-        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v0.2.3/fixtures.tar.gz",
-    },
-    "t8n_testdata": {
-        "url": "https://github.com/gurukamath/t8n_testdata.git",
-        "commit_hash": "6b6a0fe",
-    },
-    "fixtures": {
-        "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "69c4c2a",
-    },
-}
+from tests.helpers import TEST_FIXTURES
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -109,8 +94,13 @@ def pytest_sessionstart(session: Session) -> None:
 
     fixtures_location = "tests"
 
-    for idx, props in test_fixtures.items():
-        fixture_path = f"{fixtures_location}/{idx}"
+    for _, props in TEST_FIXTURES.items():
+        fixture_path = props["fixture_path"]
+
+        try:
+            os.makedirs(os.path.dirname(fixture_path))
+        except FileExistsError:
+            pass
 
         if "commit_hash" in props:
             git_clone_fixtures(

--- a/tests/constantinople/test_ethash.py
+++ b/tests/constantinople/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -25,9 +26,11 @@ run_constantinople_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -85,9 +88,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -122,9 +123,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
 
@@ -158,7 +157,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.constantinople.fork import (
 )
 from ethereum.constantinople.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_constantinople_transaction = partial(
     load_test_transaction, network="ConstantinopleFix"

--- a/tests/constantinople/test_trie.py
+++ b/tests/constantinople/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/constantinople/vm/test_arithmetic_operations.py
+++ b/tests/constantinople/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/constantinople/vm/test_bitwise_logic_operations.py
+++ b/tests/constantinople/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/constantinople/vm/test_block_operations.py
+++ b/tests/constantinople/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/constantinople/vm/test_control_flow_operations.py
+++ b/tests/constantinople/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/constantinople/vm/test_environmental_operations.py
+++ b/tests/constantinople/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/constantinople/vm/test_keccak.py
+++ b/tests/constantinople/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/constantinople/vm/test_logging_operations.py
+++ b/tests/constantinople/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/constantinople/vm/test_memory_operations.py
+++ b/tests/constantinople/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/constantinople/vm/test_stack_operations.py
+++ b/tests/constantinople/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/constantinople/vm/test_storage_operations.py
+++ b/tests/constantinople/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/constantinople/vm/test_system_operations.py
+++ b/tests/constantinople/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/frontier/test_ethash.py
+++ b/tests/frontier/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,10 +24,12 @@ run_frontier_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -55,9 +58,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -85,9 +86,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
 
@@ -122,7 +121,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.frontier.fork import (
 )
 from ethereum.frontier.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_frontier_transaction = partial(load_test_transaction, network="Frontier")
 

--- a/tests/frontier/test_trie.py
+++ b/tests/frontier/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/frontier/vm/test_bitwise_logic_operations.py
+++ b/tests/frontier/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/frontier/vm/test_block_operations.py
+++ b/tests/frontier/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/frontier/vm/test_control_flow_operations.py
+++ b/tests/frontier/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/frontier/vm/test_keccak.py
+++ b/tests/frontier/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/frontier/vm/test_logging_operations.py
+++ b/tests/frontier/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/frontier/vm/test_memory_operations.py
+++ b/tests/frontier/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/frontier/vm/test_stack_operations.py
+++ b/tests/frontier/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/frontier/vm/test_storage_operations.py
+++ b/tests/frontier/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/frontier/vm/test_system_operations.py
+++ b/tests/frontier/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,18 @@
+# Update the links and commit has in order to consume
+# newer/other tests
+TEST_FIXTURES = {
+    "execution_spec_tests": {
+        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v0.2.3/fixtures.tar.gz",
+        "fixture_path": "tests/fixtures/execution_spec_tests",
+    },
+    "t8n_testdata": {
+        "url": "https://github.com/gurukamath/t8n_testdata.git",
+        "commit_hash": "6b6a0fe",
+        "fixture_path": "tests/fixtures/t8n_testdata",
+    },
+    "ethereum_tests": {
+        "url": "https://github.com/ethereum/tests.git",
+        "commit_hash": "69c4c2a",
+        "fixture_path": "tests/fixtures/ethereum_tests",
+    },
+}

--- a/tests/homestead/test_ethash.py
+++ b/tests/homestead/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,10 +24,12 @@ run_homestead_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -141,9 +144,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -178,9 +179,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_Homestead",)
 
@@ -212,7 +211,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.homestead.fork import (
 )
 from ethereum.homestead.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_homestead_transaction = partial(
     load_test_transaction, network="Homestead"

--- a/tests/homestead/test_trie.py
+++ b/tests/homestead/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/homestead/vm/test_arithmetic_operations.py
+++ b/tests/homestead/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/homestead/vm/test_bitwise_logic_operations.py
+++ b/tests/homestead/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/homestead/vm/test_block_operations.py
+++ b/tests/homestead/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/homestead/vm/test_control_flow_operations.py
+++ b/tests/homestead/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/homestead/vm/test_environmental_operations.py
+++ b/tests/homestead/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/homestead/vm/test_keccak.py
+++ b/tests/homestead/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/homestead/vm/test_logging_operations.py
+++ b/tests/homestead/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/homestead/vm/test_memory_operations.py
+++ b/tests/homestead/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/homestead/vm/test_stack_operations.py
+++ b/tests/homestead/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/homestead/vm/test_storage_operations.py
+++ b/tests/homestead/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/homestead/vm/test_system_operations.py
+++ b/tests/homestead/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/istanbul/test_ethash.py
+++ b/tests/istanbul/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,8 +24,10 @@ run_istanbul_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -115,7 +118,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.istanbul.fork import (
 )
 from ethereum.istanbul.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_istanbul_transaction = partial(load_test_transaction, network="Istanbul")
 

--- a/tests/istanbul/test_trie.py
+++ b/tests/istanbul/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,8 +24,10 @@ run_london_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -83,7 +86,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
 
 only_in = (
     "bcUncleTest/oneUncle.json",
@@ -109,7 +112,7 @@ def test_uncles_correctness(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -6,10 +6,13 @@ from ethereum import rlp
 from ethereum.london.fork import calculate_intrinsic_cost, validate_transaction
 from ethereum.london.fork_types import LegacyTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_london_transaction = partial(load_test_transaction, network="London")
 

--- a/tests/london/test_trie.py
+++ b/tests/london/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,8 +24,10 @@ run_paris_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 # Run legacy general state tests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
@@ -85,10 +88,10 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = "tests/fixtures/BlockchainTests/ValidBlocks/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
 
 # Run legacy invalid block tests
-test_dir = "tests/fixtures/BlockchainTests/InvalidBlocks"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
 
 # TODO: Handle once https://github.com/ethereum/tests/issues/1037
 # is resolved

--- a/tests/paris/test_trie.py
+++ b/tests/paris/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/shanghai/test_state_transition.py
+++ b/tests/shanghai/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock, RLPDecodingError
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,6 +24,11 @@ run_shanghai_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+ETHEREUM_SPEC_TESTS_PATH = TEST_FIXTURES["execution_spec_tests"][
+    "fixture_path"
+]
+
 
 def is_in_list(test_case: Dict, test_list: Tuple) -> bool:
     for test in test_list:
@@ -33,7 +39,7 @@ def is_in_list(test_case: Dict, test_list: Tuple) -> bool:
 
 
 # Run EIP-4895 tests
-test_dir = "tests/fixtures/BlockchainTests/EIPTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/EIPTests/"
 
 invalid_rlp_tests = (
     "bc4895-withdrawals/withdrawalsRLPlessElements.json",
@@ -79,9 +85,7 @@ def test_general_state_tests_4895(test_case: Dict) -> None:
 
 
 # Run EIP-3860 tests
-test_dir = (
-    "tests/fixtures/BlockchainTests/GeneralStateTests/EIPTests/stEIP3860"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/EIPTests/stEIP3860"
 
 
 @pytest.mark.parametrize(
@@ -98,7 +102,7 @@ def test_general_state_tests_3860(test_case: Dict) -> None:
 
 
 # Run execution-spec-generated-tests
-test_dir = "tests/execution-spec-generated-tests/fixtures/withdrawals"
+test_dir = f"{ETHEREUM_SPEC_TESTS_PATH}/fixtures/withdrawals"
 
 
 @pytest.mark.parametrize(

--- a/tests/shanghai/test_trie.py
+++ b/tests/shanghai/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+FIXTURE_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{FIXTURE_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/spurious_dragon/test_ethash.py
+++ b/tests/spurious_dragon/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -23,10 +24,12 @@ run_spurious_dragon_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -56,9 +59,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -90,9 +91,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
 
@@ -126,7 +125,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.spurious_dragon.fork import (
 )
 from ethereum.spurious_dragon.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_spurious_dragon_transaction = partial(
     load_test_transaction, network="EIP158"

--- a/tests/spurious_dragon/test_trie.py
+++ b/tests/spurious_dragon/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/spurious_dragon/vm/test_arithmetic_operations.py
+++ b/tests/spurious_dragon/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/spurious_dragon/vm/test_bitwise_logic_operations.py
+++ b/tests/spurious_dragon/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/spurious_dragon/vm/test_block_operations.py
+++ b/tests/spurious_dragon/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/spurious_dragon/vm/test_control_flow_operations.py
+++ b/tests/spurious_dragon/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/spurious_dragon/vm/test_environmental_operations.py
+++ b/tests/spurious_dragon/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/spurious_dragon/vm/test_keccak.py
+++ b/tests/spurious_dragon/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/spurious_dragon/vm/test_logging_operations.py
+++ b/tests/spurious_dragon/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/spurious_dragon/vm/test_memory_operations.py
+++ b/tests/spurious_dragon/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/spurious_dragon/vm/test_stack_operations.py
+++ b/tests/spurious_dragon/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/spurious_dragon/vm/test_storage_operations.py
+++ b/tests/spurious_dragon/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/spurious_dragon/vm/test_system_operations.py
+++ b/tests/spurious_dragon/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/tangerine_whistle/test_ethash.py
+++ b/tests/tangerine_whistle/test_ethash.py
@@ -25,8 +25,10 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes32,
 )
 from ethereum.utils.numeric import le_uint32_sequence_to_bytes
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_state_tests import Load
 
-from ..helpers.load_state_tests import Load
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def test_ethtest_fixtures() -> None:
@@ -59,7 +61,7 @@ def test_ethtest_fixtures() -> None:
 
 def load_pow_test_fixtures() -> List[Dict[str, Any]]:
     with open(
-        "tests/fixtures/PoWTests/ethash_tests.json"
+        f"{ETHEREUM_TESTS_PATH}/PoWTests/ethash_tests.json"
     ) as pow_test_file_handler:
         return [
             {

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -7,6 +7,7 @@ from ethereum import rlp
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import InvalidBlock
+from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
     NoPostState,
@@ -25,10 +26,12 @@ run_tangerine_whistle_blockchain_st_tests = partial(
     run_blockchain_st_test, load=FIXTURES_LOADER
 )
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 # Run legacy general state tests
 test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/"
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
     "GeneralStateTests/"
 )
 
@@ -58,9 +61,7 @@ def test_general_state_tests(test_case: Dict) -> None:
 
 
 # Run legacy valid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
 
 IGNORE_LIST = (
     "bcForkStressTest/ForkStressTest.json",
@@ -92,9 +93,7 @@ def test_valid_block_tests(test_case: Dict) -> None:
 
 
 # Run legacy invalid block tests
-test_dir = (
-    "tests/fixtures/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-)
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
 
 xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
 
@@ -129,7 +128,7 @@ def test_invalid_block_tests(test_case: Dict) -> None:
 
 
 # Run Non-Legacy GeneralStateTests
-test_dir = "tests/fixtures/BlockchainTests/GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -9,10 +9,13 @@ from ethereum.tangerine_whistle.fork import (
 )
 from ethereum.tangerine_whistle.fork_types import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
+from tests.helpers import TEST_FIXTURES
 
 from ..helpers.fork_types_helpers import load_test_transaction
 
-test_dir = "tests/fixtures/TransactionTests"
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
+test_dir = f"{ETHEREUM_TESTS_PATH}/TransactionTests"
 
 load_tangerine_whistle_transaction = partial(
     load_test_transaction, network="EIP150"

--- a/tests/tangerine_whistle/test_trie.py
+++ b/tests/tangerine_whistle/test_trie.py
@@ -8,6 +8,9 @@ from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     remove_hex_prefix,
 )
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 def to_bytes(data: str) -> Bytes:
@@ -80,7 +83,7 @@ def test_trie_any_order() -> None:
 
 
 def load_tests(path: str) -> Any:
-    with open("tests/fixtures/TrieTests/" + path) as f:
+    with open(f"{ETHEREUM_TESTS_PATH}/TrieTests/" + path) as f:
         tests = json.load(f)
 
     return tests

--- a/tests/tangerine_whistle/vm/test_arithmetic_operations.py
+++ b/tests/tangerine_whistle/vm/test_arithmetic_operations.py
@@ -2,11 +2,16 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 run_arithmetic_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmArithmeticTest",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_bitwise_logic_operations.py
+++ b/tests/tangerine_whistle/vm/test_bitwise_logic_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_bitwise_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_block_operations.py
+++ b/tests/tangerine_whistle/vm/test_block_operations.py
@@ -1,10 +1,14 @@
 from functools import partial
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_block_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmBlockInfoTest",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_control_flow_operations.py
+++ b/tests/tangerine_whistle/vm/test_control_flow_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from .vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_control_flow_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_environmental_operations.py
+++ b/tests/tangerine_whistle/vm/test_environmental_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_environmental_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_keccak.py
+++ b/tests/tangerine_whistle/vm/test_keccak.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSha3Test",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSha3Test",
 )
 run_special_sha3_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_logging_operations.py
+++ b/tests/tangerine_whistle/vm/test_logging_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_logging_ops_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmLogTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmLogTest",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_memory_operations.py
+++ b/tests/tangerine_whistle/vm/test_memory_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_memory_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_stack_operations.py
+++ b/tests/tangerine_whistle/vm/test_stack_operations.py
@@ -2,15 +2,19 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_push_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmPushDupSwapTest",
 )
 run_pop_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 

--- a/tests/tangerine_whistle/vm/test_storage_operations.py
+++ b/tests/tangerine_whistle/vm/test_storage_operations.py
@@ -2,11 +2,15 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_storage_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
 )
 
 

--- a/tests/tangerine_whistle/vm/test_system_operations.py
+++ b/tests/tangerine_whistle/vm/test_system_operations.py
@@ -2,16 +2,20 @@ from functools import partial
 
 import pytest
 
+from tests.helpers import TEST_FIXTURES
+
 from ..vm.vm_test_helpers import run_test
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 run_system_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmSystemOperations",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmSystemOperations",
 )
 
 run_vm_test = partial(
     run_test,
-    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmTests",
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmTests",
 )
 
 

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -9,6 +9,10 @@ from ethereum.exceptions import RLPEncodingError
 from ethereum.frontier.fork_types import U256, Bytes, Uint
 from ethereum.rlp import RLP
 from ethereum.utils.hexadecimal import hex_to_bytes
+from tests.helpers import TEST_FIXTURES
+
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+
 
 #
 # Tests for RLP encode
@@ -357,7 +361,7 @@ def convert_to_rlp_native(
 def ethtest_fixtures_as_pytest_fixtures(
     *test_files: str,
 ) -> List[Tuple[RLP, Bytes]]:
-    base_path = "tests/fixtures/RLPTests/"
+    base_path = f"{ETHEREUM_TESTS_PATH}/RLPTests/"
 
     test_data = dict()
     for test_file in test_files:

--- a/tests/test_t8n.py
+++ b/tests/test_t8n.py
@@ -14,8 +14,9 @@ from ethereum.utils.hexadecimal import (
 from ethereum_spec_tools.evm_tools import parser, subparsers
 from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
 from ethereum_spec_tools.evm_tools.utils import FatalException
+from tests.helpers import TEST_FIXTURES
 
-testdata_dir = "tests/t8n_testdata"
+T8N_TEST_PATH = TEST_FIXTURES["t8n_testdata"]["fixture_path"]
 
 ignore_tests = [
     "fixtures/expected/26/Merge.json",
@@ -23,7 +24,7 @@ ignore_tests = [
 
 
 def find_test_fixtures() -> Any:
-    with open(os.path.join(testdata_dir, "commands.json")) as f:
+    with open(os.path.join(T8N_TEST_PATH, "commands.json")) as f:
         data = json.load(f)
 
     for key, value in data.items():
@@ -31,13 +32,13 @@ def find_test_fixtures() -> Any:
         final_args = []
         for arg in value["args"]:
             if "__BASEDIR__" in arg:
-                final_args.append(arg.replace("__BASEDIR__", testdata_dir))
+                final_args.append(arg.replace("__BASEDIR__", T8N_TEST_PATH))
             else:
                 final_args.append(arg)
         yield {
             "name": key,
             "args": final_args,
-            "expected": os.path.join(testdata_dir, key),
+            "expected": os.path.join(T8N_TEST_PATH, key),
             "success": value["success"],
         }
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -23,7 +23,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]
@@ -71,5 +71,5 @@ extras =
     test
     optimized
 commands =
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/execution-spec-generated-tests/*' --ignore-glob='tests/t8n_testdata/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
 


### PR DESCRIPTION
### What was wrong?
Currently, the test fixtures are downloaded or cloned into their own individual folders. The paths to these fixtures are also hard coded in the test source files.


### How was it fixed?
This commit consolidates all the fixtures into a single directory. Also, the paths to the fixtures are set as environment variables in `conftest.py` and used in the tesing source files

#### Cute Animal Picture

![Cute Animal](https://user-images.githubusercontent.com/48196632/227779455-3e885e8c-bdbe-4de2-affb-535421fc9fa9.jpg)
