### PR TITLE
Consistent type hints in `fork_types.py`

### DIFF
--- a/src/ethereum/arrow_glacier/blocks.py
+++ b/src/ethereum/arrow_glacier/blocks.py
@@ -72,7 +72,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/arrow_glacier/bloom.py
+++ b/src/ethereum/arrow_glacier/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/arrow_glacier/utils/hexadecimal.py
+++ b/src/ethereum/arrow_glacier/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Arrow Glacier types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/arrow_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -680,7 +680,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/arrow_glacier/vm/runtime.py
+++ b/src/ethereum/arrow_glacier/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/berlin/blocks.py
+++ b/src/ethereum/berlin/blocks.py
@@ -66,7 +66,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/berlin/bloom.py
+++ b/src/ethereum/berlin/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/berlin/utils/hexadecimal.py
+++ b/src/ethereum/berlin/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Berlin types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/berlin/vm/instructions/arithmetic.py
+++ b/src/ethereum/berlin/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -692,7 +692,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/berlin/vm/runtime.py
+++ b/src/ethereum/berlin/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/byzantium/blocks.py
+++ b/src/ethereum/byzantium/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/byzantium/bloom.py
+++ b/src/ethereum/byzantium/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -35,7 +35,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/byzantium/utils/hexadecimal.py
+++ b/src/ethereum/byzantium/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Byzantium types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/byzantium/vm/instructions/arithmetic.py
+++ b/src/ethereum/byzantium/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ...fork_types import Address
@@ -587,7 +587,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/byzantium/vm/runtime.py
+++ b/src/ethereum/byzantium/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/cancun/blocks.py
+++ b/src/ethereum/cancun/blocks.py
@@ -91,7 +91,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/cancun/bloom.py
+++ b/src/ethereum/cancun/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/cancun/fork_types.py
+++ b/src/ethereum/cancun/fork_types.py
@@ -37,7 +37,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/cancun/utils/hexadecimal.py
+++ b/src/ethereum/cancun/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Cancun types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/cancun/vm/instructions/arithmetic.py
+++ b/src/ethereum/cancun/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -702,7 +702,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/cancun/vm/runtime.py
+++ b/src/ethereum/cancun/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/constantinople/blocks.py
+++ b/src/ethereum/constantinople/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/constantinople/bloom.py
+++ b/src/ethereum/constantinople/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/constantinople/utils/hexadecimal.py
+++ b/src/ethereum/constantinople/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Constantinople types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/constantinople/vm/instructions/arithmetic.py
+++ b/src/ethereum/constantinople/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -658,7 +658,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/constantinople/vm/runtime.py
+++ b/src/ethereum/constantinople/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/dao_fork/blocks.py
+++ b/src/ethereum/dao_fork/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/dao_fork/bloom.py
+++ b/src/ethereum/dao_fork/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/dao_fork/utils/hexadecimal.py
+++ b/src/ethereum/dao_fork/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to Dao Fork
 types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/dao_fork/vm/instructions/arithmetic.py
+++ b/src/ethereum/dao_fork/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/dao_fork/vm/runtime.py
+++ b/src/ethereum/dao_fork/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/ethash.py
+++ b/src/ethereum/ethash.py
@@ -28,7 +28,7 @@ At a high level, the Ethash algorithm is as follows:
 
 from typing import Callable, Tuple, Union
 
-from ethereum_types.bytes import Bytes8
+from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import U32, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, Hash64, keccak256, keccak512
@@ -239,7 +239,7 @@ def generate_cache(block_number: Uint) -> Tuple[Tuple[U32, ...], ...]:
             second_cache_item = cache[
                 U32.from_le_bytes(cache[index][0:4]) % U32(cache_size_words)
             ]
-            result = bytes(
+            result = Bytes(
                 [a ^ b for a, b in zip(first_cache_item, second_cache_item)]
             )
             cache[index] = keccak512(result)
@@ -342,7 +342,7 @@ def hashimoto(
     nonce: Bytes8,
     dataset_size: Uint,
     fetch_dataset_item: Callable[[Uint], Tuple[U32, ...]],
-) -> Tuple[bytes, Hash32]:
+) -> Tuple[Bytes, Hash32]:
     """
     Obtain the mix digest and the final value for a header, by aggregating
     data from the full dataset.
@@ -363,7 +363,7 @@ def hashimoto(
 
     [`dataset_size`]: ref:ethereum.ethash.dataset_size
     """
-    nonce_le = bytes(reversed(nonce))
+    nonce_le = Bytes(reversed(nonce))
     seed_hash = keccak512(header_hash + nonce_le)
     seed_head = U32.from_le_bytes(seed_hash[:4])
 
@@ -397,7 +397,7 @@ def hashimoto_light(
     nonce: Bytes8,
     cache: Tuple[Tuple[U32, ...], ...],
     dataset_size: Uint,
-) -> Tuple[bytes, Hash32]:
+) -> Tuple[Bytes, Hash32]:
     """
     Run the [`hashimoto`] algorithm by generating dataset item using the cache
     instead of loading the full dataset into main memory.

--- a/src/ethereum/frontier/blocks.py
+++ b/src/ethereum/frontier/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/frontier/bloom.py
+++ b/src/ethereum/frontier/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/frontier/utils/hexadecimal.py
+++ b/src/ethereum/frontier/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to Frontier
 types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/frontier/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/frontier/vm/runtime.py
+++ b/src/ethereum/frontier/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/genesis.py
+++ b/src/ethereum/genesis.py
@@ -143,7 +143,7 @@ class GenesisFork(
     """
 
     Address: Type[FixedBytes]
-    Account: Callable[[Uint, U256, bytes], AccountT]
+    Account: Callable[[Uint, U256, Bytes], AccountT]
     Trie: Callable[[bool, object], TrieT]
     Bloom: Type[FixedBytes]
     Header: Type[HeaderT]

--- a/src/ethereum/gray_glacier/blocks.py
+++ b/src/ethereum/gray_glacier/blocks.py
@@ -72,7 +72,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/gray_glacier/bloom.py
+++ b/src/ethereum/gray_glacier/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/gray_glacier/utils/hexadecimal.py
+++ b/src/ethereum/gray_glacier/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Gray Glacier types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/gray_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/gray_glacier/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -680,7 +680,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/gray_glacier/vm/runtime.py
+++ b/src/ethereum/gray_glacier/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/homestead/blocks.py
+++ b/src/ethereum/homestead/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/homestead/bloom.py
+++ b/src/ethereum/homestead/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/homestead/utils/hexadecimal.py
+++ b/src/ethereum/homestead/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to Homestead
 types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/homestead/vm/instructions/arithmetic.py
+++ b/src/ethereum/homestead/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/homestead/vm/runtime.py
+++ b/src/ethereum/homestead/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/istanbul/blocks.py
+++ b/src/ethereum/istanbul/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/istanbul/bloom.py
+++ b/src/ethereum/istanbul/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/istanbul/utils/hexadecimal.py
+++ b/src/ethereum/istanbul/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Istanbul types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/istanbul/vm/instructions/arithmetic.py
+++ b/src/ethereum/istanbul/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -658,7 +658,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/istanbul/vm/runtime.py
+++ b/src/ethereum/istanbul/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/london/blocks.py
+++ b/src/ethereum/london/blocks.py
@@ -72,7 +72,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/london/bloom.py
+++ b/src/ethereum/london/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/london/utils/hexadecimal.py
+++ b/src/ethereum/london/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 London types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/london/vm/instructions/arithmetic.py
+++ b/src/ethereum/london/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -680,7 +680,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/london/vm/runtime.py
+++ b/src/ethereum/london/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/muir_glacier/blocks.py
+++ b/src/ethereum/muir_glacier/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/muir_glacier/bloom.py
+++ b/src/ethereum/muir_glacier/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/muir_glacier/utils/hexadecimal.py
+++ b/src/ethereum/muir_glacier/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Muir Glacier types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/muir_glacier/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -11,7 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -658,7 +658,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/muir_glacier/vm/runtime.py
+++ b/src/ethereum/muir_glacier/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/paris/blocks.py
+++ b/src/ethereum/paris/blocks.py
@@ -72,7 +72,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/paris/bloom.py
+++ b/src/ethereum/paris/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/paris/utils/hexadecimal.py
+++ b/src/ethereum/paris/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Paris types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/paris/vm/instructions/arithmetic.py
+++ b/src/ethereum/paris/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -680,7 +680,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/paris/vm/runtime.py
+++ b/src/ethereum/paris/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/prague/blocks.py
+++ b/src/ethereum/prague/blocks.py
@@ -93,7 +93,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/prague/bloom.py
+++ b/src/ethereum/prague/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/prague/fork_types.py
+++ b/src/ethereum/prague/fork_types.py
@@ -37,7 +37,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/prague/utils/hexadecimal.py
+++ b/src/ethereum/prague/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Prague types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/prague/vm/instructions/arithmetic.py
+++ b/src/ethereum/prague/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -290,7 +290,7 @@ def generic_call(
     memory_input_size: U256,
     memory_output_start_position: U256,
     memory_output_size: U256,
-    code: bytes,
+    code: Bytes,
     disable_precompiles: bool,
 ) -> None:
     """
@@ -745,7 +745,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/prague/vm/runtime.py
+++ b/src/ethereum/prague/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/shanghai/blocks.py
+++ b/src/ethereum/shanghai/blocks.py
@@ -87,7 +87,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/bloom.py
+++ b/src/ethereum/shanghai/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/shanghai/utils/hexadecimal.py
+++ b/src/ethereum/shanghai/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Shanghai types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/shanghai/vm/instructions/arithmetic.py
+++ b/src/ethereum/shanghai/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -12,7 +12,7 @@ Introduction
 Implementations of the EVM system related instructions.
 """
 
-from ethereum_types.bytes import Bytes0
+from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import ceil32
@@ -703,7 +703,7 @@ def revert(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     output = memory_read_bytes(evm.memory, memory_start_index, size)
-    evm.output = bytes(output)
+    evm.output = Bytes(output)
     raise Revert
 
     # PROGRAM COUNTER

--- a/src/ethereum/shanghai/vm/runtime.py
+++ b/src/ethereum/shanghai/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/spurious_dragon/blocks.py
+++ b/src/ethereum/spurious_dragon/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/spurious_dragon/bloom.py
+++ b/src/ethereum/spurious_dragon/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/spurious_dragon/utils/hexadecimal.py
+++ b/src/ethereum/spurious_dragon/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Spurious Dragon types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/spurious_dragon/vm/runtime.py
+++ b/src/ethereum/spurious_dragon/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/tangerine_whistle/blocks.py
+++ b/src/ethereum/tangerine_whistle/blocks.py
@@ -65,7 +65,7 @@ class Log:
 
     address: Address
     topics: Tuple[Hash32, ...]
-    data: bytes
+    data: Bytes
 
 
 @slotted_freezable

--- a/src/ethereum/tangerine_whistle/bloom.py
+++ b/src/ethereum/tangerine_whistle/bloom.py
@@ -18,6 +18,7 @@ eliminating blocks and receipts from their search.
 
 from typing import Tuple
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import keccak256
@@ -26,7 +27,7 @@ from .blocks import Log
 from .fork_types import Bloom
 
 
-def add_to_bloom(bloom: bytearray, bloom_entry: bytes) -> None:
+def add_to_bloom(bloom: bytearray, bloom_entry: Bytes) -> None:
     """
     Add a bloom entry to the bloom filter (`bloom`).
 

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -36,7 +36,7 @@ class Account:
 
     nonce: Uint
     balance: U256
-    code: bytes
+    code: Bytes
 
 
 EMPTY_ACCOUNT = Account(

--- a/src/ethereum/tangerine_whistle/utils/hexadecimal.py
+++ b/src/ethereum/tangerine_whistle/utils/hexadecimal.py
@@ -12,6 +12,8 @@ Introduction
 Hexadecimal utility functions used in this specification, specific to
 Tangerine Whistle types.
 """
+from ethereum_types.bytes import Bytes
+
 from ethereum.utils.hexadecimal import remove_hex_prefix
 
 from ..fork_types import Address, Bloom, Root
@@ -31,7 +33,7 @@ def hex_to_root(hex_string: str) -> Root:
     root : `Root`
         Trie root obtained from the given hexadecimal string.
     """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Root(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_bloom(hex_string: str) -> Bloom:
@@ -48,7 +50,7 @@ def hex_to_bloom(hex_string: str) -> Bloom:
     bloom : `Bloom`
         Bloom obtained from the given hexadecimal string.
     """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Bloom(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_address(hex_string: str) -> Address:
@@ -65,4 +67,4 @@ def hex_to_address(hex_string: str) -> Address:
     address : `Address`
         The address obtained from the given hexadecimal string.
     """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
+    return Address(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/arithmetic.py
@@ -12,6 +12,7 @@ Introduction
 Implementations of the EVM Arithmetic instructions.
 """
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.utils.numeric import get_sign
@@ -354,7 +355,7 @@ def signextend(evm: Evm) -> None:
         result = value
     else:
         # U256(0).to_be_bytes() gives b'' instead b'\x00'.
-        value_bytes = bytes(value.to_be_bytes32())
+        value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.
         value_bytes = value_bytes[31 - int(byte_num) :]

--- a/src/ethereum/tangerine_whistle/vm/runtime.py
+++ b/src/ethereum/tangerine_whistle/vm/runtime.py
@@ -13,12 +13,13 @@ Runtime related operations used while executing EVM code.
 """
 from typing import Set
 
+from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
 
 from .instructions import Ops
 
 
-def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
+def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
     Analyze the evm code to obtain the set of valid jump destinations.
 

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -20,6 +20,8 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Protocol, Union
 
+from ethereum_types.bytes import Bytes
+
 from ethereum.exceptions import EthereumException
 
 
@@ -41,7 +43,7 @@ class TransactionEnd:
     Total gas consumed by this transaction.
     """
 
-    output: bytes
+    output: Bytes
     """
     Return value or revert reason of the outermost frame of execution.
     """
@@ -64,7 +66,7 @@ class PrecompileStart:
     Trace event that is triggered before executing a precompile.
     """
 
-    address: bytes
+    address: Bytes
     """
     Precompile that is about to be executed.
     """

--- a/src/ethereum/utils/hexadecimal.py
+++ b/src/ethereum/utils/hexadecimal.py
@@ -69,7 +69,7 @@ def hex_to_bytes(hex_string: str) -> Bytes:
     byte_stream : `bytes`
         Byte stream corresponding to the given hexadecimal string.
     """
-    return bytes.fromhex(remove_hex_prefix(hex_string))
+    return Bytes.fromhex(remove_hex_prefix(hex_string))
 
 
 def hex_to_bytes8(hex_string: str) -> Bytes8:
@@ -86,7 +86,7 @@ def hex_to_bytes8(hex_string: str) -> Bytes8:
     8_byte_stream : `Bytes8`
         8-byte stream corresponding to the given hexadecimal string.
     """
-    return Bytes8(bytes.fromhex(remove_hex_prefix(hex_string).rjust(16, "0")))
+    return Bytes8(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(16, "0")))
 
 
 def hex_to_bytes20(hex_string: str) -> Bytes20:
@@ -103,7 +103,7 @@ def hex_to_bytes20(hex_string: str) -> Bytes20:
     20_byte_stream : `Bytes20`
         20-byte stream corresponding to the given hexadecimal string.
     """
-    return Bytes20(bytes.fromhex(remove_hex_prefix(hex_string).rjust(20, "0")))
+    return Bytes20(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(20, "0")))
 
 
 def hex_to_bytes32(hex_string: str) -> Bytes32:
@@ -120,7 +120,7 @@ def hex_to_bytes32(hex_string: str) -> Bytes32:
     32_byte_stream : `Bytes32`
         32-byte stream corresponding to the given hexadecimal string.
     """
-    return Bytes32(bytes.fromhex(remove_hex_prefix(hex_string).rjust(64, "0")))
+    return Bytes32(Bytes.fromhex(remove_hex_prefix(hex_string).rjust(64, "0")))
 
 
 def hex_to_bytes256(hex_string: str) -> Bytes256:
@@ -138,7 +138,7 @@ def hex_to_bytes256(hex_string: str) -> Bytes256:
         256-byte stream corresponding to the given hexadecimal string.
     """
     return Bytes256(
-        bytes.fromhex(remove_hex_prefix(hex_string).rjust(512, "0"))
+        Bytes.fromhex(remove_hex_prefix(hex_string).rjust(512, "0"))
     )
 
 
@@ -156,7 +156,7 @@ def hex_to_hash(hex_string: str) -> Hash32:
     hash : `Hash32`
         32-byte stream obtained from the given hexadecimal string.
     """
-    return Hash32(bytes.fromhex(remove_hex_prefix(hex_string)))
+    return Hash32(Bytes.fromhex(remove_hex_prefix(hex_string)))
 
 
 def hex_to_uint(hex_string: str) -> Uint:


### PR DESCRIPTION
### What was wrong?

Some type annotations in `fork_types.py` for each fork use `bytes` type, and some use `Bytes` alias imported from `..base_types`. 

[fork_types.py](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/spurious_dragon/fork_types.py#L142)

```
class Transaction:
    ...
    data: Bytes

class Account:
    ...
    code: bytes

class Log:
    ...
    data: bytes

```

Issue #752 suggests that spec would be more consistent if `Bytes` alias was applied everywhere to match surrounding code.

This change should not result in any functional difference as `Bytes` is [alias](https://github.com/ethereum/execution-specs/blob/0f9e4345b60d36c23fffaa69f70cf9cdb975f4ba/src/ethereum/base_types.py#L975) for `bytes`.

### How was it fixed?

For every `Log.data` and `Account.code` in `src/ethereum/$fork_name/fork_types.py` replaced type annotation like so: `bytes` => `Bytes`.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/originals/4b/a3/8f/4ba38f37cfa34c33af3dd1c0e0928b61.jpg)
