### PR TITLE
Make `evm tools` compatible with `execution-spec-tests` `tf` tool 

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -25,6 +25,15 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
 )
 
+# Add -v option to parser to show the version of the tool
+parser.add_argument(
+    "-v",
+    "--version",
+    action="version",
+    version="%(prog)s 0.1.0",
+    help="Show the version of the tool.",
+)
+
 
 # Add options to the t8n tool
 subparsers = parser.add_subparsers(dest="evm_tool")
@@ -35,7 +44,7 @@ def main() -> int:
     t8n_arguments(subparsers)
     b11r_arguments(subparsers)
 
-    options = parser.parse_args()
+    options, _ = parser.parse_known_args()
 
     if options.evm_tool == "t8n":
         t8n_tool = T8N(options)

--- a/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/__init__.py
@@ -102,7 +102,7 @@ class B11R:
             self.body.ommers,
         ]
 
-        if len(self.body.withdrawals):
+        if self.body.withdrawals is not None:
             block.append(self.body.withdrawals)
 
         self.block_rlp = rlp.encode(block)

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -74,7 +74,7 @@ class Body:
 
         if options.input_withdrawals == "stdin":
             assert stdin is not None
-             # The tf tool does not pass empty list when there
+            # The tf tool does not pass empty list when there
             # are no withdrawals.
             withdrawals_data = stdin.get("withdrawals", [])
         else:

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -61,7 +61,7 @@ class Body:
 
         # Parse withdrawals
         if options.input_withdrawals is None:
-            self.withdrawals = []
+            self.withdrawals = None
             return
 
         if options.input_withdrawals == "stdin":

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -33,7 +33,7 @@ class Body:
 
     transactions: rlp.RLP
     ommers: rlp.RLP
-    withdrawals: List[Tuple[U64, U64, Bytes20, Uint]]
+    withdrawals: Optional[List[Tuple[U64, U64, Bytes20, Uint]]]
 
     def __init__(self, options: Any, stdin: Any = None):
         # Parse transactions
@@ -44,12 +44,20 @@ class Body:
             with open(options.input_txs) as f:
                 txs_data = json.load(f)
 
-        self.transactions = rlp.decode(hex_to_bytes(txs_data))
+        # The tf tool inputs "" when there are no transactions
+        if txs_data == "":
+            self.transactions = []
+        else:
+            self.transactions = rlp.decode(hex_to_bytes(txs_data))
 
         # Parse ommers
         if options.input_ommers == "stdin":
             assert stdin is not None
-            ommers_data = stdin["ommers"]
+            # The tests use "ommers" whereas the tf tool uses "uncles"
+            try:
+                ommers_data = stdin["ommers"]
+            except KeyError:
+                ommers_data = stdin["uncles"]
         else:
             with open(options.input_ommers) as f:
                 ommers_data = json.load(f)
@@ -66,7 +74,9 @@ class Body:
 
         if options.input_withdrawals == "stdin":
             assert stdin is not None
-            withdrawals_data = stdin["withdrawals"]
+             # The tf tool does not pass empty list when there
+            # are no withdrawals.
+            withdrawals_data = stdin.get("withdrawals", [])
         else:
             with open(options.input_withdrawals) as f:
                 withdrawals_data = json.load(f)

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -27,6 +27,7 @@ class UnsupportedTx(Exception):
     """Exception for unsupported transactions"""
 
     def __init__(self, encoded_params: bytes, error_message: str) -> None:
+        super().__init__(error_message)
         self.encoded_params = encoded_params
         self.error_message = error_message
 
@@ -306,7 +307,9 @@ class Load(BaseLoad):
                     )
                 )
             except AttributeError as e:
-                raise UnsupportedTx(b"\x02" + rlp.encode(parameters), str(e))
+                raise UnsupportedTx(
+                    b"\x02" + rlp.encode(parameters), str(e)
+                ) from e
 
         parameters.insert(1, hex_to_u256(raw.get("gasPrice")))
         # Access List Transaction
@@ -322,7 +325,9 @@ class Load(BaseLoad):
                     )
                 )
             except AttributeError as e:
-                raise UnsupportedTx(b"\x01" + rlp.encode(parameters), str(e))
+                raise UnsupportedTx(
+                    b"\x01" + rlp.encode(parameters), str(e)
+                ) from e
 
         # Legacy Transaction
         if hasattr(self._module("fork_types"), "LegacyTransaction"):

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -23,6 +23,14 @@ from ethereum.utils.hexadecimal import (
 from ethereum_spec_tools.forks import Hardfork
 
 
+class UnsupportedTx(Exception):
+    """Exception for unsupported transactions"""
+
+    def __init__(self, encoded_params: bytes, error_message: str) -> None:
+        self.encoded_params = encoded_params
+        self.error_message = error_message
+
+
 class BaseLoad(ABC):
     """Base class for loading json fixtures"""
 
@@ -291,9 +299,14 @@ class Load(BaseLoad):
             parameters.insert(
                 8, self.json_to_access_list(raw.get("accessList"))
             )
-            return b"\x02" + rlp.encode(
-                self._module("fork_types").FeeMarketTransaction(*parameters)
-            )
+            try:
+                return b"\x02" + rlp.encode(
+                    self._module("fork_types").FeeMarketTransaction(
+                        *parameters
+                    )
+                )
+            except AttributeError as e:
+                raise UnsupportedTx(b"\x02" + rlp.encode(parameters), str(e))
 
         parameters.insert(1, hex_to_u256(raw.get("gasPrice")))
         # Access List Transaction
@@ -302,9 +315,14 @@ class Load(BaseLoad):
             parameters.insert(
                 7, self.json_to_access_list(raw.get("accessList"))
             )
-            return b"\x01" + rlp.encode(
-                self._module("fork_types").AccessListTransaction(*parameters)
-            )
+            try:
+                return b"\x01" + rlp.encode(
+                    self._module("fork_types").AccessListTransaction(
+                        *parameters
+                    )
+                )
+            except AttributeError as e:
+                raise UnsupportedTx(b"\x01" + rlp.encode(parameters), str(e))
 
         # Legacy Transaction
         if hasattr(self._module("fork_types"), "LegacyTransaction"):

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -4,6 +4,7 @@ Create a transition tool for the given fork.
 
 import argparse
 import json
+import os
 import sys
 from typing import Any
 
@@ -40,9 +41,8 @@ def t8n_arguments(subparsers: argparse._SubParsersAction) -> None:
     t8n_parser.add_argument(
         "--output.alloc", dest="output_alloc", type=str, default="alloc.json"
     )
-    # TODO: Support the base directory and output body options
     t8n_parser.add_argument(
-        "--output.basedir", dest="output_basedir", type=str
+        "--output.basedir", dest="output_basedir", type=str, default="."
     )
     t8n_parser.add_argument("--output.body", dest="output_body", type=str)
     t8n_parser.add_argument(
@@ -399,21 +399,39 @@ class T8N(Load):
         json_state = self.alloc.to_json()
         json_result = self.result.to_json()
 
+        if self.options.output_body:
+            txs_rlp_path = os.path.join(
+                self.options.output_basedir,
+                self.options.output_body,
+            )
+            txs_rlp = "0x" + rlp.encode(self.txs.all_txs).hex()
+            with open(txs_rlp_path, "w") as f:
+                json.dump(txs_rlp, f)
+            self.logger.info(f"Wrote transaction rlp to {txs_rlp_path}")
+
         json_output = {}
 
         if self.options.output_alloc == "stdout":
             json_output["alloc"] = json_state
         else:
-            with open(self.options.output_alloc, "w") as f:
+            alloc_output_path = os.path.join(
+                self.options.output_basedir,
+                self.options.output_alloc,
+            )
+            with open(alloc_output_path, "w") as f:
                 json.dump(json_state, f, indent=4)
-            self.logger.info(f"Wrote alloc to {self.options.output_alloc}")
+            self.logger.info(f"Wrote alloc to {alloc_output_path}")
 
         if self.options.output_result == "stdout":
             json_output["result"] = json_result
         else:
-            with open(self.options.output_result, "w") as f:
+            result_output_path = os.path.join(
+                self.options.output_basedir,
+                self.options.output_result,
+            )
+            with open(result_output_path, "w") as f:
                 json.dump(json_result, f, indent=4)
-            self.logger.info(f"Wrote result to {self.options.output_result}")
+            self.logger.info(f"Wrote result to {result_output_path}")
 
         if json_output:
             json.dump(json_output, sys.stdout, indent=4)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -329,7 +329,9 @@ class T8N(Load):
 
                 process_transaction_return = self.process_transaction(env, tx)
             except Exception as e:
-                self.txs.rejected_txs[tx_idx] = str(e)
+                # The tf tools expects some non-blank error message
+                # even in case e is blank.
+                self.txs.rejected_txs[tx_idx] = f"Failed transaction: {str(e)}"
                 self.restore_state()
                 self.logger.warning(f"Transaction {tx_idx} failed: {str(e)}")
                 if isinstance(e, FatalException):

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -334,14 +334,15 @@ class Txs:
                     transaction = t8n.fork_types.decode_transaction(tx)
                     self.all_txs.append(tx)
                 else:
-                    transaction = rlp.decode_to(t8n.fork_types.LegacyTransaction, tx_rlp)
+                    transaction = rlp.decode_to(
+                        t8n.fork_types.LegacyTransaction, tx_rlp
+                    )
                     self.all_txs.append(transaction)
             else:
                 transaction = rlp.decode_to(t8n.fork_types.Transaction, tx_rlp)
                 self.all_txs.append(transaction)
 
             yield idx, transaction
-
 
     def parse_json_tx(self) -> Iterator[Tuple[int, Any]]:
         """
@@ -357,7 +358,7 @@ class Txs:
             if "to" not in json_tx:
                 json_tx["to"] = ""
 
-            # tf tool might provide None instead of 0x00
+            # tf tool might provide None instead of 0
             # for v, r, s
             if not json_tx["v"]:
                 json_tx["v"] = "0x00"

--- a/tests/evm_tools/test_t8n.py
+++ b/tests/evm_tools/test_t8n.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 
 import pytest
 
+from ethereum import rlp
 from ethereum.base_types import U64, U256, Uint
 from ethereum.utils.hexadecimal import (
     Hash32,
@@ -96,6 +97,7 @@ def t8n_tool_test(test_case: Dict) -> None:
     assert hex_to_u256(json_result["gasUsed"]) == hex_to_u256(
         data["result"]["gasUsed"]
     )
+    assert rlp.encode(t8n_tool.txs.all_txs) == hex_to_bytes(data["txs_rlp"])
     if not t8n_tool.is_after_fork("ethereum.paris"):
         assert hex_to_uint(json_result["currentDifficulty"]) == hex_to_uint(
             data["result"]["currentDifficulty"]

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -7,7 +7,7 @@ TEST_FIXTURES = {
     },
     "evm_tools_testdata": {
         "url": "https://github.com/gurukamath/evm-tools-testdata.git",
-        "commit_hash": "d84fcd1",
+        "commit_hash": "3a6f09a",
         "fixture_path": "tests/fixtures/evm_tools_testdata",
     },
     "ethereum_tests": {

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -128,25 +128,27 @@ def load_evm_tools_test(
             pass
 
         if t8n.result.withdrawals_root:
-            header["withdrawalsRoot"] = "0x" + t8n.result.withdrawals_root.hex()
+            header["withdrawalsRoot"] = (
+                "0x" + t8n.result.withdrawals_root.hex()
+            )
 
         ommers: List[Any] = []
 
         stdin_data = {
-                "header": header,
-                "ommers": ommers,
-                "txs": "0x" + txs_rlp.hex(),
-            }
+            "header": header,
+            "ommers": ommers,
+            "txs": "0x" + txs_rlp.hex(),
+        }
 
         b11r_args = [
-                "b11r",
-                "--input.header",
-                "stdin",
-                "--input.ommers",
-                "stdin",
-                "--input.txs",
-                "stdin",
-            ]
+            "b11r",
+            "--input.header",
+            "stdin",
+            "--input.ommers",
+            "stdin",
+            "--input.txs",
+            "stdin",
+        ]
 
         if t8n.result.withdrawals_root:
             b11r_args += ["--input.withdrawals", "stdin"]

--- a/tests/shanghai/test_evm_tools.py
+++ b/tests/shanghai/test_evm_tools.py
@@ -1,0 +1,26 @@
+import importlib
+from functools import partial
+from typing import Dict
+
+import pytest
+
+from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+
+FORK_NAME = "Shanghai"
+FORK_PACKAGE = "shanghai"
+
+fetch_general_state_tests = importlib.import_module(
+    f"tests.{FORK_PACKAGE}.test_state_transition"
+).fetch_general_state_tests  # type: ignore
+
+run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
+
+
+@pytest.mark.evm_tools
+@pytest.mark.parametrize(
+    "test_case",
+    fetch_general_state_tests(),
+    ids=idfn,
+)
+def test_evm_tools(test_case: Dict) -> None:
+    run_evm_tools_test(test_case)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -381,3 +381,5 @@ txs
 subparsers
 subparser
 Parsers
+params
+basedir

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -383,3 +383,4 @@ subparser
 Parsers
 params
 basedir
+tf


### PR DESCRIPTION
( closes #759 )

### What was wrong?
Currently, the evm tools are not fully compatible with the `tf` tool on the `execution-spec-tests` repo.

Related to Issue #759 

### How was it fixed?
The following updates are included in this PR

1. evm tools tests are implemented for Shanghai
2. `t8n` tool updated to accept transaction rlp input and provide transaction rlp output.
3. Other minor fixes that allow the evm tools from `go-ethereum` to be swapped 1-1 with the evm tools from the specs in `execution-spec-tests`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/ethereum/execution-specs/assets/48196632/6c4de357-519e-44a1-85c9-ac8c7130c7fd)
