### PR TITLE
Update pending-opcodes.md (DATA*, RETURNDATALOAD, EXCHANGE)

### DIFF
--- a/lists/evm/pending-opcodes.md
+++ b/lists/evm/pending-opcodes.md
@@ -11,6 +11,10 @@ next or subsequent hard fork.
 |   0x5C   | TLOAD           | Transient data load                             | [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)                          |
 |   0x5D   | TSTORE          | Transient data store                            | [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)                          |
 |   0x5E   | MCOPY           | Memory copy                                     | [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656)                          |
+|   0xD0   | DATALOAD        | Loads data from EOF data section, via stack     | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
+|   0xD1   | DATALOADN       | Loads data from EOF data section, via immediate | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
+|   0xD2   | DATASIZE        | Size of the EOF data section                    | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
+|   0xD3   | DATACOPY        | Bulk EOF data copy                              | [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) |
 |   0xE0   | RJUMP           | relative jump                                   | [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)                          |
 |   0xE1   | RJUMPI          | relative conditional jump                       | [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)                          |
 |   0xE2   | RJUMV           | relative jump table                             | [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)                          |
@@ -19,15 +23,13 @@ next or subsequent hard fork.
 |   0xE5   | JUMPF           | EOF Function Jump                               | [EIP-6209](https://eips.ethereum.org/EIPS/eip-6209)                          |
 |   0xE6   | DUPN            | Unlimited dup                                   | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
 |   0xE7   | SWAPN           | Unlimited swap                                  | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
-|   0xE8   | DATALOAD        | Loads data from EOF data section, via stack     | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xE9   | DATALOADN       | Loads data from EOF data section, via immediate | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xEA   | DATASIZE        | Size of the EOF data section                    | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xEB   | DATACOPY        | Bulk EOF data copy                              | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
+|   0xE8   | EXCHANGE        | Deep swap                                       | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
 |   0xEC   | CREATE3         | Create from EOF contained initcode              | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
 |   0xED   | CREATE4         | Create from transaction contained initcode      | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
 |   0xEE   | RETURNCONTRACT  | Contract to be created, references EOF data     | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
 |   0xEF   | -               | Reserved for EOF compatibility                  | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
 |   0xF6   | PAY             | transfers value from caller to target           | [EIP-5920](https://eips.ethereum.org/EIPS/eip-5920)                          |
+|   0xF7   | RETURNDATALOAD  | Loads data returned from a call to the stack    | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
 |   0xF8   | CALL2           | CALL without gas and output memory              | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
 |   0xF9   | DELEGATECALL2   | DELEGATECALL without gas and output memory      | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
 |   0xFB   | STATICCALL2     | STATICCALL without gas and output memory        | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
@@ -255,10 +257,10 @@ scheduled or accepted) are in *italics*.
 | 0XCD   |                  |                         |                  |                                                                                |
 | 0XCE   |                  |                         |                  |                                                                                |
 | 0XCF   |                  |                         |                  |                                                                                |
-| 0XD0   |                  |                         |                  |                                                                                |
-| 0XD1   |                  |                         |                  |                                                                                |
-| 0XD2   |                  |                         |                  |                                                                                |
-| 0XD3   |                  |                         |                  |                                                                                |
+| *0xD0* | *DATALOAD*       | *EOF*                   | *????*           | *[EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)* |
+| *0xD1* | *DATALOADN*      | *EOF*                   | *????*           | *[EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)* |
+| *0xD2* | *DATASIZE*       | *EOF*                   | *????*           | *[EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)* |
+| *0xD3* | *DATACOPY*       | *EOF*                   | *????*           | *[EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)* |
 | 0XD4   |                  |                         |                  |                                                                                |
 | 0XD5   |                  |                         |                  |                                                                                |
 | 0XD6   |                  |                         |                  |                                                                                |
@@ -279,10 +281,10 @@ scheduled or accepted) are in *italics*.
 | *0xE5* | *JUMPF*          | *EOF*                   | *????*           | *[EIP-4750](https://eips.ethereum.org/EIPS/eip-6209)*                          |
 | *0xE6* | *DUPN*           | *EOF*                   | *????*           | *[EIP-663](https://eips.ethereum.org/EIPS/eip-663)*                            |
 | *0xE7* | *SWAPN*          | *EOF*                   | *????*           | *[EIP-663](https://eips.ethereum.org/EIPS/eip-663)*                            |
-| *0xE8* | *DATALOAD*       | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xE9* | *DATALOADN*      | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xEA* | *DATASIZE*       | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xEB* | *DATACOPY*       | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
+| *0xE8* | *EXCHANGE*       | *EOF*                   | *????*           | *[EIP-663](https://eips.ethereum.org/EIPS/eip-663)*                            |
+| 0xE9   |                  |                         |                  |                                                                                |
+| 0xEA   |                  |                         |                  |                                                                                |
+| 0xEB   |                  |                         |                  |                                                                                |
 | *0xEC* | *CREATE3*        | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
 | *0xED* | *CREATE4*        | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
 | *0xEE* | *RETURNCONTRACT* | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
@@ -294,7 +296,7 @@ scheduled or accepted) are in *italics*.
 | 0xF4   | DELEGATECALL     | System                  | Homestead        | [EIP-7](https://eips.ethereum.org/EIPS/eip-7)                                  |
 | 0xF5   | CREATE2          | System                  | Constantinople   | [EIP-1014](https://eips.ethereum.org/EIPS/eip-1014)                            |
 | *0xF6* | *PAY*            | *System*                | *????*           | *[EIP-5920](https://eips.ethereum.org/EIPS/eip-5920)*                          |
-| 0xF7   |                  |                         |                  |                                                                                |
+| *0xF7* | *RETURNDATALOAD* | *Environmental*         | *????*           | *[EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)*                          |
 | *0xF8* | *CALL2*          | *System*                | *????*           | *[EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)*                          |
 | *0xF9* | *DELEGATECALL2*  | *System*                | *????*           | *[EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)*                          |
 | 0xFA   | STATICCALL       | System                  | Byzantium        | [EIP-214](https://eips.ethereum.org/EIPS/eip-214)                              |

--- a/lists/evm/pending-opcodes.md
+++ b/lists/evm/pending-opcodes.md
@@ -24,10 +24,10 @@ next or subsequent hard fork.
 |   0xE6   | DUPN            | Unlimited dup                                   | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
 |   0xE7   | SWAPN           | Unlimited swap                                  | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
 |   0xE8   | EXCHANGE        | Deep swap                                       | [EIP-663](https://eips.ethereum.org/EIPS/eip-663)                            |
-|   0xEC   | CREATE3         | Create from EOF contained initcode              | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xED   | CREATE4         | Create from transaction contained initcode      | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xEE   | RETURNCONTRACT  | Contract to be created, references EOF data     | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
-|   0xEF   | -               | Reserved for EOF compatibility                  | TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) |
+|   0xEC   | CREATE3         | Create from EOF contained initcode              | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                          |
+|   0xED   | CREATE4         | Create from transaction contained initcode      | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                          |
+|   0xEE   | RETURNCONTRACT  | Contract to be created, references EOF data     | [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                          |
+|   0xEF   | -               | Reserved for EOF compatibility                  | [EIP-3540](https://eips.ethereum.org/EIPS/eip-3540)                          |
 |   0xF6   | PAY             | transfers value from caller to target           | [EIP-5920](https://eips.ethereum.org/EIPS/eip-5920)                          |
 |   0xF7   | RETURNDATALOAD  | Loads data returned from a call to the stack    | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
 |   0xF8   | CALL2           | CALL without gas and output memory              | [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                          |
@@ -285,10 +285,10 @@ scheduled or accepted) are in *italics*.
 | 0xE9   |                  |                         |                  |                                                                                |
 | 0xEA   |                  |                         |                  |                                                                                |
 | 0xEB   |                  |                         |                  |                                                                                |
-| *0xEC* | *CREATE3*        | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xED* | *CREATE4*        | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xEE* | *RETURNCONTRACT* | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
-| *0xEF* | *-RESERVED-*     | *EOF*                   | *????*           | *TBD - [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification)* |
+| *0xEC* | *CREATE3*        | *EOF*                   | *????*           | *[EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)*                          |
+| *0xED* | *CREATE4*        | *EOF*                   | *????*           | *[EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)*                          |
+| *0xEE* | *RETURNCONTRACT* | *EOF*                   | *????*           | *[EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)*                          |
+| *0xEF* | *-RESERVED-*     | *EOF*                   | *????*           | *[EIP-3540](https://eips.ethereum.org/EIPS/eip-3540)*                          |
 | 0xF0   | CREATE           | System                  |                  |                                                                                |
 | 0xF1   | CALL             | System                  |                  |                                                                                |
 | 0xF2   | CALLCODE         | System                  |                  |                                                                                |

--- a/lists/evm/proposed-opcodes.md
+++ b/lists/evm/proposed-opcodes.md
@@ -68,13 +68,14 @@ unshipped EIPs, even withdrawn and non-viable proposals.
 | [6888](https://eips.ethereum.org/EIPS/eip-6888)                        | 0x5B   | JUMPC              | Jump if the most recent arithmetic op set the carry bit                      |
 | [6888](https://eips.ethereum.org/EIPS/eip-6888)                        | 0x5C   | JUMPO              | Jump if the most recent arithmetic op set the overflow bit                   |
 | [6913](https://eips.ethereum.org/EIPS/eip-6913)                        | 0x49   | SETCODE            | Replace code of current contract                                             |
-| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF7   | RETURNDATALOAD     | Loads data returned from a call to the stack                                 |
-| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF8   | CALL2              | CALL without gas and output memory                                           |
-| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF9   | DELEGATECALL2      | DELEGATECALL without gas and output memory                                   |
-| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xFB   | STATICCALL2        | STATICCALL without gas and output memory                                     |
-| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD0   | DATALOAD           | Loads data from EOF data section, via stack                                  |
-| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD1   | DATALOADN          | Loads data from EOF data section, via immediate                              |
-| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD2   | DATASIZE           | Size of the EOF data section                                                 |
-| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD3   | DATACOPY           | Bulk data section copy                                                       |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xEC   | CREATE3            | Create from EOF contained initcode                                           |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xED   | CREATE4            | Create from transaction contained initcode                                   |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                    | 0xF7   | RETURNDATALOAD     | Loads data returned from a call to the stack                                 |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                    | 0xF8   | CALL2              | CALL without gas and output memory                                           |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                    | 0xF9   | DELEGATECALL2      | DELEGATECALL without gas and output memory                                   |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)                    | 0xFB   | STATICCALL2        | STATICCALL without gas and output memory                                     |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)                    | 0xD0   | DATALOAD           | Loads data from EOF data section, via stack                                  |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)                    | 0xD1   | DATALOADN          | Loads data from EOF data section, via immediate                              |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)                    | 0xD2   | DATASIZE           | Size of the EOF data section                                                 |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)                    | 0xD3   | DATACOPY           | Bulk data section copy                                                       |
+| [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xEC   | CREATE3            | Create from EOF contained initcode                                           |
+| [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xED   | CREATE4            | Create from transaction contained initcode                                   |
+| [EIP-7620](https://eips.ethereum.org/EIPS/eip-7620)                    | 0xEE   | RETURNCONTRACT     | Contract to be created, references EOF data                                  |

--- a/lists/evm/proposed-opcodes.md
+++ b/lists/evm/proposed-opcodes.md
@@ -18,8 +18,9 @@ unshipped EIPs, even withdrawn and non-viable proposals.
 | [615](https://eips.ethereum.org/EIPS/eip-615)                          | 0xB7   | RETURNSUB          | subroutine return                                                            |
 | [615](https://eips.ethereum.org/EIPS/eip-615)                          | 0xB8   | PUTLOCAL           | call local storage                                                           |
 | [615](https://eips.ethereum.org/EIPS/eip-615)                          | 0xB9   | GETLOCAL           | call local storage                                                           |
-| [663](https://eips.ethereum.org/EIPS/eip-663)                          | 0xB5   | DUPN               | Unlimited dup                                                                |
-| [663](https://eips.ethereum.org/EIPS/eip-663)                          | 0xB6   | SWAPN              | Unlimited swap                                                               |
+| [663](https://eips.ethereum.org/EIPS/eip-663)                          | 0xE6   | DUPN               | Unlimited dup                                                                |
+| [663](https://eips.ethereum.org/EIPS/eip-663)                          | 0xE7   | SWAPN              | Unlimited swap                                                               |
+| [663](https://eips.ethereum.org/EIPS/eip-663)                          | 0xE8   | EXCHANGE           | Deep swap                                                                    |
 | [698](https://eips.ethereum.org/EIPS/eip-698)                          | 0x46   | BLOCKREWARD        | Get the block reward for the current block                                   |
 | [1109](https://eips.ethereum.org/EIPS/eip-1109)                        | 0xFB   | PRECOMPILEDCALL    | call only precompiled addresses                                              |
 | [1153](https://eips.ethereum.org/EIPS/eip-1153)                        | 0xB3   | TLOAD              | Transient data load                                                          |
@@ -49,13 +50,13 @@ unshipped EIPs, even withdrawn and non-viable proposals.
 | [3508](https://eips.ethereum.org/EIPS/eip-3508)                        | 0x48   | ORIGINDATASIZE     | Size of transaction calldata                                                 |
 | [3508](https://eips.ethereum.org/EIPS/eip-3508)                        | 0x49   | ORIGINDATACOPY     | Bulk load transaction calldata                                               |
 | [3520](https://eips.ethereum.org/EIPS/eip-3520)                        | 0x4A   | ENTRYPOINT         | To address of transaction                                                    |
-| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0x5C   | RJUMP              | relative jump                                                                |
-| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0x5D   | RJUMI              | relative conditional jump                                                    |
-| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0x5E   | RJUMV              | relative jump table                                                          |
+| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0xE0   | RJUMP              | relative jump                                                                |
+| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0xE1   | RJUMI              | relative conditional jump                                                    |
+| [4200](https://eips.ethereum.org/EIPS/eip-4200)                        | 0xE2   | RJUMV              | relative jump table                                                          |
 | [4520](https://eips.ethereum.org/EIPS/eip-4520)                        | 0xEB   | -                  | Reserve for multi-byte opcodes                                               |
 | [4520](https://eips.ethereum.org/EIPS/eip-4520)                        | 0xEC   | -                  | Reserve for multi-byte opcodes                                               |
-| [4750](https://eips.ethereum.org/EIPS/eip-4750)                        | 0xB0   | CALLF              | EOF Subroutine Call                                                          |
-| [4750](https://eips.ethereum.org/EIPS/eip-4750)                        | 0xB1   | RETF               | EOF Subroutine return                                                        |
+| [4750](https://eips.ethereum.org/EIPS/eip-4750)                        | 0xE3   | CALLF              | EOF Subroutine Call                                                          |
+| [4750](https://eips.ethereum.org/EIPS/eip-4750)                        | 0xE4   | RETF               | EOF Subroutine return                                                        |
 | [4788](https://eips.ethereum.org/EIPS/eip-4788)                        | 0x4A   | BEACON_ROOT        | Exposes the Beacon Chain Root                                                |
 | [4844](https://eips.ethereum.org/EIPS/eip-4844)                        | 0x49   | BLOBHASH           | Returns hashes of blobs in the transaction                                   |
 | [5000](https://eips.ethereum.org/EIPS/eip-5000)                        | 0x1E   | MULDIV             | combo multiply then divide trinary operation                                 |
@@ -63,17 +64,17 @@ unshipped EIPs, even withdrawn and non-viable proposals.
 | [5478](https://eips.ethereum.org/EIPS/eip-5478)                        | 0xF6   | CREATE2COPY        | Create 2 with no initcode and contract copying                               |
 | [5656](https://eips.ethereum.org/EIPS/eip-5656)                        | 0xB7   | MCOPY              | Memory copy                                                                  |
 | [5920](https://eips.ethereum.org/EIPS/eip-5920)                        | 0xF9   | PAY                | transfers value from caller to target                                        |
-| [6206](https://eips.ethereum.org/EIPS/eip-6206)                        | 0xB2   | JUMPF              | EOF Function Jump                                                            |
+| [6206](https://eips.ethereum.org/EIPS/eip-6206)                        | 0xE5   | JUMPF              | EOF Function Jump                                                            |
 | [6888](https://eips.ethereum.org/EIPS/eip-6888)                        | 0x5B   | JUMPC              | Jump if the most recent arithmetic op set the carry bit                      |
 | [6888](https://eips.ethereum.org/EIPS/eip-6888)                        | 0x5C   | JUMPO              | Jump if the most recent arithmetic op set the overflow bit                   |
 | [6913](https://eips.ethereum.org/EIPS/eip-6913)                        | 0x49   | SETCODE            | Replace code of current contract                                             |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xF6   | CREATE3            | Create from EOF contained initcode                                           |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xF7   | CREATE4            | Create from transaction contained initcode                                   |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xF8   | RETURNCONTRACT     | contract to be created, references EOF data                                  |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xB8   | DATALOAD           | Loads data from EOF data section, via stack                                  |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xB9   | DATALOADN          | Loads data from EOF data section, via immediate                              |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xBA   | DATASIZE           | Size of the EOF data section                                                 |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xBB   | DATACOPY           | Bulk data section copy                                                       |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xF9   | CALL2              | CALL without gas and output memory                                           |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xFB   | DELEGATECALL2      | DELEGATECALL without gas and output memory                                   |
-| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xFC   | STATICCALL2        | STATICCALL without gas and output memory                                     |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF7   | RETURNDATALOAD     | Loads data returned from a call to the stack                                 |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF8   | CALL2              | CALL without gas and output memory                                           |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xF9   | DELEGATECALL2      | DELEGATECALL without gas and output memory                                   |
+| [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069) | 0xFB   | STATICCALL2        | STATICCALL without gas and output memory                                     |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD0   | DATALOAD           | Loads data from EOF data section, via stack                                  |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD1   | DATALOADN          | Loads data from EOF data section, via immediate                              |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD2   | DATASIZE           | Size of the EOF data section                                                 |
+| [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480) | 0xD3   | DATACOPY           | Bulk data section copy                                                       |
+| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xEC   | CREATE3            | Create from EOF contained initcode                                           |
+| [mega EOF](https://notes.ethereum.org/@ipsilon/mega-eof-specification) | 0xED   | CREATE4            | Create from transaction contained initcode                                   |


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ipsilon/eof/issues/43. Two opcodes proposed for EOF are in conflict (EXCHANGE and DATALOAD)

Also, EXCHANGE and RETURNDATALOAD proposed by Mega-EOF spec and their respective EIPs were missing, so adding them in as well. 

Various EOF-related opcodes were out-of-date in the `proposed-opcodes.md`.

### How was it fixed?

Conflict resolved by moving all DATA* opcodes to the currently empty D section (https://github.com/ipsilon/eof/pull/46).

EXCHANGE and RETURNDATALOAD added,

`proposed-opcodes.md` updated to match `pending-opcodes.md`
