### PR TITLE
Add other evm trace options

### DIFF
--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -97,7 +97,13 @@ TraceEvent = Union[
 ]
 
 
-def evm_trace(evm: object, event: TraceEvent) -> None:
+def evm_trace(
+    evm: object,
+    event: TraceEvent,
+    trace_memory: bool = False,
+    trace_stack: bool = True,
+    trace_return_data: bool = False,
+) -> None:
     """
     Create a trace of the event.
     """

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -4,14 +4,7 @@ The module implements the raw EVM tracer for t8n.
 import json
 import os
 from dataclasses import dataclass, fields
-from typing import (
-    List,
-    Optional,
-    Protocol,
-    TextIO,
-    Union,
-    runtime_checkable,
-)
+from typing import List, Optional, Protocol, TextIO, Union, runtime_checkable
 
 from ethereum.base_types import U256, Bytes, Uint
 from ethereum.trace import (

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -4,7 +4,14 @@ The module implements the raw EVM tracer for t8n.
 import json
 import os
 from dataclasses import dataclass, fields
-from typing import List, Optional, Protocol, TextIO, Union, runtime_checkable
+from typing import (
+    List,
+    Optional,
+    Protocol,
+    TextIO,
+    Union,
+    runtime_checkable,
+)
 
 from ethereum.base_types import U256, Bytes, Uint
 from ethereum.trace import (
@@ -33,8 +40,10 @@ class Trace:
     op: str
     gas: str
     gasCost: str
+    memory: Optional[str]
     memSize: int
-    stack: List[str]
+    stack: Optional[List[str]]
+    returnData: Optional[str]
     depth: int
     refund: int
     opName: str
@@ -95,20 +104,44 @@ class Evm(Protocol):
     refund_counter: int
     running: bool
     message: Message
+    return_data: Bytes
 
 
-def evm_trace(evm: object, event: TraceEvent) -> None:
+def evm_trace(
+    evm: object,
+    event: TraceEvent,
+    trace_memory: bool = False,
+    trace_stack: bool = True,
+    trace_return_data: bool = False,
+) -> None:
     """
     Create a trace of the event.
     """
     assert isinstance(evm, Evm)
-    last_trace: Optional[Union[Trace, FinalTrace]]
+
+    last_trace = None
+    if evm.env.traces:
+        last_trace = evm.env.traces[-1]
 
     refund_counter = evm.refund_counter
     parent_evm = evm.message.parent_evm
     while parent_evm is not None:
         refund_counter += parent_evm.refund_counter
         parent_evm = parent_evm.message.parent_evm
+
+    len_memory = len(evm.memory)
+
+    return_data = None
+    if trace_return_data and evm.return_data:
+        return_data = "0x" + evm.return_data.hex()
+
+    memory = None
+    if trace_memory and len_memory > 0:
+        memory = "0x" + evm.memory.hex()
+
+    stack = None
+    if trace_stack:
+        stack = [hex(i) for i in evm.stack]
 
     if isinstance(event, TransactionStart):
         pass
@@ -121,8 +154,10 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
             op="0x" + event.address.hex().lstrip("0"),
             gas=hex(evm.gas_left),
             gasCost="0x0",
-            memSize=len(evm.memory),
-            stack=[hex(i) for i in evm.stack],
+            memory=memory,
+            memSize=len_memory,
+            stack=stack,
+            returnData=return_data,
             depth=evm.message.depth + 1,
             refund=refund_counter,
             opName="0x" + event.address.hex().lstrip("0"),
@@ -131,7 +166,6 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
 
         evm.env.traces.append(new_trace)
     elif isinstance(event, PrecompileEnd):
-        last_trace = evm.env.traces[-1]
         assert isinstance(last_trace, Trace)
 
         last_trace.gasCostTraced = True
@@ -142,8 +176,10 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
             op=event.op.value,
             gas=hex(evm.gas_left),
             gasCost="0x0",
-            memSize=len(evm.memory),
-            stack=[hex(i) for i in evm.stack],
+            memory=memory,
+            memSize=len_memory,
+            stack=stack,
+            returnData=return_data,
             depth=evm.message.depth + 1,
             refund=refund_counter,
             opName=str(event.op).split(".")[-1],
@@ -151,15 +187,11 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
 
         evm.env.traces.append(new_trace)
     elif isinstance(event, OpEnd):
-        last_trace = evm.env.traces[-1]
         assert isinstance(last_trace, Trace)
 
         last_trace.gasCostTraced = True
         last_trace.errorTraced = True
     elif isinstance(event, OpException):
-        last_trace = None
-        if evm.env.traces:
-            last_trace = evm.env.traces[-1]
         if last_trace is not None:
             assert isinstance(last_trace, Trace)
         if (
@@ -180,8 +212,10 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
                 op="InvalidOpcode",
                 gas=hex(evm.gas_left),
                 gasCost="0x0",
-                memSize=len(evm.memory),
-                stack=[hex(i) for i in evm.stack],
+                memory=memory,
+                memSize=len_memory,
+                stack=stack,
+                returnData=return_data,
                 depth=evm.message.depth + 1,
                 refund=refund_counter,
                 opName="InvalidOpcode",
@@ -202,13 +236,18 @@ def evm_trace(evm: object, event: TraceEvent) -> None:
         elif len(evm.code) == 0:
             return
         else:
-            evm_trace(evm, OpStart(event.op))
+            evm_trace(
+                evm,
+                OpStart(event.op),
+                trace_memory,
+                trace_stack,
+                trace_return_data,
+            )
     elif isinstance(event, GasAndRefund):
         if not evm.env.traces:
             # In contract creation transactions, there may not be any traces
             return
 
-        last_trace = evm.env.traces[-1]
         assert isinstance(last_trace, Trace)
 
         if not last_trace.gasCostTraced:


### PR DESCRIPTION
(closes #835 )

### What was wrong?
Not all the evm trace options were currently supported.

Related to Issue #835 

### How was it fixed?
Added support for the various trace flags.

#### Cute Animal Picture

![Swan](https://github.com/ethereum/execution-specs/assets/48196632/cebd34cb-b3b9-4c20-9a96-30bc14d63683)

