### PR TITLE
Moved Transaction types into their own files (eg. FeeMarketTransaction, LegacyTransaction) as mentioned in the issue assigned to me 

### DIFF
--- a/src/ethereum/arrow_glacier/blocks.py
+++ b/src/ethereum/arrow_glacier/blocks.py
@@ -1,0 +1,79 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Uint
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/arrow_glacier/bloom.py
+++ b/src/ethereum/arrow_glacier/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -750,7 +751,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -26,7 +26,18 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    create_ether,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -39,26 +50,6 @@ from .transactions import(
     Transaction,
     decode_transaction,
     encode_transaction,
-)
-
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    create_ether,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -26,7 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -34,18 +34,21 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     decode_transaction,
     encode_transaction,
+)
+
+from .fork_types import (
+    Address,
+    Block,
+    Bloom,
+    Header,
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,
@@ -35,106 +35,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class FeeMarketTransaction:
-    """
-    The transaction type added in EIP-1559.
-    """
-
-    chain_id: U64
-    nonce: U256
-    max_priority_fee_per_gas: Uint
-    max_fee_per_gas: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[
-    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
-]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    elif isinstance(tx, FeeMarketTransaction):
-        return b"\x02" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        if tx[0] == 1:
-            return rlp.decode_to(AccessListTransaction, tx[1:])
-        elif tx[0] == 2:
-            return rlp.decode_to(FeeMarketTransaction, tx[1:])
-        else:
-            raise InvalidBlock
-    else:
-        return tx
 
 
 @slotted_freezable

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,
@@ -29,7 +30,6 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,65 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-    base_fee_per_gas: Uint
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -106,7 +106,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -13,15 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
+
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -16,9 +16,8 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32
 from ..exceptions import InvalidBlock
+from .fork_types import Address
 
-Address = Bytes20
-Root = Hash32
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -1,3 +1,8 @@
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
 
@@ -7,17 +12,12 @@ from ..base_types import (
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32
 from ..exceptions import InvalidBlock
 from .fork_types import Address
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -1,0 +1,122 @@
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from .. import rlp
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32, keccak256
+from ..exceptions import InvalidBlock
+
+Address = Bytes20
+Root = Hash32
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+TX_ACCESS_LIST_ADDRESS_COST = 2400
+TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
+
+Address = Bytes20
+
+@slotted_freezable
+@dataclass
+class LegacyTransaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class AccessListTransaction:
+    """
+    The transaction type added in EIP-2930 to support access lists.
+    """
+
+    chain_id: U64
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class FeeMarketTransaction:
+    """
+    The transaction type added in EIP-1559.
+    """
+
+    chain_id: U64
+    nonce: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+Transaction = Union[
+    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
+]
+
+
+def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
+    """
+    Encode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, LegacyTransaction):
+        return tx
+    elif isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(tx)
+    elif isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(tx)
+    else:
+        raise Exception(f"Unable to encode transaction of type {type(tx)}")
+
+
+def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
+    """
+    Decode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, Bytes):
+        if tx[0] == 1:
+            return rlp.decode_to(AccessListTransaction, tx[1:])
+        elif tx[0] == 2:
+            return rlp.decode_to(FeeMarketTransaction, tx[1:])
+        else:
+            raise InvalidBlock
+    else:
+        return tx

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/arrow_glacier/vm/instructions/log.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/berlin/blocks.py
+++ b/src/ethereum/berlin/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/berlin/bloom.py
+++ b/src/ethereum/berlin/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -26,7 +26,18 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    create_ether,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -38,25 +49,6 @@ from .transactions import(
     Transaction,
     decode_transaction,
     encode_transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header, 
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    create_ether,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -647,7 +648,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -26,7 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -34,17 +34,19 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     decode_transaction,
     encode_transaction,
+)
+from .fork_types import (
+    Address,
+    Block,
+    Bloom,
+    Header, 
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -13,15 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
+
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -30,8 +30,6 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
-from ..utils.ensure import ensure
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,
@@ -36,77 +36,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[LegacyTransaction, AccessListTransaction]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        ensure(tx[0] == 1, InvalidBlock)
-        return rlp.decode_to(AccessListTransaction, tx[1:])
-    else:
-        return tx
 
 
 @slotted_freezable

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -107,7 +107,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -1,23 +1,24 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
+
 from .. import rlp
 from ..base_types import (
     U64,
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
 from ..exceptions import InvalidBlock
-from .fork_types import Address
 from ..utils.ensure import ensure
-
+from .fork_types import Address
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -89,4 +90,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         return rlp.decode_to(AccessListTransaction, tx[1:])
     else:
         return tx
-

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -1,0 +1,97 @@
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from .. import rlp
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32, keccak256
+from ..exceptions import InvalidBlock
+from ..utils.ensure import ensure
+
+Address = Bytes20
+Root = Hash32
+
+Bloom = Bytes256
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+TX_ACCESS_LIST_ADDRESS_COST = 2400
+TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
+
+
+@slotted_freezable
+@dataclass
+class LegacyTransaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class AccessListTransaction:
+    """
+    The transaction type added in EIP-2930 to support access lists.
+    """
+
+    chain_id: U64
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+Transaction = Union[LegacyTransaction, AccessListTransaction]
+
+
+def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
+    """
+    Encode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, LegacyTransaction):
+        return tx
+    elif isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(tx)
+    else:
+        raise Exception(f"Unable to encode transaction of type {type(tx)}")
+
+
+def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
+    """
+    Decode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, Bytes):
+        ensure(tx[0] == 1, InvalidBlock)
+        return rlp.decode_to(AccessListTransaction, tx[1:])
+    else:
+        return tx
+

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from typing import Tuple, Union
 from .. import rlp
-
 from ..base_types import (
     U64,
     U256,
@@ -16,9 +15,9 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..exceptions import InvalidBlock
+from .fork_types import Address
 from ..utils.ensure import ensure
 
-Address = Bytes20
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -1,8 +1,8 @@
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
 from .. import rlp
+
 from ..base_types import (
     U64,
     U256,
@@ -15,14 +15,10 @@ from ..base_types import (
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32, keccak256
 from ..exceptions import InvalidBlock
 from ..utils.ensure import ensure
 
 Address = Bytes20
-Root = Hash32
-
-Bloom = Bytes256
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/berlin/vm/instructions/log.py
+++ b/src/ethereum/berlin/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/byzantium/blocks.py
+++ b/src/ethereum/byzantium/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/byzantium/bloom.py
+++ b/src/ethereum/byzantium/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -51,6 +36,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -635,7 +636,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import Transaction
+from typ_ing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -29,6 +30,7 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32, keccak256
 
+Address = Bytes20
 Root = Hash32
 Bloom = Bytes256
 
@@ -101,7 +103,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -13,7 +13,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typ_ing import Tuple, Union, TYPE_CHECKING
+from typing import Tuple, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from .transactions import Transaction
 from .. import rlp

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -13,7 +13,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from .transactions import Transaction
 from .. import rlp

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -70,64 +64,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -13,14 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
+
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -29,33 +29,8 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32, keccak256
 
-Address = Bytes20
 Root = Hash32
-
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
 
 
 @slotted_freezable

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from typing import Union
 
-from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
@@ -14,7 +13,6 @@ from ..base_types import (
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -1,0 +1,43 @@
+
+from dataclasses import dataclass
+from typing import Union
+
+from .. import rlp
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32, keccak256
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -1,21 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Union
+
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -1,6 +1,7 @@
 
 from dataclasses import dataclass
 from typing import Union
+from .fork_types import Address
 
 from ..base_types import (
     U256,
@@ -14,7 +15,6 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/byzantium/vm/instructions/log.py
+++ b/src/ethereum/byzantium/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/constantinople/blocks.py
+++ b/src/ethereum/constantinople/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/constantinople/bloom.py
+++ b/src/ethereum/constantinople/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -51,6 +36,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -635,7 +636,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import Transaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -105,7 +106,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -13,14 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
+
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -34,8 +35,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-
 
 
 @slotted_freezable

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -13,7 +13,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 if TYPE_CHECKING:
     from .transactions import Transaction
 from .. import rlp

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -34,28 +34,7 @@ Root = Hash32
 
 Bloom = Bytes256
 
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
 
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
 
 
 @slotted_freezable

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from typing import Union
 
-from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
@@ -14,7 +13,7 @@ from ..base_types import (
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32, keccak256
+
 
 Address = Bytes20
 

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -1,0 +1,44 @@
+
+from dataclasses import dataclass
+from typing import Union
+
+from .. import rlp
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32, keccak256
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -1,7 +1,7 @@
 
 from dataclasses import dataclass
 from typing import Union
-
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -14,8 +14,6 @@ from ..base_types import (
     slotted_freezable,
 )
 
-
-Address = Bytes20
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -1,20 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Union
+
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68
@@ -38,4 +31,3 @@ class Transaction:
     v: U256
     r: U256
     s: U256
-

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/constantinople/vm/instructions/log.py
+++ b/src/ethereum/constantinople/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/dao_fork/blocks.py
+++ b/src/ethereum/dao_fork/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    post_state: Root
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/dao_fork/bloom.py
+++ b/src/ethereum/dao_fork/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -29,22 +29,7 @@ from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import FORK_CRITERIA, vm
 from .bloom import logs_bloom
 from .dao import apply_dao
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-     Transaction,
-)
-from .fork_types import ( 
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     create_ether,
@@ -53,6 +38,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -27,9 +27,10 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import FORK_CRITERIA, vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
 from .dao import apply_dao
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     create_ether,
@@ -640,7 +641,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -29,11 +29,14 @@ from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import FORK_CRITERIA, vm
 from .bloom import logs_bloom
 from .dao import apply_dao
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+     Transaction,
+)
+from .fork_types import ( 
     Address,
     Block,
     Bloom,
@@ -41,7 +44,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    post_state: Root
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -13,14 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
+
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -34,7 +35,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
 
 
 @slotted_freezable

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import Transaction
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -104,7 +105,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -34,28 +34,6 @@ Root = Hash32
 
 Bloom = Bytes256
 
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
 
 
 @slotted_freezable

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -1,21 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
+
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68
@@ -39,4 +31,3 @@ class Transaction:
     v: U256
     r: U256
     s: U256
-

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -1,7 +1,7 @@
 
 from dataclasses import dataclass
 from typing import  Union
-
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -14,7 +14,7 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
+
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -1,0 +1,44 @@
+
+from dataclasses import dataclass
+from typing import  Union
+
+from .. import rlp
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32, keccak256
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State
 
 __all__ = ("Environment", "Evm", "Message")

--- a/src/ethereum/dao_fork/vm/instructions/log.py
+++ b/src/ethereum/dao_fork/vm/instructions/log.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ethereum.base_types import U256
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -26,7 +26,8 @@ from ethereum.trace import (
     evm_trace,
 )
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_has_code_or_nonce,
     begin_transaction,

--- a/src/ethereum/frontier/blocks.py
+++ b/src/ethereum/frontier/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    post_state: Root
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/frontier/bloom.py
+++ b/src/ethereum/frontier/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -25,21 +25,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-     Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     create_ether,
@@ -48,6 +34,12 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -25,10 +25,13 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+     Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
@@ -36,7 +39,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -24,8 +24,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     create_ether,
@@ -621,7 +622,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -14,6 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
+from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -33,28 +34,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
 
 
 @slotted_freezable

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    post_state: Root
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
 
@@ -21,7 +22,6 @@ from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import Transaction
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -104,7 +105,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import  Union
-
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -14,7 +14,6 @@ from ..base_types import (
 )
 
 
-Address = Bytes20
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from typing import  Union
 
@@ -14,13 +13,12 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
 
+Address = Bytes20
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68
 TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
 
 
 @slotted_freezable

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -1,19 +1,13 @@
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
+
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68
@@ -36,4 +30,3 @@ class Transaction:
     v: U256
     r: U256
     s: U256
-

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -35,7 +35,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -35,14 +35,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State
 
 __all__ = ("Environment", "Evm", "Message")

--- a/src/ethereum/frontier/vm/instructions/log.py
+++ b/src/ethereum/frontier/vm/instructions/log.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ethereum.base_types import U256
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -26,7 +26,8 @@ from ethereum.trace import (
     evm_trace,
 )
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_has_code_or_nonce,
     begin_transaction,

--- a/src/ethereum/genesis.py
+++ b/src/ethereum/genesis.py
@@ -183,17 +183,17 @@ def add_genesis_block(
         "nonce": genesis.nonce,
     }
 
-    if hasattr(hardfork.fork_types.Header, "mix_digest"):
+    if hasattr(hardfork.blocks.Header, "mix_digest"):
         fields["mix_digest"] = hardfork.fork_types.Hash32(b"\0" * 32)
     else:
         fields["prev_randao"] = hardfork.fork_types.Hash32(b"\0" * 32)
 
-    if hasattr(hardfork.fork_types.Header, "base_fee_per_gas"):
+    if hasattr(hardfork.blocks.Header, "base_fee_per_gas"):
         fields["base_fee_per_gas"] = Uint(10**9)
 
-    genesis_header = hardfork.fork_types.Header(**fields)
+    genesis_header = hardfork.blocks.Header(**fields)
 
-    genesis_block = hardfork.fork_types.Block(
+    genesis_block = hardfork.blocks.Block(
         header=genesis_header,
         transactions=(),
         ommers=(),

--- a/src/ethereum/gray_glacier/blocks.py
+++ b/src/ethereum/gray_glacier/blocks.py
@@ -1,0 +1,79 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Uint
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/gray_glacier/bloom.py
+++ b/src/ethereum/gray_glacier/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -26,7 +26,18 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    create_ether,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -39,25 +50,6 @@ from .transactions import(
     Transaction,
     decode_transaction,
     encode_transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    create_ether,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -750,7 +751,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -26,7 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -34,18 +34,20 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     decode_transaction,
     encode_transaction,
+)
+from .fork_types import (
+    Address,
+    Block,
+    Bloom,
+    Header,
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -14,7 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,
@@ -35,106 +35,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class FeeMarketTransaction:
-    """
-    The transaction type added in EIP-1559.
-    """
-
-    chain_id: U64
-    nonce: U256
-    max_priority_fee_per_gas: Uint
-    max_fee_per_gas: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[
-    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
-]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    elif isinstance(tx, FeeMarketTransaction):
-        return b"\x02" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        if tx[0] == 1:
-            return rlp.decode_to(AccessListTransaction, tx[1:])
-        elif tx[0] == 2:
-            return rlp.decode_to(FeeMarketTransaction, tx[1:])
-        else:
-            raise InvalidBlock
-    else:
-        return tx
 
 
 @slotted_freezable

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,65 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-    base_fee_per_gas: Uint
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 from .. import rlp
 from ..base_types import (
     U64,
@@ -106,7 +107,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -13,15 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
+
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -30,7 +30,6 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -1,3 +1,4 @@
+
 from dataclasses import dataclass
 from typing import Tuple, Union
 
@@ -14,11 +15,9 @@ from ..base_types import (
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32
 from ..exceptions import InvalidBlock
 
 Address = Bytes20
-Root = Hash32
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -119,3 +118,4 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
+

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -16,8 +16,8 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..exceptions import InvalidBlock
+from .fork_types import Address
 
-Address = Bytes20
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -1,4 +1,8 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
 
@@ -8,16 +12,12 @@ from ..base_types import (
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
 from ..exceptions import InvalidBlock
 from .fork_types import Address
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -118,4 +118,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/gray_glacier/vm/instructions/log.py
+++ b/src/ethereum/gray_glacier/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/homestead/blocks.py
+++ b/src/ethereum/homestead/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    post_state: Root
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/homestead/bloom.py
+++ b/src/ethereum/homestead/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     create_ether,
@@ -50,6 +35,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     create_ether,
@@ -623,7 +624,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    post_state: Root
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -34,29 +34,6 @@ Root = Hash32
 
 Bloom = Bytes256
 
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -103,7 +104,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -13,14 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
+
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -1,0 +1,42 @@
+
+from dataclasses import dataclass
+from typing import Union
+
+
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -1,8 +1,7 @@
 
 from dataclasses import dataclass
 from typing import Union
-
-
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -15,7 +14,6 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -1,20 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Union
+
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State
 
 __all__ = ("Environment", "Evm", "Message")

--- a/src/ethereum/homestead/vm/instructions/log.py
+++ b/src/ethereum/homestead/vm/instructions/log.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ethereum.base_types import U256
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -26,7 +26,8 @@ from ethereum.trace import (
     evm_trace,
 )
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_has_code_or_nonce,
     begin_transaction,

--- a/src/ethereum/istanbul/blocks.py
+++ b/src/ethereum/istanbul/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/istanbul/bloom.py
+++ b/src/ethereum/istanbul/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -636,7 +637,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import ( 
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -51,6 +36,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import ( 
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -34,29 +34,6 @@ Root = Hash32
 
 Bloom = Bytes256
 
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 from .. import rlp
 from ..base_types import (
     U256,
@@ -103,7 +104,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -13,14 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
+
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -1,0 +1,43 @@
+
+from dataclasses import dataclass
+from typing import  Union
+
+from .. import rlp
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -1,22 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
 
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from .. import rlp
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -40,4 +31,3 @@ class Transaction:
     v: U256
     r: U256
     s: U256
-

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from typing import  Union
 
+from .fork_types import Address
 from .. import rlp
 from ..base_types import (
     U256,
@@ -15,7 +16,6 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/istanbul/vm/instructions/log.py
+++ b/src/ethereum/istanbul/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/london/blocks.py
+++ b/src/ethereum/london/blocks.py
@@ -1,0 +1,79 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Uint
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/london/bloom.py
+++ b/src/ethereum/london/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -26,7 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import FORK_CRITERIA, vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -34,18 +34,20 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     decode_transaction,
     encode_transaction,
+)
+from .fork_types import (
+    Address,
+    Block,
+    Bloom, 
+    Header,
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import FORK_CRITERIA, vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -758,7 +759,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -26,7 +26,18 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import FORK_CRITERIA, vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    create_ether,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -39,25 +50,6 @@ from .transactions import(
     Transaction,
     decode_transaction,
     encode_transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom, 
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    create_ether,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,65 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-    base_fee_per_gas: Uint
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
@@ -106,7 +107,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -14,6 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
+from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
@@ -29,113 +30,12 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
+
 
 Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class FeeMarketTransaction:
-    """
-    The transaction type added in EIP-1559.
-    """
-
-    chain_id: U64
-    nonce: U256
-    max_priority_fee_per_gas: Uint
-    max_fee_per_gas: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[
-    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
-]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    elif isinstance(tx, FeeMarketTransaction):
-        return b"\x02" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        if tx[0] == 1:
-            return rlp.decode_to(AccessListTransaction, tx[1:])
-        elif tx[0] == 2:
-            return rlp.decode_to(FeeMarketTransaction, tx[1:])
-        else:
-            raise InvalidBlock
-    else:
-        return tx
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -13,16 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -32,11 +31,11 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32, keccak256
 
-
 Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -1,7 +1,7 @@
 
 from dataclasses import dataclass
 from typing import Tuple, Union
-
+from .fork_types import Address
 from .. import rlp
 from ..base_types import (
     U64,
@@ -18,7 +18,7 @@ from ..base_types import (
 
 from ..exceptions import InvalidBlock
 
-Address = Bytes20
+
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -1,0 +1,123 @@
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from .. import rlp
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+
+from ..exceptions import InvalidBlock
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+TX_ACCESS_LIST_ADDRESS_COST = 2400
+TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
+
+
+@slotted_freezable
+@dataclass
+class LegacyTransaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class AccessListTransaction:
+    """
+    The transaction type added in EIP-2930 to support access lists.
+    """
+
+    chain_id: U64
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class FeeMarketTransaction:
+    """
+    The transaction type added in EIP-1559.
+    """
+
+    chain_id: U64
+    nonce: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+Transaction = Union[
+    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
+]
+
+
+def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
+    """
+    Encode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, LegacyTransaction):
+        return tx
+    elif isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(tx)
+    elif isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(tx)
+    else:
+        raise Exception(f"Unable to encode transaction of type {type(tx)}")
+
+
+def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
+    """
+    Decode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, Bytes):
+        if tx[0] == 1:
+            return rlp.decode_to(AccessListTransaction, tx[1:])
+        elif tx[0] == 2:
+            return rlp.decode_to(FeeMarketTransaction, tx[1:])
+        else:
+            raise InvalidBlock
+    else:
+        return tx
+

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -1,25 +1,23 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
-from .fork_types import Address
+
 from .. import rlp
 from ..base_types import (
     U64,
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
-
 from ..exceptions import InvalidBlock
-
-
-
+from .fork_types import Address
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -120,4 +118,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/london/vm/instructions/log.py
+++ b/src/ethereum/london/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/muir_glacier/blocks.py
+++ b/src/ethereum/muir_glacier/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/muir_glacier/bloom.py
+++ b/src/ethereum/muir_glacier/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -26,19 +26,21 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
     Header,
     Log,
     Receipt,
-    Root,
-    Transaction,
+    Root,  
 )
 from .state import (
     State,

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -636,7 +637,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,  
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -51,6 +36,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Tuple
+from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -33,30 +34,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
 
@@ -21,7 +22,6 @@ from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -35,6 +35,7 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
-from .transactions import Transaction
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -103,7 +104,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -1,0 +1,41 @@
+
+from dataclasses import dataclass
+from typing import  Union
+
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from typing import  Union
 
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -14,7 +15,7 @@ from ..base_types import (
     slotted_freezable,
 )
 
-Address = Bytes20
+
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -1,22 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
 
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/muir_glacier/vm/instructions/log.py
+++ b/src/ethereum/muir_glacier/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/paris/blocks.py
+++ b/src/ethereum/paris/blocks.py
@@ -1,0 +1,79 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    prev_randao: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Uint
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/paris/bloom.py
+++ b/src/ethereum/paris/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -25,7 +25,7 @@ from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -33,18 +33,20 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     decode_transaction,
     encode_transaction,
+)
+from .fork_types import ( 
+    Address,
+    Block,
+    Bloom,
+    Header,
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -24,8 +24,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -538,7 +539,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -25,7 +25,17 @@ from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -38,24 +48,6 @@ from .transactions import(
     Transaction,
     decode_transaction,
     encode_transaction,
-)
-from .fork_types import ( 
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -14,6 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
+from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -29,112 +29,12 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
+
 
 Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class FeeMarketTransaction:
-    """
-    The transaction type added in EIP-1559.
-    """
-
-    chain_id: U64
-    nonce: U256
-    max_priority_fee_per_gas: Uint
-    max_fee_per_gas: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[
-    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
-]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    elif isinstance(tx, FeeMarketTransaction):
-        return b"\x02" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        if tx[0] == 1:
-            return rlp.decode_to(AccessListTransaction, tx[1:])
-        elif tx[0] == 2:
-            return rlp.decode_to(FeeMarketTransaction, tx[1:])
-        else:
-            raise InvalidBlock
-    else:
-        return tx
 
 
 @slotted_freezable

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,65 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    prev_randao: Bytes32
-    nonce: Bytes8
-    base_fee_per_gas: Uint
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
@@ -107,7 +108,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -13,16 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -31,7 +30,6 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -1,24 +1,23 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
 
-from .fork_types import Address
 from .. import rlp
 from ..base_types import (
     U64,
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
-from ..crypto.hash import Hash32
 from ..exceptions import InvalidBlock
-
+from .fork_types import Address
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -119,4 +118,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from typing import Tuple, Union
 
+from .fork_types import Address
 from .. import rlp
 from ..base_types import (
     U64,
@@ -18,10 +19,6 @@ from ..base_types import (
 from ..crypto.hash import Hash32
 from ..exceptions import InvalidBlock
 
-Address = Bytes20
-Root = Hash32
-
-Bloom = Bytes256
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -1,0 +1,125 @@
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from .. import rlp
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32
+from ..exceptions import InvalidBlock
+
+Address = Bytes20
+Root = Hash32
+
+Bloom = Bytes256
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+TX_ACCESS_LIST_ADDRESS_COST = 2400
+TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
+
+
+@slotted_freezable
+@dataclass
+class LegacyTransaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class AccessListTransaction:
+    """
+    The transaction type added in EIP-2930 to support access lists.
+    """
+
+    chain_id: U64
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class FeeMarketTransaction:
+    """
+    The transaction type added in EIP-1559.
+    """
+
+    chain_id: U64
+    nonce: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+Transaction = Union[
+    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
+]
+
+
+def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
+    """
+    Encode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, LegacyTransaction):
+        return tx
+    elif isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(tx)
+    elif isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(tx)
+    else:
+        raise Exception(f"Unable to encode transaction of type {type(tx)}")
+
+
+def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
+    """
+    Decode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, Bytes):
+        if tx[0] == 1:
+            return rlp.decode_to(AccessListTransaction, tx[1:])
+        elif tx[0] == 2:
+            return rlp.decode_to(FeeMarketTransaction, tx[1:])
+        else:
+            raise InvalidBlock
+    else:
+        return tx
+

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/paris/vm/instructions/log.py
+++ b/src/ethereum/paris/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/shanghai/blocks.py
+++ b/src/ethereum/shanghai/blocks.py
@@ -1,0 +1,102 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes8,
+    Bytes32,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import LegacyTransaction
+
+
+@slotted_freezable
+@dataclass
+class Withdrawal:
+    """
+    Withdrawals that have been validated on the consensus layer.
+    """
+
+    index: U64
+    validator_index: U64
+    address: Address
+    amount: U256
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    prev_randao: Bytes32
+    nonce: Bytes8
+    base_fee_per_gas: Uint
+    withdrawals_root: Root
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    ommers: Tuple[Header, ...]
+    withdrawals: Tuple[Withdrawal, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    succeeded: bool
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/shanghai/bloom.py
+++ b/src/ethereum/shanghai/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -25,7 +25,18 @@ from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .state import (
+    State,
+    account_exists_and_is_empty,
+    destroy_account,
+    get_account,
+    increment_nonce,
+    process_withdrawal,
+    set_account_balance,
+    state_root,
+)
+from .transactions import (
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -39,25 +50,6 @@ from .transactions import(
     Withdrawal,
     decode_transaction,
     encode_transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
-from .state import (
-    State,
-    account_exists_and_is_empty,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    process_withdrawal,
-    set_account_balance,
-    state_root,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -25,7 +25,16 @@ from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import (
+    Address,
+    Block,
+    Bloom,
+    Header,
+    Log,
+    Receipt,
+    Root,
+    Withdrawal,
+)
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -47,7 +56,6 @@ from .transactions import (
     FeeMarketTransaction,
     LegacyTransaction,
     Transaction,
-    Withdrawal,
     decode_transaction,
     encode_transaction,
 )

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -25,7 +25,7 @@ from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_ACCESS_LIST_ADDRESS_COST,
     TX_ACCESS_LIST_STORAGE_KEY_COST,
     TX_BASE_COST,
@@ -33,19 +33,21 @@ from .fork_types import (
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
     AccessListTransaction,
-    Address,
-    Block,
-    Bloom,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
-    Root,
     Transaction,
     Withdrawal,
     decode_transaction,
     encode_transaction,
+)
+from .fork_types import (
+    Address,
+    Block,
+    Bloom,
+    Header,
+    Log,
+    Receipt,
+    Root,
 )
 from .state import (
     State,

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -24,17 +24,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, Bytes, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt, Withdrawal
 from .bloom import logs_bloom
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-    Withdrawal,
-)
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -567,7 +559,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, Union
+
 if TYPE_CHECKING:
     from .transactions import LegacyTransaction
 
@@ -22,7 +23,6 @@ from ..base_types import (
     U64,
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -32,12 +32,10 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32, keccak256
 
-
 Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -14,6 +14,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 
 from dataclasses import dataclass
 from typing import Tuple, Union
+from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
@@ -29,112 +30,13 @@ from ..base_types import (
     slotted_freezable,
 )
 from ..crypto.hash import Hash32, keccak256
-from ..exceptions import InvalidBlock
+
 
 Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
 
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 16
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-TX_ACCESS_LIST_ADDRESS_COST = 2400
-TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
-
-
-@slotted_freezable
-@dataclass
-class LegacyTransaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class AccessListTransaction:
-    """
-    The transaction type added in EIP-2930 to support access lists.
-    """
-
-    chain_id: U64
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-@slotted_freezable
-@dataclass
-class FeeMarketTransaction:
-    """
-    The transaction type added in EIP-1559.
-    """
-
-    chain_id: U64
-    nonce: U256
-    max_priority_fee_per_gas: Uint
-    max_fee_per_gas: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
-    y_parity: U256
-    r: U256
-    s: U256
-
-
-Transaction = Union[
-    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
-]
-
-
-def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
-    """
-    Encode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, LegacyTransaction):
-        return tx
-    elif isinstance(tx, AccessListTransaction):
-        return b"\x01" + rlp.encode(tx)
-    elif isinstance(tx, FeeMarketTransaction):
-        return b"\x02" + rlp.encode(tx)
-    else:
-        raise Exception(f"Unable to encode transaction of type {type(tx)}")
-
-
-def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
-    """
-    Decode a transaction. Needed because non-legacy transactions aren't RLP.
-    """
-    if isinstance(tx, Bytes):
-        if tx[0] == 1:
-            return rlp.decode_to(AccessListTransaction, tx[1:])
-        elif tx[0] == 2:
-            return rlp.decode_to(FeeMarketTransaction, tx[1:])
-        else:
-            raise InvalidBlock
-    else:
-        return tx
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -16,11 +16,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple, Union
 
 if TYPE_CHECKING:
-    from .transactions import LegacyTransaction,Withdrawal
+    from .transactions import LegacyTransaction, Withdrawal
 
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
     Bytes8,
@@ -72,7 +71,6 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple, Union
 
 if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
+    from .transactions import LegacyTransaction,Withdrawal
 
 from .. import rlp
 from ..base_types import (
@@ -74,18 +74,6 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     )
 
 
-@slotted_freezable
-@dataclass
-class Withdrawal:
-    """
-    Withdrawals that have been validated on the consensus layer.
-    """
-
-    index: U64
-    validator_index: U64
-    address: Address
-    amount: U256
-
 
 @slotted_freezable
 @dataclass
@@ -123,7 +111,7 @@ class Block:
     header: Header
     transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
-    withdrawals: Tuple[Withdrawal, ...]
+    withdrawals: Tuple["Withdrawal", ...]
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
-from .transactions import LegacyTransaction
+from typing import Tuple, Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
@@ -122,7 +123,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
+    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
 

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -13,19 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Union
-
-if TYPE_CHECKING:
-    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
-    U64,
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -72,80 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Withdrawal:
-    """
-    Withdrawals that have been validated on the consensus layer.
-    """
-
-    index: U64
-    validator_index: U64
-    address: Address
-    amount: U256
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    prev_randao: Bytes32
-    nonce: Bytes8
-    base_fee_per_gas: Uint
-    withdrawals_root: Root
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple[Union[Bytes, "LegacyTransaction"], ...]
-    ommers: Tuple[Header, ...]
-    withdrawals: Tuple["Withdrawal", ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    succeeded: bool
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -16,10 +16,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple, Union
 
 if TYPE_CHECKING:
-    from .transactions import LegacyTransaction, Withdrawal
+    from .transactions import LegacyTransaction
 
 from .. import rlp
 from ..base_types import (
+    U64,
     U256,
     Bytes,
     Bytes8,
@@ -71,6 +72,19 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
+
+
+@slotted_freezable
+@dataclass
+class Withdrawal:
+    """
+    Withdrawals that have been validated on the consensus layer.
+    """
+
+    index: U64
+    validator_index: U64
+    address: Address
+    amount: U256
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -22,8 +22,7 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 from ethereum.base_types import U256, Bytes, Uint, modify
 from ethereum.utils.ensure import ensure
 
-from .fork_types import EMPTY_ACCOUNT, Account, Address, Root
-from .transactions import Withdrawal
+from .fork_types import EMPTY_ACCOUNT, Account, Address, Root, Withdrawal
 from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
 
 

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -22,7 +22,8 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 from ethereum.base_types import U256, Bytes, Uint, modify
 from ethereum.utils.ensure import ensure
 
-from .fork_types import EMPTY_ACCOUNT, Account, Address, Root, Withdrawal
+from .blocks import Withdrawal
+from .fork_types import EMPTY_ACCOUNT, Account, Address, Root
 from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
 
 

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -22,7 +22,8 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 from ethereum.base_types import U256, Bytes, Uint, modify
 from ethereum.utils.ensure import ensure
 
-from .fork_types import EMPTY_ACCOUNT, Account, Address, Root, Withdrawal
+from .fork_types import EMPTY_ACCOUNT, Account, Address, Root
+from .transactions import Withdrawal
 from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
 
 

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -1,7 +1,10 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
 from typing import Tuple, Union
-from .fork_types import Address
 
 from .. import rlp
 from ..base_types import (
@@ -9,18 +12,12 @@ from ..base_types import (
     U256,
     Bytes,
     Bytes0,
-    Bytes8,
-    Bytes20,
     Bytes32,
-    Bytes256,
     Uint,
     slotted_freezable,
 )
-
 from ..exceptions import InvalidBlock
-
-
-
+from .fork_types import Address
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 16
@@ -121,4 +118,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -118,7 +118,8 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-    
+
+
 @slotted_freezable
 @dataclass
 class Withdrawal:

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -1,6 +1,7 @@
 
 from dataclasses import dataclass
 from typing import Tuple, Union
+from .fork_types import Address
 
 from .. import rlp
 from ..base_types import (
@@ -18,7 +19,7 @@ from ..base_types import (
 
 from ..exceptions import InvalidBlock
 
-Address = Bytes20
+
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -118,3 +118,15 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
+    
+@slotted_freezable
+@dataclass
+class Withdrawal:
+    """
+    Withdrawals that have been validated on the consensus layer.
+    """
+
+    index: U64
+    validator_index: U64
+    address: Address
+    amount: U256

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -1,0 +1,123 @@
+
+from dataclasses import dataclass
+from typing import Tuple, Union
+
+from .. import rlp
+from ..base_types import (
+    U64,
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+
+from ..exceptions import InvalidBlock
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 16
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+TX_ACCESS_LIST_ADDRESS_COST = 2400
+TX_ACCESS_LIST_STORAGE_KEY_COST = 1900
+
+
+@slotted_freezable
+@dataclass
+class LegacyTransaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class AccessListTransaction:
+    """
+    The transaction type added in EIP-2930 to support access lists.
+    """
+
+    chain_id: U64
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+@slotted_freezable
+@dataclass
+class FeeMarketTransaction:
+    """
+    The transaction type added in EIP-1559.
+    """
+
+    chain_id: U64
+    nonce: U256
+    max_priority_fee_per_gas: Uint
+    max_fee_per_gas: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    y_parity: U256
+    r: U256
+    s: U256
+
+
+Transaction = Union[
+    LegacyTransaction, AccessListTransaction, FeeMarketTransaction
+]
+
+
+def encode_transaction(tx: Transaction) -> Union[LegacyTransaction, Bytes]:
+    """
+    Encode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, LegacyTransaction):
+        return tx
+    elif isinstance(tx, AccessListTransaction):
+        return b"\x01" + rlp.encode(tx)
+    elif isinstance(tx, FeeMarketTransaction):
+        return b"\x02" + rlp.encode(tx)
+    else:
+        raise Exception(f"Unable to encode transaction of type {type(tx)}")
+
+
+def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
+    """
+    Decode a transaction. Needed because non-legacy transactions aren't RLP.
+    """
+    if isinstance(tx, Bytes):
+        if tx[0] == 1:
+            return rlp.decode_to(AccessListTransaction, tx[1:])
+        elif tx[0] == 2:
+            return rlp.decode_to(FeeMarketTransaction, tx[1:])
+        else:
+            raise InvalidBlock
+    else:
+        return tx
+

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -118,16 +118,3 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
             raise InvalidBlock
     else:
         return tx
-
-
-@slotted_freezable
-@dataclass
-class Withdrawal:
-    """
-    Withdrawals that have been validated on the consensus layer.
-    """
-
-    index: U64
-    validator_index: U64
-    address: Address
-    amount: U256

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -36,8 +36,15 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
-from .transactions import LegacyTransaction, Withdrawal
+from .fork_types import (
+    Account,
+    Address,
+    Receipt,
+    Root,
+    Withdrawal,
+    encode_account,
+)
+from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -36,15 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    LegacyTransaction,
-    Receipt,
-    Root,
-    Withdrawal,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import LegacyTransaction, Withdrawal
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Withdrawal,
-    encode_account,
-)
+from .blocks import Receipt, Withdrawal
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes32, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/shanghai/vm/instructions/log.py
+++ b/src/ethereum/shanghai/vm/instructions/log.py
@@ -16,7 +16,7 @@ from functools import partial
 from ethereum.base_types import U256
 from ethereum.utils.ensure import ensure
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..exceptions import WriteInStaticContext
 from ..gas import (

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/spurious_dragon/blocks.py
+++ b/src/ethereum/spurious_dragon/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    post_state: Root
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/spurious_dragon/bloom.py
+++ b/src/ethereum/spurious_dragon/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -631,7 +632,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     account_exists_and_is_empty,
@@ -51,6 +36,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Tuple
+from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -33,29 +34,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
 
 
 @slotted_freezable

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    post_state: Root
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
-from .transactions import Transaction
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -104,7 +105,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
     from .transactions import Transaction
 
@@ -21,7 +22,6 @@ from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -1,22 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
 
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-from ..crypto.hash import Hash32
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68
@@ -40,4 +31,3 @@ class Transaction:
     v: U256
     r: U256
     s: U256
-

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -1,0 +1,43 @@
+
+from dataclasses import dataclass
+from typing import  Union
+
+
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32
+
+Address = Bytes20
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256
+

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import  Union
 
-
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -16,7 +16,7 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32
 
-Address = Bytes20
+
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State, account_exists_and_is_empty
 from .precompiled_contracts import RIPEMD160_ADDRESS
 

--- a/src/ethereum/spurious_dragon/vm/instructions/log.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/log.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ethereum.base_types import U256
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -27,7 +27,8 @@ from ethereum.trace import (
 )
 from ethereum.utils.ensure import ensure
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_exists_and_is_empty,
     account_has_code_or_nonce,

--- a/src/ethereum/tangerine_whistle/blocks.py
+++ b/src/ethereum/tangerine_whistle/blocks.py
@@ -1,0 +1,78 @@
+"""
+A `Block` is a single link in the chain that is Ethereum. Each `Block` contains
+a `Header` and zero or more transactions. Each `Header` contains associated
+metadata like the block number, parent block hash, and how much gas was
+consumed by its transactions.
+
+Together, these blocks form a cryptographically secure journal recording the
+history of all state transitions that have happened since the genesis of the
+chain.
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+from ..base_types import U256, Bytes, Bytes8, Bytes32, Uint, slotted_freezable
+from ..crypto.hash import Hash32
+from .fork_types import Address, Bloom, Root
+from .transactions import Transaction
+
+
+@slotted_freezable
+@dataclass
+class Header:
+    """
+    Header portion of a block on the chain.
+    """
+
+    parent_hash: Hash32
+    ommers_hash: Hash32
+    coinbase: Address
+    state_root: Root
+    transactions_root: Root
+    receipt_root: Root
+    bloom: Bloom
+    difficulty: Uint
+    number: Uint
+    gas_limit: Uint
+    gas_used: Uint
+    timestamp: U256
+    extra_data: Bytes
+    mix_digest: Bytes32
+    nonce: Bytes8
+
+
+@slotted_freezable
+@dataclass
+class Block:
+    """
+    A complete block.
+    """
+
+    header: Header
+    transactions: Tuple[Transaction, ...]
+    ommers: Tuple[Header, ...]
+
+
+@slotted_freezable
+@dataclass
+class Log:
+    """
+    Data record produced during the execution of a transaction.
+    """
+
+    address: Address
+    topics: Tuple[Hash32, ...]
+    data: bytes
+
+
+@slotted_freezable
+@dataclass
+class Receipt:
+    """
+    Result of a transaction.
+    """
+
+    post_state: Root
+    cumulative_gas_used: Uint
+    bloom: Bloom
+    logs: Tuple[Log, ...]

--- a/src/ethereum/tangerine_whistle/bloom.py
+++ b/src/ethereum/tangerine_whistle/bloom.py
@@ -21,7 +21,8 @@ from typing import Tuple
 from ethereum.base_types import Uint
 from ethereum.crypto.hash import keccak256
 
-from .fork_types import Bloom, Log
+from .blocks import Log
+from .fork_types import Bloom
 
 
 def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -26,22 +26,7 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .transactions import(
-    TX_BASE_COST,
-    TX_CREATE_COST,
-    TX_DATA_COST_PER_NON_ZERO,
-    TX_DATA_COST_PER_ZERO,
-    Transaction,
-)
-from .fork_types import (  
-    Address,
-    Block,
-    Bloom,
-    Header,
-    Log,
-    Receipt,
-    Root,
-)
+from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
 from .state import (
     State,
     create_ether,
@@ -50,6 +35,13 @@ from .state import (
     increment_nonce,
     set_account_balance,
     state_root,
+)
+from .transactions import (
+    TX_BASE_COST,
+    TX_CREATE_COST,
+    TX_DATA_COST_PER_NON_ZERO,
+    TX_DATA_COST_PER_ZERO,
+    Transaction,
 )
 from .trie import Trie, root, trie_set
 from .utils.message import prepare_message

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -25,8 +25,9 @@ from ethereum.utils.ensure import ensure
 from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
+from .blocks import Block, Header, Log, Receipt
 from .bloom import logs_bloom
-from .fork_types import Address, Block, Bloom, Header, Log, Receipt, Root
+from .fork_types import Address, Bloom, Root
 from .state import (
     State,
     create_ether,
@@ -623,7 +624,7 @@ def process_transaction(
     -------
     gas_left : `ethereum.base_types.U256`
         Remaining gas after execution.
-    logs : `Tuple[ethereum.fork_types.Log, ...]`
+    logs : `Tuple[ethereum.blocks.Log, ...]`
         Logs generated during execution.
     """
     ensure(validate_transaction(tx), InvalidBlock)

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -26,11 +26,14 @@ from .. import rlp
 from ..base_types import U64, U256, U256_CEIL_VALUE, Bytes, Bytes32, Uint
 from . import vm
 from .bloom import logs_bloom
-from .fork_types import (
+from .transactions import(
     TX_BASE_COST,
     TX_CREATE_COST,
     TX_DATA_COST_PER_NON_ZERO,
     TX_DATA_COST_PER_ZERO,
+    Transaction,
+)
+from .fork_types import (  
     Address,
     Block,
     Bloom,
@@ -38,7 +41,6 @@ from .fork_types import (
     Log,
     Receipt,
     Root,
-    Transaction,
 )
 from .state import (
     State,

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -13,18 +13,12 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple
-
-if TYPE_CHECKING:
-    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes8,
     Bytes20,
-    Bytes32,
     Bytes256,
     Uint,
     slotted_freezable,
@@ -71,64 +65,3 @@ def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
             keccak256(raw_account_data.code),
         )
     )
-
-
-@slotted_freezable
-@dataclass
-class Header:
-    """
-    Header portion of a block on the chain.
-    """
-
-    parent_hash: Hash32
-    ommers_hash: Hash32
-    coinbase: Address
-    state_root: Root
-    transactions_root: Root
-    receipt_root: Root
-    bloom: Bloom
-    difficulty: Uint
-    number: Uint
-    gas_limit: Uint
-    gas_used: Uint
-    timestamp: U256
-    extra_data: Bytes
-    mix_digest: Bytes32
-    nonce: Bytes8
-
-
-@slotted_freezable
-@dataclass
-class Block:
-    """
-    A complete block.
-    """
-
-    header: Header
-    transactions: Tuple["Transaction", ...]
-    ommers: Tuple[Header, ...]
-
-
-@slotted_freezable
-@dataclass
-class Log:
-    """
-    Data record produced during the execution of a transaction.
-    """
-
-    address: Address
-    topics: Tuple[Hash32, ...]
-    data: bytes
-
-
-@slotted_freezable
-@dataclass
-class Receipt:
-    """
-    Result of a transaction.
-    """
-
-    post_state: Root
-    cumulative_gas_used: Uint
-    bloom: Bloom
-    logs: Tuple[Log, ...]

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -13,8 +13,9 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
-from .transactions import Transaction
+from typing import Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .transactions import  Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -103,7 +104,7 @@ class Block:
     """
 
     header: Header
-    transactions: Tuple[Transaction, ...]
+    transactions: Tuple["Transaction", ...]
     ommers: Tuple[Header, ...]
 
 

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -13,15 +13,15 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
+
 if TYPE_CHECKING:
-    from .transactions import  Transaction
+    from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
     U256,
     Bytes,
-    Bytes0,
     Bytes8,
     Bytes20,
     Bytes32,
@@ -35,6 +35,7 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -13,7 +13,8 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Tuple, Union
+from typing import Tuple
+from .transactions import Transaction
 
 from .. import rlp
 from ..base_types import (
@@ -33,30 +34,6 @@ Address = Bytes20
 Root = Hash32
 
 Bloom = Bytes256
-
-TX_BASE_COST = 21000
-TX_DATA_COST_PER_NON_ZERO = 68
-TX_DATA_COST_PER_ZERO = 4
-TX_CREATE_COST = 32000
-
-
-@slotted_freezable
-@dataclass
-class Transaction:
-    """
-    Atomic operation performed on the block chain.
-    """
-
-    nonce: U256
-    gas_price: Uint
-    gas: Uint
-    to: Union[Bytes0, Address]
-    value: U256
-    data: Bytes
-    v: U256
-    r: U256
-    s: U256
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from typing import  Union
 
+from .fork_types import Address
 from ..base_types import (
     U256,
     Bytes,
@@ -15,7 +16,6 @@ from ..base_types import (
 )
 from ..crypto.hash import Hash32
 
-Address = Bytes20
 
 
 TX_BASE_COST = 21000

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -1,0 +1,42 @@
+
+from dataclasses import dataclass
+from typing import  Union
+
+from ..base_types import (
+    U256,
+    Bytes,
+    Bytes0,
+    Bytes8,
+    Bytes20,
+    Bytes32,
+    Bytes256,
+    Uint,
+    slotted_freezable,
+)
+from ..crypto.hash import Hash32
+
+Address = Bytes20
+
+
+TX_BASE_COST = 21000
+TX_DATA_COST_PER_NON_ZERO = 68
+TX_DATA_COST_PER_ZERO = 4
+TX_CREATE_COST = 32000
+
+
+@slotted_freezable
+@dataclass
+class Transaction:
+    """
+    Atomic operation performed on the block chain.
+    """
+
+    nonce: U256
+    gas_price: Uint
+    gas: Uint
+    to: Union[Bytes0, Address]
+    value: U256
+    data: Bytes
+    v: U256
+    r: U256
+    s: U256

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -1,22 +1,13 @@
-
+"""
+Transactions are atomic units of work created externally to Ethereum and
+submitted to be executed. If Ethereum is viewed as a state machine,
+transactions are the events that move between states.
+"""
 from dataclasses import dataclass
-from typing import  Union
+from typing import Union
 
+from ..base_types import U256, Bytes, Bytes0, Uint, slotted_freezable
 from .fork_types import Address
-from ..base_types import (
-    U256,
-    Bytes,
-    Bytes0,
-    Bytes8,
-    Bytes20,
-    Bytes32,
-    Bytes256,
-    Uint,
-    slotted_freezable,
-)
-from ..crypto.hash import Hash32
-
-
 
 TX_BASE_COST = 21000
 TX_DATA_COST_PER_NON_ZERO = 68

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -36,7 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import Account, Address, Receipt, Root, encode_account
+from .blocks import Receipt
+from .fork_types import Account, Address, Root, encode_account
 from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -36,14 +36,8 @@ from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .. import rlp
 from ..base_types import U256, Bytes, Uint, slotted_freezable
-from .fork_types import (
-    Account,
-    Address,
-    Receipt,
-    Root,
-    Transaction,
-    encode_account,
-)
+from .fork_types import Account, Address, Receipt, Root, encode_account
+from .transactions import Transaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
 #

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Optional, Set, Tuple, Union
 from ethereum.base_types import U256, Bytes, Bytes0, Uint
 from ethereum.crypto.hash import Hash32
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import State
 
 __all__ = ("Environment", "Evm", "Message")

--- a/src/ethereum/tangerine_whistle/vm/instructions/log.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/log.py
@@ -15,7 +15,7 @@ from functools import partial
 
 from ethereum.base_types import U256
 
-from ...fork_types import Log
+from ...blocks import Log
 from .. import Evm
 from ..gas import (
     GAS_LOG,

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -26,7 +26,8 @@ from ethereum.trace import (
     evm_trace,
 )
 
-from ..fork_types import Address, Log
+from ..blocks import Log
+from ..fork_types import Address
 from ..state import (
     account_has_code_or_nonce,
     begin_transaction,

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -329,10 +329,10 @@ class Load(BaseLoad):
                 ) from e
 
         # Legacy Transaction
-        if hasattr(self._module("fork_types"), "LegacyTransaction"):
-            return self._module("fork_types").LegacyTransaction(*parameters)
+        if hasattr(self._module("transactions"), "LegacyTransaction"):
+            return self._module("transactions").LegacyTransaction(*parameters)
         else:
-            return self._module("fork_types").Transaction(*parameters)
+            return self._module("transactions").Transaction(*parameters)
 
     def json_to_withdrawals(self, raw: Any) -> Any:
         """Converts json withdrawal data to a withdrawal object"""

--- a/src/ethereum_spec_tools/evm_tools/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/fixture_loader.py
@@ -157,7 +157,7 @@ class Load(BaseLoad):
     @property
     def Block(self) -> Any:
         """Block class of the fork"""
-        return self._module("fork_types").Block
+        return self._module("blocks").Block
 
     @property
     def Bloom(self) -> Any:
@@ -167,7 +167,7 @@ class Load(BaseLoad):
     @property
     def Header(self) -> Any:
         """Header class of the fork"""
-        return self._module("fork_types").Header
+        return self._module("blocks").Header
 
     @property
     def Environment(self) -> Any:
@@ -177,7 +177,7 @@ class Load(BaseLoad):
     @property
     def LegacyTransaction(self) -> Any:
         """Legacy transaction class of the fork"""
-        mod = self._module("fork_types")
+        mod = self._module("transactions")
         try:
             return mod.LegacyTransaction
         except AttributeError:
@@ -301,7 +301,7 @@ class Load(BaseLoad):
             )
             try:
                 return b"\x02" + rlp.encode(
-                    self._module("fork_types").FeeMarketTransaction(
+                    self._module("transactions").FeeMarketTransaction(
                         *parameters
                     )
                 )
@@ -319,7 +319,7 @@ class Load(BaseLoad):
             )
             try:
                 return b"\x01" + rlp.encode(
-                    self._module("fork_types").AccessListTransaction(
+                    self._module("transactions").AccessListTransaction(
                         *parameters
                     )
                 )
@@ -343,7 +343,7 @@ class Load(BaseLoad):
             hex_to_u256(raw.get("amount")),
         ]
 
-        return self._module("fork_types").Withdrawal(*parameters)
+        return self._module("blocks").Withdrawal(*parameters)
 
     def json_to_block(
         self,

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -123,6 +123,16 @@ class T8N(Load):
         return self._module("fork")
 
     @property
+    def transactions(self) -> Any:
+        """The transactions module of the given fork."""
+        return self._module("transactions")
+
+    @property
+    def blocks(self) -> Any:
+        """The blocks module of the given fork."""
+        return self._module("blocks")
+
+    @property
     def fork_types(self) -> Any:
         """The fork_types model of the given fork."""
         return self._module("fork_types")

--- a/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
@@ -244,3 +244,12 @@ class _Visitor(ast.NodeVisitor):
                 f"AnnAssign node with target of type {type(assign.target)}"
                 " has been ignored."
             )
+
+    def visit_If(self, node: ast.If) -> None:
+        """
+        Visit an if statement.
+        """
+        for child in node.body:
+            self.visit(child)
+        for child in node.orelse:
+            self.visit(child)

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -288,7 +288,7 @@ class BlockDownloader(ForkTracking):
                     ],
                 )
             )
-        if hasattr(self.module("fork_types"), "LegacyTransaction"):
+        if hasattr(self.module("transactions"), "LegacyTransaction"):
             if t["type"] == "0x1":
                 return b"\x01" + rlp.encode(
                     self.module("fork_types").AccessListTransaction(

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -265,9 +265,7 @@ class BlockDownloader(ForkTracking):
                     )
                     self.advance_block(timestamp)
                     blocks.append(
-                        rlp.decode_to(
-                            self.module("fork_types").Block, block_rlp
-                        )
+                        rlp.decode_to(self.module("blocks").Block, block_rlp)
                     )
             return blocks
 
@@ -291,7 +289,7 @@ class BlockDownloader(ForkTracking):
         if hasattr(self.module("transactions"), "LegacyTransaction"):
             if t["type"] == "0x1":
                 return b"\x01" + rlp.encode(
-                    self.module("fork_types").AccessListTransaction(
+                    self.module("transactions").AccessListTransaction(
                         hex_to_u64(t["chainId"]),
                         hex_to_u256(t["nonce"]),
                         hex_to_u256(t["gasPrice"]),
@@ -311,7 +309,7 @@ class BlockDownloader(ForkTracking):
                 )
             elif t["type"] == "0x2":
                 return b"\x02" + rlp.encode(
-                    self.module("fork_types").FeeMarketTransaction(
+                    self.module("transactions").FeeMarketTransaction(
                         hex_to_u64(t["chainId"]),
                         hex_to_u256(t["nonce"]),
                         hex_to_u256(t["maxPriorityFeePerGas"]),
@@ -331,7 +329,7 @@ class BlockDownloader(ForkTracking):
                     )
                 )
             else:
-                return self.module("fork_types").LegacyTransaction(
+                return self.module("transactions").LegacyTransaction(
                     hex_to_u256(t["nonce"]),
                     hex_to_u256(t["gasPrice"]),
                     hex_to_u256(t["gas"]),
@@ -345,7 +343,7 @@ class BlockDownloader(ForkTracking):
                     hex_to_u256(t["s"]),
                 )
         else:
-            return self.module("fork_types").Transaction(
+            return self.module("transactions").Transaction(
                 hex_to_u256(t["nonce"]),
                 hex_to_u256(t["gasPrice"]),
                 hex_to_u256(t["gas"]),
@@ -526,11 +524,11 @@ class BlockDownloader(ForkTracking):
             hex_to_bytes32(json["mixHash"]),
             hex_to_bytes8(json["nonce"]),
         ]
-        if hasattr(self.module("fork_types").Header, "base_fee_per_gas"):
+        if hasattr(self.module("blocks").Header, "base_fee_per_gas"):
             fields.append(hex_to_uint(json["baseFeePerGas"]))
-        if hasattr(self.module("fork_types").Header, "withdrawals_root"):
+        if hasattr(self.module("blocks").Header, "withdrawals_root"):
             fields.append(hex_to_bytes32(json["withdrawalsRoot"]))
-        return self.module("fork_types").Header(*fields)
+        return self.module("blocks").Header(*fields)
 
     def make_block(self, json: Any, ommers: Any) -> Any:
         """
@@ -545,7 +543,7 @@ class BlockDownloader(ForkTracking):
             withdrawals = []
             for j in json["withdrawals"]:
                 withdrawals.append(
-                    self.module("fork_types").Withdrawal(
+                    self.module("blocks").Withdrawal(
                         hex_to_u64(j["index"]),
                         hex_to_u64(j["validatorIndex"]),
                         self.module("utils.hexadecimal").hex_to_address(
@@ -556,10 +554,10 @@ class BlockDownloader(ForkTracking):
                 )
 
         extra_fields = []
-        if hasattr(self.module("fork_types").Block, "withdrawals"):
+        if hasattr(self.module("blocks").Block, "withdrawals"):
             extra_fields.append(withdrawals)
 
-        return self.module("fork_types").Block(
+        return self.module("blocks").Block(
             header,
             tuple(transactions),
             ommers,

--- a/tests/berlin/test_ethash.py
+++ b/tests/berlin/test_ethash.py
@@ -6,11 +6,11 @@ import pytest
 
 from ethereum import rlp
 from ethereum.base_types import Uint
+from ethereum.berlin.blocks import Header
 from ethereum.berlin.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.berlin.fork_types import Header
 from ethereum.crypto.hash import keccak256
 from ethereum.ethash import (
     cache_size,

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -2,7 +2,7 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.berlin.fork_types import Block, Header, Log, Receipt
+from ethereum.berlin.blocks import Block, Header, Log, Receipt
 from ethereum.berlin.transactions import (
     AccessListTransaction,
     LegacyTransaction,

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -2,13 +2,10 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.berlin.fork_types import (
+from ethereum.berlin.fork_types import Block, Header, Log, Receipt
+from ethereum.berlin.transactions import (
     AccessListTransaction,
-    Block,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
     Transaction,
     decode_transaction,
     encode_transaction,

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -4,7 +4,7 @@ import pytest
 
 from ethereum import rlp
 from ethereum.berlin.fork import calculate_intrinsic_cost, validate_transaction
-from ethereum.berlin.fork_types import LegacyTransaction
+from ethereum.berlin.transactions import LegacyTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/byzantium/test_ethash.py
+++ b/tests/byzantium/test_ethash.py
@@ -6,11 +6,11 @@ import pytest
 
 from ethereum import rlp
 from ethereum.base_types import Uint
+from ethereum.byzantium.blocks import Header
 from ethereum.byzantium.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.byzantium.fork_types import Header
 from ethereum.crypto.hash import keccak256
 from ethereum.ethash import (
     cache_size,

--- a/tests/byzantium/test_rlp.py
+++ b/tests/byzantium/test_rlp.py
@@ -2,13 +2,8 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.byzantium.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.byzantium.fork_types import Block, Header, Log, Receipt
+from ethereum.byzantium.transactions import Transaction
 from ethereum.byzantium.utils.hexadecimal import hex_to_address
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/byzantium/test_rlp.py
+++ b/tests/byzantium/test_rlp.py
@@ -2,7 +2,7 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.byzantium.fork_types import Block, Header, Log, Receipt
+from ethereum.byzantium.blocks import Block, Header, Log, Receipt
 from ethereum.byzantium.transactions import Transaction
 from ethereum.byzantium.utils.hexadecimal import hex_to_address
 from ethereum.crypto.hash import keccak256

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.byzantium.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.byzantium.fork_types import Transaction
+from ethereum.byzantium.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/constantinople/test_ethash.py
+++ b/tests/constantinople/test_ethash.py
@@ -6,11 +6,11 @@ import pytest
 
 from ethereum import rlp
 from ethereum.base_types import Uint
+from ethereum.constantinople.blocks import Header
 from ethereum.constantinople.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.constantinople.fork_types import Header
 from ethereum.crypto.hash import keccak256
 from ethereum.ethash import (
     cache_size,

--- a/tests/constantinople/test_rlp.py
+++ b/tests/constantinople/test_rlp.py
@@ -2,7 +2,7 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.constantinople.fork_types import Block, Header, Log, Receipt
+from ethereum.constantinople.blocks import Block, Header, Log, Receipt
 from ethereum.constantinople.transactions import Transaction
 from ethereum.constantinople.utils.hexadecimal import hex_to_address
 from ethereum.crypto.hash import keccak256

--- a/tests/constantinople/test_rlp.py
+++ b/tests/constantinople/test_rlp.py
@@ -2,13 +2,8 @@ import pytest
 
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
-from ethereum.constantinople.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.constantinople.fork_types import Block, Header, Log, Receipt
+from ethereum.constantinople.transactions import Transaction
 from ethereum.constantinople.utils.hexadecimal import hex_to_address
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.constantinople.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.constantinople.fork_types import Transaction
+from ethereum.constantinople.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/frontier/test_ethash.py
+++ b/tests/frontier/test_ethash.py
@@ -14,11 +14,11 @@ from ethereum.ethash import (
     generate_seed,
     hashimoto_light,
 )
+from ethereum.frontier.blocks import Header
 from ethereum.frontier.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.frontier.fork_types import Header
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,

--- a/tests/frontier/test_rlp.py
+++ b/tests/frontier/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.frontier.fork_types import Block, Header, Log, Receipt
+from ethereum.frontier.blocks import Block, Header, Log, Receipt
 from ethereum.frontier.transactions import Transaction
 from ethereum.frontier.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/frontier/test_rlp.py
+++ b/tests/frontier/test_rlp.py
@@ -3,13 +3,8 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.frontier.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.frontier.fork_types import Block, Header, Log, Receipt
+from ethereum.frontier.transactions import Transaction
 from ethereum.frontier.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256
 

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.frontier.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.frontier.fork_types import Transaction
+from ethereum.frontier.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/homestead/test_ethash.py
+++ b/tests/homestead/test_ethash.py
@@ -14,11 +14,11 @@ from ethereum.ethash import (
     generate_seed,
     hashimoto_light,
 )
+from ethereum.homestead.blocks import Header
 from ethereum.homestead.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.homestead.fork_types import Header
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,

--- a/tests/homestead/test_rlp.py
+++ b/tests/homestead/test_rlp.py
@@ -3,13 +3,8 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.homestead.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.homestead.fork_types import Block, Header, Log, Receipt
+from ethereum.homestead.transactions import Transaction
 from ethereum.homestead.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256
 

--- a/tests/homestead/test_rlp.py
+++ b/tests/homestead/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.homestead.fork_types import Block, Header, Log, Receipt
+from ethereum.homestead.blocks import Block, Header, Log, Receipt
 from ethereum.homestead.transactions import Transaction
 from ethereum.homestead.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.homestead.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.homestead.fork_types import Transaction
+from ethereum.homestead.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/istanbul/test_ethash.py
+++ b/tests/istanbul/test_ethash.py
@@ -14,11 +14,11 @@ from ethereum.ethash import (
     generate_seed,
     hashimoto_light,
 )
+from ethereum.istanbul.blocks import Header
 from ethereum.istanbul.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.istanbul.fork_types import Header
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,

--- a/tests/istanbul/test_rlp.py
+++ b/tests/istanbul/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.istanbul.fork_types import Block, Header, Log, Receipt
+from ethereum.istanbul.blocks import Block, Header, Log, Receipt
 from ethereum.istanbul.transactions import Transaction
 from ethereum.istanbul.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/istanbul/test_rlp.py
+++ b/tests/istanbul/test_rlp.py
@@ -3,13 +3,8 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.istanbul.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.istanbul.fork_types import Block, Header, Log, Receipt
+from ethereum.istanbul.transactions import Transaction
 from ethereum.istanbul.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256
 

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.istanbul.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.istanbul.fork_types import Transaction
+from ethereum.istanbul.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.london.fork_types import Block, Header, Log, Receipt
+from ethereum.london.blocks import Block, Header, Log, Receipt
 from ethereum.london.transactions import (
     AccessListTransaction,
     FeeMarketTransaction,

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -3,14 +3,11 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.london.fork_types import (
+from ethereum.london.fork_types import Block, Header, Log, Receipt
+from ethereum.london.transactions import (
     AccessListTransaction,
-    Block,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
     Transaction,
     decode_transaction,
     encode_transaction,

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -4,7 +4,7 @@ import pytest
 
 from ethereum import rlp
 from ethereum.london.fork import calculate_intrinsic_cost, validate_transaction
-from ethereum.london.fork_types import LegacyTransaction
+from ethereum.london.transactions import LegacyTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.paris.fork_types import Block, Header, Log, Receipt
+from ethereum.paris.blocks import Block, Header, Log, Receipt
 from ethereum.paris.transactions import (
     AccessListTransaction,
     FeeMarketTransaction,

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -3,14 +3,11 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.paris.fork_types import (
+from ethereum.paris.fork_types import Block, Header, Log, Receipt
+from ethereum.paris.transactions import (
     AccessListTransaction,
-    Block,
     FeeMarketTransaction,
-    Header,
     LegacyTransaction,
-    Log,
-    Receipt,
     Transaction,
     decode_transaction,
     encode_transaction,

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -3,13 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.shanghai.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Withdrawal,
-)
+from ethereum.shanghai.blocks import Block, Header, Log, Receipt, Withdrawal
 from ethereum.shanghai.transactions import (
     AccessListTransaction,
     FeeMarketTransaction,

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -4,15 +4,17 @@ import ethereum.rlp as rlp
 from ethereum.base_types import U64, U256, Bytes, Bytes0, Bytes8, Bytes32, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.shanghai.fork_types import (
-    AccessListTransaction,
     Block,
-    FeeMarketTransaction,
     Header,
-    LegacyTransaction,
     Log,
     Receipt,
-    Transaction,
     Withdrawal,
+)
+from ethereum.shanghai.transactions import (
+    AccessListTransaction,
+    FeeMarketTransaction,
+    LegacyTransaction,
+    Transaction,
     decode_transaction,
     encode_transaction,
 )

--- a/tests/spurious_dragon/test_ethash.py
+++ b/tests/spurious_dragon/test_ethash.py
@@ -14,11 +14,11 @@ from ethereum.ethash import (
     generate_seed,
     hashimoto_light,
 )
+from ethereum.spurious_dragon.blocks import Header
 from ethereum.spurious_dragon.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.spurious_dragon.fork_types import Header
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,

--- a/tests/spurious_dragon/test_rlp.py
+++ b/tests/spurious_dragon/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.spurious_dragon.fork_types import Block, Header, Log, Receipt
+from ethereum.spurious_dragon.blocks import Block, Header, Log, Receipt
 from ethereum.spurious_dragon.transactions import Transaction
 from ethereum.spurious_dragon.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/spurious_dragon/test_rlp.py
+++ b/tests/spurious_dragon/test_rlp.py
@@ -3,13 +3,8 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.spurious_dragon.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.spurious_dragon.fork_types import Block, Header, Log, Receipt
+from ethereum.spurious_dragon.transactions import Transaction
 from ethereum.spurious_dragon.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256
 

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.spurious_dragon.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.spurious_dragon.fork_types import Transaction
+from ethereum.spurious_dragon.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/tests/tangerine_whistle/test_ethash.py
+++ b/tests/tangerine_whistle/test_ethash.py
@@ -14,11 +14,11 @@ from ethereum.ethash import (
     generate_seed,
     hashimoto_light,
 )
+from ethereum.tangerine_whistle.blocks import Header
 from ethereum.tangerine_whistle.fork import (
     generate_header_hash_for_pow,
     validate_proof_of_work,
 )
-from ethereum.tangerine_whistle.fork_types import Header
 from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,

--- a/tests/tangerine_whistle/test_rlp.py
+++ b/tests/tangerine_whistle/test_rlp.py
@@ -3,13 +3,8 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.tangerine_whistle.fork_types import (
-    Block,
-    Header,
-    Log,
-    Receipt,
-    Transaction,
-)
+from ethereum.tangerine_whistle.fork_types import Block, Header, Log, Receipt
+from ethereum.tangerine_whistle.transactions import Transaction
 from ethereum.tangerine_whistle.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256
 

--- a/tests/tangerine_whistle/test_rlp.py
+++ b/tests/tangerine_whistle/test_rlp.py
@@ -3,7 +3,7 @@ import pytest
 import ethereum.rlp as rlp
 from ethereum.base_types import U256, Bytes, Bytes0, Bytes8, Uint
 from ethereum.crypto.hash import keccak256
-from ethereum.tangerine_whistle.fork_types import Block, Header, Log, Receipt
+from ethereum.tangerine_whistle.blocks import Block, Header, Log, Receipt
 from ethereum.tangerine_whistle.transactions import Transaction
 from ethereum.tangerine_whistle.utils.hexadecimal import hex_to_address
 from ethereum.utils.hexadecimal import hex_to_bytes256

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.tangerine_whistle.fork import (
     calculate_intrinsic_cost,
     validate_transaction,
 )
-from ethereum.tangerine_whistle.fork_types import Transaction
+from ethereum.tangerine_whistle.transactions import Transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -407,3 +407,4 @@ listable
 treediff
 strikethrough
 setext
+orelse


### PR DESCRIPTION
### The fork_types modules are gonna increase in size in the future so I refactored transactions-related functions and variables in a separate module for all the forks 

Related to Issue #

### I created a separate file named transactions.py  in the same directory as fork_types.py for different forks from arrow-glacier to tangerine-whistle. I moved the transaction-related content into transactions.py with the necessary imports and variables used in it .
###Also, I created different commits for each fork for my accountability for which forks are done so far by me in another branch transaction_types_refactoring. 




#### Cute Animal Picture
Thank you for allowing me to contribute to my dream org.😌

![229ad628cbdf49c5a0ae302d2e59bdf4](https://github.com/ethereum/execution-specs/assets/114795592/bbea9002-12e6-4d41-9512-45f2c5fa3885)

