### PR TITLE
add error messages to traces

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -442,7 +442,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -453,8 +453,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -467,7 +467,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -579,11 +579,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -732,7 +732,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -838,7 +838,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -87,7 +87,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/arrow_glacier/vm/exceptions.py
+++ b/src/ethereum/arrow_glacier/vm/exceptions.py
@@ -118,3 +118,11 @@ class InvalidContractPrefix(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -118,7 +118,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -288,7 +288,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -129,9 +129,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -187,10 +185,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
                 ensure(contract_code[0] != 0xEF, InvalidContractPrefix)
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -299,13 +298,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -72,7 +73,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -80,7 +81,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -109,7 +110,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -118,7 +119,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -138,7 +139,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -177,7 +178,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -190,7 +191,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -229,7 +229,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -272,7 +272,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
         accessed_addresses=message.accessed_addresses,
@@ -303,9 +302,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -347,7 +347,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -358,8 +358,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -372,7 +372,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -476,11 +476,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -629,7 +629,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -721,7 +721,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -86,7 +86,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/berlin/vm/exceptions.py
+++ b/src/ethereum/berlin/vm/exceptions.py
@@ -110,3 +110,11 @@ class InvalidParameter(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -119,7 +119,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -289,7 +289,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -71,7 +72,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -79,7 +80,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -108,7 +109,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -117,7 +118,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -137,7 +138,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -176,7 +177,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -187,7 +188,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -226,7 +226,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -269,7 +269,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
         accessed_addresses=message.accessed_addresses,
@@ -300,9 +299,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -128,9 +128,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -184,10 +182,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         try:
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -296,13 +295,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -83,7 +83,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
 

--- a/src/ethereum/byzantium/vm/exceptions.py
+++ b/src/ethereum/byzantium/vm/exceptions.py
@@ -102,3 +102,11 @@ class OutOfBoundsRead(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -123,7 +123,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             evm.return_data = child_evm.output
             push(evm.stack, U256(0))
@@ -216,7 +216,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -127,9 +127,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = evm.refund_counter
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -177,10 +175,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         try:
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -287,13 +286,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -45,6 +45,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -70,7 +71,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -78,7 +79,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -107,7 +108,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -116,7 +117,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -136,7 +137,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -169,7 +170,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -180,7 +181,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -219,7 +219,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -262,7 +262,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
     )
@@ -291,9 +290,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -83,7 +83,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
 

--- a/src/ethereum/constantinople/vm/exceptions.py
+++ b/src/ethereum/constantinople/vm/exceptions.py
@@ -102,3 +102,11 @@ class OutOfBoundsRead(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -114,7 +114,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -282,7 +282,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -127,9 +127,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = evm.refund_counter
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -178,10 +176,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         try:
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -288,13 +287,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -45,6 +45,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -70,7 +71,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -78,7 +79,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -107,7 +108,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -116,7 +117,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -136,7 +137,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -170,7 +171,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -181,7 +182,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -220,7 +220,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -263,7 +263,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
     )
@@ -292,9 +291,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -81,6 +81,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     has_erred: bool
+    error: Optional[Exception]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -80,7 +80,6 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    has_erred: bool
     error: Optional[Exception]
 
 

--- a/src/ethereum/dao_fork/vm/exceptions.py
+++ b/src/ethereum/dao_fork/vm/exceptions.py
@@ -73,3 +73,11 @@ class StackDepthLimitError(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -110,7 +110,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             push(evm.stack, U256(0))
         else:
@@ -197,7 +197,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -108,9 +108,7 @@ def process_message_call(
         accounts_to_delete = evm.accounts_to_delete
         refund_counter = evm.refund_counter
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -147,9 +145,10 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
             charge_gas(evm, contract_code_gas)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -232,6 +231,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         has_erred=False,
+        error=None,
     )
     try:
 
@@ -253,8 +253,9 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -79,7 +79,6 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    has_erred: bool
     error: Optional[Exception]
 
 

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -80,6 +80,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     has_erred: bool
+    error: Optional[Exception]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/frontier/vm/exceptions.py
+++ b/src/ethereum/frontier/vm/exceptions.py
@@ -73,3 +73,11 @@ class StackDepthLimitError(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -108,7 +108,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             push(evm.stack, U256(0))
         else:
@@ -193,7 +193,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -41,7 +41,12 @@ from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
-from .exceptions import ExceptionalHalt, InvalidOpcode, StackDepthLimitError
+from .exceptions import (
+    AddressCollision,
+    ExceptionalHalt,
+    InvalidOpcode,
+    StackDepthLimitError,
+)
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_jump_destinations
 
@@ -59,14 +64,14 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `has_erred`: True if execution has caused an error.
+          5. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -94,13 +99,15 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(
+                Uint(0), U256(0), tuple(), set(), AddressCollision()
+            )
         else:
             evm = process_create_message(message, env)
     else:
         evm = process_message(message, env)
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         refund_counter = U256(0)
@@ -117,7 +124,7 @@ def process_message_call(
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -148,14 +155,13 @@ def process_create_message(message: Message, env: Environment) -> Evm:
     destroy_storage(env.state, message.current_target)
 
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
             charge_gas(evm, contract_code_gas)
-        except ExceptionalHalt as error:
+        except ExceptionalHalt:
             evm.output = b""
-            evm.error = error
         else:
             set_code(env.state, message.current_target, contract_code)
         commit_transaction(env.state)
@@ -194,7 +200,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -236,7 +242,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         message=message,
         output=b"",
         accounts_to_delete=set(),
-        has_erred=False,
         error=None,
     )
     try:
@@ -263,5 +268,4 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -442,7 +442,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -453,8 +453,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -467,7 +467,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -579,11 +579,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -732,7 +732,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -838,7 +838,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -87,7 +87,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/gray_glacier/vm/exceptions.py
+++ b/src/ethereum/gray_glacier/vm/exceptions.py
@@ -118,3 +118,11 @@ class InvalidContractPrefix(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -118,7 +118,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -288,7 +288,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -129,9 +129,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -187,10 +185,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
                 ensure(contract_code[0] != 0xEF, InvalidContractPrefix)
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -299,13 +298,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -72,7 +73,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -80,7 +81,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -109,7 +110,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -118,7 +119,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -138,7 +139,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -177,7 +178,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -190,7 +191,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -229,7 +229,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -272,7 +272,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
         accessed_addresses=message.accessed_addresses,
@@ -303,9 +302,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -81,6 +81,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     has_erred: bool
+    error: Optional[Exception]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -80,7 +80,6 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    has_erred: bool
     error: Optional[Exception]
 
 

--- a/src/ethereum/homestead/vm/exceptions.py
+++ b/src/ethereum/homestead/vm/exceptions.py
@@ -73,3 +73,11 @@ class StackDepthLimitError(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -110,7 +110,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             push(evm.stack, U256(0))
         else:
@@ -197,7 +197,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -41,7 +41,12 @@ from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
-from .exceptions import ExceptionalHalt, InvalidOpcode, StackDepthLimitError
+from .exceptions import (
+    AddressCollision,
+    ExceptionalHalt,
+    InvalidOpcode,
+    StackDepthLimitError,
+)
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_jump_destinations
 
@@ -59,14 +64,14 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `has_erred`: True if execution has caused an error.
+          5. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -94,13 +99,15 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(
+                Uint(0), U256(0), tuple(), set(), AddressCollision()
+            )
         else:
             evm = process_create_message(message, env)
     else:
         evm = process_message(message, env)
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         refund_counter = U256(0)
@@ -117,7 +124,7 @@ def process_message_call(
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -148,7 +155,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
     destroy_storage(env.state, message.current_target)
 
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -157,7 +164,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -196,7 +202,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -238,7 +244,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         message=message,
         output=b"",
         accounts_to_delete=set(),
-        has_erred=False,
         error=None,
     )
     try:
@@ -265,5 +270,4 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -341,7 +341,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -352,8 +352,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -366,7 +366,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -465,11 +465,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -618,7 +618,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -700,7 +700,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -84,7 +84,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
 

--- a/src/ethereum/istanbul/vm/exceptions.py
+++ b/src/ethereum/istanbul/vm/exceptions.py
@@ -110,3 +110,11 @@ class InvalidParameter(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -114,7 +114,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -282,7 +282,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -71,7 +72,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -79,7 +80,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -108,7 +109,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -117,7 +118,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -140,7 +141,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -179,7 +180,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -190,7 +191,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -229,7 +229,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -272,7 +272,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
     )
@@ -301,9 +300,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -450,7 +450,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -461,8 +461,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -475,7 +475,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -587,11 +587,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -740,7 +740,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -846,7 +846,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -87,7 +87,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/london/vm/exceptions.py
+++ b/src/ethereum/london/vm/exceptions.py
@@ -118,3 +118,11 @@ class InvalidContractPrefix(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -118,7 +118,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -288,7 +288,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -129,9 +129,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -187,10 +185,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
                 ensure(contract_code[0] != 0xEF, InvalidContractPrefix)
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -299,13 +298,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -72,7 +73,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -80,7 +81,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -109,7 +110,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -118,7 +119,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -138,7 +139,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -177,7 +178,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -190,7 +191,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -229,7 +229,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -272,7 +272,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
         accessed_addresses=message.accessed_addresses,
@@ -303,9 +302,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -341,7 +341,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -352,8 +352,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -366,7 +366,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -465,11 +465,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -618,7 +618,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -700,7 +700,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -84,7 +84,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
 

--- a/src/ethereum/muir_glacier/vm/exceptions.py
+++ b/src/ethereum/muir_glacier/vm/exceptions.py
@@ -110,3 +110,11 @@ class InvalidParameter(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -114,7 +114,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -282,7 +282,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -46,6 +46,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -71,7 +72,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -79,7 +80,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -108,7 +109,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -117,7 +118,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -137,7 +138,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -176,7 +177,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -187,7 +188,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -226,7 +226,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -269,7 +269,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         return_data=b"",
         error=None,
     )
@@ -298,9 +297,7 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
-        evm.has_erred = True
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -128,9 +128,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -184,10 +182,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
         try:
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -294,13 +293,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -354,7 +354,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -365,8 +365,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        The error from the execution if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -379,7 +379,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -490,11 +490,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -520,7 +520,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -626,7 +626,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -87,7 +87,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/paris/vm/exceptions.py
+++ b/src/ethereum/paris/vm/exceptions.py
@@ -118,3 +118,11 @@ class InvalidContractPrefix(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -118,7 +118,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -288,7 +288,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -129,9 +129,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -187,10 +185,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
                 ensure(contract_code[0] != 0xEF, InvalidContractPrefix)
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -299,13 +298,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -360,7 +360,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    has_erred: bool,
+    error: Optional[Exception],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -371,8 +371,8 @@ def make_receipt(
     ----------
     tx :
         The executed transaction.
-    has_erred :
-        Whether the top level frame of the transaction exited with an error.
+    error :
+        Error in the top level frame of the transaction, if any.
     cumulative_gas_used :
         The total gas used so far in the block after the transaction was
         executed.
@@ -385,7 +385,7 @@ def make_receipt(
         The receipt for the transaction.
     """
     receipt = Receipt(
-        succeeded=not has_erred,
+        succeeded=error is None,
         cumulative_gas_used=cumulative_gas_used,
         bloom=logs_bloom(logs),
         logs=logs,
@@ -502,11 +502,11 @@ def apply_body(
             traces=[],
         )
 
-        gas_used, logs, has_erred = process_transaction(env, tx)
+        gas_used, logs, error = process_transaction(env, tx)
         gas_available -= gas_used
 
         receipt = make_receipt(
-            tx, has_erred, (block_gas_limit - gas_available), logs
+            tx, error, (block_gas_limit - gas_available), logs
         )
 
         trie_set(
@@ -541,7 +541,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], bool]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
     """
     Execute a transaction against the provided environment.
 
@@ -648,7 +648,7 @@ def process_transaction(
         if account_exists_and_is_empty(env.state, address):
             destroy_account(env.state, address)
 
-    return total_gas_used, output.logs, output.has_erred
+    return total_gas_used, output.logs, output.error
 
 
 def validate_transaction(tx: Transaction) -> bool:

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -87,7 +87,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     return_data: Bytes
     error: Optional[Exception]
     accessed_addresses: Set[Address]

--- a/src/ethereum/shanghai/vm/exceptions.py
+++ b/src/ethereum/shanghai/vm/exceptions.py
@@ -118,3 +118,11 @@ class InvalidContractPrefix(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -126,7 +126,7 @@ def generic_create(
     )
     child_evm = process_create_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
@@ -311,7 +311,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -129,9 +129,7 @@ def process_message_call(
         touched_accounts = evm.touched_accounts
         refund_counter = U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(
-        message.gas - evm.gas_left, evm.output, evm.has_erred
-    )
+    tx_end = TransactionEnd(message.gas - evm.gas_left, evm.output, evm.error)
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -187,10 +185,11 @@ def process_create_message(message: Message, env: Environment) -> Evm:
                 ensure(contract_code[0] != 0xEF, InvalidContractPrefix)
             charge_gas(evm, contract_code_gas)
             ensure(len(contract_code) <= MAX_CODE_SIZE, OutOfGasError)
-        except ExceptionalHalt:
+        except ExceptionalHalt as error:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.output = b""
+            evm.error = error
             evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
@@ -299,13 +298,14 @@ def execute_code(message: Message, env: Environment) -> Evm:
 
         evm_trace(evm, EvmStop(Ops.STOP))
 
-    except ExceptionalHalt:
-        evm_trace(evm, OpException())
+    except ExceptionalHalt as error:
+        evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
+        evm.error = error
         evm.has_erred = True
-    except Revert as e:
-        evm_trace(evm, OpException())
-        evm.error = e
+    except Revert as error:
+        evm_trace(evm, OpException(error))
+        evm.error = error
         evm.has_erred = True
     return evm

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -83,6 +83,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     has_erred: bool
+    error: Optional[Exception]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -82,7 +82,6 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    has_erred: bool
     error: Optional[Exception]
 
 

--- a/src/ethereum/spurious_dragon/vm/exceptions.py
+++ b/src/ethereum/spurious_dragon/vm/exceptions.py
@@ -73,3 +73,11 @@ class StackDepthLimitError(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -117,7 +117,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             push(evm.stack, U256(0))
         else:
@@ -204,7 +204,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -45,6 +45,7 @@ from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
+    AddressCollision,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -69,7 +70,7 @@ class MessageCallOutput:
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
           5. `touched_accounts`: Accounts that have been touched.
-          6. `has_erred`: True if execution has caused an error.
+          6. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
@@ -77,7 +78,7 @@ class MessageCallOutput:
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -106,7 +107,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), True
+                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -115,7 +116,7 @@ def process_message_call(
         if account_exists_and_is_empty(env.state, Address(message.target)):
             evm.touched_accounts.add(Address(message.target))
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
@@ -135,7 +136,7 @@ def process_message_call(
         logs=logs,
         accounts_to_delete=accounts_to_delete,
         touched_accounts=touched_accounts,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -168,7 +169,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
 
     increment_nonce(env.state, message.current_target)
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -178,7 +179,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -217,7 +217,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -260,7 +260,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         output=b"",
         accounts_to_delete=set(),
         touched_accounts=set(),
-        has_erred=False,
         error=None,
     )
     try:
@@ -287,5 +286,4 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -81,6 +81,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     has_erred: bool
+    error: Optional[Exception]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -80,7 +80,6 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    has_erred: bool
     error: Optional[Exception]
 
 

--- a/src/ethereum/tangerine_whistle/vm/exceptions.py
+++ b/src/ethereum/tangerine_whistle/vm/exceptions.py
@@ -73,3 +73,11 @@ class StackDepthLimitError(ExceptionalHalt):
     """
 
     pass
+
+
+class AddressCollision(ExceptionalHalt):
+    """
+    Raised when the new contract address has a collision.
+    """
+
+    pass

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -116,7 +116,7 @@ def create(evm: Evm) -> None:
         )
         child_evm = process_create_message(child_message, evm.env)
 
-        if child_evm.has_erred:
+        if child_evm.error:
             incorporate_child_on_error(evm, child_evm)
             push(evm.stack, U256(0))
         else:
@@ -203,7 +203,7 @@ def generic_call(
     )
     child_evm = process_message(child_message, evm.env)
 
-    if child_evm.has_erred:
+    if child_evm.error:
         incorporate_child_on_error(evm, child_evm)
         push(evm.stack, U256(0))
     else:

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -12,7 +12,7 @@ Introduction
 A straightforward interpreter that executes EVM code.
 """
 from dataclasses import dataclass
-from typing import Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes0, Uint
 from ethereum.trace import (
@@ -41,7 +41,12 @@ from ..vm import Message
 from ..vm.gas import GAS_CODE_DEPOSIT, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
-from .exceptions import ExceptionalHalt, InvalidOpcode, StackDepthLimitError
+from .exceptions import (
+    AddressCollision,
+    ExceptionalHalt,
+    InvalidOpcode,
+    StackDepthLimitError,
+)
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_jump_destinations
 
@@ -59,14 +64,14 @@ class MessageCallOutput:
           2. `refund_counter`: gas to refund after execution.
           3. `logs`: list of `Log` generated during execution.
           4. `accounts_to_delete`: Contracts which have self-destructed.
-          5. `has_erred`: True if execution has caused an error.
+          5. `error`: The error from the execution if any.
     """
 
     gas_left: Uint
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    has_erred: bool
+    error: Optional[Exception]
 
 
 def process_message_call(
@@ -94,13 +99,15 @@ def process_message_call(
             env.state, message.current_target
         )
         if is_collision:
-            return MessageCallOutput(Uint(0), U256(0), tuple(), set(), True)
+            return MessageCallOutput(
+                Uint(0), U256(0), tuple(), set(), AddressCollision()
+            )
         else:
             evm = process_create_message(message, env)
     else:
         evm = process_message(message, env)
 
-    if evm.has_erred:
+    if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         refund_counter = U256(0)
@@ -117,7 +124,7 @@ def process_message_call(
         refund_counter=refund_counter,
         logs=logs,
         accounts_to_delete=accounts_to_delete,
-        has_erred=evm.has_erred,
+        error=evm.error,
     )
 
 
@@ -148,7 +155,7 @@ def process_create_message(message: Message, env: Environment) -> Evm:
     destroy_storage(env.state, message.current_target)
 
     evm = process_message(message, env)
-    if not evm.has_erred:
+    if not evm.error:
         contract_code = evm.output
         contract_code_gas = len(contract_code) * GAS_CODE_DEPOSIT
         try:
@@ -157,7 +164,6 @@ def process_create_message(message: Message, env: Environment) -> Evm:
             rollback_transaction(env.state)
             evm.gas_left = Uint(0)
             evm.error = error
-            evm.has_erred = True
         else:
             set_code(env.state, message.current_target, contract_code)
             commit_transaction(env.state)
@@ -196,7 +202,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         )
 
     evm = execute_code(message, env)
-    if evm.has_erred:
+    if evm.error:
         # revert state to the last saved checkpoint
         # since the message call resulted in an error
         rollback_transaction(env.state)
@@ -238,7 +244,6 @@ def execute_code(message: Message, env: Environment) -> Evm:
         message=message,
         output=b"",
         accounts_to_delete=set(),
-        has_erred=False,
         error=None,
     )
     try:
@@ -265,5 +270,4 @@ def execute_code(message: Message, env: Environment) -> Evm:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
-        evm.has_erred = True
     return evm

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -16,7 +16,7 @@ Defines the functions required for creating evm traces during execution.
 
 import enum
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 
 @dataclass
@@ -32,7 +32,7 @@ class TransactionEnd:
 
     gas_used: int
     output: bytes
-    has_erred: bool
+    error: Optional[Exception]
 
 
 @dataclass
@@ -67,7 +67,7 @@ class OpEnd:
 class OpException:
     """Trace event that is triggered when an opcode raises an exception."""
 
-    pass
+    error: Exception
 
 
 @dataclass

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -147,11 +147,7 @@ def evm_trace(
     len_memory = len(evm.memory)
 
     return_data = None
-    if (
-        isinstance(evm, EvmWithReturnData)
-        and trace_return_data
-        and evm.return_data
-    ):
+    if isinstance(evm, EvmWithReturnData) and trace_return_data:
         return_data = "0x" + evm.return_data.hex()
 
     memory = None

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -56,11 +56,13 @@ class FinalTrace:
     gasUsed: str
     error: Optional[str] = None
 
-    def __init__(self, gas_used: int, output: bytes, has_erred: bool) -> None:
+    def __init__(
+        self, gas_used: int, output: bytes, error: Optional[Exception]
+    ) -> None:
         self.output = output.hex()
         self.gasUsed = hex(gas_used)
-        if has_erred:
-            self.error = ""
+        if error:
+            self.error = type(error).__name__
 
 
 @runtime_checkable
@@ -83,9 +85,26 @@ class Message(Protocol):
 
 
 @runtime_checkable
-class Evm(Protocol):
+class EvmWithoutReturnData(Protocol):
     """
-    The class implements the EVM interface for trace.
+    The class implements the EVM interface for pre-byzantium forks trace.
+    """
+
+    pc: Uint
+    stack: List[U256]
+    memory: bytearray
+    code: Bytes
+    gas_left: Uint
+    env: Environment
+    refund_counter: int
+    running: bool
+    message: Message
+
+
+@runtime_checkable
+class EvmWithReturnData(Protocol):
+    """
+    The class implements the EVM interface for post-byzantium forks trace.
     """
 
     pc: Uint
@@ -100,6 +119,9 @@ class Evm(Protocol):
     return_data: Bytes
 
 
+Evm = Union[EvmWithoutReturnData, EvmWithReturnData]
+
+
 def evm_trace(
     evm: object,
     event: TraceEvent,
@@ -110,7 +132,7 @@ def evm_trace(
     """
     Create a trace of the event.
     """
-    assert isinstance(evm, Evm)
+    assert isinstance(evm, (EvmWithoutReturnData, EvmWithReturnData))
 
     last_trace = None
     if evm.env.traces:
@@ -125,7 +147,11 @@ def evm_trace(
     len_memory = len(evm.memory)
 
     return_data = None
-    if trace_return_data and evm.return_data:
+    if (
+        isinstance(evm, EvmWithReturnData)
+        and trace_return_data
+        and evm.return_data
+    ):
         return_data = "0x" + evm.return_data.hex()
 
     memory = None
@@ -139,7 +165,7 @@ def evm_trace(
     if isinstance(event, TransactionStart):
         pass
     elif isinstance(event, TransactionEnd):
-        final_trace = FinalTrace(event.gas_used, event.output, event.has_erred)
+        final_trace = FinalTrace(event.gas_used, event.output, event.error)
         evm.env.traces.append(final_trace)
     elif isinstance(event, PrecompileStart):
         new_trace = Trace(
@@ -214,14 +240,14 @@ def evm_trace(
                 opName="InvalidOpcode",
                 gasCostTraced=True,
                 errorTraced=True,
-                error="",
+                error=type(event.error).__name__,
             )
 
             evm.env.traces.append(new_trace)
         elif not last_trace.errorTraced:
             # If the error for the last trace is not covered
             # the exception is attributed to the last trace.
-            last_trace.error = ""
+            last_trace.error = type(event.error).__name__
             last_trace.errorTraced = True
     elif isinstance(event, EvmStop):
         if not evm.running:

--- a/tests/helpers/load_vm_tests.py
+++ b/tests/helpers/load_vm_tests.py
@@ -90,7 +90,7 @@ class VmTestLoader:
                     test_data["expected_post_state"], addr
                 ) == self.storage_root(env.state, addr)
         else:
-            assert output.has_erred is True
+            assert output.error is not None
         self.close_state(env.state)
         self.close_state(test_data["expected_post_state"])
 


### PR DESCRIPTION
(closes #795 )

### What was wrong?
The error messages in the evm traces are not clear.

Related to Issue #795 

### How was it fixed?
Add error messages based on the exception types.

#### Cute Animal Picture

![](https://factanimal.com/wp-content/uploads/2023/03/cute-mini-pig.jpg)

