### PR TITLE
Add mainnet dencun fork date

### DIFF
--- a/network-upgrades/mainnet-upgrades/cancun.md
+++ b/network-upgrades/mainnet-upgrades/cancun.md
@@ -16,8 +16,8 @@ Execution layer changes included in the Network Upgrade.
 |---------|--------------|-------------------------|--------------| ------------------ |
 | Goerli  | `1705473120` | 2024-01-17 06:32:00     | `0x70cc14e2` | 231680 
 | Sepolia | `1706655072` | 2024-01-30 22:51:12     | `0x88cf81d9` | 132608 
-| Holesky | `1707305664` | 2024-02-07 11:34:24.    | `0x9b192ad0` | 29696 
-| Mainnet |              |                         |              |  
+| Holesky | `1707305664` | 2024-02-07 11:34:24     | `0x9b192ad0` | 29696 
+| Mainnet | `1710338135` | 2024-03-13 13:55:35     | `0x9f3d2254` | 269568 
 
 
 ### Readiness Checklist
@@ -28,7 +28,7 @@ Execution layer changes included in the Network Upgrade.
   - [x] [Devnets](https://github.com/ethpandaops/dencun-testnet)
   - [x] [Testing suites](https://notes.ethereum.org/@ethpandaops/dencun-testing-overview)
  - [x] Select Testnet Fork Blocks
- - [ ] Select Mainnet Fork Block
+ - [x] Select Mainnet Fork Block
  - [ ] Release Mainnet Compatible Clients
    - [ ]  Geth
    - [ ]  Besu


### PR DESCRIPTION
On https://github.com/ethereum/pm/issues/951 we agreed to schedule Dencun's mainnet activation time.
Epoch `269568`
Starting slot is `8626176`
Timestamp is `1710338135`
Fork hash `0x9f3d2254`

Times are taken from: https://slots.symphonious.net/