### PR TITLE
check create/create2 code size upfront

### DIFF
--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -76,6 +76,12 @@ def generic_create(
         process_create_message,
     )
 
+    call_data = memory_read_bytes(
+        evm.memory, memory_start_position, memory_size
+    )
+
+    ensure(len(call_data) <= 2 * MAX_CODE_SIZE, OutOfGasError)
+
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
@@ -100,12 +106,6 @@ def generic_create(
         increment_nonce(evm.env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    ensure(len(call_data) <= 2 * MAX_CODE_SIZE, OutOfGasError)
 
     increment_nonce(evm.env.state, evm.message.current_target)
 

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -75,6 +75,12 @@ def generic_create(
         process_create_message,
     )
 
+    call_data = memory_read_bytes(
+        evm.memory, memory_start_position, memory_size
+    )
+
+    ensure(len(call_data) <= 2 * MAX_CODE_SIZE, OutOfGasError)
+
     evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
@@ -99,12 +105,6 @@ def generic_create(
         increment_nonce(evm.env.state, evm.message.current_target)
         push(evm.stack, U256(0))
         return
-
-    call_data = memory_read_bytes(
-        evm.memory, memory_start_position, memory_size
-    )
-
-    ensure(len(call_data) <= 2 * MAX_CODE_SIZE, OutOfGasError)
 
     increment_nonce(evm.env.state, evm.message.current_target)
 


### PR DESCRIPTION
(closes #914)

 ### What was wrong?
In EIP-3860, the initcode length should not exceed MAX_INITCODE_SIZE. Although the specs do perform this check, the other clients seem to make this check upfront.

Related to Issue #914 

### How was it fixed?
This commit aligns specs with the live client implementations
