### PR TITLE
re-run failed tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,7 @@ test =
     pytest>=6.2,<7
     pytest-cov>=2.12,<3
     pytest-xdist>=2.3.0,<3
+    pytest-rerunfailures>=11.1,<12
     GitPython>=3.1.0,<3.2
     filelock>=3.9.0,<3.10
     requests

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --reruns 2 --reruns-delay 10
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -23,7 +23,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest" --reruns 2 --reruns-delay 10
     ethereum-spec-lint
 
 [testenv:doc]
@@ -71,5 +71,5 @@ extras =
     test
     optimized
 commands =
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized --reruns 2 --reruns-delay 10
 


### PR DESCRIPTION
### What was wrong?
The test workflow on GitHub actions have been failing every now and then due to crashed workers.

### How was it fixed?
Re-run the failed test using `pytest-rerunfailures`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/48196632/233641224-3295719d-3ad8-462a-9aba-8c4e03c7a904.jpg)
