### PR TITLE
Add B11R Tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,5 @@ line-length = 79
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "bigmem: marks tests as big memory (deselect with '-m \"not bigmem\"')",
+    "evm_tools: marks tests as evm_tools (deselect with '-m \"not evm_tools\"')",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ packages =
     ethereum_spec_tools
     ethereum_spec_tools/evm_tools
     ethereum_spec_tools/evm_tools/t8n
+    ethereum_spec_tools/evm_tools/b11r
     ethereum_spec_tools/lint
     ethereum_spec_tools/lint/lints
     ethereum

--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -4,6 +4,7 @@ Defines EVM tools for use in the Ethereum specification.
 
 import argparse
 
+from .b11r import B11R, b11r_arguments
 from .t8n import T8N, t8n_arguments
 
 DESCRIPTION = """
@@ -16,6 +17,7 @@ https://github.com/ethereum/go-ethereum/blob/master/cmd/evm/README.md
 
 You can use this to run the following tools:
     1. t8n: A stateless state transition utility.
+    2. b11r: The tool is used to assemble and seal full block rlps.
 """
 
 parser = argparse.ArgumentParser(
@@ -31,11 +33,16 @@ subparsers = parser.add_subparsers(dest="evm_tool")
 def main() -> int:
     """Run the tools based on the given options."""
     t8n_arguments(subparsers)
+    b11r_arguments(subparsers)
+
     options = parser.parse_args()
+
     if options.evm_tool == "t8n":
         t8n_tool = T8N(options)
         return t8n_tool.run()
+    elif options.evm_tool == "b11r":
+        b11r_tool = B11R(options)
+        return b11r_tool.run()
     else:
-        # TODO: Add support for b11r tool
         parser.print_help()
         return 0

--- a/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
@@ -3,6 +3,8 @@ Create a block builder tool for the given fork.
 """
 
 import argparse
+from .b11r_types import Header, Body
+from ethereum import rlp
 
 
 def b11r_arguments(subparsers: argparse._SubParsersAction) -> None:
@@ -58,10 +60,26 @@ class B11R:
         Initializes the b11r tool.
         """
         self.options = options
+        self.body = Body(options)
+        self.header = Header(options, self.body)
+        self.block_rlp = None
+        self.block_hash = None
 
     def run(self) -> int:
         """
         Runs the b11r tool.
         """
-        print("This is the b11r tool.")
+        print("Building the block...")
+
+        block = [
+            self.header.to_list(),
+            self.body.transactions,
+            self.body.ommers,
+        ]
+
+        if len(self.body.withdrawals):
+            block.append(self.body.withdrawals)
+
+        self.block_rlp = rlp.encode(block)
+
         return 0

--- a/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
@@ -60,6 +60,7 @@ class B11R:
         Initializes the b11r tool.
         """
         self.options = options
+        # Add functionality for stdin
         self.body = Body(options)
         self.header = Header(options, self.body)
         self.block_rlp = None
@@ -71,8 +72,12 @@ class B11R:
         """
         print("Building the block...")
 
+        header_to_list = [
+            value for _, value in self.header.__dict__.items() if value is not None
+        ]
+
         block = [
-            self.header.to_list(),
+            header_to_list,
             self.body.transactions,
             self.body.ommers,
         ]
@@ -81,5 +86,6 @@ class B11R:
             block.append(self.body.withdrawals)
 
         self.block_rlp = rlp.encode(block)
+        self.block_hash = rlp.rlp_hash(header_to_list)
 
         return 0

--- a/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
@@ -1,0 +1,67 @@
+"""
+Create a block builder tool for the given fork.
+"""
+
+import argparse
+
+
+def b11r_arguments(subparsers: argparse._SubParsersAction) -> None:
+    """
+    Adds the arguments for the b11r tool subparser.
+    """
+    b11r_parser = subparsers.add_parser("b11r", help="This is the b11r tool.")
+
+    b11r_parser.add_argument(
+        "--input.header", dest="input_header", type=str, default="header.json"
+    )
+    b11r_parser.add_argument("--input.ommers", dest="input_ommers", type=str)
+    b11r_parser.add_argument(
+        "--input.txs", dest="input_txs", type=str, default="txs.rlp"
+    )
+    b11r_parser.add_argument(
+        "--input.withdrawals", dest="input_withdrawals", type=str
+    )
+    b11r_parser.add_argument(
+        "--output.basedir", dest="output_basedir", type=str
+    )
+    b11r_parser.add_argument(
+        "--output.block", dest="output_block", type=str, default="block.json"
+    )
+    b11r_parser.add_argument("--seal.clique", dest="seal_clique", type=str)
+    b11r_parser.add_argument(
+        "--seal.ethash",
+        dest="seal_ethash",
+        type=bool,
+        default=False,
+    )
+    b11r_parser.add_argument(
+        "--seal.ethash.dir", dest="seal_ethash_dir", type=str, default=None
+    )
+    b11r_parser.add_argument(
+        "--seal.ethash.mode",
+        dest="seal_ethash_mode",
+        type=str,
+        default="normal",
+    )
+    b11r_parser.add_argument(
+        "--verbosity", dest="verbosity", type=int, default=3
+    )
+
+
+class B11R:
+    """
+    Creates the b11r tool.
+    """
+
+    def __init__(self, options: argparse.Namespace) -> None:
+        """
+        Initializes the b11r tool.
+        """
+        self.options = options
+
+    def run(self) -> int:
+        """
+        Runs the b11r tool.
+        """
+        print("This is the b11r tool.")
+        return 0

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -1,0 +1,116 @@
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from ethereum import rlp
+from ethereum.base_types import U256, U64, Bytes32, Uint, Bytes20, Bytes256, Bytes, Bytes8
+from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.utils.byte import left_pad_zero_bytes
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_u256, hex_to_uint
+
+from ..utils import FatalException, parse_hex_or_int, secp256k1_sign
+
+class Header:
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Bytes20
+    state_root: Hash32
+    transactions_root: Hash32
+    receipt_root: Hash32
+    bloom: Bytes256
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Optional[Uint]
+    withdrawals_root: Optional[Hash32]
+
+    def __init__(self, options, body):
+        with open(options.input_header) as f:
+            data = json.load(f)
+
+        self.parent_hash = Hash32(hex_to_bytes(data["parentHash"]))
+        # TODO: Calculate ommers_hash if none are provided and there are ommers
+        # self.ommers_hash = Hash32(hex_to_bytes(data.get("ommersHash", "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")))
+        try:
+            self.ommers_hash = Hash32(hex_to_bytes(data["ommersHash"]))
+        except KeyError:
+            self.ommers_hash = keccak256(rlp.encode(body.ommers))
+
+        self.coinbase = Bytes20(hex_to_bytes(data.get("miner", "0x0000000000000000000000000000000000000000")))
+        self.state_root = Hash32(hex_to_bytes(data["stateRoot"]))
+        self.transactions_root = Hash32(hex_to_bytes(data.get("transactionsRoot", "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")))
+        self.receipt_root = Hash32(hex_to_bytes(data.get("receiptsRoot", "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")))
+        self.bloom = Bytes256(hex_to_bytes(data["logsBloom"]))
+        self.difficulty = parse_hex_or_int(data.get("difficulty", 0), Uint)
+        self.number = parse_hex_or_int(data["number"], Uint)
+        self.gas_limit = parse_hex_or_int(data["gasLimit"], Uint)
+        self.gas_used = parse_hex_or_int(data["gasUsed"], Uint)
+        self.timestamp = parse_hex_or_int(data["timestamp"], U256)
+        self.extra_data = hex_to_bytes(data.get("extraData", "0x"))
+        self.mix_digest = Bytes32(hex_to_bytes(data["mixHash"]))
+        self.nonce = hex_to_bytes(data.get("nonce", "0x0000000000000000"))
+        
+        try:
+            self.base_fee_per_gas = parse_hex_or_int(data["baseFeePerGas"], Uint)
+        except KeyError:
+            self.base_fee_per_gas = None
+
+        try:
+            self.withdrawals_root = Hash32(hex_to_bytes(data["withdrawalsRoot"]))
+            # Cannot have wirhdrawal root but no base fee
+            if self.base_fee_per_gas is None:
+                self.base_fee_per_gas = Uint(0)
+        except KeyError:
+            self.withdrawals_root = None
+
+
+
+    def to_list(self) -> List[Any]:
+        return [value for _, value in self.__dict__.items() if value is not None]
+
+
+class Body:
+
+    transactions: List
+    ommers: List
+    withdrawals: List
+
+    def __init__(self, options):
+        # Parse transactions
+        with open(options.input_txs) as f:
+            txs_data = json.load(f)
+
+        self.transactions = rlp.decode(hex_to_bytes(txs_data))
+
+        # Parse ommers
+        with open(options.input_ommers) as f:
+            ommers_data = json.load(f)
+
+        self.ommers = []
+        for ommer in ommers_data:
+            decoded_ommer = rlp.decode(hex_to_bytes(ommer))
+            self.ommers.append(decoded_ommer[0]) # ommer[0] is the header
+
+        # Parse withdrawals
+        if options.input_withdrawals is None:
+            self.withdrawals = []
+            return
+
+        with open(options.input_withdrawals) as f:
+            withdrawals_data = json.load(f)
+
+        self.withdrawals = []
+        for wd in withdrawals_data:
+            self.withdrawals.append(
+                [
+                    parse_hex_or_int(wd["index"], U64),
+                    parse_hex_or_int(wd["validatorIndex"], U64),
+                    Bytes20(hex_to_bytes(wd["address"])),
+                    parse_hex_or_int(wd["amount"], Uint),
+                ]
+            )

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -2,7 +2,7 @@
 Define the types used by the b11r tool.
 """
 import json
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from ethereum import rlp
 from ethereum.base_types import (
@@ -26,9 +26,9 @@ class Body:
     A class representing a block body.
     """
 
-    transactions: List
-    ommers: List
-    withdrawals: List
+    transactions: rlp.RLP
+    ommers: rlp.RLP
+    withdrawals: List[Tuple[U64, U64, Bytes20, Uint]]
 
     def __init__(self, options: Any, stdin: Any = None):
         # Parse transactions
@@ -69,12 +69,12 @@ class Body:
         self.withdrawals = []
         for wd in withdrawals_data:
             self.withdrawals.append(
-                [
+                (
                     parse_hex_or_int(wd["index"], U64),
                     parse_hex_or_int(wd["validatorIndex"], U64),
                     Bytes20(hex_to_bytes(wd["address"])),
                     parse_hex_or_int(wd["amount"], Uint),
-                ]
+                )
             )
 
 

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -1,16 +1,88 @@
+"""
+Define the types used by the b11r tool.
+"""
 import json
-from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, List, Optional
 
 from ethereum import rlp
-from ethereum.base_types import U256, U64, Bytes32, Uint, Bytes20, Bytes256, Bytes, Bytes8
+from ethereum.base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+)
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.utils.byte import left_pad_zero_bytes
-from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_u256, hex_to_uint
+from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_bytes8
 
-from ..utils import FatalException, parse_hex_or_int, secp256k1_sign
+from ..utils import parse_hex_or_int
+
+
+class Body:
+    """
+    A class representing a block body.
+    """
+
+    transactions: List
+    ommers: List
+    withdrawals: List
+
+    def __init__(self, options: Any, stdin: Any = None):
+        # Parse transactions
+        if options.input_txs == "stdin":
+            assert stdin is not None
+            txs_data = stdin["txs"]
+        else:
+            with open(options.input_txs) as f:
+                txs_data = json.load(f)
+
+        self.transactions = rlp.decode(hex_to_bytes(txs_data))
+
+        # Parse ommers
+        if options.input_ommers == "stdin":
+            assert stdin is not None
+            ommers_data = stdin["ommers"]
+        else:
+            with open(options.input_ommers) as f:
+                ommers_data = json.load(f)
+
+        self.ommers = []
+        for ommer in ommers_data:
+            decoded_ommer = rlp.decode(hex_to_bytes(ommer))
+            self.ommers.append(decoded_ommer[0])  # ommer[0] is the header
+
+        # Parse withdrawals
+        if options.input_withdrawals is None:
+            self.withdrawals = []
+            return
+
+        if options.input_withdrawals == "stdin":
+            assert stdin is not None
+            withdrawals_data = stdin["withdrawals"]
+        else:
+            with open(options.input_withdrawals) as f:
+                withdrawals_data = json.load(f)
+
+        self.withdrawals = []
+        for wd in withdrawals_data:
+            self.withdrawals.append(
+                [
+                    parse_hex_or_int(wd["index"], U64),
+                    parse_hex_or_int(wd["validatorIndex"], U64),
+                    Bytes20(hex_to_bytes(wd["address"])),
+                    parse_hex_or_int(wd["amount"], Uint),
+                ]
+            )
+
 
 class Header:
+    """
+    A class representing a block header.
+    """
+
     parent_hash: Hash32
     ommers_hash: Hash32
     coinbase: Bytes20
@@ -29,9 +101,13 @@ class Header:
     base_fee_per_gas: Optional[Uint]
     withdrawals_root: Optional[Hash32]
 
-    def __init__(self, options, body):
-        with open(options.input_header) as f:
-            data = json.load(f)
+    def __init__(self, options: Any, body: Body, stdin: Any = None):
+        if options.input_header == "stdin":
+            assert stdin is not None
+            data = stdin["header"]
+        else:
+            with open(options.input_header) as f:
+                data = json.load(f)
 
         self.parent_hash = Hash32(hex_to_bytes(data["parentHash"]))
         try:
@@ -39,10 +115,30 @@ class Header:
         except KeyError:
             self.ommers_hash = keccak256(rlp.encode(body.ommers))
 
-        self.coinbase = Bytes20(hex_to_bytes(data.get("miner", "0x0000000000000000000000000000000000000000")))
+        self.coinbase = Bytes20(
+            hex_to_bytes(
+                data.get("miner", "0x0000000000000000000000000000000000000000")
+            )
+        )
         self.state_root = Hash32(hex_to_bytes(data["stateRoot"]))
-        self.transactions_root = Hash32(hex_to_bytes(data.get("transactionsRoot", "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")))
-        self.receipt_root = Hash32(hex_to_bytes(data.get("receiptsRoot", "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")))
+        self.transactions_root = Hash32(
+            hex_to_bytes(
+                data.get(
+                    "transactionsRoot",
+                    "0x56e81f171bcc55a6ff8345e692c0f86"
+                    "e5b48e01b996cadc001622fb5e363b421",
+                )
+            )
+        )
+        self.receipt_root = Hash32(
+            hex_to_bytes(
+                data.get(
+                    "receiptsRoot",
+                    "0x56e81f171bcc55a6ff8345e692c0f86"
+                    "e5b48e01b996cadc001622fb5e363b421",
+                )
+            )
+        )
         self.bloom = Bytes256(hex_to_bytes(data["logsBloom"]))
         self.difficulty = parse_hex_or_int(data.get("difficulty", 0), Uint)
         self.number = parse_hex_or_int(data["number"], Uint)
@@ -51,60 +147,21 @@ class Header:
         self.timestamp = parse_hex_or_int(data["timestamp"], U256)
         self.extra_data = hex_to_bytes(data.get("extraData", "0x"))
         self.mix_digest = Bytes32(hex_to_bytes(data["mixHash"]))
-        self.nonce = hex_to_bytes(data.get("nonce", "0x0000000000000000"))
-        
+        self.nonce = hex_to_bytes8(data.get("nonce", "0x0000000000000000"))
+
         try:
-            self.base_fee_per_gas = parse_hex_or_int(data["baseFeePerGas"], Uint)
+            self.base_fee_per_gas = parse_hex_or_int(
+                data["baseFeePerGas"], Uint
+            )
         except KeyError:
             self.base_fee_per_gas = None
 
         try:
-            self.withdrawals_root = Hash32(hex_to_bytes(data["withdrawalsRoot"]))
-            # Cannot have wirhdrawal root but no base fee
+            self.withdrawals_root = Hash32(
+                hex_to_bytes(data["withdrawalsRoot"])
+            )
+            # Cannot have withdrawal root but no base fee
             if self.base_fee_per_gas is None:
                 self.base_fee_per_gas = Uint(0)
         except KeyError:
             self.withdrawals_root = None
-
-
-
-class Body:
-
-    transactions: List
-    ommers: List
-    withdrawals: List
-
-    def __init__(self, options):
-        # Parse transactions
-        with open(options.input_txs) as f:
-            txs_data = json.load(f)
-
-        self.transactions = rlp.decode(hex_to_bytes(txs_data))
-
-        # Parse ommers
-        with open(options.input_ommers) as f:
-            ommers_data = json.load(f)
-
-        self.ommers = []
-        for ommer in ommers_data:
-            decoded_ommer = rlp.decode(hex_to_bytes(ommer))
-            self.ommers.append(decoded_ommer[0]) # ommer[0] is the header
-
-        # Parse withdrawals
-        if options.input_withdrawals is None:
-            self.withdrawals = []
-            return
-
-        with open(options.input_withdrawals) as f:
-            withdrawals_data = json.load(f)
-
-        self.withdrawals = []
-        for wd in withdrawals_data:
-            self.withdrawals.append(
-                [
-                    parse_hex_or_int(wd["index"], U64),
-                    parse_hex_or_int(wd["validatorIndex"], U64),
-                    Bytes20(hex_to_bytes(wd["address"])),
-                    parse_hex_or_int(wd["amount"], Uint),
-                ]
-            )

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -34,8 +34,6 @@ class Header:
             data = json.load(f)
 
         self.parent_hash = Hash32(hex_to_bytes(data["parentHash"]))
-        # TODO: Calculate ommers_hash if none are provided and there are ommers
-        # self.ommers_hash = Hash32(hex_to_bytes(data.get("ommersHash", "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")))
         try:
             self.ommers_hash = Hash32(hex_to_bytes(data["ommersHash"]))
         except KeyError:
@@ -68,10 +66,6 @@ class Header:
         except KeyError:
             self.withdrawals_root = None
 
-
-
-    def to_list(self) -> List[Any]:
-        return [value for _, value in self.__dict__.items() if value is not None]
 
 
 class Body:

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -20,6 +20,11 @@ from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_bytes8
 
 from ..utils import parse_hex_or_int
 
+DEFAULT_TRIE_ROOT = (
+    "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+)
+DEFAULT_COINBASE = "0x0000000000000000000000000000000000000000"
+
 
 class Body:
     """
@@ -116,17 +121,14 @@ class Header:
             self.ommers_hash = keccak256(rlp.encode(body.ommers))
 
         self.coinbase = Bytes20(
-            hex_to_bytes(
-                data.get("miner", "0x0000000000000000000000000000000000000000")
-            )
+            hex_to_bytes(data.get("miner", DEFAULT_COINBASE))
         )
         self.state_root = Hash32(hex_to_bytes(data["stateRoot"]))
         self.transactions_root = Hash32(
             hex_to_bytes(
                 data.get(
                     "transactionsRoot",
-                    "0x56e81f171bcc55a6ff8345e692c0f86"
-                    "e5b48e01b996cadc001622fb5e363b421",
+                    DEFAULT_TRIE_ROOT,
                 )
             )
         )
@@ -134,8 +136,7 @@ class Header:
             hex_to_bytes(
                 data.get(
                     "receiptsRoot",
-                    "0x56e81f171bcc55a6ff8345e692c0f86"
-                    "e5b48e01b996cadc001622fb5e363b421",
+                    DEFAULT_TRIE_ROOT,
                 )
             )
         )

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -275,12 +275,14 @@ class Txs:
     """
 
     rejected_txs: Dict[int, str]
+    successful_txs: List[Any]
     t8n: Any
     data: Any
 
     def __init__(self, t8n: Any, stdin: Optional[Dict] = None):
         self.t8n = t8n
         self.rejected_txs = {}
+        self.successful_txs = []
         # TODO: Add support for reading RLP
 
         if t8n.options.input_txs == "stdin":
@@ -336,6 +338,17 @@ class Txs:
                 transaction = tx
 
             yield idx, transaction
+
+    def add_transaction(self, tx: Any) -> None:
+        """
+        Add a transaction to the list of successful transactions.
+        """
+        if self.t8n.is_after_fork("ethereum.berlin"):
+            self.successful_txs.append(
+                self.t8n.fork_types.encode_transaction(tx)
+            )
+        else:
+            self.successful_txs.append(tx)
 
     def sign_transaction(self, json_tx: Any) -> None:
         """

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -121,11 +121,12 @@ def get_stream_logger(name: str) -> Any:
     Get a logger that writes to stdout.
     """
     logger = logging.getLogger(name)
-    logger.setLevel(level=logging.INFO)
-    stream_handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-    stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
+    if not logger.handlers:
+        logger.setLevel(level=logging.INFO)
+        stream_handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        stream_handler.setFormatter(formatter)
+        logger.addHandler(stream_handler)
 
     return logger
 

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -76,7 +76,7 @@ def ensure_success(f: Callable, *args: Any) -> Any:
         raise FatalException(e)
 
 
-def get_module_name(forks: Any, options: Any) -> Tuple[str, int]:
+def get_module_name(forks: Any, options: Any, stdin: Any) -> Tuple[str, int]:
     """
     Get the module name and the fork block for the given state fork.
     """
@@ -88,8 +88,12 @@ def get_module_name(forks: Any, options: Any) -> Tuple[str, int]:
         pass
 
     if exception_config:
-        with open(options.input_env, "r") as f:
-            data = json.load(f)
+        if options.input_env == "stdin":
+            assert stdin is not None
+            data = stdin["env"]
+        else:
+            with open(options.input_env, "r") as f:
+                data = json.load(f)
 
         block_number = parse_hex_or_int(data["currentNumber"], Uint)
 

--- a/tests/berlin/test_evm_tools.py
+++ b/tests/berlin/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Berlin"
+FORK_PACKAGE = "berlin"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -66,15 +66,18 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_berlin_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    slow_list=GENERAL_STATE_SLOW_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_berlin_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=GENERAL_STATE_SLOW_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/byzantium/test_evm_tools.py
+++ b/tests/byzantium/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Byzantium"
+FORK_PACKAGE = "byzantium"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -51,14 +51,17 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_byzantium_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_byzantium_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/constantinople/test_evm_tools.py
+++ b/tests/constantinople/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Constantinople"
+FORK_PACKAGE = "constantinople"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -69,14 +69,17 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_constantinople_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_constantinople_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -1,0 +1,94 @@
+import json
+import os
+from typing import Any, Dict, List
+
+import pytest
+
+from ethereum.base_types import U64, U256, Uint
+from ethereum.utils.hexadecimal import (
+    Hash32,
+    hex_to_bytes,
+    hex_to_u256,
+    hex_to_uint,
+)
+from ethereum.rlp import decode
+from ethereum_spec_tools.evm_tools import parser, subparsers
+from ethereum_spec_tools.evm_tools.b11r import B11R, b11r_arguments
+from ethereum_spec_tools.evm_tools.utils import FatalException
+from tests.helpers import TEST_FIXTURES
+
+B11R_TEST_PATH = TEST_FIXTURES["evm_tools_testdata"]["fixture_path"]
+
+ignore_tests = []
+
+
+def find_test_fixtures() -> Any:
+    with open(os.path.join(B11R_TEST_PATH, "b11r_commands.json")) as f:
+        data = json.load(f)
+
+    for key, value in data.items():
+
+        final_args = []
+        for arg in value["args"]:
+            if "__BASEDIR__" in arg:
+                final_args.append(arg.replace("__BASEDIR__", B11R_TEST_PATH))
+            else:
+                final_args.append(arg)
+        # if key == "b11r/fixtures/expected/22/exp.json":
+        yield {
+            "name": key,
+            "args": final_args,
+            "expected": os.path.join(B11R_TEST_PATH, key),
+            "success": value["success"],
+        }
+
+
+def idfn(test_case: Dict) -> str:
+    return test_case["name"]
+
+
+def get_rejected_indices(rejected: Dict) -> List[int]:
+    rejected_indices = []
+    for item in rejected:
+        rejected_indices.append(item["index"])
+    return rejected_indices
+
+def to_hex(decoded_rlp) -> Any:
+    if isinstance(decoded_rlp, list):
+        return [to_hex(item) for item in decoded_rlp]
+    elif isinstance(decoded_rlp, bytes):
+        return "0x" + decoded_rlp.hex()
+    else:
+        return "0x" + decoded_rlp.hex()
+
+def b11r_tool_test(test_case: Dict) -> None:
+    b11r_arguments(subparsers)
+    options = parser.parse_args(test_case["args"])
+
+
+
+    try:
+        b11r_tool = B11R(options)
+        b11r_tool.run()
+    except Exception as e:
+        raise FatalException(e)
+
+    # json_result = b11r_tool.result.to_json()
+    with open(test_case["expected"], "r") as f:
+        data = json.load(f)
+
+    assert hex_to_bytes(data["rlp"]) == b11r_tool.block_rlp
+
+@pytest.mark.parametrize(
+    "test_case",
+    find_test_fixtures(),
+    ids=idfn,
+)
+def test_b11r(test_case: Dict) -> None:
+    if test_case["name"] in ignore_tests:
+        pytest.xfail("Undefined behavior for specs")
+    elif test_case["success"]:
+        b11r_tool_test(test_case)
+    else:
+        with pytest.raises(FatalException):
+            b11r_tool_test(test_case)

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -72,6 +72,7 @@ def b11r_tool_test(test_case: Dict) -> None:
     assert hex_to_bytes(data["hash"]) == b11r_tool.block_hash
 
 
+@pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
     find_test_fixtures(),

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -19,7 +19,9 @@ from tests.helpers import TEST_FIXTURES
 
 B11R_TEST_PATH = TEST_FIXTURES["evm_tools_testdata"]["fixture_path"]
 
-ignore_tests: List[str] = []
+IGNORE_TESTS: List[str] = []
+
+b11r_arguments(subparsers)
 
 
 def find_test_fixtures() -> Any:
@@ -51,7 +53,6 @@ def get_rejected_indices(rejected: Dict) -> List[int]:
 
 
 def b11r_tool_test(test_case: Dict) -> None:
-    b11r_arguments(subparsers)
     options = parser.parse_args(test_case["args"])
 
     try:
@@ -75,7 +76,7 @@ def b11r_tool_test(test_case: Dict) -> None:
     ids=idfn,
 )
 def test_b11r(test_case: Dict) -> None:
-    if test_case["name"] in ignore_tests:
+    if test_case["name"] in IGNORE_TESTS:
         pytest.xfail("Undefined behavior for specs")
     elif test_case["success"]:
         b11r_tool_test(test_case)

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -5,13 +5,13 @@ from typing import Any, Dict, List
 import pytest
 
 from ethereum.base_types import U64, U256, Uint
+from ethereum.rlp import decode
 from ethereum.utils.hexadecimal import (
     Hash32,
     hex_to_bytes,
     hex_to_u256,
     hex_to_uint,
 )
-from ethereum.rlp import decode
 from ethereum_spec_tools.evm_tools import parser, subparsers
 from ethereum_spec_tools.evm_tools.b11r import B11R, b11r_arguments
 from ethereum_spec_tools.evm_tools.utils import FatalException
@@ -19,7 +19,7 @@ from tests.helpers import TEST_FIXTURES
 
 B11R_TEST_PATH = TEST_FIXTURES["evm_tools_testdata"]["fixture_path"]
 
-ignore_tests = []
+ignore_tests: List[str] = []
 
 
 def find_test_fixtures() -> Any:
@@ -53,14 +53,6 @@ def get_rejected_indices(rejected: Dict) -> List[int]:
         rejected_indices.append(item["index"])
     return rejected_indices
 
-def to_hex(decoded_rlp) -> Any:
-    # TODO: Remove this function after testing
-    if isinstance(decoded_rlp, list):
-        return [to_hex(item) for item in decoded_rlp]
-    elif isinstance(decoded_rlp, bytes):
-        return "0x" + decoded_rlp.hex()
-    else:
-        return "0x" + decoded_rlp.hex()
 
 def b11r_tool_test(test_case: Dict) -> None:
     b11r_arguments(subparsers)
@@ -68,7 +60,7 @@ def b11r_tool_test(test_case: Dict) -> None:
 
     try:
         b11r_tool = B11R(options)
-        b11r_tool.run()
+        b11r_tool.build_block()
     except Exception as e:
         raise FatalException(e)
 
@@ -78,6 +70,7 @@ def b11r_tool_test(test_case: Dict) -> None:
 
     assert hex_to_bytes(data["rlp"]) == b11r_tool.block_rlp
     assert hex_to_bytes(data["hash"]) == b11r_tool.block_hash
+
 
 @pytest.mark.parametrize(
     "test_case",

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -30,11 +30,7 @@ def find_test_fixtures() -> Any:
 
         final_args = []
         for arg in value["args"]:
-            if "__BASEDIR__" in arg:
-                final_args.append(arg.replace("__BASEDIR__", B11R_TEST_PATH))
-            else:
-                final_args.append(arg)
-        # if key == "b11r/fixtures/expected/22/exp.json":
+            final_args.append(arg.replace("__BASEDIR__", B11R_TEST_PATH))
         yield {
             "name": key,
             "args": final_args,

--- a/tests/evm_tools/test_b11r.py
+++ b/tests/evm_tools/test_b11r.py
@@ -54,6 +54,7 @@ def get_rejected_indices(rejected: Dict) -> List[int]:
     return rejected_indices
 
 def to_hex(decoded_rlp) -> Any:
+    # TODO: Remove this function after testing
     if isinstance(decoded_rlp, list):
         return [to_hex(item) for item in decoded_rlp]
     elif isinstance(decoded_rlp, bytes):
@@ -64,8 +65,6 @@ def to_hex(decoded_rlp) -> Any:
 def b11r_tool_test(test_case: Dict) -> None:
     b11r_arguments(subparsers)
     options = parser.parse_args(test_case["args"])
-
-
 
     try:
         b11r_tool = B11R(options)
@@ -78,6 +77,7 @@ def b11r_tool_test(test_case: Dict) -> None:
         data = json.load(f)
 
     assert hex_to_bytes(data["rlp"]) == b11r_tool.block_rlp
+    assert hex_to_bytes(data["hash"]) == b11r_tool.block_hash
 
 @pytest.mark.parametrize(
     "test_case",

--- a/tests/evm_tools/test_t8n.py
+++ b/tests/evm_tools/test_t8n.py
@@ -18,9 +18,11 @@ from tests.helpers import TEST_FIXTURES
 
 T8N_TEST_PATH = TEST_FIXTURES["evm_tools_testdata"]["fixture_path"]
 
-ignore_tests = [
+IGNORE_TESTS = [
     "t8n/fixtures/expected/26/Merge.json",
 ]
+
+t8n_arguments(subparsers)
 
 
 def find_test_fixtures() -> Any:
@@ -52,7 +54,6 @@ def get_rejected_indices(rejected: Dict) -> List[int]:
 
 
 def t8n_tool_test(test_case: Dict) -> None:
-    t8n_arguments(subparsers)
     options = parser.parse_args(test_case["args"])
 
     try:
@@ -112,7 +113,7 @@ def t8n_tool_test(test_case: Dict) -> None:
     ids=idfn,
 )
 def test_t8n(test_case: Dict) -> None:
-    if test_case["name"] in ignore_tests:
+    if test_case["name"] in IGNORE_TESTS:
         pytest.xfail("Undefined behavior for specs")
     elif test_case["success"]:
         t8n_tool_test(test_case)

--- a/tests/evm_tools/test_t8n.py
+++ b/tests/evm_tools/test_t8n.py
@@ -31,10 +31,7 @@ def find_test_fixtures() -> Any:
 
         final_args = []
         for arg in value["args"]:
-            if "__BASEDIR__" in arg:
-                final_args.append(arg.replace("__BASEDIR__", T8N_TEST_PATH))
-            else:
-                final_args.append(arg)
+            final_args.append(arg.replace("__BASEDIR__", T8N_TEST_PATH))
         yield {
             "name": key,
             "args": final_args,

--- a/tests/evm_tools/test_t8n.py
+++ b/tests/evm_tools/test_t8n.py
@@ -16,15 +16,15 @@ from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
 from ethereum_spec_tools.evm_tools.utils import FatalException
 from tests.helpers import TEST_FIXTURES
 
-T8N_TEST_PATH = TEST_FIXTURES["t8n_testdata"]["fixture_path"]
+T8N_TEST_PATH = TEST_FIXTURES["evm_tools_testdata"]["fixture_path"]
 
 ignore_tests = [
-    "fixtures/expected/26/Merge.json",
+    "t8n/fixtures/expected/26/Merge.json",
 ]
 
 
 def find_test_fixtures() -> Any:
-    with open(os.path.join(T8N_TEST_PATH, "commands.json")) as f:
+    with open(os.path.join(T8N_TEST_PATH, "t8n_commands.json")) as f:
         data = json.load(f)
 
     for key, value in data.items():
@@ -62,7 +62,7 @@ def t8n_tool_test(test_case: Dict) -> None:
         t8n_tool = T8N(options)
         t8n_tool.apply_body()
     except Exception as e:
-        raise FatalException
+        raise FatalException(e)
 
     json_result = t8n_tool.result.to_json()
     with open(test_case["expected"], "r") as f:

--- a/tests/evm_tools/test_t8n.py
+++ b/tests/evm_tools/test_t8n.py
@@ -108,6 +108,7 @@ def t8n_tool_test(test_case: Dict) -> None:
         ) == t8n_tool.hex_to_root(data["result"]["withdrawalsRoot"])
 
 
+@pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
     find_test_fixtures(),

--- a/tests/frontier/test_evm_tools.py
+++ b/tests/frontier/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Frontier"
+FORK_PACKAGE = "frontier"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -40,13 +40,16 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "/stSpecialTest/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_frontier_tests,
+    test_dir,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(
-        test_dir,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -5,10 +5,10 @@ TEST_FIXTURES = {
         "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v0.2.3/fixtures.tar.gz",
         "fixture_path": "tests/fixtures/execution_spec_tests",
     },
-    "t8n_testdata": {
-        "url": "https://github.com/gurukamath/t8n_testdata.git",
-        "commit_hash": "bea5c4d",
-        "fixture_path": "tests/fixtures/t8n_testdata",
+    "evm_tools_testdata": {
+        "url": "https://github.com/gurukamath/evm-tools-testdata.git",
+        "commit_hash": "042c0ef",
+        "fixture_path": "tests/fixtures/evm_tools_testdata",
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -7,7 +7,7 @@ TEST_FIXTURES = {
     },
     "evm_tools_testdata": {
         "url": "https://github.com/gurukamath/evm-tools-testdata.git",
-        "commit_hash": "042c0ef",
+        "commit_hash": "d84fcd1",
         "fixture_path": "tests/fixtures/evm_tools_testdata",
     },
     "ethereum_tests": {

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -1,0 +1,165 @@
+import json
+import sys
+from io import StringIO
+from typing import Any, Dict, List
+
+import pytest
+
+from ethereum import rlp
+from ethereum.base_types import Uint
+from ethereum.utils.hexadecimal import hex_to_bytes
+from ethereum_spec_tools.evm_tools import parser, subparsers
+from ethereum_spec_tools.evm_tools.b11r import B11R, b11r_arguments
+from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
+from ethereum_spec_tools.evm_tools.utils import parse_hex_or_int
+
+t8n_arguments(subparsers)
+b11r_arguments(subparsers)
+
+
+def load_evm_tools_test(
+    test_case: Dict,
+    fork_name: str,
+    block_reward: int = None,
+) -> None:
+    test_file = test_case["test_file"]
+    test_key = test_case["test_key"]
+
+    with open(test_file, "r") as fp:
+        data = json.load(fp)
+
+    json_data = data[test_key]
+
+    alloc = json_data["pre"]
+
+    block_hashes = {}
+
+    for block in json_data["blocks"]:
+
+        # Assemble the environment for the t8n tool
+        current_number = block["blockHeader"]["number"]
+        # The t8n tool expects block hashes in the form {number: hash}
+        # number being in str
+        block_hashes[
+            str(parse_hex_or_int(block["blockHeader"]["number"], Uint) - 1)
+        ] = block["blockHeader"]["parentHash"]
+
+        env = {
+            "currentCoinbase": block["blockHeader"]["coinbase"],
+            "currentDifficulty": block["blockHeader"]["difficulty"],
+            "currentGasLimit": block["blockHeader"]["gasLimit"],
+            "currentNumber": block["blockHeader"]["number"],
+            "currentTimestamp": block["blockHeader"]["timestamp"],
+            "blockHashes": block_hashes,
+        }
+
+        try:
+            env["currentBaseFee"] = block["blockHeader"]["baseFeePerGas"]
+            # Starting paris, randomness is availavle in the difficulty
+            # field of the fixture. T8N will just ignore it if it is
+            # before paris
+            env["currentRandom"] = block["blockHeader"]["mixHash"]
+        except KeyError:
+            pass
+
+        # Assemble the transactions for the t8n tool
+        txs = []
+        for tx in block["transactions"]:
+            tx["input"] = tx["data"]
+            tx["gas"] = tx["gasLimit"]
+            txs.append(tx)
+
+        sys.stdin = StringIO(
+            json.dumps(
+                {
+                    "env": env,
+                    "alloc": alloc,
+                    "txs": txs,
+                }
+            )
+        )
+
+        # Run the t8n tool
+        t8n_args = [
+            "t8n",
+            "--input.alloc",
+            "stdin",
+            "--input.env",
+            "stdin",
+            "--input.txs",
+            "stdin",
+            "--state.fork",
+            f"{fork_name}",
+        ]
+        if block_reward:
+            t8n_args += ["--state.reward", f"{block_reward}"]
+        t8n_options = parser.parse_args(t8n_args)
+
+        t8n = T8N(t8n_options)
+        t8n.apply_body()
+
+        # Update the state for the next block
+        alloc = t8n.alloc.to_json()
+        # Assemble the transactions rlp for the b11r tool
+        txs_rlp = rlp.encode(t8n.txs.successful_txs)
+
+        # Assemble the header for the b11r tool
+        header = {
+            "parentHash": block["blockHeader"]["parentHash"],
+            "miner": block["blockHeader"]["coinbase"],
+            "stateRoot": "0x" + t8n.result.state_root.hex(),
+            "transactionsRoot": "0x" + t8n.result.tx_root.hex(),
+            "receiptsRoot": "0x" + t8n.result.receipt_root.hex(),
+            "logsBloom": "0x" + t8n.result.bloom.hex(),
+            "difficulty": block["blockHeader"]["difficulty"],
+            "number": block["blockHeader"]["number"],
+            "gasLimit": block["blockHeader"]["gasLimit"],
+            "gasUsed": t8n.result.gas_used,
+            "timestamp": block["blockHeader"]["timestamp"],
+            "extraData": block["blockHeader"]["extraData"],
+            "mixHash": block["blockHeader"]["mixHash"],
+            "nonce": block["blockHeader"]["nonce"],
+        }
+
+        try:
+            header["baseFeePerGas"] = block["blockHeader"]["baseFeePerGas"]
+        except KeyError:
+            pass
+
+        ommers: List[Any] = []
+
+        sys.stdin = StringIO(
+            json.dumps(
+                {
+                    "header": header,
+                    "ommers": ommers,
+                    "txs": "0x" + txs_rlp.hex(),
+                }
+            )
+        )
+
+        # Run the b11r tool
+        b11r_options = parser.parse_args(
+            [
+                "b11r",
+                "--input.header",
+                "stdin",
+                "--input.ommers",
+                "stdin",
+                "--input.txs",
+                "stdin",
+            ]
+        )
+
+        b11r = B11R(b11r_options)
+        b11r.build_block()
+
+        assert b11r.block_rlp == hex_to_bytes(block["rlp"])
+
+
+# Test case Identifier
+def idfn(test_case: Dict) -> str:
+    if isinstance(test_case, dict):
+        folder_name = test_case["test_file"].split("/")[-2]
+        # Assign Folder name and test_key to identify tests in output
+        return folder_name + " - " + test_case["test_key"] + " - evm_tools"

--- a/tests/homestead/test_evm_tools.py
+++ b/tests/homestead/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Homestead"
+FORK_PACKAGE = "homestead"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -125,14 +125,17 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_homestead_tests,
+    test_dir,
+    slow_list=GENERAL_STATE_SLOW_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_homestead_tests(
-        test_dir,
-        slow_list=GENERAL_STATE_SLOW_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/istanbul/test_evm_tools.py
+++ b/tests/istanbul/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Istanbul"
+FORK_PACKAGE = "istanbul"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -66,15 +66,18 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_istanbul_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    slow_list=GENERAL_STATE_SLOW_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_istanbul_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=GENERAL_STATE_SLOW_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/london/test_evm_tools.py
+++ b/tests/london/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "London"
+FORK_PACKAGE = "london"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -66,15 +66,18 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_london_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    slow_list=SLOW_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_london_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=SLOW_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/paris/test_evm_tools.py
+++ b/tests/paris/test_evm_tools.py
@@ -1,0 +1,26 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Merge"
+FORK_PACKAGE = "paris"
+
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -68,15 +68,18 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stStaticCall/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_paris_tests,
+    test_dir,
+    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    slow_list=SLOW_TESTS,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_paris_tests(
-        test_dir,
-        ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-        slow_list=SLOW_TESTS,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_evm_tools.py
+++ b/tests/spurious_dragon/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "EIP158"
+FORK_PACKAGE = "spurious_dragon"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -41,13 +41,16 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_spurious_dragon_tests,
+    test_dir,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(
-        test_dir,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_evm_tools.py
+++ b/tests/tangerine_whistle/test_evm_tools.py
@@ -1,0 +1,31 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "EIP150"
+FORK_PACKAGE = "tangerine_whistle"
+
+block_reward = importlib.import_module(
+    f"ethereum.{FORK_PACKAGE}.fork"
+).BLOCK_REWARD  # type: ignore
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(
+    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -43,13 +43,16 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
+fetch_general_state_tests = partial(
+    fetch_tangerine_whistle_tests,
+    test_dir,
+    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+)
+
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(
-        test_dir,
-        big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-    ),
+    fetch_general_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
     pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -24,7 +25,6 @@ commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
     pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
-    pytest -m "not slow and evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ commands =
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
     pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
-    pytest -m "not slow and evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -25,6 +24,7 @@ commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
     pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     black src tests setup.py --check --diff --exclude "tests/fixtures/*"
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
-    pytest -m "not slow" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:pypy3]
@@ -23,7 +23,8 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow and evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]
@@ -71,5 +72,5 @@ extras =
     test
     optimized
 commands =
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
+    pytest -m "not slow and not evm_tools" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --ignore-glob='tests/test_t8n.py' --basetemp="{temp_dir}/pytest" --optimized
 


### PR DESCRIPTION
(closes #625)

### What was wrong?

The specs currently do not have a block builder utility like the `b11r` tool on `go-ethereum`

Related to Issue #625 

### How was it fixed?
Implement the b11r tool. Run the evm tools (t8n and b11r) on the existing set of test fixtures to ensure that they pass.

A couple of points to be noted here
1. The `b11r` tool in this PR does not yet support sealing the block with `Ethash` or `Clique`. This functionality will be explored as part of another issue. (See #755)
2. The general state tests are run for all forks except `Shanghai`. The spec tests for `Shanghai` are currently not up to date and the evm tools tests will also have to be updated along with the usual tests. (See #753 )
3. The `evm_tools` tests do take almost the same amount of time as the regular state transition tests. This PR configures them to be run only in the `pypy` environment in order to optimise Github checks time.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/48196632/235058304-c0b0c2c2-21b6-401b-963d-ca060dd02683.jpg)
