### PR TITLE
setup.cfg: Force astroid version to 2.15.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -153,6 +153,7 @@ doc =
     rstdiff>=0.5.1,<0.6
     picklebuilder>=0.2.0,<0.3
     sphinx-rtd-theme>=1.0.0,<2.0
+    astroid==2.15.7
 
 doc-autobuild =
     sphinx-autobuild==2021.3.14


### PR DESCRIPTION
### What was wrong?
Running `tox -e doc` was failing as the astroid version is now automatically bumped up to 3.0.0.

This is the error:
```
Running Sphinx v4.0.2
making output directory... done

Extension error (autoapi.extension):
Handler <function run_autoapi at 0x7f9658043f70> for event 'builder-inited' threw an exception (exception: 'Module' object has no attribute 'doc')
[AutoAPI] Reading files... [  0%] /home/runner/work/execution-specs/execution-specs/src/ethereum/ethash.py
doc: exit 2 (2.32 seconds) /home/runner/work/execution-specs/execution-specs> sphinx-build -j auto -t stage0 -d /home/runner/work/execution-specs/execution-specs/.tox/docs/stage0_doctree doc /home/runner/work/execution-specs/execution-specs/.tox/docs/stage0_out --color -W -brpickle pid=1866
.pkg: _exit> python /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  doc: FAIL code 2 (24.99=setup[22.67]+cmd[2.32] seconds)
  evaluation failed :( (25.43 seconds)
Error: Process completed with exit code 2.
```

More error logs can be found in the last GitHub Pages run -> https://github.com/ethereum/execution-specs/actions/runs/6324911221/job/17175336696


### How was it fixed?
Forcing `astroid==2.15.7` wtihin `setup.cfg` resolves the issue.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images-cdn.9gag.com/photo/aerGGpQ_700b.jpg)
