### PR TITLE
Update README.md

### DIFF
--- a/lists/signature-types/README.md
+++ b/lists/signature-types/README.md
@@ -15,7 +15,7 @@ Reserved or Tentative.
 | 0x00  | Reserved: indicates legacy (untyped) trancactions |
 | 0x01  | Reserved: [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) *(available in Berlin)* |
 | 0x02  | Reserved: [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) *(available in London)* |
-| 0x02  | Reserved: [EIP-4844](https://eips.ethereum.org/EIPS/eip-1559) *(available in Cancun)* |
+| 0x03  | Reserved: [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) *(available in Cancun)* |
 | 0x04  | Reserved: [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) |
 | 0x19  | Reserved: prevents collision with [EIP-191](https://eips.ethereum.org/EIPS/eip-191) |
 | 0xc0 - 0xff  | Invalid; collides with the initial byte of valid RLP encoded transactions |


### PR DESCRIPTION
Fix: wrong tx type(0x03) and link to EIP4844

### What was wrong?
The signature types have two 0x02. 
The link to EIP4844 pointed to 1559.

I compared the EIP4844, BLOBTYPE  is 0x03, the link should point to EIP4844.

Related to Issue #

### How was it fixed?
One of 0x02 should be 0x03(4844 related line).
The link should point to EIP4844.

#### Cute Animal Picture
🐼 ETHPanda
![Put a link to a cute animal picture inside the parenthesis-->]()
