### PR TITLE
chore: bump the required major version of coincurve (20.0.0)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,7 @@ package_dir =
 python_requires = >=3.10
 install_requires =
     pycryptodome>=3,<4
-    coincurve>=18,<19
+    coincurve>=20,<21
     typing_extensions>=4
     eth2spec @ git+https://github.com/ethereum/consensus-specs.git@d302b35d40c72842d444ef2ea64344e3cb889804
 


### PR DESCRIPTION
### What was wrong?

Currently, tox in ethereum/execution-spec-tests seems to be failing on python 3.12 when installing coincurve:

https://github.com/ethereum/execution-spec-tests/actions/runs/9587245705/job/26436878955

This PR bumps coincurve to the latest version which seems to fix the issue.

### How was it fixed?

Bumped coincurve to the latest version, 20.0.0.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/npc3x87fk5c51.jpg)
