### PR TITLE
Run single thread pytest in github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: Run Tox (PyPy)
         if: ${{ matrix.python == 'pypy-3.8' }}
         run: tox -e pypy3
+        env:
+          PYTEST_XDIST_WORKERS: 1
       - name: Run Tox (CPython)
         if: ${{ matrix.python != 'pypy-3.8' }}
         run: tox -e py3

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ extras =
 commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
-    pytest -m "not slow" -n auto --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
+    pytest -m "not slow" -n {env:PYTEST_XDIST_WORKERS:auto} --maxprocesses 8 --ignore-glob='tests/fixtures/*' --basetemp="{temp_dir}/pytest"
     ethereum-spec-lint
 
 [testenv:doc]


### PR DESCRIPTION
Alternative to #751 

Instead of re-running the tests as proposed in #751, we simply run a single thread of `pytest` if we are on GitHub actions (for the `pypy` env). When run locally, `pytest` automatically uses `-n auto`. 