### PR TITLE
add supported fork info to `evm tools` help

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -6,8 +6,10 @@ import argparse
 
 from .b11r import B11R, b11r_arguments
 from .t8n import T8N, t8n_arguments
+from .utils import get_supported_forks
 
-DESCRIPTION = """
+DESCRIPTION = (
+    """
 This is the EVM tool for execution specs. The EVM tool
 provides a few useful subcommands to facilitate testing
 at the EVM layer.
@@ -18,7 +20,12 @@ https://github.com/ethereum/go-ethereum/blob/master/cmd/evm/README.md
 You can use this to run the following tools:
     1. t8n: A stateless state transition utility.
     2. b11r: The tool is used to assemble and seal full block rlps.
+
+
+The following forks are supported:
 """
+    + get_supported_forks()
+)
 
 parser = argparse.ArgumentParser(
     description=DESCRIPTION,

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -12,6 +12,8 @@ import coincurve
 from ethereum.base_types import U64, U256, Uint
 from ethereum.crypto.hash import Hash32
 
+from ..forks import Hardfork
+
 W = TypeVar("W", Uint, U64, U256)
 
 EXCEPTION_MAPS = {
@@ -121,6 +123,27 @@ def get_module_name(forks: Any, options: Any, stdin: Any) -> Tuple[str, int]:
 
     # Neither in exception nor a standard fork name.
     sys.exit(f"Unsupported state fork: {options.state_fork}")
+
+
+def get_supported_forks() -> str:
+    """
+    Get the supported forks.
+    """
+    supported_forks = [
+        fork.title_case_name.replace(" ", "") for fork in Hardfork.discover()
+    ]
+
+    # Add the exception forks
+    supported_forks.extend(EXCEPTION_MAPS.keys())
+
+    # Remove the unsupported forks
+    supported_forks = [
+        fork
+        for fork in supported_forks
+        if fork.casefold() not in UNSUPPORTED_FORKS
+    ]
+
+    return "\n".join(supported_forks)
 
 
 def get_stream_logger(name: str) -> Any:


### PR DESCRIPTION
### What was wrong?
The forks supported by the current evm tools was not documented in the description (`-h` command)

### How was it fixed?
Add the supported forks to help

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/ethereum/execution-specs/assets/48196632/7f5c4cd1-4473-4bc0-a59e-74075d6cfc74)
