### PR TITLE
Rename `v` to `y_parity`

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -935,12 +935,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     sender : `ethereum.fork_types.Address`
         The address of the account that signed the transaction.
     """
-    v, r, s = tx.v, tx.r, tx.s
+    r, s = tx.r, tx.s
 
     ensure(0 < r and r < SECP256K1N, InvalidBlock)
     ensure(0 < s and s <= SECP256K1N // 2, InvalidBlock)
 
     if isinstance(tx, LegacyTransaction):
+        v = tx.v
         if v == 27 or v == 28:
             public_key = secp256k1_recover(
                 r, s, v - 27, signing_hash_pre155(tx)
@@ -953,9 +954,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 r, s, v - 35 - chain_id * 2, signing_hash_155(tx, chain_id)
             )
     elif isinstance(tx, AccessListTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_2930(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_2930(tx)
+        )
     elif isinstance(tx, FeeMarketTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_1559(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_1559(tx)
+        )
 
     return Address(keccak256(public_key)[12:32])
 

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -77,7 +77,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 
@@ -98,7 +98,7 @@ class FeeMarketTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -818,12 +818,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     sender : `ethereum.fork_types.Address`
         The address of the account that signed the transaction.
     """
-    v, r, s = tx.v, tx.r, tx.s
+    r, s = tx.r, tx.s
 
     ensure(0 < r and r < SECP256K1N, InvalidBlock)
     ensure(0 < s and s <= SECP256K1N // 2, InvalidBlock)
 
     if isinstance(tx, LegacyTransaction):
+        v = tx.v
         if v == 27 or v == 28:
             public_key = secp256k1_recover(
                 r, s, v - 27, signing_hash_pre155(tx)
@@ -836,7 +837,9 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 r, s, v - 35 - chain_id * 2, signing_hash_155(tx, chain_id)
             )
     elif isinstance(tx, AccessListTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_2930(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_2930(tx)
+        )
 
     return Address(keccak256(public_key)[12:32])
 

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -78,7 +78,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -935,12 +935,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     sender : `ethereum.fork_types.Address`
         The address of the account that signed the transaction.
     """
-    v, r, s = tx.v, tx.r, tx.s
+    r, s = tx.r, tx.s
 
     ensure(0 < r and r < SECP256K1N, InvalidBlock)
     ensure(0 < s and s <= SECP256K1N // 2, InvalidBlock)
 
     if isinstance(tx, LegacyTransaction):
+        v = tx.v
         if v == 27 or v == 28:
             public_key = secp256k1_recover(
                 r, s, v - 27, signing_hash_pre155(tx)
@@ -953,9 +954,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 r, s, v - 35 - chain_id * 2, signing_hash_155(tx, chain_id)
             )
     elif isinstance(tx, AccessListTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_2930(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_2930(tx)
+        )
     elif isinstance(tx, FeeMarketTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_1559(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_1559(tx)
+        )
 
     return Address(keccak256(public_key)[12:32])
 

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -77,7 +77,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 
@@ -98,7 +98,7 @@ class FeeMarketTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -943,12 +943,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     sender : `ethereum.fork_types.Address`
         The address of the account that signed the transaction.
     """
-    v, r, s = tx.v, tx.r, tx.s
+    r, s = tx.r, tx.s
 
     ensure(0 < r and r < SECP256K1N, InvalidBlock)
     ensure(0 < s and s <= SECP256K1N // 2, InvalidBlock)
 
     if isinstance(tx, LegacyTransaction):
+        v = tx.v
         if v == 27 or v == 28:
             public_key = secp256k1_recover(
                 r, s, v - 27, signing_hash_pre155(tx)
@@ -961,9 +962,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 r, s, v - 35 - chain_id * 2, signing_hash_155(tx, chain_id)
             )
     elif isinstance(tx, AccessListTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_2930(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_2930(tx)
+        )
     elif isinstance(tx, FeeMarketTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_1559(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_1559(tx)
+        )
 
     return Address(keccak256(public_key)[12:32])
 

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -77,7 +77,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 
@@ -98,7 +98,7 @@ class FeeMarketTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -723,12 +723,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
     sender : `ethereum.fork_types.Address`
         The address of the account that signed the transaction.
     """
-    v, r, s = tx.v, tx.r, tx.s
+    r, s = tx.r, tx.s
 
     ensure(0 < r and r < SECP256K1N, InvalidBlock)
     ensure(0 < s and s <= SECP256K1N // 2, InvalidBlock)
 
     if isinstance(tx, LegacyTransaction):
+        v = tx.v
         if v == 27 or v == 28:
             public_key = secp256k1_recover(
                 r, s, v - 27, signing_hash_pre155(tx)
@@ -741,9 +742,13 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 r, s, v - 35 - chain_id * 2, signing_hash_155(tx, chain_id)
             )
     elif isinstance(tx, AccessListTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_2930(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_2930(tx)
+        )
     elif isinstance(tx, FeeMarketTransaction):
-        public_key = secp256k1_recover(r, s, v, signing_hash_1559(tx))
+        public_key = secp256k1_recover(
+            r, s, tx.y_parity, signing_hash_1559(tx)
+        )
 
     return Address(keccak256(public_key)[12:32])
 

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -77,7 +77,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 
@@ -98,7 +98,7 @@ class FeeMarketTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -77,7 +77,7 @@ class AccessListTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 
@@ -98,7 +98,7 @@ class FeeMarketTransaction:
     value: U256
     data: Bytes
     access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    v: U256
+    y_parity: U256
     r: U256
     s: U256
 

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -284,7 +284,7 @@ class Load(BaseLoad):
             else self.hex_to_address(raw.get("to")),
             hex_to_u256(raw.get("value")),
             hex_to_bytes(raw.get("data")),
-            hex_to_u256(raw.get("v")),
+            hex_to_u256(raw.get("y_parity") if "y_parity" in raw else raw.get("v")),
             hex_to_u256(raw.get("r")),
             hex_to_u256(raw.get("s")),
         ]

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -284,7 +284,9 @@ class Load(BaseLoad):
             else self.hex_to_address(raw.get("to")),
             hex_to_u256(raw.get("value")),
             hex_to_bytes(raw.get("data")),
-            hex_to_u256(raw.get("y_parity") if "y_parity" in raw else raw.get("v")),
+            hex_to_u256(
+                raw.get("y_parity") if "y_parity" in raw else raw.get("v")
+            ),
             hex_to_u256(raw.get("r")),
             hex_to_u256(raw.get("s")),
         ]

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -178,7 +178,7 @@ class Txs:
 
         # tf tool might provide None instead of 0
         # for v, r, s
-        raw_tx["v"] = raw_tx.get("v") or "0x00"
+        raw_tx["v"] = raw_tx.get("v") or "0x00" or raw_tx.get("y_parity")
         raw_tx["r"] = raw_tx.get("r") or "0x00"
         raw_tx["s"] = raw_tx.get("s") or "0x00"
 
@@ -276,6 +276,9 @@ class Txs:
         json_tx["r"] = hex(r)
         json_tx["s"] = hex(s)
         json_tx["v"] = hex(y + v_addend)
+
+        if v_addend == 0:
+            json_tx["y_parity"] = json_tx["v"]
 
 
 @dataclass

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -178,7 +178,7 @@ class Txs:
 
         # tf tool might provide None instead of 0
         # for v, r, s
-        raw_tx["v"] = raw_tx.get("v") or "0x00" or raw_tx.get("y_parity")
+        raw_tx["v"] = raw_tx.get("v") or raw_tx.get("y_parity") or "0x00"
         raw_tx["r"] = raw_tx.get("r") or "0x00"
         raw_tx["s"] = raw_tx.get("s") or "0x00"
 


### PR DESCRIPTION
### What was wrong?

Fixes #814 

### How was it fixed?

`v` has now been renamed to `y_parity` in the appropriate places. For compatibility reasons, we accept either `v` or `y_parity` in JSON and emit both.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/3xft90qk8yjb1.jpg?width=640&crop=smart&auto=webp&s=a21a8f3a9ce95bc54cb9fbe1b0b928409d229012)
