### PR TITLE
Add more retroactive EIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Some clarifications were enabled without protocol releases:
 |-----|-----------|
 | [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681) | 0 |
 | [EIP-3607](https://eips.ethereum.org/EIPS/eip-3607) | 0 |
+| [EIP-7523](https://eips.ethereum.org/EIPS/eip-7523) | 15537394 | 
+| [EIP-7610](https://github.com/ethereum/EIPs/pull/8161) | 0 | 
+
 
 ## Execution Specification (work-in-progress)
 


### PR DESCRIPTION
### What was wrong?

Missing two retro EIPs, which were included in [ACDE#184](https://github.com/ethereum/pm/issues/982)

### How was it fixed?

Added them to the list 😄  

#### Cute Animal Picture

![Screenshot 2024-04-04 at 6 56 05 AM](https://github.com/ethereum/execution-specs/assets/9390255/3195f028-6915-4b11-9cbb-1d8b27d15034)
