### PR TITLE
chore: bump required minimum version of coincurve

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ package_dir =
 python_requires = >=3.8
 install_requires =
     pycryptodome>=3,<4
-    coincurve>=17,<18
+    coincurve>=18,<19
     typing_extensions>=4
 
 [options.package_data]


### PR DESCRIPTION
### What was wrong?

[ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) installs the `ethereum` package provided by `execution-specs` as a dependency. Both `execution-spec-tests` and `execution-specs` require [coincurve](https://github.com/ofek/coincurve) and currently require `>=17,<18`.

We'd like to upgrade the required minimum major version of coincurve from 17 to [18](https://github.com/ofek/coincurve/releases/tag/v18.0.0) in order to get full Python 3.11 support (https://github.com/ethereum/execution-spec-tests/pull/280). This simplifies installation of `execution-test-specs` on macOS cf https://github.com/ethereum/execution-spec-tests/issues/274. 

Before we can do that, we need `execution-specs` to upgrade first :-)

### How was it fixed?

![image](https://github.com/ethereum/execution-specs/assets/91727015/4f97e659-172f-4257-bb97-dedc59c2ca09)

#### Cute Animal Picture

![image](https://github.com/ethereum/execution-specs/assets/91727015/b54e689d-7faa-4231-a678-1fdd630c5f4c)
"Psst, plz upgrade to coincurve 18!"
