### PR TITLE
Remove type import comment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ install_requires =
     pycryptodome>=3,<4
     coincurve>=18,<19
     typing_extensions>=4
-    eth2spec @ git+https://github.com/ethereum/consensus-specs.git@fe8db03f45609e9dd0abeede10294d77ef6fb92c
+    eth2spec @ git+https://github.com/ethereum/consensus-specs.git@fe344b79d420a3d1020ebc9f254b77b7ed931591
 
 [options.package_data]
 ethereum =

--- a/src/ethereum/cancun/vm/precompiled_contracts/point_evaluation.py
+++ b/src/ethereum/cancun/vm/precompiled_contracts/point_evaluation.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementation of the POINT EVALUATION precompiled contract.
 """
-from eth2spec.deneb.mainnet import (  # type: ignore
+from eth2spec.deneb.mainnet import (
     KZGCommitment,
     kzg_commitment_to_versioned_hash,
     verify_kzg_proof,


### PR DESCRIPTION
(closes #880)

### What was wrong?
The type import comment is no longer needed.

Related to Issue #880 

### How was it fixed?
Added a `py.typed` file in the `consensus-specs`


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/f/ff/Bat_eared_fox_Kenya_crop.jpg)
