### PR TITLE
Cancun fixes

### DIFF
--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -53,6 +53,7 @@ from .state import (
     State,
     account_exists_and_is_empty,
     destroy_account,
+    destroy_touched_empty_accounts,
     get_account,
     increment_nonce,
     process_withdrawal,
@@ -549,7 +550,11 @@ def apply_body(
         excess_blob_gas=excess_blob_gas,
     )
 
-    process_message_call(system_tx_message, system_tx_env)
+    system_tx_output = process_message_call(system_tx_message, system_tx_env)
+
+    destroy_touched_empty_accounts(
+        system_tx_env.state, system_tx_output.touched_accounts
+    )
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
         trie_set(
@@ -749,9 +754,7 @@ def process_transaction(
     for address in output.accounts_to_delete:
         destroy_account(env.state, address)
 
-    for address in output.touched_accounts:
-        if account_exists_and_is_empty(env.state, address):
-            destroy_account(env.state, address)
+    destroy_touched_empty_accounts(env.state, output.touched_accounts)
 
     return total_gas_used, output.logs, output.error
 

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -17,7 +17,7 @@ There is a distinction between an account that does not exist and
 `EMPTY_ACCOUNT`.
 """
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 from ethereum.base_types import U256, Bytes, Uint, modify
 from ethereum.utils.ensure import ensure
@@ -689,3 +689,20 @@ def set_transient_storage(
     trie_set(trie, key, value)
     if trie._data == {}:
         del transient_storage._tries[address]
+
+
+def destroy_touched_empty_accounts(
+    state: State, touched_accounts: Iterable[Address]
+) -> None:
+    """
+    Destroy all touched accounts that are empty.
+    Parameters
+    ----------
+    state: `State`
+        The current state.
+    touched_accounts: `Iterable[Address]`
+        All the accounts that have been touched in the current transaction.
+    """
+    for address in touched_accounts:
+        if account_exists_and_is_empty(state, address):
+            destroy_account(state, address)

--- a/src/ethereum/cancun/utils/message.py
+++ b/src/ethereum/cancun/utils/message.py
@@ -16,7 +16,7 @@ from typing import FrozenSet, Optional, Tuple, Union
 
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes32, Uint
 
-from ..fork_types import Address, VersionedHash
+from ..fork_types import Address
 from ..state import get_account
 from ..vm import Environment, Message
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
@@ -37,7 +37,6 @@ def prepare_message(
     preaccessed_storage_keys: FrozenSet[
         Tuple[(Address, Bytes32)]
     ] = frozenset(),
-    blob_versioned_hashes: Tuple[VersionedHash, ...] = (),
 ) -> Message:
     """
     Execute a transaction against the provided environment.
@@ -70,8 +69,6 @@ def prepare_message(
     preaccessed_storage_keys:
         Storage keys that should be marked as accessed prior to the message
         call
-    blob_versioned_hashes:
-        A list of hashes obtained from the kzg commitments.
 
     Returns
     -------
@@ -115,5 +112,4 @@ def prepare_message(
         accessed_addresses=accessed_addresses,
         accessed_storage_keys=set(preaccessed_storage_keys),
         parent_evm=None,
-        blob_versioned_hashes=blob_versioned_hashes,
     )

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -46,6 +46,7 @@ class Environment:
     chain_id: U64
     traces: List[dict]
     excess_blob_gas: U64
+    blob_versioned_hashes: Tuple[VersionedHash, ...]
 
 
 @dataclass
@@ -68,7 +69,6 @@ class Message:
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     parent_evm: Optional["Evm"]
-    blob_versioned_hashes: Tuple[VersionedHash, ...]
 
 
 @dataclass

--- a/src/ethereum/cancun/vm/instructions/environment.py
+++ b/src/ethereum/cancun/vm/instructions/environment.py
@@ -556,8 +556,8 @@ def blob_hash(evm: Evm) -> None:
     charge_gas(evm, GAS_BLOBHASH_OPCODE)
 
     # OPERATION
-    if index < len(evm.message.blob_versioned_hashes):
-        blob_hash = evm.message.blob_versioned_hashes[index]
+    if index < len(evm.env.blob_versioned_hashes):
+        blob_hash = evm.env.blob_versioned_hashes[index]
     else:
         blob_hash = Bytes32(b"\x00" * 32)
     push(evm.stack, U256.from_be_bytes(blob_hash))

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -124,7 +124,6 @@ def generic_create(
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
-        blob_versioned_hashes=evm.message.blob_versioned_hashes,
     )
     child_evm = process_create_message(child_message, evm.env)
 
@@ -310,7 +309,6 @@ def generic_call(
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
         parent_evm=evm,
-        blob_versioned_hashes=evm.message.blob_versioned_hashes,
     )
     child_evm = process_message(child_message, evm.env)
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -377,8 +377,12 @@ class T8N(Load):
                 excess_blob_gas=self.env.excess_blob_gas,
             )
 
-            self.interpreter.process_message_call(
+            system_tx_output = self.interpreter.process_message_call(
                 system_tx_message, system_tx_env
+            )
+
+            self.state.destroy_touched_empty_accounts(
+                system_tx_env.state, system_tx_output.touched_accounts
             )
 
         for i, (tx_idx, tx) in enumerate(self.txs.transactions):

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -222,7 +222,22 @@ class T8N(Load):
         if self.is_after_fork("ethereum.istanbul"):
             kw_arguments["chain_id"] = self.chain_id
 
-        if self.is_after_fork("ethereum.london"):
+        if self.is_after_fork("ethereum.cancun"):
+            (
+                sender_address,
+                effective_gas_price,
+                blob_versioned_hashes,
+            ) = self.fork.check_transaction(
+                tx,
+                self.env.base_fee_per_gas,
+                gas_available,
+                self.chain_id,
+            )
+            kw_arguments["base_fee_per_gas"] = self.env.base_fee_per_gas
+            kw_arguments["caller"] = kw_arguments["origin"] = sender_address
+            kw_arguments["gas_price"] = effective_gas_price
+            kw_arguments["blob_versioned_hashes"] = blob_versioned_hashes
+        elif self.is_after_fork("ethereum.london"):
             sender_address, effective_gas_price = self.fork.check_transaction(
                 tx,
                 self.env.base_fee_per_gas,
@@ -357,7 +372,6 @@ class T8N(Load):
                 accessed_addresses=set(),
                 accessed_storage_keys=set(),
                 parent_evm=None,
-                blob_versioned_hashes=(),
             )
 
             system_tx_env = self.vm.Environment(
@@ -375,6 +389,7 @@ class T8N(Load):
                 chain_id=self.chain_id,
                 traces=[],
                 excess_blob_gas=self.env.excess_blob_gas,
+                blob_versioned_hashes=(),
             )
 
             system_tx_output = self.interpreter.process_message_call(


### PR DESCRIPTION
### What was wrong?

1. Cancun spec does not handle undeployed beacon roots contract properly.
2. `blob_versioned_hashes` are constant and need to be part of the `Environment` class instead of the `Message` class.


### How was it fixed?
1. Delete touched beacon roots contract at the end of the system message call
2. Move `blob_versioned_hashes`

#### Cute Animal Picture

![cute dog](https://github.com/ethereum/execution-specs/assets/48196632/4ab77f1c-a24d-4a83-9eb9-2f45d9bc6037)
