### PR TITLE
Fix memory bloat in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run Tox (CPython)
         if: "${{ !startsWith(matrix.py, 'pypy') }}"
-        run: tox -e static,optimized,py3
+        run: tox -e static,py3
 
       - name: Run Tox (PyPy)
         if: "${{ startsWith(matrix.py, 'pypy') }}"

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -12,7 +12,7 @@ TEST_FIXTURES = {
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "0ec53d0",
+        "commit_hash": "52ddcbc",
         "fixture_path": "tests/fixtures/ethereum_tests",
     },
 }


### PR DESCRIPTION
### What was wrong?
The DeprecationWarnings in the Hardfork.discover method were causing significant memory bloat resulting in a crash in the CI.


### How was it fixed?
Migrating to the latest APIs for loading the modules removes these warnings.

#### Cute Animal Picture

![Library - 1 of 1](https://github.com/ethereum/execution-specs/assets/48196632/b8f2c273-d1ae-4ac2-ae79-c9d177dacbc9)
