### PR TITLE
Replace gas_available with gas_used in the description of apply_body

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -533,7 +533,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -533,8 +533,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -433,7 +433,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -433,8 +433,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -424,7 +424,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -424,8 +424,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -424,7 +424,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -424,8 +424,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -429,8 +429,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -429,7 +429,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -410,7 +410,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -410,8 +410,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -533,7 +533,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -533,8 +533,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -412,8 +412,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -412,7 +412,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -424,7 +424,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -424,8 +424,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -541,7 +541,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -541,8 +541,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -424,7 +424,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -424,8 +424,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -444,8 +444,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -444,7 +444,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -453,7 +453,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -453,8 +453,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -420,8 +420,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -420,7 +420,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -412,8 +412,8 @@ def apply_body(
 
     Returns
     -------
-    gas_available : `ethereum.base_types.Uint`
-        Remaining gas after all transactions have been executed.
+    gas_used : `ethereum.base_types.Uint`
+        Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.
     receipt_root : `ethereum.fork_types.Root`

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -412,7 +412,7 @@ def apply_body(
 
     Returns
     -------
-    gas_used : `ethereum.base_types.Uint`
+    block_gas_used : `ethereum.base_types.Uint`
         Gas used for executing all transactions.
     transactions_root : `ethereum.fork_types.Root`
         Trie root of all the transactions in the block.


### PR DESCRIPTION
### What was wrong?

The first return value in the description of `apply_body`is `gas_available` instead of `gas_used`.

### How was it fixed?

Replacing `gas_available` with `gas_used`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.zooplus.co.uk/magazine/wp-content/uploads/2019/08/british-shorthair-kitten.jpg)
