### PR TITLE
Automatically detect expected exceptions

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -360,12 +360,9 @@ class Txs:
 
             # tf tool might provide None instead of 0
             # for v, r, s
-            if not json_tx.get("v"):
-                json_tx["v"] = "0x00"
-            if not json_tx.get("r"):
-                json_tx["r"] = "0x00"
-            if not json_tx.get("s"):
-                json_tx["s"] = "0x00"
+            json_tx["v"] = json_tx.get("v") or "0x00"
+            json_tx["r"] = json_tx.get("r") or "0x00"
+            json_tx["s"] = json_tx.get("s") or "0x00"
 
             v = hex_to_u256(json_tx["v"])
             r = hex_to_u256(json_tx["r"])

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -360,11 +360,11 @@ class Txs:
 
             # tf tool might provide None instead of 0
             # for v, r, s
-            if not json_tx["v"]:
+            if not json_tx.get("v"):
                 json_tx["v"] = "0x00"
-            if not json_tx["r"]:
+            if not json_tx.get("r"):
                 json_tx["r"] = "0x00"
-            if not json_tx["s"]:
+            if not json_tx.get("s"):
                 json_tx["s"] = "0x00"
 
             v = hex_to_u256(json_tx["v"])

--- a/tests/berlin/test_evm_tools.py
+++ b/tests/berlin/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "berlin"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -26,12 +25,13 @@ run_berlin_blockchain_st_tests = partial(
 
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
-# Run legacy general state tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
+# Run state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-GENERAL_STATE_SLOW_TESTS = (
+SLOW_TESTS = (
+    # GeneralStateTests
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -39,11 +39,13 @@ GENERAL_STATE_SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Berlin",
     "CALLBlake2f_d9g0v0_Berlin",
     "CALLCODEBlake2f_d9g0v0",
+    # ValidBlockTest
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -54,10 +56,26 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus.
     "stSStoreTest/InitCollision.json",
+    # ValidBlockTest
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTest
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Berlin",
+    # TODO: The below tests are being ignored due to a bug in
+    # upstream repo. They should be removed from the ignore list
+    # once the bug is resolved
+    # See: https://github.com/ethereum/execution-spec-tests/pull/134
+    "Pyspecs/vm/dup.json",
+    "Pyspecs/vm/chain_id.json",
+    "Pyspecs/example/yul.json",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+BIG_MEMORY_TESTS = (
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
@@ -66,109 +84,22 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
-fetch_general_state_tests = partial(
+fetch_state_tests = partial(
     fetch_berlin_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-    slow_list=GENERAL_STATE_SLOW_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ignore_list=IGNORE_LIST,
+    slow_list=SLOW_TESTS,
+    big_memory_list=BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_berlin_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest",
-    "bcTotalDifficultyTest",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_berlin_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=VALID_BLOCKS_SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_berlin_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
-
-# TODO: Handle once https://github.com/ethereum/tests/issues/1037
-# is resolved
-# All except GasLimitHigherThan2p63m1_Berlin
-xfail_candidates = (
-    ("bcUncleHeaderValidity", "timestampTooLow_Berlin"),
-    ("bcUncleHeaderValidity", "timestampTooHigh_Berlin"),
-    ("bcUncleHeaderValidity", "wrongStateRoot_Berlin"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp4_Berlin"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp5_Berlin"),
-    ("bcUncleSpecialTests", "futureUncleTimestamp3_Berlin"),
-    ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Berlin"),
-)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-def is_in_xfail(test_case: Dict) -> bool:
-    for dir, test_key in xfail_candidates:
-        if dir in test_case["test_file"] and test_case["test_key"] == test_key:
-            return True
-
-    return False
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_berlin_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_Berlin":
-            run_berlin_blockchain_st_tests(test_case)
-        elif is_in_xfail(test_case):
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_berlin_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
+    run_berlin_blockchain_st_tests(test_case)
 
 
 def test_transaction_with_insufficient_balance_for_value() -> None:

--- a/tests/berlin/test_state_transition.py
+++ b/tests/berlin/test_state_transition.py
@@ -39,13 +39,18 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Berlin",
     "CALLBlake2f_d9g0v0_Berlin",
     "CALLCODEBlake2f_d9g0v0",
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-IGNORE_LIST = (
+IGNORE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -87,7 +92,7 @@ BIG_MEMORY_TESTS = (
 fetch_state_tests = partial(
     fetch_berlin_tests,
     test_dir,
-    ignore_list=IGNORE_LIST,
+    ignore_list=IGNORE_TESTS,
     slow_list=SLOW_TESTS,
     big_memory_list=BIG_MEMORY_TESTS,
 )

--- a/tests/byzantium/test_evm_tools.py
+++ b/tests/byzantium/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "byzantium"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_legacy_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -26,120 +25,64 @@ run_byzantium_blockchain_st_tests = partial(
 
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
-# Run legacy general state tests
-test_dir = (
-    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
-)
+# Run legacy state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+LEGACY_IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
     "stRevertTest/RevertInCreateInInit_d0g0v0.json",
+    # ValidBlockTests
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTests
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Byzantium",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
     "/stSpecialTest/",
     "stTimeConsuming/",
+    # ValidBlockTests
+    "randomStatetest94_",
 )
 
-fetch_general_state_tests = partial(
+LEGACY_SLOW_TESTS = (
+    # ValidBlockTests
+    "bcExploitTest/DelegateCallSpam.json",
+)
+
+fetch_legacy_state_tests = partial(
     fetch_byzantium_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=LEGACY_SLOW_TESTS,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_byzantium_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+def test_legacy_state_tests(test_case: Dict) -> None:
+    run_byzantium_blockchain_st_tests(test_case)
 
 
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest",
-    "bcTotalDifficultyTest",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_byzantium_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
-        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_byzantium_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_Byzantium",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_byzantium_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_Byzantium":
-            run_byzantium_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_byzantium_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
+# Run Non-Legacy StateTests
 test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
@@ -153,7 +96,7 @@ non_legacy_only_in = (
     fetch_byzantium_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_state_tests(test_case: Dict) -> None:
     run_byzantium_blockchain_st_tests(test_case)
 
 

--- a/tests/byzantium/test_state_transition.py
+++ b/tests/byzantium/test_state_transition.py
@@ -60,8 +60,14 @@ LEGACY_BIG_MEMORY_TESTS = (
 )
 
 LEGACY_SLOW_TESTS = (
-    # ValidBlockTests
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
+    # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 fetch_legacy_state_tests = partial(

--- a/tests/constantinople/test_evm_tools.py
+++ b/tests/constantinople/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "constantinople"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_legacy_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -78,8 +78,14 @@ LEGACY_BIG_MEMORY_TESTS = (
 )
 
 LEGACY_SLOW_TESTS = (
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 fetch_legacy_state_tests = partial(

--- a/tests/constantinople/test_state_transition.py
+++ b/tests/constantinople/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -28,16 +27,13 @@ run_constantinople_blockchain_st_tests = partial(
 
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
-# Run legacy general state tests
-test_dir = (
-    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
-)
+# Run legacy state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
 
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+LEGACY_IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -57,109 +53,54 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus.
     "stSStoreTest/InitCollision_d3g0v0.json",
+    # ValidBlockTest
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTest
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_ConstantinopleFix",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
     "/stSpecialTest/",
     "stTimeConsuming/",
+    # ValidBlockTest
+    "randomStatetest94_",
 )
 
-fetch_general_state_tests = partial(
+LEGACY_SLOW_TESTS = (
+    # ValidBlockTest
+    "bcExploitTest/DelegateCallSpam.json",
+)
+
+fetch_legacy_state_tests = partial(
     fetch_constantinople_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=LEGACY_SLOW_TESTS,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_constantinople_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+def test_legacy_state_tests(test_case: Dict) -> None:
+    run_constantinople_blockchain_st_tests(test_case)
 
 
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest",
-    "bcTotalDifficultyTest",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_constantinople_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
-        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_constantinople_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_ConstantinopleFix",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_constantinople_tests(
-        test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_ConstantinopleFix":
-            run_constantinople_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_constantinople_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
+# Run Non-Legacy state tests
 test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
@@ -173,7 +114,7 @@ non_legacy_only_in = (
     fetch_constantinople_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_state_tests(test_case: Dict) -> None:
     run_constantinople_blockchain_st_tests(test_case)
 
 

--- a/tests/frontier/test_evm_tools.py
+++ b/tests/frontier/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "frontier"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -52,10 +52,17 @@ LEGACY_BIG_MEMORY_TESTS = (
     "/stSpecialTest/",
 )
 
+SLOW_LIST = (
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
+)
+
 fetch_legacy_state_tests = partial(
     fetch_frontier_tests,
     legacy_test_dir,
     ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=SLOW_LIST,
     big_memory_list=LEGACY_BIG_MEMORY_TESTS,
 )
 

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -67,11 +66,7 @@ fetch_legacy_state_tests = partial(
     ids=idfn,
 )
 def test_legacy_state_tests(test_case: Dict) -> None:
-    try:
-        run_frontier_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+    run_frontier_blockchain_st_tests(test_case)
 
 
 # Run Non-Legacy Tests

--- a/tests/frontier/test_state_transition.py
+++ b/tests/frontier/test_state_transition.py
@@ -28,31 +28,45 @@ ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 # Run legacy general state tests
-test_dir = (
+legacy_test_dir = (
     f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
 )
 
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_IGNORE_LIST = (
+    # Valid block tests to be ignored
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/",
+    "bcTotalDifficultyTest/",
+    "stTimeConsuming/",
+    # Invalid block tests to be ignored
+    "bcForgedTest",
+    "bcMultiChainTest",
+    # TODO: See https://github.com/ethereum/tests/issues/1218
+    "GasLimitHigherThan2p63m1_Frontier",
+)
+
+LEGACY_BIG_MEMORY_TESTS = (
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
     "/stSpecialTest/",
 )
 
-fetch_general_state_tests = partial(
+fetch_legacy_state_tests = partial(
     fetch_frontier_tests,
-    test_dir,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    legacy_test_dir,
+    ignore_list=LEGACY_IGNORE_LIST,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
+def test_legacy_state_tests(test_case: Dict) -> None:
     try:
         run_frontier_blockchain_st_tests(test_case)
     except NoPostState:
@@ -60,71 +74,10 @@ def test_general_state_tests(test_case: Dict) -> None:
         pytest.xfail(f"{test_case} doesn't have post state")
 
 
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/",
-    "bcTotalDifficultyTest/",
-    "stTimeConsuming/",
+# Run Non-Legacy Tests
+non_legacy_test_dir = (
+    f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 )
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_frontier_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_frontier_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_Frontier",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_frontier_tests(
-        test_dir,
-        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_Frontier":
-            run_frontier_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_frontier_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
     "stCreateTest/CREATE_HighNonce.json",
@@ -134,10 +87,10 @@ non_legacy_only_in = (
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_frontier_tests(test_dir, only_in=non_legacy_only_in),
+    fetch_frontier_tests(non_legacy_test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_tests(test_case: Dict) -> None:
     run_frontier_blockchain_st_tests(test_case)
 
 

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -35,6 +35,9 @@ def run_blockchain_st_test(test_case: Dict, load: Load) -> None:
 
     json_data = data[test_key]
 
+    if "postState" not in json_data:
+        pytest.xfail(f"{test_case} doesn't have post state")
+
     genesis_header = load.json_to_header(json_data["genesisBlockHeader"])
     parameters = [
         genesis_header,
@@ -88,8 +91,7 @@ def run_blockchain_st_test(test_case: Dict, load: Load) -> None:
 
     last_block_hash = hex_to_bytes(json_data["lastblockhash"])
     assert rlp.rlp_hash(chain.blocks[-1].header) == last_block_hash
-    if "postState" not in json_data:
-        pytest.xfail(f"{test_case} doesn't have post state")
+
     expected_post_state = load.json_to_state(json_data["postState"])
     assert chain.state == expected_post_state
     load.close_state(chain.state)

--- a/tests/homestead/test_evm_tools.py
+++ b/tests/homestead/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "homestead"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_legacy_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -107,8 +107,13 @@ LEGACY_SLOW_TESTS = (
     "stCallDelegateCodesHomestead/callcallcodecall_010_OOGMAfter_d0g0v0.json",
     "stCallDelegateCodesHomestead/callcallcode_01_OOGE_d0g0v0.json",
     "stCallDelegateCodesHomestead/callcodecallcodecallcode_ABCB_RECURSIVE_d0g0v0.json",
+    "stSpecialTest/JUMPDEST_AttackwithJump_d0g0v0.json",
+    "stSpecialTest/JUMPDEST_Attack_d0g0v0.json",
     # ValidBlockTests
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTests
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 

--- a/tests/homestead/test_state_transition.py
+++ b/tests/homestead/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -27,15 +26,13 @@ run_homestead_blockchain_st_tests = partial(
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
-# Run legacy general state tests
-test_dir = (
-    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
-)
+# Run legacy state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-GENERAL_STATE_SLOW_TESTS = (
+LEGACY_SLOW_TESTS = (
+    # GeneralStateTests
     "stRandom/randomStatetest177_d0g0v0.json",
     "stQuadraticComplexityTest/Call50000_d0g1v0.json",
     "stQuadraticComplexityTest/Call50000_sha256_d0g1v0.json",
@@ -110,110 +107,55 @@ GENERAL_STATE_SLOW_TESTS = (
     "stCallDelegateCodesHomestead/callcallcodecall_010_OOGMAfter_d0g0v0.json",
     "stCallDelegateCodesHomestead/callcallcode_01_OOGE_d0g0v0.json",
     "stCallDelegateCodesHomestead/callcodecallcodecallcode_ABCB_RECURSIVE_d0g0v0.json",
+    # ValidBlockTests
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = ()
+LEGACY_IGNORE_LIST = (
+    # ValidBlockTests
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest/",
+    "bcTotalDifficultyTest/",
+    # InvalidBlockTests
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Homestead",
+)
 
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
     "/stSpecialTest/",
     "stTimeConsuming/",
+    # ValidBlockTests
+    "randomStatetest94_",
 )
 
-fetch_general_state_tests = partial(
+fetch_legacy_state_tests = partial(
     fetch_homestead_tests,
     test_dir,
-    slow_list=GENERAL_STATE_SLOW_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=LEGACY_SLOW_TESTS,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_homestead_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+def test_legacy_state_tests(test_case: Dict) -> None:
+    run_homestead_blockchain_st_tests(test_case)
 
 
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest/",
-    "bcTotalDifficultyTest/",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-VALID_BLOCKS_BIG_MEMORY_TESTS = ("randomStatetest94_",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_homestead_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=VALID_BLOCKS_SLOW_TESTS,
-        big_memory_list=VALID_BLOCKS_BIG_MEMORY_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_homestead_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_Homestead",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_homestead_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_Homestead":
-            run_homestead_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_homestead_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
+# Run Non-Legacy state tests
 test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
@@ -227,7 +169,7 @@ non_legacy_only_in = (
     fetch_homestead_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_tests(test_case: Dict) -> None:
     run_homestead_blockchain_st_tests(test_case)
 
 

--- a/tests/istanbul/test_evm_tools.py
+++ b/tests/istanbul/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "istanbul"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -39,13 +39,19 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Istanbul",
     "CALLBlake2f_d9g0v0_Istanbul",
     "CALLCODEBlake2f_d9g0v0",
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-IGNORE_LIST = (
+IGNORE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -87,7 +93,7 @@ BIG_MEMORY_TESTS = (
 fetch_state_tests = partial(
     fetch_istanbul_tests,
     test_dir,
-    ignore_list=IGNORE_LIST,
+    ignore_list=IGNORE_TESTS,
     slow_list=SLOW_TESTS,
     big_memory_list=BIG_MEMORY_TESTS,
 )

--- a/tests/istanbul/test_state_transition.py
+++ b/tests/istanbul/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -26,12 +25,13 @@ run_istanbul_blockchain_st_tests = partial(
 
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
-# Run legacy general state tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
+# Run state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
-GENERAL_STATE_SLOW_TESTS = (
+SLOW_TESTS = (
+    # GeneralStateTests
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -39,11 +39,13 @@ GENERAL_STATE_SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Istanbul",
     "CALLBlake2f_d9g0v0_Istanbul",
     "CALLCODEBlake2f_d9g0v0",
+    # ValidBlockTest
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -54,10 +56,26 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus.
     "stSStoreTest/InitCollision.json",
+    # ValidBlockTest
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTest
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Istanbul",
+    # TODO: The below tests are being ignored due to a bug in
+    # upstream repo. They should be removed from the ignore list
+    # once the bug is resolved
+    # See: https://github.com/ethereum/execution-spec-tests/pull/134
+    "Pyspecs/vm/dup.json",
+    "Pyspecs/vm/chain_id.json",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
@@ -66,112 +84,22 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
-fetch_general_state_tests = partial(
+fetch_state_tests = partial(
     fetch_istanbul_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
-    slow_list=GENERAL_STATE_SLOW_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    ignore_list=IGNORE_LIST,
+    slow_list=SLOW_TESTS,
+    big_memory_list=BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_istanbul_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest",
-    "bcTotalDifficultyTest",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_istanbul_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=VALID_BLOCKS_SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_istanbul_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
-
-# TODO: Handle once https://github.com/ethereum/tests/issues/1037
-# is resolved
-# All except GasLimitHigherThan2p63m1_Istanbul
-xfail_candidates = (
-    ("bcUncleHeaderValidity", "timestampTooLow_Istanbul"),
-    ("bcUncleHeaderValidity", "timestampTooHigh_Istanbul"),
-    ("bcUncleHeaderValidity", "wrongStateRoot_Istanbul"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp4_Istanbul"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp5_Istanbul"),
-    ("bcUncleSpecialTests", "futureUncleTimestamp3_Istanbul"),
-    ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Istanbul"),
-)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-def is_in_xfail(test_case: Dict) -> bool:
-    for dir, test_key in xfail_candidates:
-        if dir in test_case["test_file"] and test_case["test_key"] == test_key:
-            return True
-
-    return False
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_istanbul_tests(
-        test_dir,
-        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_Istanbul":
-            run_istanbul_blockchain_st_tests(test_case)
-        elif is_in_xfail(test_case):
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_istanbul_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
+def test_state_tests(test_case: Dict) -> None:
+    run_istanbul_blockchain_st_tests(test_case)
 
 
 def test_transaction_with_insufficient_balance_for_value() -> None:

--- a/tests/london/test_evm_tools.py
+++ b/tests/london/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "london"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/london/test_state_transition.py
+++ b/tests/london/test_state_transition.py
@@ -39,13 +39,19 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_London",
     "CALLBlake2f_d9g0v0_London",
     "CALLCODEBlake2f_d9g0v0",
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-IGNORE_LIST = (
+IGNORE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -88,7 +94,7 @@ BIG_MEMORY_TESTS = (
 fetch_state_tests = partial(
     fetch_london_tests,
     test_dir,
-    ignore_list=IGNORE_LIST,
+    ignore_list=IGNORE_TESTS,
     slow_list=SLOW_TESTS,
     big_memory_list=BIG_MEMORY_TESTS,
 )

--- a/tests/paris/test_evm_tools.py
+++ b/tests/paris/test_evm_tools.py
@@ -9,9 +9,9 @@ from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
 FORK_NAME = "Merge"
 FORK_PACKAGE = "paris"
 
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
 
@@ -19,7 +19,7 @@ run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -39,13 +39,19 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Merge",
     "CALLBlake2f_d9g0v0_Merge",
     "CALLCODEBlake2f_d9g0v0",
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-IGNORE_LIST = (
+IGNORE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -88,7 +94,7 @@ BIG_MEMORY_TESTS = (
 fetch_state_tests = partial(
     fetch_paris_tests,
     test_dir,
-    ignore_list=IGNORE_LIST,
+    ignore_list=IGNORE_TESTS,
     slow_list=SLOW_TESTS,
     big_memory_list=BIG_MEMORY_TESTS,
 )

--- a/tests/paris/test_state_transition.py
+++ b/tests/paris/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -26,12 +25,13 @@ run_paris_blockchain_st_tests = partial(
 
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
-# Run legacy general state tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
+# Run state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/"
 
 # Every test below takes more than  60s to run and
 # hence they've been marked as slow
 SLOW_TESTS = (
+    # GeneralStateTests
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -39,11 +39,13 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Merge",
     "CALLBlake2f_d9g0v0_Merge",
     "CALLCODEBlake2f_d9g0v0",
+    # ValidBlockTest
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -54,94 +56,51 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus.
     "stSStoreTest/InitCollision.json",
+    # ValidBlockTest
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTest
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Merge",
+    # TODO: The below tests are being ignored due to a bug in
+    # upstream repo. They should be removed from the ignore list
+    # once the bug is resolved
+    # See: https://github.com/ethereum/execution-spec-tests/pull/134
+    "Pyspecs/vm/dup.json",
+    "Pyspecs/vm/chain_id.json",
+    "Pyspecs/example/yul.json",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
     "/stSpecialTest/",
     "stTimeConsuming/",
-    "stBadOpcode/",
-    "stStaticCall/",
 )
 
-fetch_general_state_tests = partial(
+fetch_state_tests = partial(
     fetch_paris_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    ignore_list=IGNORE_LIST,
     slow_list=SLOW_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    big_memory_list=BIG_MEMORY_TESTS,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_paris_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
-
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
-
-# TODO: Handle once https://github.com/ethereum/tests/issues/1037
-# is resolved
-# All except GasLimitHigherThan2p63m1_Merge
-xfail_candidates = (
-    ("bcUncleHeaderValidity", "timestampTooLow_Merge"),
-    ("bcUncleHeaderValidity", "timestampTooHigh_Merge"),
-    ("bcUncleHeaderValidity", "wrongStateRoot_Merge"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp4_Merge"),
-    ("bcUncleHeaderValidity", "incorrectUncleTimestamp5_Merge"),
-    ("bcUncleSpecialTests", "futureUncleTimestamp3_Merge"),
-    ("bcInvalidHeaderTest", "GasLimitHigherThan2p63m1_Merge"),
-)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-def is_in_xfail(test_case: Dict) -> bool:
-    for dir, test_key in xfail_candidates:
-        if dir in test_case["test_file"] and test_case["test_key"] == test_key:
-            return True
-
-    return False
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_paris_tests(test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] in "DifficultyIsZero_Merge":
-            run_paris_blockchain_st_tests(test_case)
-        elif is_in_xfail(test_case):
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_paris_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
+def test_state_tests(test_case: Dict) -> None:
+    run_paris_blockchain_st_tests(test_case)
 
 
 def test_transaction_with_insufficient_balance_for_value() -> None:

--- a/tests/shanghai/test_evm_tools.py
+++ b/tests/shanghai/test_evm_tools.py
@@ -9,9 +9,9 @@ from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
 FORK_NAME = "Shanghai"
 FORK_PACKAGE = "shanghai"
 
-fetch_general_state_tests = importlib.import_module(
+fetch_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
 
@@ -19,7 +19,7 @@ run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/shanghai/test_state_transition.py
+++ b/tests/shanghai/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock, RLPDecodingError
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -30,10 +29,11 @@ ETHEREUM_SPEC_TESTS_PATH = TEST_FIXTURES["execution_spec_tests"][
 ]
 
 
-# Run general state tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
+# Run state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/"
 
 SLOW_TESTS = (
+    # GeneralStateTests
     "stTimeConsuming/CALLBlake2f_MaxRounds.json",
     "stTimeConsuming/static_Call50000_sha256.json",
     "vmPerformance/loopExp.json",
@@ -41,11 +41,13 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Shanghai",
     "CALLBlake2f_d9g0v0_Shanghai",
     "CALLCODEBlake2f_d9g0v0",
+    # ValidBlockTest
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-INCORRECT_UPSTREAM_STATE_TESTS = (
+IGNORE_LIST = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -56,10 +58,29 @@ INCORRECT_UPSTREAM_STATE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus.
     "stSStoreTest/InitCollision.json",
+    # ValidBlockTest
+    "bcForkStressTest/ForkStressTest.json",
+    "bcGasPricerTest/RPC_API_Test.json",
+    "bcMultiChainTest",
+    "bcTotalDifficultyTest",
+    # InvalidBlockTest
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_Shanghai",
+    # TODO: The below tests are being ignored due to a bug in
+    # upstream repo. They should be removed from the ignore list
+    # once the bug is resolved
+    # See: https://github.com/ethereum/execution-spec-tests/pull/134
+    "Pyspecs/vm/chain_id.json",
+    "Pyspecs/vm/dup.json",
+    "Pyspecs/example/yul.json",
+    "Pyspecs/eips/warm_coinbase_gas_usage.json",
+    "Pyspecs/eips/warm_coinbase_call_out_of_gas.json",
 )
 
 # All tests that recursively create a large number of frames (50000)
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+BIG_MEMORY_TEST = (
+    # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
@@ -70,107 +91,22 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stStaticCall/",
 )
 
-fetch_general_state_tests = partial(
+fetch_state_tests = partial(
     fetch_shanghai_tests,
     test_dir,
-    ignore_list=INCORRECT_UPSTREAM_STATE_TESTS,
+    ignore_list=IGNORE_LIST,
     slow_list=SLOW_TESTS,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
+    big_memory_list=BIG_MEMORY_TEST,
 )
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_state_tests(),
     ids=idfn,
 )
 def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_shanghai_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
-    "bcForkStressTest/ForkStressTest.json",
-    "bcGasPricerTest/RPC_API_Test.json",
-    "bcMultiChainTest",
-    "bcTotalDifficultyTest",
-)
-
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-VALID_BLOCKS_SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_shanghai_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=VALID_BLOCKS_SLOW_TESTS,
-    ),
-    ids=idfn,
-)
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_shanghai_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/InvalidBlocks"
-
-# TODO: Detect tests that throw exceptions automatically
-# See: https://github.com/ethereum/execution-specs/issues/760
-valid_tests = (
-    "amountIs0_Shanghai",
-    "twoIdenticalIndex_Shanghai",
-    "staticcall_Shanghai",
-    "amountIs0TouchAccountAndTransaction_Shanghai",
-    "differentValidatorToTheSameAddress_Shanghai",
-    "twoIdenticalIndexDifferentValidator_Shanghai",
-    "accountInteractions_Shanghai",
-    "warmup_Shanghai",
-    "amountIs0TouchAccount_Shanghai",
-    "DifficultyIsZero_Shanghai",
-)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_shanghai_tests(
-        test_dir,
-        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] in valid_tests:
-            run_shanghai_blockchain_st_tests(test_case)
-        elif test_case["test_key"] == "GasLimitHigherThan2p63m1_Shanghai":
-            # TODO: Unclear where this failed requirement comes from
-            # See: https://github.com/ethereum/tests/issues/1218
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_shanghai_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
+    run_shanghai_blockchain_st_tests(test_case)
 
 
 # Run execution-spec-generated-tests
@@ -183,17 +119,4 @@ test_dir = f"{ETHEREUM_SPEC_TESTS_PATH}/fixtures/withdrawals"
     ids=idfn,
 )
 def test_execution_specs_generated_tests(test_case: Dict) -> None:
-    try:
-        # TODO: Detect this automatically
-        # See: https://github.com/ethereum/execution-specs/issues/760
-        if (
-            "use_value_in_tx" in test_case["test_file"]
-            and test_case["test_key"] == "000/shanghai"
-        ):
-            with pytest.raises(InvalidBlock):
-                run_shanghai_blockchain_st_tests(test_case)
-        else:
-            run_shanghai_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+    run_shanghai_blockchain_st_tests(test_case)

--- a/tests/shanghai/test_state_transition.py
+++ b/tests/shanghai/test_state_transition.py
@@ -41,13 +41,19 @@ SLOW_TESTS = (
     "QuadraticComplexitySolidity_CallDataCopy_d0g1v0_Shanghai",
     "CALLBlake2f_d9g0v0_Shanghai",
     "CALLCODEBlake2f_d9g0v0",
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
     # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 # These are tests that are considered to be incorrect,
 # Please provide an explanation when adding entries
-IGNORE_LIST = (
+IGNORE_TESTS = (
     # The test considers a scenario that cannot be reached by following the
     # rules of consensus. For more details, read:
     # https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
@@ -79,7 +85,7 @@ IGNORE_LIST = (
 )
 
 # All tests that recursively create a large number of frames (50000)
-BIG_MEMORY_TEST = (
+BIG_MEMORY_TESTS = (
     # GeneralStateTests
     "50000_",
     "/stQuadraticComplexityTest/",
@@ -94,9 +100,9 @@ BIG_MEMORY_TEST = (
 fetch_state_tests = partial(
     fetch_shanghai_tests,
     test_dir,
-    ignore_list=IGNORE_LIST,
+    ignore_list=IGNORE_TESTS,
     slow_list=SLOW_TESTS,
-    big_memory_list=BIG_MEMORY_TEST,
+    big_memory_list=BIG_MEMORY_TESTS,
 )
 
 

--- a/tests/spurious_dragon/test_evm_tools.py
+++ b/tests/spurious_dragon/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "spurious_dragon"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_legacy_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -28,12 +27,15 @@ ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
 # Run legacy general state tests
-test_dir = (
-    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
+
+LEGACY_SLOW_TESTS = (
+    # ValidBlockTests
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
@@ -41,93 +43,36 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
-fetch_general_state_tests = partial(
-    fetch_spurious_dragon_tests,
-    test_dir,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_general_state_tests(),
-    ids=idfn,
-)
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_spurious_dragon_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
+LEGACY_IGNORE_LIST = (
+    # ValidBlockTests
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
     "bcMultiChainTest",
     "bcTotalDifficultyTest",
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_EIP158",
 )
 
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
+fetch_legacy_state_tests = partial(
+    fetch_spurious_dragon_tests,
+    test_dir,
+    ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=LEGACY_SLOW_TESTS,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
+)
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_spurious_dragon_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
-    ),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_spurious_dragon_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+def test_legacy_state_tests(test_case: Dict) -> None:
+    run_spurious_dragon_blockchain_st_tests(test_case)
 
 
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_EIP158",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_spurious_dragon_tests(
-        test_dir, ignore_list=IGNORE_INVALID_BLOCK_TESTS
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_EIP158":
-            run_spurious_dragon_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_spurious_dragon_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
+# Run Non-Legacy State tests
 test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
@@ -141,7 +86,7 @@ non_legacy_only_in = (
     fetch_spurious_dragon_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_state_tests(test_case: Dict) -> None:
     run_spurious_dragon_blockchain_st_tests(test_case)
 
 

--- a/tests/spurious_dragon/test_state_transition.py
+++ b/tests/spurious_dragon/test_state_transition.py
@@ -30,8 +30,14 @@ ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
 
 LEGACY_SLOW_TESTS = (
-    # ValidBlockTests
+    # GeneralStateTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
+    # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 LEGACY_BIG_MEMORY_TESTS = (

--- a/tests/tangerine_whistle/test_evm_tools.py
+++ b/tests/tangerine_whistle/test_evm_tools.py
@@ -12,9 +12,9 @@ FORK_PACKAGE = "tangerine_whistle"
 block_reward = importlib.import_module(
     f"ethereum.{FORK_PACKAGE}.fork"
 ).BLOCK_REWARD  # type: ignore
-fetch_general_state_tests = importlib.import_module(
+fetch_legacy_state_tests = importlib.import_module(
     f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_general_state_tests  # type: ignore
+).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
     load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
@@ -24,7 +24,7 @@ run_evm_tools_test = partial(
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_general_state_tests(),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -10,7 +10,6 @@ from ethereum.exceptions import InvalidBlock
 from tests.helpers import TEST_FIXTURES
 from tests.helpers.load_state_tests import (
     Load,
-    NoPostState,
     fetch_state_test_files,
     idfn,
     run_blockchain_st_test,
@@ -29,13 +28,16 @@ run_tangerine_whistle_blockchain_st_tests = partial(
 ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 
 
-# Run legacy general state tests
-test_dir = (
-    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
-    "GeneralStateTests/"
+# Run legacy state tests
+test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
+
+LEGACY_SLOW_TESTS = (
+    # ValidBlockTests
+    "bcExploitTest/DelegateCallSpam.json",
 )
 
-GENERAL_STATE_BIG_MEMORY_TESTS = (
+LEGACY_BIG_MEMORY_TESTS = (
+    # GeneralStateTests
     "/stQuadraticComplexityTest/",
     "/stRandom2/",
     "/stRandom/",
@@ -43,94 +45,37 @@ GENERAL_STATE_BIG_MEMORY_TESTS = (
     "stTimeConsuming/",
 )
 
-fetch_general_state_tests = partial(
-    fetch_tangerine_whistle_tests,
-    test_dir,
-    big_memory_list=GENERAL_STATE_BIG_MEMORY_TESTS,
-)
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_general_state_tests(),
-    ids=idfn,
-)
-def test_general_state_tests(test_case: Dict) -> None:
-    try:
-        run_tangerine_whistle_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
-
-
-# Run legacy valid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/ValidBlocks/"
-
-IGNORE_LIST = (
+LEGACY_IGNORE_LIST = (
+    # ValidBlockTests
     "bcForkStressTest/ForkStressTest.json",
     "bcGasPricerTest/RPC_API_Test.json",
     "bcMultiChainTest",
     "bcTotalDifficultyTest",
+    # InvalidBlockTests
+    "bcForgedTest",
+    "bcMultiChainTest",
+    "GasLimitHigherThan2p63m1_EIP150",
 )
 
-# Every test below takes more than  60s to run and
-# hence they've been marked as slow
-SLOW_TESTS = ("bcExploitTest/DelegateCallSpam.json",)
+fetch_legacy_state_tests = partial(
+    fetch_tangerine_whistle_tests,
+    test_dir,
+    ignore_list=LEGACY_IGNORE_LIST,
+    slow_list=LEGACY_SLOW_TESTS,
+    big_memory_list=LEGACY_BIG_MEMORY_TESTS,
+)
 
 
 @pytest.mark.parametrize(
     "test_case",
-    fetch_tangerine_whistle_tests(
-        test_dir,
-        ignore_list=IGNORE_LIST,
-        slow_list=SLOW_TESTS,
-    ),
+    fetch_legacy_state_tests(),
     ids=idfn,
 )
-def test_valid_block_tests(test_case: Dict) -> None:
-    try:
-        run_tangerine_whistle_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(f"{test_case} doesn't have post state")
+def test_legacy_state_tests(test_case: Dict) -> None:
+    run_tangerine_whistle_blockchain_st_tests(test_case)
 
 
-# Run legacy invalid block tests
-test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/InvalidBlocks"
-
-xfail_candidates = ("GasLimitHigherThan2p63m1_EIP150",)
-
-# FIXME: Check if these tests should in fact be ignored
-IGNORE_INVALID_BLOCK_TESTS = ("bcForgedTest", "bcMultiChainTest")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    fetch_tangerine_whistle_tests(
-        test_dir,
-        ignore_list=IGNORE_INVALID_BLOCK_TESTS,
-    ),
-    ids=idfn,
-)
-def test_invalid_block_tests(test_case: Dict) -> None:
-    try:
-        # Ideally correct.json should not have been in the InvalidBlocks folder
-        if test_case["test_key"] == "correct_EIP150":
-            run_tangerine_whistle_blockchain_st_tests(test_case)
-        elif test_case["test_key"] in xfail_candidates:
-            # Unclear where this failed requirement comes from
-            pytest.xfail()
-        else:
-            with pytest.raises(InvalidBlock):
-                run_tangerine_whistle_blockchain_st_tests(test_case)
-    except NoPostState:
-        # FIXME: Handle tests that don't have post state
-        pytest.xfail(
-            "{} doesn't have post state".format(test_case["test_key"])
-        )
-
-
-# Run Non-Legacy GeneralStateTests
+# Run Non-Legacy State Tests
 test_dir = f"{ETHEREUM_TESTS_PATH}/BlockchainTests/GeneralStateTests/"
 
 non_legacy_only_in = (
@@ -144,7 +89,7 @@ non_legacy_only_in = (
     fetch_tangerine_whistle_tests(test_dir, only_in=non_legacy_only_in),
     ids=idfn,
 )
-def test_general_state_tests_new(test_case: Dict) -> None:
+def test_non_legacy_state_tests(test_case: Dict) -> None:
     run_tangerine_whistle_blockchain_st_tests(test_case)
 
 

--- a/tests/tangerine_whistle/test_state_transition.py
+++ b/tests/tangerine_whistle/test_state_transition.py
@@ -32,8 +32,13 @@ ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
 test_dir = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/BlockchainTests/"
 
 LEGACY_SLOW_TESTS = (
-    # ValidBlockTests
+    "stRandom/randomStatetest177.json",
+    "stCreateTest/CreateOOGafterMaxCodesize.json",
+    # ValidBlockTest
     "bcExploitTest/DelegateCallSpam.json",
+    # InvalidBlockTest
+    "bcUncleHeaderValidity/nonceWrong.json",
+    "bcUncleHeaderValidity/wrongMixHash.json",
 )
 
 LEGACY_BIG_MEMORY_TESTS = (


### PR DESCRIPTION
(closes #760 )

### What was wrong?
The tests that throw exceptions were currently hardcoded in the testing framework.

Related to Issue #760 

### How was it fixed?
Automatically detect which test fixtures have the `expectException` fields. This PR also does some refactoring of the testing framework, making it more streamlined and a bit more efficient.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/ethereum/execution-specs/assets/48196632/1f982df9-a2ea-4024-bd68-5c04b2633f1d)

