### PR TITLE
t8n: write output body to sys.stdout if specified

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -404,17 +404,20 @@ class T8N(Load):
         json_state = self.alloc.to_json()
         json_result = self.result.to_json()
 
-        if self.options.output_body:
-            txs_rlp_path = os.path.join(
-                self.options.output_basedir,
-                self.options.output_body,
-            )
-            txs_rlp = "0x" + rlp.encode(self.txs.all_txs).hex()
-            with open(txs_rlp_path, "w") as f:
-                json.dump(txs_rlp, f)
-            self.logger.info(f"Wrote transaction rlp to {txs_rlp_path}")
-
         json_output = {}
+
+        if self.options.output_body:
+            txs_rlp = "0x" + rlp.encode(self.txs.all_txs).hex()
+            if self.options.output_body == "stdout":
+                json_output["body"] = txs_rlp
+            else:
+                txs_rlp_path = os.path.join(
+                    self.options.output_basedir,
+                    self.options.output_body,
+                )
+                with open(txs_rlp_path, "w") as f:
+                    json.dump(txs_rlp, f)
+                self.logger.info(f"Wrote transaction rlp to {txs_rlp_path}")
 
         if self.options.output_alloc == "stdout":
             json_output["alloc"] = json_state

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -406,18 +406,18 @@ class T8N(Load):
 
         json_output = {}
 
-        if self.options.output_body:
+        if self.options.output_body == "stdout":
             txs_rlp = "0x" + rlp.encode(self.txs.all_txs).hex()
-            if self.options.output_body == "stdout":
-                json_output["body"] = txs_rlp
-            else:
-                txs_rlp_path = os.path.join(
-                    self.options.output_basedir,
-                    self.options.output_body,
-                )
-                with open(txs_rlp_path, "w") as f:
-                    json.dump(txs_rlp, f)
-                self.logger.info(f"Wrote transaction rlp to {txs_rlp_path}")
+            json_output["body"] = txs_rlp
+        elif self.options.output_body is not None:
+            txs_rlp_path = os.path.join(
+                self.options.output_basedir,
+                self.options.output_body,
+            )
+            txs_rlp = "0x" + rlp.encode(self.txs.all_txs).hex()
+            with open(txs_rlp_path, "w") as f:
+                json.dump(txs_rlp, f)
+            self.logger.info(f"Wrote transaction rlp to {txs_rlp_path}")
 
         if self.options.output_alloc == "stdout":
             json_output["alloc"] = json_state


### PR DESCRIPTION
### What was wrong?

Specifying `--output.body=stdout` doesn't write the body to `sys.stdout`, but rather to a file called "stdout" in the directory specified by `--output.basedir`, or the current working directory, if unspecified. 

Both the Geth and Nimbus t8n tools support specifying "stdout" to `--output.body` in order to write the txs rlp to the system's stdout. The geth, nimbus and ethereum-spec-evm share a common interface implementation in ethereum/execution-spec-tests; this is a discrepancy in their behavior.

Related to Issue https://github.com/ethereum/execution-spec-tests/issues/268. 

### How was it fixed?

Write the txs rlp to `sys.stdout` if `--output.body=stdout` is specified, otherwise to the specified file. As previously, there is no output for the txs rlp if `--output.body` is omitted.

#### Cute Animal Picture

![image](https://github.com/ethereum/execution-specs/assets/91727015/150c92ef-a237-429d-87c3-2eb9dc9eb570)
