### PR TITLE
Improve `MessageCallGas` documentation

### DIFF
--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -89,7 +89,7 @@ class MessageCallGas:
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -82,18 +82,18 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -86,7 +86,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -190,8 +191,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -376,11 +376,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -450,11 +450,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -576,7 +576,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -640,7 +640,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -87,7 +87,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -191,8 +192,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -83,18 +83,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -85,11 +85,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -377,11 +377,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -451,11 +451,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -588,7 +588,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -652,7 +652,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -84,11 +84,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -82,18 +82,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -86,7 +86,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -190,8 +191,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/byzantium/vm/instructions/system.py
+++ b/src/ethereum/byzantium/vm/instructions/system.py
@@ -297,11 +297,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -364,11 +364,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -489,7 +489,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -547,7 +547,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/cancun/vm/gas.py
+++ b/src/ethereum/cancun/vm/gas.py
@@ -92,18 +92,19 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:
@@ -200,8 +201,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -396,11 +396,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -470,11 +470,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -590,7 +590,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -654,7 +654,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -87,7 +87,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -191,8 +192,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -83,18 +83,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -85,11 +85,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/constantinople/vm/instructions/system.py
+++ b/src/ethereum/constantinople/vm/instructions/system.py
@@ -367,11 +367,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -434,11 +434,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -560,7 +560,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -618,7 +618,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -85,7 +85,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -83,11 +83,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -81,18 +81,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/dao_fork/vm/instructions/system.py
+++ b/src/ethereum/dao_fork/vm/instructions/system.py
@@ -267,11 +267,11 @@ def call(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -327,11 +327,11 @@ def callcode(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -85,7 +85,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -83,11 +83,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -81,18 +81,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/frontier/vm/instructions/system.py
+++ b/src/ethereum/frontier/vm/instructions/system.py
@@ -263,11 +263,11 @@ def call(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -322,11 +322,11 @@ def callcode(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -84,11 +84,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -82,18 +82,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -86,7 +86,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -190,8 +191,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -376,11 +376,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -450,11 +450,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -576,7 +576,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -640,7 +640,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -85,7 +85,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -83,11 +83,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -81,18 +81,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/homestead/vm/instructions/system.py
+++ b/src/ethereum/homestead/vm/instructions/system.py
@@ -267,11 +267,11 @@ def call(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -327,11 +327,11 @@ def callcode(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -85,18 +85,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -89,7 +89,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -193,8 +194,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -87,11 +87,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/istanbul/vm/instructions/system.py
+++ b/src/ethereum/istanbul/vm/instructions/system.py
@@ -367,11 +367,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -434,11 +434,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -560,7 +560,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -618,7 +618,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -84,11 +84,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -82,18 +82,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -86,7 +86,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -190,8 +191,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -376,11 +376,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -450,11 +450,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -576,7 +576,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -640,7 +640,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -85,18 +85,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -89,7 +89,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -193,8 +194,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -87,11 +87,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/muir_glacier/vm/instructions/system.py
@@ -367,11 +367,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -434,11 +434,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -560,7 +560,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -618,7 +618,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -84,11 +84,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -82,18 +82,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -86,7 +86,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -190,8 +191,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -375,11 +375,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -449,11 +449,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -571,7 +571,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -635,7 +635,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/prague/vm/gas.py
+++ b/src/ethereum/prague/vm/gas.py
@@ -99,18 +99,19 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:
@@ -207,8 +208,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -408,11 +408,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -492,11 +492,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -622,7 +622,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -695,7 +695,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/shanghai/vm/gas.py
+++ b/src/ethereum/shanghai/vm/gas.py
@@ -87,7 +87,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -191,8 +192,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/shanghai/vm/gas.py
+++ b/src/ethereum/shanghai/vm/gas.py
@@ -83,18 +83,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/shanghai/vm/gas.py
+++ b/src/ethereum/shanghai/vm/gas.py
@@ -85,11 +85,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -395,11 +395,11 @@ def call(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -469,11 +469,11 @@ def callcode(evm: Evm) -> None:
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -591,7 +591,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,
@@ -655,7 +655,7 @@ def staticcall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         U256(0),
         evm.message.current_target,
         to,

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -85,7 +85,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -189,8 +190,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -83,11 +83,12 @@ class MessageCallGas:
     """
     Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
+
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -81,18 +81,17 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
-
+    Define the gas cost and gas given to the sub-call for
+    executing the call opcodes.
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed
     """
 
     cost: Uint
-    stipend: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/spurious_dragon/vm/instructions/system.py
+++ b/src/ethereum/spurious_dragon/vm/instructions/system.py
@@ -284,11 +284,11 @@ def call(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -349,11 +349,11 @@ def callcode(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -471,7 +471,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -81,18 +81,18 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and stipend for executing the call opcodes.
+    Define the gas cost and gas given to the sub-context for
+    executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The non-refundable portion of gas reserved for executing the
-        call opcode.
-    `stipend`: `ethereum.base_types.Uint`
+        The gas required to execute the call opcode.
+    `sub_context`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
-        if not consumed
+        if not consumed.
     """
 
     cost: Uint
-    stipend: Uint
+    sub_context: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -85,7 +85,8 @@ class MessageCallGas:
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
-        The gas required to execute the call opcode.
+        The gas required to execute the call opcode, excludes
+        memory expansion costs.
     `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
@@ -189,8 +190,8 @@ def calculate_message_call_gas(
     call_stipend: Uint = GAS_CALL_STIPEND,
 ) -> MessageCallGas:
     """
-    Calculates the MessageCallGas (cost and stipend) for
-    executing call Opcodes.
+    Calculates the MessageCallGas (cost and gas made available to the sub-call)
+    for executing call Opcodes.
 
     Parameters
     ----------

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -81,18 +81,18 @@ class ExtendMemory:
 @dataclass
 class MessageCallGas:
     """
-    Define the gas cost and gas given to the sub-context for
+    Define the gas cost and gas given to the sub-call for
     executing the call opcodes.
 
     `cost`: `ethereum.base_types.Uint`
         The gas required to execute the call opcode.
-    `sub_context`: `ethereum.base_types.Uint`
+    `sub_call`: `ethereum.base_types.Uint`
         The portion of gas available to sub-calls that is refundable
         if not consumed.
     """
 
     cost: Uint
-    sub_context: Uint
+    sub_call: Uint
 
 
 def charge_gas(evm: Evm, amount: Uint) -> None:

--- a/src/ethereum/tangerine_whistle/vm/instructions/system.py
+++ b/src/ethereum/tangerine_whistle/vm/instructions/system.py
@@ -280,11 +280,11 @@ def call(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -345,11 +345,11 @@ def callcode(evm: Evm) -> None:
     ).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
-        evm.gas_left += message_call_gas.stipend
+        evm.gas_left += message_call_gas.sub_call
     else:
         generic_call(
             evm,
-            message_call_gas.stipend,
+            message_call_gas.sub_call,
             value,
             evm.message.current_target,
             to,
@@ -458,7 +458,7 @@ def delegatecall(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     generic_call(
         evm,
-        message_call_gas.stipend,
+        message_call_gas.sub_call,
         evm.message.value,
         evm.message.caller,
         evm.message.current_target,


### PR DESCRIPTION
### What was wrong?

- `MessageCallGas.cost`'s documentation stated that it was _"The non-refundable portion of gas reserved for executing the call opcode."_. However, `MessageCallGas.cost` includes the gas to be passed to the sub-call (excluding the `2300` gas stipend) and hence, it is not true that it is non-refundable since some of the gas passed might be refunded upon returning from the sub-call.

- The name `MessageCallGas.stipend` can be misleading as "stipend" is also often used to refer to the `2300` gas stipend appended to calls with a non-null value.

### How was it fixed?

- Updated the documentation of `MessageCallGas.cost` to remove the "non-refundable" mention.
- Renamed `MessageCallGas.stipend` to `MessageCallGas.sub_call`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://paradisepark.org.uk/wp-content/uploads/2023/09/Otter-pups-at-Paradise-Park-in-Hayle-Cornwall-1024x774.jpg)
