### PR TITLE
handle `to` address in transaction being None

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -171,7 +171,7 @@ class Txs:
         # for idx, json_tx in enumerate(self.data):
         raw_tx["gasLimit"] = raw_tx["gas"]
         raw_tx["data"] = raw_tx["input"]
-        if "to" not in raw_tx:
+        if "to" not in raw_tx or raw_tx["to"] is None:
             raw_tx["to"] = ""
 
         # tf tool might provide None instead of 0


### PR DESCRIPTION
### What was wrong?
`t8n` does not handle the case where `None` is provided for the `to` field.

### How was it fixed?
Set `to` to empty string in case `None` is provided.
