### PR TITLE
Delete empty account at `BEACON_ROOTS_ADDRESS`

### DIFF
--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -17,7 +17,7 @@ There is a distinction between an account that does not exist and
 `EMPTY_ACCOUNT`.
 """
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes, Uint, modify
 from ethereum.utils.ensure import ensure
@@ -689,3 +689,21 @@ def set_transient_storage(
     trie_set(trie, key, value)
     if trie._data == {}:
         del transient_storage._tries[address]
+
+
+def destroy_touched_empty_accounts(
+    state: State, touched_accounts: Iterable[Address]
+) -> None:
+    """
+    Destroy all touched accounts that are empty.
+
+    Parameters
+    ----------
+    state: `State`
+        The current state.
+    touched_accounts: `Iterable[Address]`
+        All the accounts that have been touched in the current transaction.
+    """
+    for address in touched_accounts:
+        if account_exists_and_is_empty(state, address):
+            destroy_account(state, address)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -376,6 +376,13 @@ class T8N(Load):
                 system_tx_message, system_tx_env
             )
 
+        if self.state.account_exists_and_is_empty(
+            self.alloc.state, self.BEACON_ROOTS_ADDRESS
+        ):
+            self.state.destroy_account(
+                self.alloc.state, self.BEACON_ROOTS_ADDRESS
+            )
+
         for i, (tx_idx, tx) in enumerate(self.txs.transactions):
             # i is the index among valid transactions
             # tx_idx is the index among all transactions. tx_idx is only used


### PR DESCRIPTION
### What was wrong?
The current implementation of EIP-4788 did not delete the account at `BEACON_ROOTS_ADDRESS` if it is empty after being touched by the system message call. For example, in a case where the contract has not been deployed yet. EIP-4788 does not explicitly mention this deletion but it is implied post EIP-161


### How was it fixed?
Delete the account at `BEACON_ROOTS_ADDRESS` if it is empty.
