### PR TITLE
create transient storage snapshots for `process_create_message`

### DIFF
--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -51,6 +51,7 @@ from .fork_types import (
 )
 from .state import (
     State,
+    TransientStorage,
     account_exists_and_is_empty,
     destroy_account,
     destroy_touched_empty_accounts,
@@ -556,6 +557,7 @@ def apply_body(
         traces=[],
         excess_blob_gas=excess_blob_gas,
         blob_versioned_hashes=(),
+        transient_storage=TransientStorage(),
     )
 
     system_tx_output = process_message_call(system_tx_message, system_tx_env)
@@ -591,6 +593,7 @@ def apply_body(
             traces=[],
             excess_blob_gas=excess_blob_gas,
             blob_versioned_hashes=blob_versioned_hashes,
+            transient_storage=TransientStorage(),
         )
 
         gas_used, logs, error = process_transaction(env, tx)

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -71,7 +71,7 @@ def close_state(state: State) -> None:
 
 
 def begin_transaction(
-    state: State, transient_storage: Optional[TransientStorage] = None
+    state: State, transient_storage: TransientStorage
 ) -> None:
     """
     Start a state transaction.
@@ -92,14 +92,13 @@ def begin_transaction(
             {k: copy_trie(t) for (k, t) in state._storage_tries.items()},
         )
     )
-    if transient_storage is not None:
-        transient_storage._snapshots.append(
-            {k: copy_trie(t) for (k, t) in transient_storage._tries.items()}
-        )
+    transient_storage._snapshots.append(
+        {k: copy_trie(t) for (k, t) in transient_storage._tries.items()}
+    )
 
 
 def commit_transaction(
-    state: State, transient_storage: Optional[TransientStorage] = None
+    state: State, transient_storage: TransientStorage
 ) -> None:
     """
     Commit a state transaction.
@@ -115,12 +114,11 @@ def commit_transaction(
     if not state._snapshots:
         state.created_accounts.clear()
 
-    if transient_storage and transient_storage._snapshots:
-        transient_storage._snapshots.pop()
+    transient_storage._snapshots.pop()
 
 
 def rollback_transaction(
-    state: State, transient_storage: Optional[TransientStorage] = None
+    state: State, transient_storage: TransientStorage
 ) -> None:
     """
     Rollback a state transaction, resetting the state to the point when the
@@ -137,8 +135,7 @@ def rollback_transaction(
     if not state._snapshots:
         state.created_accounts.clear()
 
-    if transient_storage and transient_storage._snapshots:
-        transient_storage._tries = transient_storage._snapshots.pop()
+    transient_storage._tries = transient_storage._snapshots.pop()
 
 
 def get_account(state: State, address: Address) -> Account:

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -47,6 +47,7 @@ class Environment:
     traces: List[dict]
     excess_blob_gas: U64
     blob_versioned_hashes: Tuple[VersionedHash, ...]
+    transient_storage: TransientStorage
 
 
 @dataclass
@@ -93,7 +94,6 @@ class Evm:
     error: Optional[Exception]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
-    transient_storage: TransientStorage
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/cancun/vm/instructions/storage.py
+++ b/src/ethereum/cancun/vm/instructions/storage.py
@@ -149,7 +149,7 @@ def tload(evm: Evm) -> None:
 
     # OPERATION
     value = get_transient_storage(
-        evm.transient_storage, evm.message.current_target, key
+        evm.env.transient_storage, evm.message.current_target, key
     )
     push(evm.stack, value)
 
@@ -175,7 +175,7 @@ def tstore(evm: Evm) -> None:
     # OPERATION
     ensure(not evm.message.is_static, WriteInStaticContext)
     set_transient_storage(
-        evm.transient_storage, evm.message.current_target, key, new_value
+        evm.env.transient_storage, evm.message.current_target, key, new_value
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -183,6 +183,11 @@ class ForkLoad:
         return self._module("state").State
 
     @property
+    def TransientStorage(self) -> Any:
+        """Transient storage class of the fork"""
+        return self._module("state").TransientStorage
+
+    @property
     def get_account(self) -> Any:
         """get_account function of the fork"""
         return self._module("state").get_account

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -224,6 +224,7 @@ class T8N(Load):
 
         if self.fork.is_after_fork("ethereum.cancun"):
             kw_arguments["excess_blob_gas"] = self.env.excess_blob_gas
+            kw_arguments["transient_storage"] = self.fork.TransientStorage()
 
         return self.fork.Environment(**kw_arguments)
 
@@ -356,6 +357,7 @@ class T8N(Load):
                 traces=[],
                 excess_blob_gas=self.env.excess_blob_gas,
                 blob_versioned_hashes=(),
+                transient_storage=self.fork.TransientStorage(),
             )
 
             system_tx_output = self.fork.process_message_call(


### PR DESCRIPTION
(closes #917 )

### What was wrong?
`process_create_message` did not create the right snapshots for rollback in case something went wrong.

Related to Issue #917 

### How was it fixed?
Add `transient_storage` to `Environment` and create appropriate snapshots.

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/ethereum/execution-specs/assets/48196632/74b3cb5a-59df-48f1-98b1-4dfb8ec26357)
