### PR TITLE
Rename `gas_fee` to `max_gas_fee`

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -765,12 +765,12 @@ def process_transaction(
     sender_account = get_account(env.state, sender)
 
     if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
+        max_gas_fee = tx.gas * tx.max_fee_per_gas
     else:
-        gas_fee = tx.gas * tx.gas_price
+        max_gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
-    ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
+    ensure(sender_account.balance >= max_gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)
 
     effective_gas_fee = tx.gas * env.gas_price

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -765,12 +765,12 @@ def process_transaction(
     sender_account = get_account(env.state, sender)
 
     if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
+        max_gas_fee = tx.gas * tx.max_fee_per_gas
     else:
-        gas_fee = tx.gas * tx.gas_price
+        max_gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
-    ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
+    ensure(sender_account.balance >= max_gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)
 
     effective_gas_fee = tx.gas * env.gas_price

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -773,12 +773,12 @@ def process_transaction(
     sender_account = get_account(env.state, sender)
 
     if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
+        max_gas_fee = tx.gas * tx.max_fee_per_gas
     else:
-        gas_fee = tx.gas * tx.gas_price
+        max_gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
-    ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
+    ensure(sender_account.balance >= max_gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)
 
     effective_gas_fee = tx.gas * env.gas_price

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -553,12 +553,12 @@ def process_transaction(
     sender_account = get_account(env.state, sender)
 
     if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
+        max_gas_fee = tx.gas * tx.max_fee_per_gas
     else:
-        gas_fee = tx.gas * tx.gas_price
+        max_gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
-    ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
+    ensure(sender_account.balance >= max_gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)
 
     effective_gas_fee = tx.gas * env.gas_price

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -574,12 +574,12 @@ def process_transaction(
     sender_account = get_account(env.state, sender)
 
     if isinstance(tx, FeeMarketTransaction):
-        gas_fee = tx.gas * tx.max_fee_per_gas
+        max_gas_fee = tx.gas * tx.max_fee_per_gas
     else:
-        gas_fee = tx.gas * tx.gas_price
+        max_gas_fee = tx.gas * tx.gas_price
 
     ensure(sender_account.nonce == tx.nonce, InvalidBlock)
-    ensure(sender_account.balance >= gas_fee + tx.value, InvalidBlock)
+    ensure(sender_account.balance >= max_gas_fee + tx.value, InvalidBlock)
     ensure(sender_account.code == bytearray(), InvalidBlock)
 
     effective_gas_fee = tx.gas * env.gas_price


### PR DESCRIPTION
### What was wrong?
Post London, the `gas_fee` calculated in `fork.py` in in fact the max gas that can be paid in the transaction. The variable is renamed accordingly.

Related to Issue #877 

### How was it fixed?
Renamed the relevant variable.

#### Cute Animal Picture

![iceland-1979445_640](https://github.com/ethereum/execution-specs/assets/48196632/1d3f4a4a-5421-45a9-ba61-0cb278a68ac9)
