### PR TITLE
fix t8n tool errors

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -394,7 +394,7 @@ def check_transaction(
     base_fee_per_gas: Uint,
     gas_available: Uint,
     chain_id: U64,
-) -> Tuple[Address, U256]:
+) -> Tuple[Address, Uint]:
     """
     Check if the transaction is includable in the block.
 
@@ -731,7 +731,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -763,13 +763,10 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    try:
-        if isinstance(tx, FeeMarketTransaction):
-            gas_fee = tx.gas * tx.max_fee_per_gas
-        else:
-            gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    if isinstance(tx, FeeMarketTransaction):
+        gas_fee = tx.gas * tx.max_fee_per_gas
+    else:
+        gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -426,6 +426,7 @@ def check_transaction(
 
     if isinstance(tx, FeeMarketTransaction):
         ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+        ensure(tx.max_fee_per_gas >= base_fee_per_gas, InvalidBlock)
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -762,10 +763,13 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
-    else:
-        gas_fee = tx.gas * tx.gas_price
+    try:
+        if isinstance(tx, FeeMarketTransaction):
+            gas_fee = tx.gas * tx.max_fee_per_gas
+        else:
+            gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -52,8 +52,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -71,8 +71,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -91,9 +91,9 @@ class FeeMarketTransaction:
 
     chain_id: U64
     nonce: U256
-    max_priority_fee_per_gas: U256
-    max_fee_per_gas: U256
-    gas: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/arrow_glacier/utils/message.py
+++ b/src/ethereum/arrow_glacier/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -39,7 +39,7 @@ class Environment:
     number: Uint
     base_fee_per_gas: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -55,7 +55,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -75,7 +75,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/arrow_glacier/vm/instructions/environment.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -103,7 +103,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -272,7 +272,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -66,7 +66,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -100,7 +100,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -175,7 +175,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -281,7 +281,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -628,7 +628,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -659,10 +659,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -659,7 +659,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -53,8 +53,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -72,8 +72,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/berlin/utils/message.py
+++ b/src/ethereum/berlin/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -54,7 +54,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -74,7 +74,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/berlin/vm/instructions/environment.py
+++ b/src/ethereum/berlin/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -103,7 +103,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -272,7 +272,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -65,7 +65,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -99,7 +99,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -174,7 +174,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -280,7 +280,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -616,7 +616,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -647,10 +647,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -647,7 +647,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/byzantium/utils/message.py
+++ b/src/ethereum/byzantium/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -53,7 +53,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -71,7 +71,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/byzantium/vm/instructions/environment.py
@@ -312,7 +312,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -74,7 +74,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     # OPERATION
     ensure(not evm.message.is_static, WriteInStaticContext)
@@ -109,7 +109,7 @@ def create(evm: Evm) -> None:
         child_message = Message(
             caller=evm.message.current_target,
             target=Bytes0(),
-            gas=U256(create_message_gas),
+            gas=create_message_gas,
             value=endowment,
             data=b"",
             code=call_data,
@@ -201,7 +201,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -64,7 +64,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -98,7 +98,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -167,7 +167,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -271,7 +271,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -616,7 +616,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -647,10 +647,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -647,7 +647,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/constantinople/utils/message.py
+++ b/src/ethereum/constantinople/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -53,7 +53,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -71,7 +71,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/constantinople/vm/instructions/environment.py
@@ -315,7 +315,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -69,7 +69,7 @@ def generic_create(
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -100,7 +100,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -267,7 +267,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -64,7 +64,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -98,7 +98,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -168,7 +168,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -272,7 +272,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -652,7 +652,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -621,7 +621,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...]]:
+) -> Tuple[Uint, Tuple[Log, ...]]:
     """
     Execute a transaction against the provided environment.
 
@@ -652,10 +652,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/dao_fork/utils/message.py
+++ b/src/ethereum/dao_fork/utils/message.py
@@ -26,7 +26,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -37,7 +37,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -52,7 +52,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -69,7 +69,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/dao_fork/vm/instructions/environment.py
+++ b/src/ethereum/dao_fork/vm/instructions/environment.py
@@ -309,7 +309,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -60,7 +60,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = U256(0)
+    evm.gas_left = Uint(0)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -111,7 +111,7 @@ def create(evm: Evm) -> None:
                 evm.stack, U256.from_be_bytes(child_evm.message.current_target)
             )
         evm.gas_left = child_evm.gas_left
-        child_evm.gas_left = U256(0)
+        child_evm.gas_left = Uint(0)
 
     # PROGRAM COUNTER
     evm.pc += 1
@@ -179,7 +179,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,
@@ -204,7 +204,7 @@ def generic_call(
         child_evm.output[:actual_output_size],
     )
     evm.gas_left += child_evm.gas_left
-    child_evm.gas_left = U256(0)
+    child_evm.gas_left = Uint(0)
 
 
 def call(evm: Evm) -> None:

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -53,7 +53,7 @@ class MessageCallOutput:
           5. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
@@ -85,7 +85,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -133,7 +133,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -234,7 +234,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.has_erred = True
     return evm
 

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -602,7 +602,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...]]:
+) -> Tuple[Uint, Tuple[Log, ...]]:
     """
     Execute a transaction against the provided environment.
 
@@ -633,10 +633,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -633,7 +633,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -47,8 +47,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/frontier/utils/message.py
+++ b/src/ethereum/frontier/utils/message.py
@@ -26,7 +26,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
 ) -> Message:

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -37,7 +37,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -52,7 +52,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -68,7 +68,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -309,7 +309,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -64,7 +64,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = U256(0)
+    evm.gas_left = Uint(0)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -180,7 +180,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -53,7 +53,7 @@ class MessageCallOutput:
           5. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -85,7 +85,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -243,6 +243,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.has_erred = True
     return evm

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -394,7 +394,7 @@ def check_transaction(
     base_fee_per_gas: Uint,
     gas_available: Uint,
     chain_id: U64,
-) -> Tuple[Address, U256]:
+) -> Tuple[Address, Uint]:
     """
     Check if the transaction is includable in the block.
 
@@ -731,7 +731,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -763,13 +763,10 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    try:
-        if isinstance(tx, FeeMarketTransaction):
-            gas_fee = tx.gas * tx.max_fee_per_gas
-        else:
-            gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    if isinstance(tx, FeeMarketTransaction):
+        gas_fee = tx.gas * tx.max_fee_per_gas
+    else:
+        gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -426,6 +426,7 @@ def check_transaction(
 
     if isinstance(tx, FeeMarketTransaction):
         ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+        ensure(tx.max_fee_per_gas >= base_fee_per_gas, InvalidBlock)
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -762,10 +763,13 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
-    else:
-        gas_fee = tx.gas * tx.gas_price
+    try:
+        if isinstance(tx, FeeMarketTransaction):
+            gas_fee = tx.gas * tx.max_fee_per_gas
+        else:
+            gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -52,8 +52,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -71,8 +71,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -91,9 +91,9 @@ class FeeMarketTransaction:
 
     chain_id: U64
     nonce: U256
-    max_priority_fee_per_gas: U256
-    max_fee_per_gas: U256
-    gas: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/gray_glacier/utils/message.py
+++ b/src/ethereum/gray_glacier/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -39,7 +39,7 @@ class Environment:
     number: Uint
     base_fee_per_gas: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -55,7 +55,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -75,7 +75,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/gray_glacier/vm/instructions/environment.py
+++ b/src/ethereum/gray_glacier/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -103,7 +103,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -272,7 +272,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -66,7 +66,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -100,7 +100,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -175,7 +175,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -281,7 +281,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -604,7 +604,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...]]:
+) -> Tuple[Uint, Tuple[Log, ...]]:
     """
     Execute a transaction against the provided environment.
 
@@ -635,10 +635,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -635,7 +635,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/homestead/utils/message.py
+++ b/src/ethereum/homestead/utils/message.py
@@ -26,7 +26,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -37,7 +37,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -52,7 +52,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -69,7 +69,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/homestead/vm/instructions/environment.py
+++ b/src/ethereum/homestead/vm/instructions/environment.py
@@ -309,7 +309,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -65,7 +65,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = evm.gas_left
-    evm.gas_left = U256(0)
+    evm.gas_left = Uint(0)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -183,7 +183,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -53,7 +53,7 @@ class MessageCallOutput:
           5. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -85,7 +85,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -145,7 +145,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -245,6 +245,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.has_erred = True
     return evm

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -648,7 +648,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -617,7 +617,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -648,10 +648,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/istanbul/utils/message.py
+++ b/src/ethereum/istanbul/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -54,7 +54,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -72,7 +72,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/istanbul/vm/instructions/environment.py
@@ -316,7 +316,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -69,7 +69,7 @@ def generic_create(
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -100,7 +100,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -267,7 +267,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -65,7 +65,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -99,7 +99,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -174,7 +174,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -278,7 +278,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -402,7 +402,7 @@ def check_transaction(
     base_fee_per_gas: Uint,
     gas_available: Uint,
     chain_id: U64,
-) -> Tuple[Address, U256]:
+) -> Tuple[Address, Uint]:
     """
     Check if the transaction is includable in the block.
 
@@ -739,7 +739,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -771,13 +771,10 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    try:
-        if isinstance(tx, FeeMarketTransaction):
-            gas_fee = tx.gas * tx.max_fee_per_gas
-        else:
-            gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    if isinstance(tx, FeeMarketTransaction):
+        gas_fee = tx.gas * tx.max_fee_per_gas
+    else:
+        gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -52,8 +52,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -71,8 +71,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -91,9 +91,9 @@ class FeeMarketTransaction:
 
     chain_id: U64
     nonce: U256
-    max_priority_fee_per_gas: U256
-    max_fee_per_gas: U256
-    gas: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/london/utils/message.py
+++ b/src/ethereum/london/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -39,7 +39,7 @@ class Environment:
     number: Uint
     base_fee_per_gas: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -55,7 +55,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -75,7 +75,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/london/vm/instructions/environment.py
+++ b/src/ethereum/london/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -103,7 +103,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -272,7 +272,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -66,7 +66,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -100,7 +100,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -175,7 +175,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -281,7 +281,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -648,7 +648,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -617,7 +617,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -648,10 +648,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/muir_glacier/utils/message.py
+++ b/src/ethereum/muir_glacier/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -54,7 +54,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -72,7 +72,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/muir_glacier/vm/instructions/environment.py
@@ -316,7 +316,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -69,7 +69,7 @@ def generic_create(
     from ...vm.interpreter import STACK_DEPTH_LIMIT, process_create_message
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -100,7 +100,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -267,7 +267,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -65,7 +65,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -99,7 +99,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -174,7 +174,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -278,7 +278,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -338,6 +338,7 @@ def check_transaction(
 
     if isinstance(tx, FeeMarketTransaction):
         ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+        ensure(tx.max_fee_per_gas >= base_fee_per_gas, InvalidBlock)
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -550,10 +551,13 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
-    else:
-        gas_fee = tx.gas * tx.gas_price
+    try:
+        if isinstance(tx, FeeMarketTransaction):
+            gas_fee = tx.gas * tx.max_fee_per_gas
+        else:
+            gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -306,7 +306,7 @@ def check_transaction(
     base_fee_per_gas: Uint,
     gas_available: Uint,
     chain_id: U64,
-) -> Tuple[Address, U256]:
+) -> Tuple[Address, Uint]:
     """
     Check if the transaction is includable in the block.
 
@@ -519,7 +519,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -551,13 +551,10 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    try:
-        if isinstance(tx, FeeMarketTransaction):
-            gas_fee = tx.gas * tx.max_fee_per_gas
-        else:
-            gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    if isinstance(tx, FeeMarketTransaction):
+        gas_fee = tx.gas * tx.max_fee_per_gas
+    else:
+        gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -52,8 +52,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -71,8 +71,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -91,9 +91,9 @@ class FeeMarketTransaction:
 
     chain_id: U64
     nonce: U256
-    max_priority_fee_per_gas: U256
-    max_fee_per_gas: U256
-    gas: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/paris/utils/message.py
+++ b/src/ethereum/paris/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -39,7 +39,7 @@ class Environment:
     number: Uint
     base_fee_per_gas: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     prev_randao: Bytes32
     state: State
@@ -55,7 +55,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -75,7 +75,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/paris/vm/instructions/environment.py
+++ b/src/ethereum/paris/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -103,7 +103,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -272,7 +272,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -66,7 +66,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
@@ -100,7 +100,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -175,7 +175,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -281,7 +281,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -312,7 +312,7 @@ def check_transaction(
     base_fee_per_gas: Uint,
     gas_available: Uint,
     chain_id: U64,
-) -> Tuple[Address, U256]:
+) -> Tuple[Address, Uint]:
     """
     Check if the transaction is includable in the block.
 
@@ -540,7 +540,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], bool]:
     """
     Execute a transaction against the provided environment.
 
@@ -572,13 +572,10 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    try:
-        if isinstance(tx, FeeMarketTransaction):
-            gas_fee = tx.gas * tx.max_fee_per_gas
-        else:
-            gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    if isinstance(tx, FeeMarketTransaction):
+        gas_fee = tx.gas * tx.max_fee_per_gas
+    else:
+        gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -344,6 +344,7 @@ def check_transaction(
 
     if isinstance(tx, FeeMarketTransaction):
         ensure(tx.max_fee_per_gas >= tx.max_priority_fee_per_gas, InvalidBlock)
+        ensure(tx.max_fee_per_gas >= base_fee_per_gas, InvalidBlock)
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -571,10 +572,13 @@ def process_transaction(
     sender = env.origin
     sender_account = get_account(env.state, sender)
 
-    if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
-    else:
-        gas_fee = tx.gas * tx.gas_price
+    try:
+        if isinstance(tx, FeeMarketTransaction):
+            gas_fee = tx.gas * tx.max_fee_per_gas
+        else:
+            gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -52,8 +52,8 @@ class LegacyTransaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -71,8 +71,8 @@ class AccessListTransaction:
 
     chain_id: U64
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
@@ -91,9 +91,9 @@ class FeeMarketTransaction:
 
     chain_id: U64
     nonce: U256
-    max_priority_fee_per_gas: U256
-    max_fee_per_gas: U256
-    gas: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/shanghai/utils/message.py
+++ b/src/ethereum/shanghai/utils/message.py
@@ -28,7 +28,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -39,7 +39,7 @@ class Environment:
     number: Uint
     base_fee_per_gas: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     prev_randao: Bytes32
     state: State
@@ -55,7 +55,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -75,7 +75,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/shanghai/vm/instructions/environment.py
+++ b/src/ethereum/shanghai/vm/instructions/environment.py
@@ -319,7 +319,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -78,7 +78,7 @@ def generic_create(
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     ensure(not evm.message.is_static, WriteInStaticContext)
     evm.return_data = b""
@@ -111,7 +111,7 @@ def generic_create(
     child_message = Message(
         caller=evm.message.current_target,
         target=Bytes0(),
-        gas=U256(create_message_gas),
+        gas=create_message_gas,
         value=endowment,
         data=b"",
         code=call_data,
@@ -295,7 +295,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -66,7 +66,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
@@ -100,7 +100,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -175,7 +175,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.output = b""
             evm.has_erred = True
         else:
@@ -281,7 +281,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.output = b""
         evm.has_erred = True
     except Revert as e:

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -643,7 +643,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -612,7 +612,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...]]:
+) -> Tuple[Uint, Tuple[Log, ...]]:
     """
     Execute a transaction against the provided environment.
 
@@ -643,10 +643,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/spurious_dragon/utils/message.py
+++ b/src/ethereum/spurious_dragon/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -38,7 +38,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -53,7 +53,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -70,7 +70,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/spurious_dragon/vm/instructions/environment.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/environment.py
@@ -309,7 +309,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -72,7 +72,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -104,7 +104,7 @@ def create(evm: Evm) -> None:
         child_message = Message(
             caller=evm.message.current_target,
             target=Bytes0(),
-            gas=U256(create_message_gas),
+            gas=create_message_gas,
             value=endowment,
             data=b"",
             code=call_data,
@@ -190,7 +190,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -63,7 +63,7 @@ class MessageCallOutput:
           6. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -97,7 +97,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                U256(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), True
             )
         else:
             evm = process_create_message(message, env)
@@ -166,7 +166,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -267,6 +267,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.has_erred = True
     return evm

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -604,7 +604,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[U256, Tuple[Log, ...]]:
+) -> Tuple[Uint, Tuple[Log, ...]]:
     """
     Execute a transaction against the provided environment.
 
@@ -635,10 +635,7 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    try:
-        gas_fee = tx.gas * tx.gas_price
-    except ValueError as e:
-        raise InvalidBlock from e
+    gas_fee = tx.gas * tx.gas_price
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -635,7 +635,10 @@ def process_transaction(
 
     sender = env.origin
     sender_account = get_account(env.state, sender)
-    gas_fee = tx.gas * tx.gas_price
+    try:
+        gas_fee = tx.gas * tx.gas_price
+    except ValueError as e:
+        raise InvalidBlock from e
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
     ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -48,8 +48,8 @@ class Transaction:
     """
 
     nonce: U256
-    gas_price: U256
-    gas: U256
+    gas_price: Uint
+    gas: Uint
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes

--- a/src/ethereum/tangerine_whistle/utils/message.py
+++ b/src/ethereum/tangerine_whistle/utils/message.py
@@ -27,7 +27,7 @@ def prepare_message(
     target: Union[Bytes0, Address],
     value: U256,
     data: Bytes,
-    gas: U256,
+    gas: Uint,
     env: Environment,
     code_address: Optional[Address] = None,
     should_transfer_value: bool = True,

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -37,7 +37,7 @@ class Environment:
     coinbase: Address
     number: Uint
     gas_limit: Uint
-    gas_price: U256
+    gas_price: Uint
     time: U256
     difficulty: Uint
     state: State
@@ -52,7 +52,7 @@ class Message:
     caller: Address
     target: Union[Bytes0, Address]
     current_target: Address
-    gas: U256
+    gas: Uint
     value: U256
     data: Bytes
     code_address: Optional[Address]
@@ -69,7 +69,7 @@ class Evm:
     stack: List[U256]
     memory: bytearray
     code: Bytes
-    gas_left: U256
+    gas_left: Uint
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]

--- a/src/ethereum/tangerine_whistle/vm/instructions/environment.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/environment.py
@@ -309,7 +309,7 @@ def gasprice(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    push(evm.stack, evm.env.gas_price)
+    push(evm.stack, U256(evm.env.gas_price))
 
     # PROGRAM COUNTER
     evm.pc += 1

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -71,7 +71,7 @@ def create(evm: Evm) -> None:
     charge_gas(evm, GAS_CREATE + extend_memory.cost)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
-    evm.gas_left -= U256(create_message_gas)
+    evm.gas_left -= create_message_gas
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -103,7 +103,7 @@ def create(evm: Evm) -> None:
         child_message = Message(
             caller=evm.message.current_target,
             target=Bytes0(),
-            gas=U256(create_message_gas),
+            gas=create_message_gas,
             value=endowment,
             data=b"",
             code=call_data,
@@ -189,7 +189,7 @@ def generic_call(
     child_message = Message(
         caller=caller,
         target=to,
-        gas=U256(gas),
+        gas=gas,
         value=value,
         data=call_data,
         code=code,

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -53,7 +53,7 @@ class MessageCallOutput:
           5. `has_erred`: True if execution has caused an error.
     """
 
-    gas_left: U256
+    gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
@@ -85,7 +85,7 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(U256(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
         else:
             evm = process_create_message(message, env)
     else:
@@ -145,7 +145,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             charge_gas(evm, contract_code_gas)
         except ExceptionalHalt:
             rollback_transaction(env.state)
-            evm.gas_left = U256(0)
+            evm.gas_left = Uint(0)
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -245,6 +245,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
             op_implementation[op](evm)
 
     except ExceptionalHalt:
-        evm.gas_left = U256(0)
+        evm.gas_left = Uint(0)
         evm.has_erred = True
     return evm

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -335,8 +335,6 @@ class T8N(Load):
                 self.txs.rejected_txs[tx_idx] = f"Failed transaction: {str(e)}"
                 self.restore_state()
                 self.logger.warning(f"Transaction {tx_idx} failed: {str(e)}")
-                if isinstance(e, FatalException):
-                    raise e
             else:
                 self.txs.add_transaction(tx)
                 gas_consumed = process_transaction_return[0]

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -123,23 +123,22 @@ class Txs:
                     yield idx, self.parse_rlp_tx(raw_tx)
                 else:
                     yield idx, self.parse_json_tx(raw_tx)
+            except UnsupportedTx as e:
+                self.t8n.logger.warning(
+                    f"Unsupported transaction type {idx}: "
+                    f"{e.error_message}"
+                )
+                self.rejected_txs[
+                    idx
+                ] = f"Unsupported transaction type: {e.error_message}"
+                self.all_txs.append(e.encoded_params)
             except Exception as e:
-                if isinstance(e, UnsupportedTx):
-                    self.t8n.logger.warning(
-                        f"Unsupported transaction type {idx}: "
-                        f"{e.error_message}"
-                    )
-                    self.rejected_txs[
-                        idx
-                    ] = f"Unsupported transaction type: {e.error_message}"
-                    self.all_txs.append(e.encoded_params)
-                else:
-                    self.t8n.logger.warning(
-                        f"Failed to parse transaction {idx}: {str(e)}"
-                    )
-                    self.rejected_txs[
-                        idx
-                    ] = f"Failed to parse transaction {idx}: {str(e)}"
+                self.t8n.logger.warning(
+                    f"Failed to parse transaction {idx}: {str(e)}"
+                )
+                self.rejected_txs[
+                    idx
+                ] = f"Failed to parse transaction {idx}: {str(e)}"
 
     def parse_rlp_tx(self, raw_tx: Any) -> Any:
         """

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -45,7 +45,12 @@ EXCEPTION_MAPS = {
     "Merge": {
         "fork_blocks": [("paris", 0)],
     },
+    "ConstantinopleFix": {
+        "fork_blocks": [("constantinople", 0)],
+    },
 }
+
+UNSUPPORTED_FORKS = ("CONSTANTINOPLE",)
 
 
 def parse_hex_or_int(value: str, to_type: Callable[[int], W]) -> W:
@@ -80,6 +85,8 @@ def get_module_name(forks: Any, options: Any, stdin: Any) -> Tuple[str, int]:
     """
     Get the module name and the fork block for the given state fork.
     """
+    if options.state_fork.upper() in UNSUPPORTED_FORKS:
+        sys.exit(f"Unsupported state fork: {options.state_fork}")
     # If the state fork is an exception, use the exception config.
     exception_config: Optional[Dict[str, Any]] = None
     try:

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -50,7 +50,7 @@ EXCEPTION_MAPS = {
     },
 }
 
-UNSUPPORTED_FORKS = ("CONSTANTINOPLE",)
+UNSUPPORTED_FORKS = ("constantinople",)
 
 
 def parse_hex_or_int(value: str, to_type: Callable[[int], W]) -> W:
@@ -85,7 +85,7 @@ def get_module_name(forks: Any, options: Any, stdin: Any) -> Tuple[str, int]:
     """
     Get the module name and the fork block for the given state fork.
     """
-    if options.state_fork.upper() in UNSUPPORTED_FORKS:
+    if options.state_fork.casefold() in UNSUPPORTED_FORKS:
         sys.exit(f"Unsupported state fork: {options.state_fork}")
     # If the state fork is an exception, use the exception config.
     exception_config: Optional[Dict[str, Any]] = None

--- a/tests/berlin/test_evm_tools.py
+++ b/tests/berlin/test_evm_tools.py
@@ -4,27 +4,39 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = f"{ETHEREUM_TESTS_PATH}/GeneralStateTests/"
 FORK_NAME = "Berlin"
-FORK_PACKAGE = "berlin"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
+)
+
+SLOW_TESTS = (
+    "CALLBlake2f_MaxRounds",
+    "CALLCODEBlake2f",
+    "CALLBlake2f",
+    "loopExp",
+    "loopMul",
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+        SLOW_TESTS,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -43,8 +43,8 @@ bloom = hex_to_bytes256(
 
 legacy_transaction = LegacyTransaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -56,8 +56,8 @@ legacy_transaction = LegacyTransaction(
 access_list_transaction = AccessListTransaction(
     U64(1),
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),

--- a/tests/byzantium/test_evm_tools.py
+++ b/tests/byzantium/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
 FORK_NAME = "Byzantium"
-FORK_PACKAGE = "byzantium"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_legacy_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_legacy_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/byzantium/test_rlp.py
+++ b/tests/byzantium/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/constantinople/test_evm_tools.py
+++ b/tests/constantinople/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
-FORK_NAME = "Constantinople"
-FORK_PACKAGE = "constantinople"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_legacy_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
+FORK_NAME = "ConstantinopleFix"
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_legacy_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/constantinople/test_rlp.py
+++ b/tests/constantinople/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/frontier/test_evm_tools.py
+++ b/tests/frontier/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
 FORK_NAME = "Frontier"
-FORK_PACKAGE = "frontier"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/frontier/test_rlp.py
+++ b/tests/frontier/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -7,12 +7,12 @@ TEST_FIXTURES = {
     },
     "evm_tools_testdata": {
         "url": "https://github.com/gurukamath/evm-tools-testdata.git",
-        "commit_hash": "3a6f09a",
+        "commit_hash": "f4f40aa",
         "fixture_path": "tests/fixtures/evm_tools_testdata",
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "b25623d",
+        "commit_hash": "0ec53d0",
         "fixture_path": "tests/fixtures/ethereum_tests",
     },
 }

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -7,7 +7,7 @@ TEST_FIXTURES = {
     },
     "evm_tools_testdata": {
         "url": "https://github.com/gurukamath/evm-tools-testdata.git",
-        "commit_hash": "f4f40aa",
+        "commit_hash": "792422d",
         "fixture_path": "tests/fixtures/evm_tools_testdata",
     },
     "ethereum_tests": {

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -1,236 +1,140 @@
 import json
+import os
 import sys
 from io import StringIO
-from typing import Any, Dict, List
+from typing import Dict, Generator, Tuple
 
 import pytest
 
-from ethereum import rlp
-from ethereum.base_types import U256, Bytes20, Bytes32, Bytes256, Uint
-from ethereum.crypto.hash import Hash32
-from ethereum.utils.hexadecimal import hex_to_bytes, hex_to_bytes8
+from ethereum.utils.hexadecimal import hex_to_bytes
 from ethereum_spec_tools.evm_tools import parser, subparsers
-from ethereum_spec_tools.evm_tools.b11r import B11R, b11r_arguments
 from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
-from ethereum_spec_tools.evm_tools.utils import parse_hex_or_int
+from ethereum_spec_tools.evm_tools.utils import FatalException
 
 t8n_arguments(subparsers)
-b11r_arguments(subparsers)
 
 
-def get_uncle_rlps(uncles: List[Dict[str, Any]]) -> List[str]:
-    uncles_rlp = []
-    for uncle in uncles:
-
-        header = [
-            Hash32(hex_to_bytes(uncle["parentHash"])),
-            Hash32(hex_to_bytes(uncle["uncleHash"])),
-            Bytes20(hex_to_bytes(uncle["coinbase"])),
-            Hash32(hex_to_bytes(uncle["stateRoot"])),
-            Hash32(hex_to_bytes(uncle["transactionsTrie"])),
-            Hash32(hex_to_bytes(uncle["receiptTrie"])),
-            Bytes256(hex_to_bytes(uncle["bloom"])),
-            parse_hex_or_int(uncle["difficulty"], Uint),
-            parse_hex_or_int(uncle["number"], Uint),
-            parse_hex_or_int(uncle["gasLimit"], Uint),
-            parse_hex_or_int(uncle["gasUsed"], Uint),
-            parse_hex_or_int(uncle["timestamp"], U256),
-            hex_to_bytes(uncle.get("extraData", "0x")),
-            Bytes32(hex_to_bytes(uncle["mixHash"])),
-            hex_to_bytes8(uncle.get("nonce", "0x0000000000000000")),
-        ]
-
-        uncle_block = [
-            header,
-            [],
-            [],
-        ]
-
-        try:
-            header.append(hex_to_bytes(uncle["baseFeePerGas"]))
-        except KeyError:
-            pass
-
-        try:
-            header.append(hex_to_bytes(uncle["withdrawalsRoot"]))
-            uncle_block.append([])
-        except KeyError:
-            pass
-
-        uncles_rlp.append("0x" + rlp.encode(uncle_block).hex())
-
-    return uncles_rlp
-
-
-def load_evm_tools_test(
-    test_case: Dict,
+def fetch_evm_tools_tests(
+    test_dir: str,
     fork_name: str,
-    block_reward: int = None,
-) -> None:
-    test_file = test_case["test_file"]
-    test_key = test_case["test_key"]
+    slow_tests: Tuple[str, ...] = None,
+) -> Generator:
+    """
+    Fetches all the general state tests from the given directory
+    """
+    if slow_tests is None:
+        slow_tests = tuple()
 
-    with open(test_file, "r") as fp:
-        data = json.load(fp)
+    for root, _, files in os.walk(test_dir):
+        for filename in files:
+            if filename.endswith(".json"):
+                test_file_path = os.path.join(root, filename)
+                with open(test_file_path) as test_file:
+                    tests = json.load(test_file)
 
-    json_data = data[test_key]
+                for key, test in tests.items():
+                    slow = True if key in slow_tests else False
+                    if fork_name in test["post"]:
+                        for transition in test["post"][fork_name]:
+                            post_hash = transition["hash"]
+                            exception = transition.get("expectException")
+                            indexes = transition["indexes"]
+                            d = indexes["data"]
+                            g = indexes["gas"]
+                            v = indexes["value"]
 
-    alloc = json_data["pre"]
-
-    block_hashes = {}
-
-    for block in json_data["blocks"]:
-
-        if "blockHeader" not in block:
-            pytest.skip("Skipping test case with no block header")
-
-        # Assemble the environment for the t8n tool
-        current_number = block["blockHeader"]["number"]
-        # The t8n tool expects block hashes in the form {number: hash}
-        # number being in str
-        block_hashes[
-            str(parse_hex_or_int(block["blockHeader"]["number"], Uint) - 1)
-        ] = block["blockHeader"]["parentHash"]
-
-        env = {
-            "currentCoinbase": block["blockHeader"]["coinbase"],
-            "currentDifficulty": block["blockHeader"]["difficulty"],
-            "currentGasLimit": block["blockHeader"]["gasLimit"],
-            "currentNumber": block["blockHeader"]["number"],
-            "currentTimestamp": block["blockHeader"]["timestamp"],
-            "blockHashes": block_hashes,
-        }
-
-        try:
-            env["currentBaseFee"] = block["blockHeader"]["baseFeePerGas"]
-            # Starting paris, randomness is availavle in the difficulty
-            # field of the fixture. T8N will just ignore it if it is
-            # before paris
-            env["currentRandom"] = block["blockHeader"]["mixHash"]
-            env["withdrawals"] = block["withdrawals"]
-        except KeyError:
-            pass
-
-        env_ommers = []
-        for uncle in block["uncleHeaders"]:
-            delta = parse_hex_or_int(
-                block["blockHeader"]["number"], Uint
-            ) - parse_hex_or_int(uncle["number"], Uint)
-            env_ommers.append(
-                {
-                    "delta": delta,
-                    "address": uncle["coinbase"],
-                }
-            )
-
-        if len(env_ommers):
-            env["ommers"] = env_ommers
-
-        # Assemble the transactions for the t8n tool
-        txs = []
-        for tx in block["transactions"]:
-            tx["input"] = tx["data"]
-            tx["gas"] = tx["gasLimit"]
-            txs.append(tx)
-
-        sys.stdin = StringIO(
-            json.dumps(
-                {
-                    "env": env,
-                    "alloc": alloc,
-                    "txs": txs,
-                }
-            )
-        )
-
-        # Run the t8n tool
-        t8n_args = [
-            "t8n",
-            "--input.alloc",
-            "stdin",
-            "--input.env",
-            "stdin",
-            "--input.txs",
-            "stdin",
-            "--state.fork",
-            f"{fork_name}",
-        ]
-        if block_reward:
-            t8n_args += ["--state.reward", f"{block_reward}"]
-        t8n_options = parser.parse_args(t8n_args)
-
-        t8n = T8N(t8n_options)
-        t8n.apply_body()
-
-        # Update the state for the next block
-        alloc = t8n.alloc.to_json()
-        # Assemble the transactions rlp for the b11r tool
-        txs_rlp = rlp.encode(t8n.txs.successful_txs)
-
-        # Assemble the header for the b11r tool
-        header = {
-            "parentHash": block["blockHeader"]["parentHash"],
-            "miner": block["blockHeader"]["coinbase"],
-            "stateRoot": "0x" + t8n.result.state_root.hex(),
-            "transactionsRoot": "0x" + t8n.result.tx_root.hex(),
-            "receiptsRoot": "0x" + t8n.result.receipt_root.hex(),
-            "logsBloom": "0x" + t8n.result.bloom.hex(),
-            "difficulty": block["blockHeader"]["difficulty"],
-            "number": block["blockHeader"]["number"],
-            "gasLimit": block["blockHeader"]["gasLimit"],
-            "gasUsed": t8n.result.gas_used,
-            "timestamp": block["blockHeader"]["timestamp"],
-            "extraData": block["blockHeader"]["extraData"],
-            "mixHash": block["blockHeader"]["mixHash"],
-            "nonce": block["blockHeader"]["nonce"],
-        }
-
-        try:
-            header["baseFeePerGas"] = block["blockHeader"]["baseFeePerGas"]
-        except KeyError:
-            pass
-
-        if t8n.result.withdrawals_root:
-            header["withdrawalsRoot"] = (
-                "0x" + t8n.result.withdrawals_root.hex()
-            )
-
-        ommers: List[Any] = get_uncle_rlps(block["uncleHeaders"])
-
-        stdin_data = {
-            "header": header,
-            "ommers": ommers,
-            "txs": "0x" + txs_rlp.hex(),
-        }
-
-        b11r_args = [
-            "b11r",
-            "--input.header",
-            "stdin",
-            "--input.ommers",
-            "stdin",
-            "--input.txs",
-            "stdin",
-        ]
-
-        if t8n.result.withdrawals_root:
-            b11r_args += ["--input.withdrawals", "stdin"]
-            stdin_data["withdrawals"] = env["withdrawals"]
-
-        sys.stdin = StringIO(json.dumps(stdin_data))
-
-        # Run the b11r tool
-        b11r_options = parser.parse_args(b11r_args)
-
-        b11r = B11R(b11r_options)
-        b11r.build_block()
-
-        assert b11r.block_rlp == hex_to_bytes(block["rlp"])
+                            test_case = {
+                                "test_file": test_file_path,
+                                "test_key": key,
+                                "d": d,
+                                "g": g,
+                                "v": v,
+                                "post_hash": post_hash,
+                                "exception": exception,
+                            }
+                            if slow:
+                                yield pytest.param(
+                                    test_case, marks=pytest.mark.slow
+                                )
+                            else:
+                                yield test_case
 
 
-# Test case Identifier
 def idfn(test_case: Dict) -> str:
+    """Identify the test case"""
+
     if isinstance(test_case, dict):
         folder_name = test_case["test_file"].split("/")[-2]
-        # Assign Folder name and test_key to identify tests in output
-        return folder_name + " - " + test_case["test_key"] + " - evm_tools"
+        test_key = test_case["test_key"]
+        d = test_case["d"]
+        g = test_case["g"]
+        v = test_case["v"]
+
+        return f"{folder_name} - {test_key} - d{d}g{g}v{v}"
+
+
+def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
+    """
+    Runs a single general state test
+    """
+    test_file = test_case["test_file"]
+    test_key = test_case["test_key"]
+    post_hash = test_case["post_hash"]
+    exception = test_case.get("exception")
+    d = test_case["d"]
+    g = test_case["g"]
+    v = test_case["v"]
+    with open(test_file) as f:
+        test = json.load(f)
+
+    env = test[test_key]["env"]
+    env["blockHashes"] = {"0": env["previousHash"]}
+    env["withdrawals"] = []
+
+    tx = {}
+    for k, value in test[test_key]["transaction"].items():
+        if k == "data":
+            tx["input"] = value[d]
+        elif k == "gasLimit":
+            tx["gas"] = value[g]
+        elif k == "value":
+            tx[k] = value[v]
+        elif k == "accessLists":
+            if value[d] is not None:
+                tx["accessList"] = value[d]
+        else:
+            tx[k] = value
+
+    sys.stdin = StringIO(
+        json.dumps(
+            {
+                "env": env,
+                "alloc": test[test_key]["pre"],
+                "txs": [tx],
+            }
+        )
+    )
+
+    # Run the t8n tool
+    t8n_args = [
+        "t8n",
+        "--input.alloc",
+        "stdin",
+        "--input.env",
+        "stdin",
+        "--input.txs",
+        "stdin",
+        "--state.fork",
+        f"{fork_name}",
+    ]
+    t8n_options = parser.parse_args(t8n_args)
+
+    t8n = T8N(t8n_options)
+    # An unsupported transaction cannot be signed
+    # so the t8n tool throws an exception
+    if exception == "TR_TypeNotSupported":
+        with pytest.raises(FatalException):
+            t8n.apply_body()
+    else:
+        t8n.apply_body()
+        assert hex_to_bytes(post_hash) == t8n.result.state_root

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -6,10 +6,10 @@ from typing import Dict, Generator, Tuple
 
 import pytest
 
+from ethereum import rlp
 from ethereum.utils.hexadecimal import hex_to_bytes
 from ethereum_spec_tools.evm_tools import parser, subparsers
 from ethereum_spec_tools.evm_tools.t8n import T8N, t8n_arguments
-from ethereum_spec_tools.evm_tools.utils import FatalException
 
 t8n_arguments(subparsers)
 
@@ -35,22 +35,13 @@ def fetch_evm_tools_tests(
                 for key, test in tests.items():
                     slow = True if key in slow_tests else False
                     if fork_name in test["post"]:
-                        for transition in test["post"][fork_name]:
-                            post_hash = transition["hash"]
-                            exception = transition.get("expectException")
-                            indexes = transition["indexes"]
-                            d = indexes["data"]
-                            g = indexes["gas"]
-                            v = indexes["value"]
-
+                        for idx, transition in enumerate(
+                            test["post"][fork_name]
+                        ):
                             test_case = {
                                 "test_file": test_file_path,
                                 "test_key": key,
-                                "d": d,
-                                "g": g,
-                                "v": v,
-                                "post_hash": post_hash,
-                                "exception": exception,
+                                "index": idx,
                             }
                             if slow:
                                 yield pytest.param(
@@ -66,11 +57,9 @@ def idfn(test_case: Dict) -> str:
     if isinstance(test_case, dict):
         folder_name = test_case["test_file"].split("/")[-2]
         test_key = test_case["test_key"]
-        d = test_case["d"]
-        g = test_case["g"]
-        v = test_case["v"]
+        index = test_case["index"]
 
-        return f"{folder_name} - {test_key} - d{d}g{g}v{v}"
+        return f"{folder_name} - {test_key} - {index}"
 
 
 def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
@@ -79,20 +68,24 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
     """
     test_file = test_case["test_file"]
     test_key = test_case["test_key"]
-    post_hash = test_case["post_hash"]
-    exception = test_case.get("exception")
-    d = test_case["d"]
-    g = test_case["g"]
-    v = test_case["v"]
+    index = test_case["index"]
     with open(test_file) as f:
-        test = json.load(f)
+        tests = json.load(f)
 
-    env = test[test_key]["env"]
+    env = tests[test_key]["env"]
     env["blockHashes"] = {"0": env["previousHash"]}
     env["withdrawals"] = []
 
+    alloc = tests[test_key]["pre"]
+
+    post = tests[test_key]["post"][fork_name][index]
+    post_hash = post["hash"]
+    d = post["indexes"]["data"]
+    g = post["indexes"]["gas"]
+    v = post["indexes"]["value"]
+
     tx = {}
-    for k, value in test[test_key]["transaction"].items():
+    for k, value in tests[test_key]["transaction"].items():
         if k == "data":
             tx["input"] = value[d]
         elif k == "gasLimit":
@@ -105,12 +98,14 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
         else:
             tx[k] = value
 
+    txs = [tx]
+
     sys.stdin = StringIO(
         json.dumps(
             {
                 "env": env,
-                "alloc": test[test_key]["pre"],
-                "txs": [tx],
+                "alloc": alloc,
+                "txs": txs,
             }
         )
     )
@@ -130,11 +125,6 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
     t8n_options = parser.parse_args(t8n_args)
 
     t8n = T8N(t8n_options)
-    # An unsupported transaction cannot be signed
-    # so the t8n tool throws an exception
-    if exception == "TR_TypeNotSupported":
-        with pytest.raises(FatalException):
-            t8n.apply_body()
-    else:
-        t8n.apply_body()
-        assert hex_to_bytes(post_hash) == t8n.result.state_root
+    t8n.apply_body()
+
+    assert hex_to_bytes(post_hash) == t8n.result.state_root

--- a/tests/homestead/test_evm_tools.py
+++ b/tests/homestead/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
 FORK_NAME = "Homestead"
-FORK_PACKAGE = "homestead"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_legacy_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_legacy_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/homestead/test_rlp.py
+++ b/tests/homestead/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/istanbul/test_evm_tools.py
+++ b/tests/istanbul/test_evm_tools.py
@@ -4,27 +4,39 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = f"{ETHEREUM_TESTS_PATH}/GeneralStateTests/"
 FORK_NAME = "Istanbul"
-FORK_PACKAGE = "istanbul"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
+)
+
+SLOW_TESTS = (
+    "CALLBlake2f_MaxRounds",
+    "CALLCODEBlake2f",
+    "CALLBlake2f",
+    "loopExp",
+    "loopMul",
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+        SLOW_TESTS,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/istanbul/test_rlp.py
+++ b/tests/istanbul/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/london/test_evm_tools.py
+++ b/tests/london/test_evm_tools.py
@@ -4,27 +4,39 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = f"{ETHEREUM_TESTS_PATH}/GeneralStateTests/"
 FORK_NAME = "London"
-FORK_PACKAGE = "london"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
+)
+
+SLOW_TESTS = (
+    "CALLBlake2f_MaxRounds",
+    "CALLCODEBlake2f",
+    "CALLBlake2f",
+    "loopExp",
+    "loopMul",
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+        SLOW_TESTS,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -44,8 +44,8 @@ bloom = hex_to_bytes256(
 
 legacy_transaction = LegacyTransaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -57,8 +57,8 @@ legacy_transaction = LegacyTransaction(
 access_list_transaction = AccessListTransaction(
     U64(1),
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
@@ -71,9 +71,9 @@ access_list_transaction = AccessListTransaction(
 transaction_1559 = FeeMarketTransaction(
     U64(1),
     U256(1),
-    U256(7),
-    U256(2),
-    U256(3),
+    Uint(7),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),

--- a/tests/paris/test_evm_tools.py
+++ b/tests/paris/test_evm_tools.py
@@ -4,22 +4,39 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = f"{ETHEREUM_TESTS_PATH}/GeneralStateTests/"
 FORK_NAME = "Merge"
-FORK_PACKAGE = "paris"
 
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_state_tests  # type: ignore
+run_evm_tools_test = partial(
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
+)
 
-run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
+SLOW_TESTS = (
+    "CALLBlake2f_MaxRounds",
+    "CALLCODEBlake2f",
+    "CALLBlake2f",
+    "loopExp",
+    "loopMul",
+)
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+        SLOW_TESTS,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -44,8 +44,8 @@ bloom = hex_to_bytes256(
 
 legacy_transaction = LegacyTransaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -57,8 +57,8 @@ legacy_transaction = LegacyTransaction(
 access_list_transaction = AccessListTransaction(
     U64(1),
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
@@ -71,9 +71,9 @@ access_list_transaction = AccessListTransaction(
 transaction_1559 = FeeMarketTransaction(
     U64(1),
     U256(1),
-    U256(7),
-    U256(2),
-    U256(3),
+    Uint(7),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),

--- a/tests/shanghai/test_evm_tools.py
+++ b/tests/shanghai/test_evm_tools.py
@@ -4,22 +4,39 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = f"{ETHEREUM_TESTS_PATH}/GeneralStateTests/"
 FORK_NAME = "Shanghai"
-FORK_PACKAGE = "shanghai"
 
-fetch_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_state_tests  # type: ignore
+run_evm_tools_test = partial(
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
+)
 
-run_evm_tools_test = partial(load_evm_tools_test, fork_name=FORK_NAME)
+SLOW_TESTS = (
+    "CALLBlake2f_MaxRounds",
+    "CALLCODEBlake2f",
+    "CALLBlake2f",
+    "loopExp",
+    "loopMul",
+)
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+        SLOW_TESTS,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -45,8 +45,8 @@ bloom = hex_to_bytes256(
 
 legacy_transaction = LegacyTransaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -58,8 +58,8 @@ legacy_transaction = LegacyTransaction(
 access_list_transaction = AccessListTransaction(
     U64(1),
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
@@ -72,9 +72,9 @@ access_list_transaction = AccessListTransaction(
 transaction_1559 = FeeMarketTransaction(
     U64(1),
     U256(1),
-    U256(7),
-    U256(2),
-    U256(3),
+    Uint(7),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"bar"),

--- a/tests/spurious_dragon/test_evm_tools.py
+++ b/tests/spurious_dragon/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
 FORK_NAME = "EIP158"
-FORK_PACKAGE = "spurious_dragon"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_legacy_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_legacy_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/spurious_dragon/test_rlp.py
+++ b/tests/spurious_dragon/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/tests/tangerine_whistle/test_evm_tools.py
+++ b/tests/tangerine_whistle/test_evm_tools.py
@@ -4,27 +4,32 @@ from typing import Dict
 
 import pytest
 
-from tests.helpers.load_evm_tools_tests import idfn, load_evm_tools_test
+from tests.helpers import TEST_FIXTURES
+from tests.helpers.load_evm_tools_tests import (
+    fetch_evm_tools_tests,
+    idfn,
+    load_evm_tools_test,
+)
 
+ETHEREUM_TESTS_PATH = TEST_FIXTURES["ethereum_tests"]["fixture_path"]
+TEST_DIR = (
+    f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/GeneralStateTests/"
+)
 FORK_NAME = "EIP150"
-FORK_PACKAGE = "tangerine_whistle"
-
-block_reward = importlib.import_module(
-    f"ethereum.{FORK_PACKAGE}.fork"
-).BLOCK_REWARD  # type: ignore
-fetch_legacy_state_tests = importlib.import_module(
-    f"tests.{FORK_PACKAGE}.test_state_transition"
-).fetch_legacy_state_tests  # type: ignore
 
 run_evm_tools_test = partial(
-    load_evm_tools_test, fork_name=FORK_NAME, block_reward=block_reward
+    load_evm_tools_test,
+    fork_name=FORK_NAME,
 )
 
 
 @pytest.mark.evm_tools
 @pytest.mark.parametrize(
     "test_case",
-    fetch_legacy_state_tests(),
+    fetch_evm_tools_tests(
+        TEST_DIR,
+        FORK_NAME,
+    ),
     ids=idfn,
 )
 def test_evm_tools(test_case: Dict) -> None:

--- a/tests/tangerine_whistle/test_rlp.py
+++ b/tests/tangerine_whistle/test_rlp.py
@@ -39,8 +39,8 @@ bloom = hex_to_bytes256(
 
 transaction1 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),
@@ -51,8 +51,8 @@ transaction1 = Transaction(
 
 transaction2 = Transaction(
     U256(1),
-    U256(2),
-    U256(3),
+    Uint(2),
+    Uint(3),
     Bytes0(),
     U256(4),
     Bytes(b"foo"),

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -384,6 +384,6 @@ Parsers
 params
 basedir
 tf
-
+casefold
 rlps
 jsons


### PR DESCRIPTION
### What was wrong?
Some edge cases were not handled properly by t8n

Related to Issue #773 

### How was it fixed?
1. Fix bug to accept state fork `ConstantinopleFix` instead of `Constantinople`
2. Update evm tools tests to use `GeneralStateTests` fixtures
3. Handle invalid transactions without crashing the `t8n` tool.
4. Handle a couple of testing edge cases.
 
#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/ethereum/execution-specs/assets/48196632/dfa6477f-ef53-49ff-9361-b0e02812c953)
