### PR TITLE
fix transient storage on commit

### DIFF
--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -98,7 +98,9 @@ def begin_transaction(
         )
 
 
-def commit_transaction(state: State) -> None:
+def commit_transaction(
+    state: State, transient_storage: Optional[TransientStorage] = None
+) -> None:
     """
     Commit a state transaction.
 
@@ -106,10 +108,15 @@ def commit_transaction(state: State) -> None:
     ----------
     state : State
         The state.
+    transient_storage : TransientStorage
+        The transient storage of the transaction.
     """
     state._snapshots.pop()
     if not state._snapshots:
         state.created_accounts.clear()
+
+    if transient_storage and transient_storage._snapshots:
+        transient_storage._snapshots.pop()
 
 
 def rollback_transaction(

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -238,7 +238,7 @@ def process_message(message: Message, env: Environment) -> Evm:
         # since the message call resulted in an error
         rollback_transaction(env.state, evm.transient_storage)
     else:
-        commit_transaction(env.state)
+        commit_transaction(env.state, evm.transient_storage)
     return evm
 
 


### PR DESCRIPTION
(closes #911 )

### What was wrong?
`commit_transaction` does not pop the last snapshot.

Related to Issue #911 

### How was it fixed?
Upon successful commit of a database transaction, the latest snapshot of the transient storage should pop since it is not longer relevant

#### Cute Animal Picture

![Library - 1 of 1](https://github.com/ethereum/execution-specs/assets/48196632/cca9d124-fd99-4867-9ff1-db2ad56f501e)
