### PR TITLE
Don't swallow exceptions in T8N

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -12,6 +12,7 @@ from typing import Any
 from ethereum import rlp, trace
 from ethereum.base_types import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
+from ethereum.exceptions import InvalidBlock
 from ethereum_spec_tools.forks import Hardfork
 
 from ..fixture_loader import Load
@@ -330,7 +331,7 @@ class T8N(Load):
                 env = self.environment(tx, gas_available)
 
                 process_transaction_return = self.process_transaction(env, tx)
-            except Exception as e:
+            except InvalidBlock as e:
                 # The tf tools expects some non-blank error message
                 # even in case e is blank.
                 self.txs.rejected_txs[tx_idx] = f"Failed transaction: {str(e)}"


### PR DESCRIPTION
### What was wrong?

T8N's `apply_body()` function was catching `Exception` rather than `InvalidBlock`, resulting exceptions being silently swallowed.

### How was it fixed?

Catch `InvalidBlock` instead.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/cpr17ga4t1kc1.jpg?width=640&crop=smart&auto=webp&s=2e8116ef4c5b8f26018cd818537faa340e8ca1dd)
