### PR TITLE
checks for a transaction in cancun

### DIFF
--- a/src/ethereum/cancun/vm/gas.py
+++ b/src/ethereum/cancun/vm/gas.py
@@ -20,7 +20,7 @@ from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
 from ..transactions import BlobTransaction, Transaction
-from . import Environment, Evm
+from . import Evm
 from .exceptions import OutOfGasError
 
 GAS_JUMPDEST = Uint(1)
@@ -312,14 +312,14 @@ def calculate_total_blob_gas(tx: Transaction) -> Uint:
         return Uint(0)
 
 
-def calculate_blob_gas_price(env: Environment) -> Uint:
+def calculate_blob_gas_price(excess_blob_gas: U64) -> Uint:
     """
     Calculate the blob gasprice for a block.
 
     Parameters
     ----------
-    env :
-        The execution environment.
+    excess_blob_gas :
+        The excess blob gas for the block.
 
     Returns
     -------
@@ -328,19 +328,19 @@ def calculate_blob_gas_price(env: Environment) -> Uint:
     """
     return taylor_exponential(
         MIN_BLOB_GASPRICE,
-        Uint(env.excess_blob_gas),
+        Uint(excess_blob_gas),
         BLOB_GASPRICE_UPDATE_FRACTION,
     )
 
 
-def calculate_data_fee(env: Environment, tx: Transaction) -> Uint:
+def calculate_data_fee(excess_blob_gas: U64, tx: Transaction) -> Uint:
     """
     Calculate the blob data fee for a transaction.
 
     Parameters
     ----------
-    env :
-        The execution environment.
+    excess_blob_gas :
+        The excess_blob_gas for the execution.
     tx :
         The transaction for which the blob data fee is to be calculated.
 
@@ -349,4 +349,6 @@ def calculate_data_fee(env: Environment, tx: Transaction) -> Uint:
     data_fee: `Uint`
         The blob data fee.
     """
-    return calculate_total_blob_gas(tx) * calculate_blob_gas_price(env)
+    return calculate_total_blob_gas(tx) * calculate_blob_gas_price(
+        excess_blob_gas
+    )

--- a/src/ethereum/cancun/vm/instructions/environment.py
+++ b/src/ethereum/cancun/vm/instructions/environment.py
@@ -583,7 +583,7 @@ def blob_base_fee(evm: Evm) -> None:
     charge_gas(evm, GAS_BASE)
 
     # OPERATION
-    blob_base_fee = calculate_blob_gas_price(evm.env)
+    blob_base_fee = calculate_blob_gas_price(evm.env.excess_blob_gas)
     push(evm.stack, U256(blob_base_fee))
 
     # PROGRAM COUNTER


### PR DESCRIPTION
### What was wrong?

Some incredibility checks were in the `process_transaction` function instead of the `check_transaction` function

Related to Issue #799 

### How was it fixed?

The following changes have been made in the PR

- Change the `check_transaction` function to include all the includibility checks for a transaction
- Get rid of the `validate_transaction` function and incorporate it within the `check_transaction` function.
- Change the order of the `check_transaction` function inputs to reflect the chronological order of the forks in which the parameters were introduced.
- Update the `check_transaction` function of the t8n tool work with the new signature of check_transaction for `cancun`. Note: This is a temporary change and the final version of this function can only be implemented after the changes have been ported over to the other forks.
- Replace the use of `ensure` with explicit if statements.

#### Cute Animal Picture

![Cute Animals - 1 of 1 (1)](https://github.com/ethereum/execution-specs/assets/48196632/d32f1ddf-d3bb-4e69-9471-a5c315178617)