### PR TITLE
Update Cancun PR table

### DIFF
--- a/network-upgrades/mainnet-upgrades/cancun.md
+++ b/network-upgrades/mainnet-upgrades/cancun.md
@@ -21,11 +21,11 @@ Implementation status of Included EIPs across participating clients.
 
 | EIP            | [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)                   | [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)                       | [EIP-6475](https://eips.ethereum.org/EIPS/eip-6475) | [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) |
 |----------------|-----------------------------------------------------------------------|---------------------------------------------------------------------------|----------|----------|
-| **Geth**       | [Merged](https://github.com/ethereum/go-ethereum/pull/26003)          | [Not merged](https://github.com/ethereum/go-ethereum/pull/26283)          |          |          |
-| **Besu**       | [Merged](https://github.com/hyperledger/besu/pull/4118)           | [Not Merged](https://github.com/hyperledger/besu/tree/eip-4844-interop)   |          |          |
-| **Nethermind** | [Merged](https://github.com/NethermindEth/nethermind/pull/4126)       | [Not merged](https://github.com/NethermindEth/nethermind/pull/4858)       |          |          |
-| **Erigon**     | [Not merged](https://github.com/ledgerwatch/erigon/pull/6133)         |                                                                           |          |          |
-| **EthereumJS** | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1860) | [Not merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2349) |          |          |
+| **Geth**       | [Merged](https://github.com/ethereum/go-ethereum/pull/26003)          | [Not merged](https://github.com/ethereum/go-ethereum/pull/26283)          |          | [Not merged](https://github.com/ethereum/go-ethereum/pull/27189)    |
+| **Besu**       | [Merged](https://github.com/hyperledger/besu/pull/4118)               | [Not merged](https://github.com/hyperledger/besu/tree/eip-4844-interop)   |          | [Not merged](https://github.com/hyperledger/besu/pull/5430)         |
+| **Nethermind** | [Merged](https://github.com/NethermindEth/nethermind/pull/4126)       | [Not merged](https://github.com/NethermindEth/nethermind/pull/4858)       |          | [Not merged](https://github.com/NethermindEth/nethermind/pull/4704) |
+| **Erigon**     | [Merged](https://github.com/ledgerwatch/erigon/pull/7405)             |                                                                           |          |          |
+| **EthereumJS** | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1860) | [Merged](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2349)     |          |          |
 
 
 ### Readiness Checklist


### PR DESCRIPTION
I noticed various things that could be updated in the PR table, so I did so.  I didn't update everything in the EIP-4844 column as that looks complicated; I just left alone the cells where I couldn't tell at a glance what was going on.

I didn't bother adding columns for the EIPs that are CFI, although it is worth noting that multiple clients do already have EIP-2537 merged.