### PR TITLE
Fix type bug

### DIFF
--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -733,6 +733,7 @@ class Sync(ForkTracking):
         if self.options.reset:
             import rust_pyspec_glue
 
+            assert self.options.persist is not None
             rust_pyspec_glue.DB.delete(self.options.persist)
 
         if self.options.initial_state is not None:


### PR DESCRIPTION
### What was wrong?

The addition of type checking to `rust-pyspec-glue` revealed a missing type assertion.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/p6w4bayvqfqb1.jpg)
