### PR TITLE
Ops variant refactor

### DIFF
--- a/src/ethereum/arrow_glacier/vm/instructions/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/__init__.py
@@ -198,14 +198,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/berlin/vm/instructions/__init__.py
+++ b/src/ethereum/berlin/vm/instructions/__init__.py
@@ -197,14 +197,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/cancun/vm/instructions/__init__.py
+++ b/src/ethereum/cancun/vm/instructions/__init__.py
@@ -204,14 +204,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/constantinople/vm/instructions/__init__.py
+++ b/src/ethereum/constantinople/vm/instructions/__init__.py
@@ -195,14 +195,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/gray_glacier/vm/instructions/__init__.py
+++ b/src/ethereum/gray_glacier/vm/instructions/__init__.py
@@ -198,14 +198,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/istanbul/vm/instructions/__init__.py
+++ b/src/ethereum/istanbul/vm/instructions/__init__.py
@@ -197,14 +197,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/london/vm/instructions/__init__.py
+++ b/src/ethereum/london/vm/instructions/__init__.py
@@ -198,14 +198,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/muir_glacier/vm/instructions/__init__.py
+++ b/src/ethereum/muir_glacier/vm/instructions/__init__.py
@@ -197,14 +197,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/paris/vm/instructions/__init__.py
+++ b/src/ethereum/paris/vm/instructions/__init__.py
@@ -198,14 +198,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {

--- a/src/ethereum/shanghai/vm/instructions/__init__.py
+++ b/src/ethereum/shanghai/vm/instructions/__init__.py
@@ -199,14 +199,14 @@ class Ops(enum.Enum):
 
     # System Operations
     CREATE = 0xF0
-    RETURN = 0xF3
     CALL = 0xF1
     CALLCODE = 0xF2
+    RETURN = 0xF3
     DELEGATECALL = 0xF4
+    CREATE2 = 0xF5
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
-    CREATE2 = 0xF5
 
 
 op_implementation: Dict[Ops, Callable] = {


### PR DESCRIPTION
### What was wrong?
`Ops` variants aren't in numeric order
Related to Issue #
#942 
### How was it fixed?
Sort the variants

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1587402092301-725e37c70fd8?q=80&w=2752&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
