### PR TITLE
EIP-1153 minor bug fix

### DIFF
--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -130,7 +130,7 @@ def rollback_transaction(
     if not state._snapshots:
         state._created_accounts.clear()
 
-    if transient_storage:
+    if transient_storage and transient_storage._snapshots:
         transient_storage._tries = transient_storage._snapshots.pop()
 
 


### PR DESCRIPTION


### What was wrong?
In some scenarios, rollback transaction would call a pop on empty snapshots

### How was it fixed?
Change the conditional statement to make sure the snapshot is not empty

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/b/be/Orang_Utan%2C_Semenggok_Forest_Reserve%2C_Sarawak%2C_Borneo%2C_Malaysia.JPG)
