### PR TITLE
Refactor base fee calculation

### DIFF
--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -24,7 +24,7 @@ from ethereum.utils.ensure import ensure
 
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
-from . import MAINNET_FORK_BLOCK, vm
+from . import vm
 from .bloom import logs_bloom
 from .fork_types import (
     TX_ACCESS_LIST_ADDRESS_COST,
@@ -67,7 +67,6 @@ ELASTICITY_MULTIPLIER = 2
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
 MINIMUM_DIFFICULTY = Uint(131072)
-INITIAL_BASE_FEE = 1000000000
 MAX_OMMER_DEPTH = 6
 BOMB_DELAY_BLOCKS = 11400000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
@@ -203,44 +202,39 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         chain.blocks = chain.blocks[-255:]
 
 
-def validate_header(header: Header, parent_header: Header) -> None:
+def calculate_base_fee_per_gas(
+    block_gas_limit: Uint,
+    parent_gas_limit: Uint,
+    parent_gas_used: Uint,
+    parent_base_fee_per_gas: Uint,
+) -> Uint:
     """
-    Verifies a block header.
-
-    In order to consider a block's header valid, the logic for the
-    quantities in the header should match the logic for the block itself.
-    For example the header timestamp should be greater than the block's parent
-    timestamp because the block was created *after* the parent block.
-    Additionally, the block's number should be directly folowing the parent
-    block's number since it is the next block in the sequence.
+    Calculates the base fee per gas for the block.
 
     Parameters
     ----------
-    header :
-        Header to check for correctness.
-    parent_header :
-        Parent Header of the header to check for correctness
+    block_gas_limit :
+        Gas limit of the block for which the base fee is being calculated.
+    parent_gas_limit :
+        Gas limit of the parent block.
+    parent_gas_used :
+        Gas used in the parent block.
+    parent_base_fee_per_gas :
+        Base fee per gas of the parent block.
+
+    Returns
+    -------
+    base_fee_per_gas : `Uint`
+        Base fee per gas for the block.
     """
-    if header.number == MAINNET_FORK_BLOCK:
-        parent_gas_limit = parent_header.gas_limit * ELASTICITY_MULTIPLIER
-        parent_gas_target = parent_header.gas_limit
-    else:
-        parent_gas_limit = parent_header.gas_limit
-        parent_gas_target = parent_header.gas_limit // ELASTICITY_MULTIPLIER
-        parent_base_fee_per_gas = parent_header.base_fee_per_gas
+    parent_gas_target = parent_gas_limit // ELASTICITY_MULTIPLIER
 
-    parent_gas_used = parent_header.gas_used
-
-    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
     ensure(
-        check_gas_limit(header.gas_limit, parent_gas_limit),
+        check_gas_limit(block_gas_limit, parent_gas_limit),
         InvalidBlock,
     )
 
-    # check if the base fee is correct
-    if header.number == MAINNET_FORK_BLOCK:
-        expected_base_fee_per_gas = INITIAL_BASE_FEE
-    elif parent_gas_used == parent_gas_target:
+    if parent_gas_used == parent_gas_target:
         expected_base_fee_per_gas = parent_base_fee_per_gas
     elif parent_gas_used > parent_gas_target:
         gas_used_delta = parent_gas_used - parent_gas_target
@@ -269,6 +263,36 @@ def validate_header(header: Header, parent_header: Header) -> None:
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas - base_fee_per_gas_delta
         )
+
+    return Uint(expected_base_fee_per_gas)
+
+
+def validate_header(header: Header, parent_header: Header) -> None:
+    """
+    Verifies a block header.
+
+    In order to consider a block's header valid, the logic for the
+    quantities in the header should match the logic for the block itself.
+    For example the header timestamp should be greater than the block's parent
+    timestamp because the block was created *after* the parent block.
+    Additionally, the block's number should be directly folowing the parent
+    block's number since it is the next block in the sequence.
+
+    Parameters
+    ----------
+    header :
+        Header to check for correctness.
+    parent_header :
+        Parent Header of the header to check for correctness
+    """
+    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
+
+    expected_base_fee_per_gas = calculate_base_fee_per_gas(
+        header.gas_limit,
+        parent_header.gas_limit,
+        parent_header.gas_used,
+        parent_header.base_fee_per_gas,
+    )
 
     ensure(expected_base_fee_per_gas == header.base_fee_per_gas, InvalidBlock)
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -203,44 +203,44 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         chain.blocks = chain.blocks[-255:]
 
 
-def validate_header(header: Header, parent_header: Header) -> None:
+def calculate_base_fee_per_gas(
+    block_gas_limit: Uint,
+    parent_gas_limit: Uint,
+    parent_gas_used: Uint,
+    parent_base_fee_per_gas: Uint,
+    is_fork_block: bool,
+) -> Uint:
     """
-    Verifies a block header.
-
-    In order to consider a block's header valid, the logic for the
-    quantities in the header should match the logic for the block itself.
-    For example the header timestamp should be greater than the block's parent
-    timestamp because the block was created *after* the parent block.
-    Additionally, the block's number should be directly folowing the parent
-    block's number since it is the next block in the sequence.
+    Calculates the base fee per gas for the block.
 
     Parameters
     ----------
-    header :
-        Header to check for correctness.
-    parent_header :
-        Parent Header of the header to check for correctness
+    block_gas_limit :
+        Gas limit of the block for which the base fee is being calculated.
+    parent_gas_limit :
+        Gas limit of the parent block.
+    parent_gas_used :
+        Gas used in the parent block.
+    parent_base_fee_per_gas :
+        Base fee per gas of the parent block.
+    is_fork_block :
+        Whether the block is the fork block.
+
+    Returns
+    -------
+    base_fee_per_gas : `Uint`
+        Base fee per gas for the block.
     """
-    if header.number == MAINNET_FORK_BLOCK:
-        parent_gas_limit = parent_header.gas_limit * ELASTICITY_MULTIPLIER
-        parent_gas_target = parent_header.gas_limit
-    else:
-        parent_gas_limit = parent_header.gas_limit
-        parent_gas_target = parent_header.gas_limit // ELASTICITY_MULTIPLIER
-        parent_base_fee_per_gas = parent_header.base_fee_per_gas
+    if is_fork_block:
+        return Uint(INITIAL_BASE_FEE)
+    parent_gas_target = parent_gas_limit // ELASTICITY_MULTIPLIER
 
-    parent_gas_used = parent_header.gas_used
-
-    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
     ensure(
-        check_gas_limit(header.gas_limit, parent_gas_limit),
+        check_gas_limit(block_gas_limit, parent_gas_limit),
         InvalidBlock,
     )
 
-    # check if the base fee is correct
-    if header.number == MAINNET_FORK_BLOCK:
-        expected_base_fee_per_gas = INITIAL_BASE_FEE
-    elif parent_gas_used == parent_gas_target:
+    if parent_gas_used == parent_gas_target:
         expected_base_fee_per_gas = parent_base_fee_per_gas
     elif parent_gas_used > parent_gas_target:
         gas_used_delta = parent_gas_used - parent_gas_target
@@ -269,6 +269,38 @@ def validate_header(header: Header, parent_header: Header) -> None:
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas - base_fee_per_gas_delta
         )
+
+    return Uint(expected_base_fee_per_gas)
+
+
+def validate_header(header: Header, parent_header: Header) -> None:
+    """
+    Verifies a block header.
+
+    In order to consider a block's header valid, the logic for the
+    quantities in the header should match the logic for the block itself.
+    For example the header timestamp should be greater than the block's parent
+    timestamp because the block was created *after* the parent block.
+    Additionally, the block's number should be directly folowing the parent
+    block's number since it is the next block in the sequence.
+
+    Parameters
+    ----------
+    header :
+        Header to check for correctness.
+    parent_header :
+        Parent Header of the header to check for correctness
+    """
+    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
+
+    is_fork_block = header.number == MAINNET_FORK_BLOCK
+    expected_base_fee_per_gas = calculate_base_fee_per_gas(
+        header.gas_limit,
+        parent_header.gas_limit,
+        parent_header.gas_used,
+        parent_header.base_fee_per_gas,
+        is_fork_block,
+    )
 
     ensure(expected_base_fee_per_gas == header.base_fee_per_gas, InvalidBlock)
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -195,37 +195,38 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         chain.blocks = chain.blocks[-255:]
 
 
-def validate_header(header: Header, parent_header: Header) -> None:
+def calculate_base_fee_per_gas(
+    block_gas_limit: Uint,
+    parent_gas_limit: Uint,
+    parent_gas_used: Uint,
+    parent_base_fee_per_gas: Uint,
+) -> Uint:
     """
-    Verifies a block header.
-
-    In order to consider a block's header valid, the logic for the
-    quantities in the header should match the logic for the block itself.
-    For example the header timestamp should be greater than the block's parent
-    timestamp because the block was created *after* the parent block.
-    Additionally, the block's number should be directly folowing the parent
-    block's number since it is the next block in the sequence.
+    Calculates the base fee per gas for the block.
 
     Parameters
     ----------
-    header :
-        Header to check for correctness.
-    parent_header :
-        Parent Header of the header to check for correctness
+    block_gas_limit :
+        Gas limit of the block for which the base fee is being calculated.
+    parent_gas_limit :
+        Gas limit of the parent block.
+    parent_gas_used :
+        Gas used in the parent block.
+    parent_base_fee_per_gas :
+        Base fee per gas of the parent block.
+
+    Returns
+    -------
+    base_fee_per_gas : `Uint`
+        Base fee per gas for the block.
     """
-    parent_gas_limit = parent_header.gas_limit
-    parent_gas_target = parent_header.gas_limit // ELASTICITY_MULTIPLIER
-    parent_base_fee_per_gas = parent_header.base_fee_per_gas
+    parent_gas_target = parent_gas_limit // ELASTICITY_MULTIPLIER
 
-    parent_gas_used = parent_header.gas_used
-
-    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
     ensure(
-        check_gas_limit(header.gas_limit, parent_gas_limit),
+        check_gas_limit(block_gas_limit, parent_gas_limit),
         InvalidBlock,
     )
 
-    # check if the base fee is correct
     if parent_gas_used == parent_gas_target:
         expected_base_fee_per_gas = parent_base_fee_per_gas
     elif parent_gas_used > parent_gas_target:
@@ -255,6 +256,36 @@ def validate_header(header: Header, parent_header: Header) -> None:
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas - base_fee_per_gas_delta
         )
+
+    return Uint(expected_base_fee_per_gas)
+
+
+def validate_header(header: Header, parent_header: Header) -> None:
+    """
+    Verifies a block header.
+
+    In order to consider a block's header valid, the logic for the
+    quantities in the header should match the logic for the block itself.
+    For example the header timestamp should be greater than the block's parent
+    timestamp because the block was created *after* the parent block.
+    Additionally, the block's number should be directly folowing the parent
+    block's number since it is the next block in the sequence.
+
+    Parameters
+    ----------
+    header :
+        Header to check for correctness.
+    parent_header :
+        Parent Header of the header to check for correctness
+    """
+    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
+
+    expected_base_fee_per_gas = calculate_base_fee_per_gas(
+        header.gas_limit,
+        parent_header.gas_limit,
+        parent_header.gas_used,
+        parent_header.base_fee_per_gas,
+    )
 
     ensure(expected_base_fee_per_gas == header.base_fee_per_gas, InvalidBlock)
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -201,37 +201,38 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         chain.blocks = chain.blocks[-255:]
 
 
-def validate_header(header: Header, parent_header: Header) -> None:
+def calculate_base_fee_per_gas(
+    block_gas_limit: Uint,
+    parent_gas_limit: Uint,
+    parent_gas_used: Uint,
+    parent_base_fee_per_gas: Uint,
+) -> Uint:
     """
-    Verifies a block header.
-
-    In order to consider a block's header valid, the logic for the
-    quantities in the header should match the logic for the block itself.
-    For example the header timestamp should be greater than the block's parent
-    timestamp because the block was created *after* the parent block.
-    Additionally, the block's number should be directly folowing the parent
-    block's number since it is the next block in the sequence.
+    Calculates the base fee per gas for the block.
 
     Parameters
     ----------
-    header :
-        Header to check for correctness.
-    parent_header :
-        Parent Header of the header to check for correctness
+    block_gas_limit :
+        Gas limit of the block for which the base fee is being calculated.
+    parent_gas_limit :
+        Gas limit of the parent block.
+    parent_gas_used :
+        Gas used in the parent block.
+    parent_base_fee_per_gas :
+        Base fee per gas of the parent block.
+
+    Returns
+    -------
+    base_fee_per_gas : `Uint`
+        Base fee per gas for the block.
     """
-    parent_gas_limit = parent_header.gas_limit
-    parent_gas_target = parent_header.gas_limit // ELASTICITY_MULTIPLIER
-    parent_base_fee_per_gas = parent_header.base_fee_per_gas
+    parent_gas_target = parent_gas_limit // ELASTICITY_MULTIPLIER
 
-    parent_gas_used = parent_header.gas_used
-
-    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
     ensure(
-        check_gas_limit(header.gas_limit, parent_gas_limit),
+        check_gas_limit(block_gas_limit, parent_gas_limit),
         InvalidBlock,
     )
 
-    # check if the base fee is correct
     if parent_gas_used == parent_gas_target:
         expected_base_fee_per_gas = parent_base_fee_per_gas
     elif parent_gas_used > parent_gas_target:
@@ -261,6 +262,36 @@ def validate_header(header: Header, parent_header: Header) -> None:
         expected_base_fee_per_gas = (
             parent_base_fee_per_gas - base_fee_per_gas_delta
         )
+
+    return Uint(expected_base_fee_per_gas)
+
+
+def validate_header(header: Header, parent_header: Header) -> None:
+    """
+    Verifies a block header.
+
+    In order to consider a block's header valid, the logic for the
+    quantities in the header should match the logic for the block itself.
+    For example the header timestamp should be greater than the block's parent
+    timestamp because the block was created *after* the parent block.
+    Additionally, the block's number should be directly folowing the parent
+    block's number since it is the next block in the sequence.
+
+    Parameters
+    ----------
+    header :
+        Header to check for correctness.
+    parent_header :
+        Parent Header of the header to check for correctness
+    """
+    ensure(header.gas_used <= header.gas_limit, InvalidBlock)
+
+    expected_base_fee_per_gas = calculate_base_fee_per_gas(
+        header.gas_limit,
+        parent_header.gas_limit,
+        parent_header.gas_used,
+        parent_header.base_fee_per_gas,
+    )
 
     ensure(expected_base_fee_per_gas == header.base_fee_per_gas, InvalidBlock)
 

--- a/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
@@ -15,6 +15,14 @@ from ethereum_spec_tools.lint import (
     walk_sources,
 )
 
+EXCEPTIONAL_DIFFS = [
+    # There are some differences between london and arrow_glacier
+    # in terms of how the fork block is handled.
+    ("arrow_glacier", ".fork", "calculate_base_fee_per_gas"),
+    ("arrow_glacier", ".fork", "validate_header"),
+    ("arrow_glacier", ".fork", "INITIAL_BASE_FEE"),
+]
+
 
 def add_diagnostic(diagnostics: List[Diagnostic], message: str) -> None:
     """
@@ -93,6 +101,8 @@ class GlacierForksHygiene(Lint):
         all_items = set(previous.keys()) | set(current.keys())
 
         for item in all_items:
+            if (fork_name, name, item) in EXCEPTIONAL_DIFFS:
+                continue
             try:
                 previous_item = previous[item]
             except KeyError:
@@ -119,7 +129,7 @@ class GlacierForksHygiene(Lint):
             if not compare_ast(previous_item, current_item):
                 add_diagnostic(
                     diagnostics,
-                    f"the item `{item}` in `{name}` has changed."
+                    f"`{item}` in `{name}` has changed."
                     "Glacier forks may only differ in difficulty block.",
                 )
 


### PR DESCRIPTION
### What was wrong?

1. The base fee calculation should be separated into its own function so that the t8n tool can call that function in order to derive the `base_fee_per_gas` from the parent block parameters.
2. Currently, the fork block in `Arrow Glacier` and `Gray Glacier` forks has `INITIAL_BASE_FEE` as the base fee. This was originally meant to be true only in case of London.

Related to Issue #625 

### How was it fixed?
This commit performs refactors and simplifies the base fee calculation and also corrects the bug in `Arrow Glacier` and `Gray Glacier`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/48196632/229309290-1f0be6a4-3646-4bfa-9312-6c008c9c16aa.jpg)

