### PR TITLE
Markdown & RLP

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -162,7 +162,7 @@ test =
 lint =
     types-setuptools>=68.1.0.1,<69
     isort==5.13.2
-    mypy==1.5.1
+    mypy==1.10.0
     black==23.12.0
     flake8==6.1.0
     flake8-bugbear==23.12.2

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -335,7 +335,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -350,7 +350,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.timestamp,
         header.extra_data,
         header.base_fee_per_gas,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -652,6 +652,18 @@ class FixedUint(int):
 
     # TODO: Implement neg, pos, abs ...
 
+    @classmethod
+    def from_be_bytes(cls: Type[T], buffer: "Bytes") -> T:
+        """
+        Converts a sequence of bytes into a fixed sized unsigned integer
+        from its big endian representation.
+        """
+        max_length = (7 + cls.MAX_VALUE.bit_length()) // 8
+        if len(buffer) > max_length:
+            raise ValueError()
+
+        return cls(int.from_bytes(buffer, "big"))
+
 
 class U256(FixedUint):
     """
@@ -664,17 +676,6 @@ class U256(FixedUint):
     """
 
     __slots__ = ()
-
-    @classmethod
-    def from_be_bytes(cls: Type, buffer: "Bytes") -> "U256":
-        """
-        Converts a sequence of bytes into a fixed sized unsigned integer
-        from its big endian representation.
-        """
-        if len(buffer) > 32:
-            raise ValueError()
-
-        return cls(int.from_bytes(buffer, "big"))
 
     @classmethod
     def from_signed(cls: Type, value: int) -> "U256":

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -259,7 +259,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -273,7 +273,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -253,7 +253,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -267,7 +267,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -159,7 +158,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, Withdrawal, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -81,7 +81,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -90,7 +90,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -98,14 +98,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,10 +121,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
 
     Returns
     -------
-    encoded : `rlp.RLP`
+    encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -159,7 +159,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, Withdrawal, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -253,7 +253,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -267,7 +267,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.byzantium import trie as previous_trie
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -265,7 +265,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -279,7 +279,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -245,7 +245,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -259,7 +259,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -155,7 +154,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -77,7 +77,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -86,7 +86,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -94,14 +94,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -120,7 +120,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -155,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -335,7 +335,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -350,7 +350,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.timestamp,
         header.extra_data,
         header.base_fee_per_gas,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.arrow_glacier import trie as previous_trie
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -247,7 +247,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -261,7 +261,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -253,7 +253,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -267,7 +267,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.constantinople import trie as previous_trie
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -343,7 +343,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -358,7 +358,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.timestamp,
         header.extra_data,
         header.base_fee_per_gas,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.berlin import trie as previous_trie
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -253,7 +253,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -267,7 +267,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,7 +121,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/rlp.py
+++ b/src/ethereum/rlp.py
@@ -261,10 +261,15 @@ def _deserialize_to_dataclass(cls: Type[U], decoded: Simple) -> U:
     target_fields = fields(cls)
 
     if isinstance(decoded, bytes):
-        raise RLPDecodingError
+        raise RLPDecodingError(f"got `bytes` while decoding `{cls.__name__}`")
 
     if len(target_fields) != len(decoded):
-        raise RLPDecodingError
+        name = cls.__name__
+        actual = len(decoded)
+        expected = len(target_fields)
+        raise RLPDecodingError(
+            f"`{name}` needs {expected} field(s), but got {actual} instead"
+        )
 
     values: Dict[str, Any] = {}
 

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -159,7 +158,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, Withdrawal, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -81,7 +81,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -90,7 +90,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -98,14 +98,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -121,10 +121,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
 
     Returns
     -------
-    encoded : `rlp.RLP`
+    encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -159,7 +159,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (LegacyTransaction, Receipt, Withdrawal, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -249,7 +249,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -263,7 +263,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -118,10 +118,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
 
     Returns
     -------
-    encoded : `rlp.RLP`
+    encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -247,7 +247,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
     hash : `Hash32`
         The PoW valid rlp hash of the passed in header.
     """
-    header_data_without_pow_artefacts = [
+    header_data_without_pow_artefacts = (
         header.parent_hash,
         header.ommers_hash,
         header.coinbase,
@@ -261,7 +261,7 @@ def generate_header_hash_for_pow(header: Header) -> Hash32:
         header.gas_used,
         header.timestamp,
         header.extra_data,
-    ]
+    )
 
     return rlp.rlp_hash(header_data_without_pow_artefacts)
 

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -26,7 +26,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
 )
 
 from ethereum.crypto.hash import keccak256
@@ -156,7 +155,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.Extended, node))
+        return rlp.encode(node)
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -78,7 +78,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.RLP
+    value: rlp.Extended
 
 
 @slotted_freezable
@@ -87,7 +87,7 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.RLP
+    subnode: rlp.Extended
 
 
 @slotted_freezable
@@ -95,14 +95,14 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.RLP]
-    value: rlp.RLP
+    subnodes: List[rlp.Extended]
+    value: rlp.Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
+def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -118,10 +118,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.RLP:
 
     Returns
     -------
-    encoded : `rlp.RLP`
+    encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.RLP
+    unencoded: rlp.Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -156,7 +156,7 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
         assert storage_root is not None
         return encode_account(node, storage_root)
     elif isinstance(node, (Transaction, Receipt, U256)):
-        return rlp.encode(cast(rlp.RLP, node))
+        return rlp.encode(cast(rlp.Extended, node))
     elif isinstance(node, Bytes):
         return node
     else:

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -1,87 +1,150 @@
 """
-.. _trace:
+Defines the functions required for creating EVM traces during execution.
 
-EVM Trace
-^^^^^^^^^
+A _trace_ is a log of operations that took place during an event or period of
+time. In the case of an EVM trace, the log is built from a series of
+[`TraceEvent`]s emitted during the execution of a transaction.
 
-.. contents:: Table of Contents
-    :backlinks: none
-    :local:
+Note that this module _does not_ contain a trace implementation. Instead, it
+defines only the events that can be collected into a trace by some other
+package. See [`EvmTracer`].
 
-Introduction
-------------
+See [EIP-3155] for more details on EVM traces.
 
-Defines the functions required for creating evm traces during execution.
+[`EvmTracer`]: ref:ethereum.trace.EvmTracer
+[`TraceEvent`]: ref:ethereum.trace.TraceEvent
+[EIP-3155]: https://eips.ethereum.org/EIPS/eip-3155
 """
 
 import enum
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Protocol, Union
 
 
 @dataclass
 class TransactionStart:
-    """Trace event that is triggered at the start of a transaction."""
-
-    pass
+    """
+    Trace event that is triggered at the start of a transaction.
+    """
 
 
 @dataclass
 class TransactionEnd:
-    """Trace event that is triggered at the end of a transaction."""
+    """
+    Trace event that is triggered at the end of a transaction.
+    """
 
     gas_used: int
+    """
+    Total gas consumed by this transaction.
+    """
+
     output: bytes
+    """
+    Return value or revert reason of the outermost frame of execution.
+    """
+
     error: Optional[Exception]
+    """
+    The exception, if any, that caused the transaction to fail.
+
+    See [`ethereum.exceptions`] as well as fork-specific modules like
+    [`ethereum.frontier.vm.exceptions`][vm] for details.
+
+    [`ethereum.exceptions`]: ref:ethereum.exceptions
+    [vm]: ref:ethereum.frontier.vm.exceptions
+    """
 
 
 @dataclass
 class PrecompileStart:
-    """Trace event that is triggered before executing a precompile."""
+    """
+    Trace event that is triggered before executing a precompile.
+    """
 
     address: bytes
+    """
+    Precompile that is about to be executed.
+    """
 
 
 @dataclass
 class PrecompileEnd:
-    """Trace event that is triggered after executing a precompile."""
-
-    pass
+    """
+    Trace event that is triggered after executing a precompile.
+    """
 
 
 @dataclass
 class OpStart:
-    """Trace event that is triggered before executing an opcode."""
+    """
+    Trace event that is triggered before executing an opcode.
+    """
 
     op: enum.Enum
+    """
+    Opcode that is about to be executed.
+
+    Will be an instance of a fork-specific type like, for example,
+    [`ethereum.frontier.vm.instructions.Ops`][ops].
+
+    [ops]: ref:ethereum.frontier.vm.instructions.Ops
+    """
 
 
 @dataclass
 class OpEnd:
-    """Trace event that is triggered after executing an opcode."""
-
-    pass
+    """
+    Trace event that is triggered after executing an opcode.
+    """
 
 
 @dataclass
 class OpException:
-    """Trace event that is triggered when an opcode raises an exception."""
+    """
+    Trace event that is triggered when an opcode raises an exception.
+    """
 
     error: Exception
+    """
+    Exception that was raised.
+
+    See [`ethereum.exceptions`] as well as fork-specific modules like
+    [`ethereum.frontier.vm.exceptions`][vm] for examples of exceptions that
+    might be raised.
+
+    [`ethereum.exceptions`]: ref:ethereum.exceptions
+    [vm]: ref:ethereum.frontier.vm.exceptions
+    """
 
 
 @dataclass
 class EvmStop:
-    """Trace event that is triggered when the EVM stops."""
+    """
+    Trace event that is triggered when the EVM stops.
+    """
 
     op: enum.Enum
+    """
+    Last opcode executed.
+
+    Will be an instance of a fork-specific type like, for example,
+    [`ethereum.frontier.vm.instructions.Ops`][ops].
+
+    [ops]: ref:ethereum.frontier.vm.instructions.Ops
+    """
 
 
 @dataclass
 class GasAndRefund:
-    """Trace event that is triggered when gas is deducted."""
+    """
+    Trace event that is triggered when gas is deducted.
+    """
 
     gas_cost: int
+    """
+    Amount of gas charged or refunded.
+    """
 
 
 TraceEvent = Union[
@@ -95,9 +158,14 @@ TraceEvent = Union[
     EvmStop,
     GasAndRefund,
 ]
+"""
+All possible types of events that an [`EvmTracer`] is expected to handle.
+
+[`EvmTracer`]: ref:ethereum.trace.EvmTracer
+"""
 
 
-def evm_trace(
+def discard_evm_trace(
     evm: object,
     event: TraceEvent,
     trace_memory: bool = False,
@@ -105,6 +173,60 @@ def evm_trace(
     trace_return_data: bool = False,
 ) -> None:
     """
-    Create a trace of the event.
+    An [`EvmTracer`] that discards all events.
+
+    [`EvmTracer`]: ref:ethereum.trace.EvmTracer
     """
-    pass
+
+
+class EvmTracer(Protocol):
+    """
+    [`Protocol`] that describes tracer functions.
+
+    See [`ethereum.trace`] for details about tracing in general, and
+    [`__call__`] for more on how to implement a tracer.
+
+    [`Protocol`]: https://docs.python.org/3/library/typing.html#typing.Protocol
+    [`ethereum.trace`]: ref:ethereum.trace
+    [`__call__`]: ref:ethereum.trace.EvmTracer.__call__
+    """
+
+    def __call__(
+        self,
+        evm: object,
+        event: TraceEvent,
+        /,
+        trace_memory: bool = False,
+        trace_stack: bool = True,
+        trace_return_data: bool = False,
+    ) -> None:
+        """
+        Call `self` as a function, recording a trace event.
+
+        `evm` is the live state of the EVM, and will be a fork-specific type
+        like [`ethereum.frontier.vm.Evm`][evm].
+
+        `event`, a [`TraceEvent`], is the reason why the tracer was triggered.
+
+        `trace_memory` requests a full memory dump in the resulting trace.
+
+        `trace_stack` requests the full stack in the resulting trace.
+
+        `trace_return_data` requests that return data be included in the
+        resulting trace.
+
+        See [`discard_evm_trace`] for an example function implementing this
+        protocol.
+
+        [`discard_evm_trace`]: ref:ethereum.trace.discard_evm_trace
+        [evm]: ref:ethereum.frontier.vm.Evm
+        [`TraceEvent`]: ref:ethereum.trace.TraceEvent
+        """
+
+
+evm_trace: EvmTracer = discard_evm_trace
+"""
+Active [`EvmTracer`] that is used for generating traces.
+
+[`EvmTracer`]: ref:ethereum.trace.EvmTracer
+"""

--- a/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
+++ b/src/ethereum_spec_tools/evm_tools/b11r/b11r_types.py
@@ -31,8 +31,8 @@ class Body:
     A class representing a block body.
     """
 
-    transactions: rlp.RLP
-    ommers: rlp.RLP
+    transactions: rlp.Extended
+    ommers: rlp.Extended
     withdrawals: Optional[List[Tuple[U64, U64, Bytes20, Uint]]]
 
     def __init__(self, options: Any, stdin: Any = None):
@@ -65,6 +65,7 @@ class Body:
         self.ommers = []
         for ommer in ommers_data:
             decoded_ommer = rlp.decode(hex_to_bytes(ommer))
+            assert not isinstance(decoded_ommer, bytes)
             self.ommers.append(decoded_ommer[0])  # ommer[0] is the header
 
         # Parse withdrawals

--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -260,9 +260,11 @@ class BlockDownloader(ForkTracking):
                     blocks.append(block_rlp)
                 else:
                     # Unfortunately we have to decode the RLP twice.
-                    timestamp = rlp.decode_to(
-                        U64, rlp.decode(block_rlp)[0][11]
-                    )
+                    decoded_block = rlp.decode(block_rlp)
+                    assert not isinstance(decoded_block, bytes)
+                    assert not isinstance(decoded_block[0], bytes)
+                    assert isinstance(decoded_block[0][11], bytes)
+                    timestamp = rlp.decode_to(U64, decoded_block[0][11])
                     self.advance_block(timestamp)
                     blocks.append(
                         rlp.decode_to(self.module("blocks").Block, block_rlp)

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -123,7 +123,7 @@ receipt = Receipt(
         receipt,
     ],
 )
-def test_berlin_rlp(rlp_object: rlp.RLP) -> None:
+def test_berlin_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object
 

--- a/tests/byzantium/test_rlp.py
+++ b/tests/byzantium/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_byzantium_rlp(rlp_object: rlp.RLP) -> None:
+def test_byzantium_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/cancun/test_rlp.py
+++ b/tests/cancun/test_rlp.py
@@ -151,7 +151,7 @@ receipt = Receipt(
         withdrawal,
     ],
 )
-def test_cancun_rlp(rlp_object: rlp.RLP) -> None:
+def test_cancun_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object
 

--- a/tests/constantinople/test_rlp.py
+++ b/tests/constantinople/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_constantinople_rlp(rlp_object: rlp.RLP) -> None:
+def test_constantinople_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/frontier/test_rlp.py
+++ b/tests/frontier/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_frontier_rlp(rlp_object: rlp.RLP) -> None:
+def test_frontier_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -99,7 +99,7 @@ def add_block_to_chain(
     ) = load.json_to_block(json_block)
 
     assert rlp.rlp_hash(block.header) == block_header_hash
-    assert rlp.encode(cast(rlp.RLP, block)) == block_rlp
+    assert rlp.encode(cast(rlp.Extended, block)) == block_rlp
 
     if not mock_pow:
         load.fork.state_transition(chain, block)

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -3,7 +3,7 @@ import json
 import os.path
 import re
 from glob import glob
-from typing import Any, Dict, Generator, Tuple, Union, cast
+from typing import Any, Dict, Generator, Tuple, Union
 from unittest.mock import call, patch
 
 import pytest
@@ -94,7 +94,7 @@ def add_block_to_chain(
     ) = load.json_to_block(json_block)
 
     assert rlp.rlp_hash(block.header) == block_header_hash
-    assert rlp.encode(cast(rlp.Extended, block)) == block_rlp
+    assert rlp.encode(block) == block_rlp
 
     if not mock_pow:
         load.fork.state_transition(chain, block)

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -48,13 +48,8 @@ def run_blockchain_st_test(test_case: Dict, load: Load) -> None:
 
     genesis_header_hash = hex_to_bytes(json_data["genesisBlockHeader"]["hash"])
     assert rlp.rlp_hash(genesis_header) == genesis_header_hash
-    # FIXME: Re-enable this assertion once the genesis block RLP is
-    # correctly encoded for Shanghai.
-    # See https://github.com/ethereum/execution-spec-tests/issues/64
-    # assert (
-    #     rlp.encode(cast(rlp.RLP, genesis_block))
-    #     == test_data["genesis_block_rlp"]
-    # )
+    genesis_rlp = hex_to_bytes(json_data["genesisRLP"])
+    assert rlp.encode(genesis_block) == genesis_rlp
 
     chain = load.fork.BlockChain(
         blocks=[genesis_block],

--- a/tests/homestead/test_rlp.py
+++ b/tests/homestead/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_homestead_rlp(rlp_object: rlp.RLP) -> None:
+def test_homestead_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/istanbul/test_rlp.py
+++ b/tests/istanbul/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_istanbul_rlp(rlp_object: rlp.RLP) -> None:
+def test_istanbul_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -143,7 +143,7 @@ receipt = Receipt(
         receipt,
     ],
 )
-def test_london_rlp(rlp_object: rlp.RLP) -> None:
+def test_london_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object
 

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -143,7 +143,7 @@ receipt = Receipt(
         receipt,
     ],
 )
-def test_paris_rlp(rlp_object: rlp.RLP) -> None:
+def test_paris_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object
 

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -148,7 +148,7 @@ receipt = Receipt(
         withdrawal,
     ],
 )
-def test_shanghai_rlp(rlp_object: rlp.RLP) -> None:
+def test_shanghai_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object
 

--- a/tests/spurious_dragon/test_rlp.py
+++ b/tests/spurious_dragon/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_spurious_dragon_rlp(rlp_object: rlp.RLP) -> None:
+def test_spurious_dragon_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/tangerine_whistle/test_rlp.py
+++ b/tests/tangerine_whistle/test_rlp.py
@@ -104,6 +104,6 @@ receipt = Receipt(
     "rlp_object",
     [transaction1, transaction2, header, block, log1, log2, receipt],
 )
-def test_tangerine_whistle_rlp(rlp_object: rlp.RLP) -> None:
+def test_tangerine_whistle_rlp(rlp_object: rlp.Extended) -> None:
     encoded = rlp.encode(rlp_object)
     assert rlp.decode_to(type(rlp_object), encoded) == rlp_object

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -7,7 +7,7 @@ import pytest
 from ethereum import rlp
 from ethereum.exceptions import RLPDecodingError, RLPEncodingError
 from ethereum.frontier.fork_types import U256, Bytes, Uint
-from ethereum.rlp import RLP
+from ethereum.rlp import Extended
 from ethereum.utils.hexadecimal import hex_to_bytes
 from tests.helpers import TEST_FIXTURES
 
@@ -140,7 +140,7 @@ def test_rlp_encode_20_elem_byte_uint_combo() -> None:
 
 
 def test_rlp_encode_nested_sequence() -> None:
-    nested_sequence: Sequence["RLP"] = [
+    nested_sequence: Sequence["Extended"] = [
         b"hello",
         Uint(255),
         [b"how", [b"are", b"you", [b"doing"]]],
@@ -171,7 +171,7 @@ def test_rlp_encode_successfully() -> None:
         ),
     ]
     for raw_data, expected_encoding in test_cases:
-        assert rlp.encode(cast(RLP, raw_data)) == expected_encoding
+        assert rlp.encode(cast(Extended, raw_data)) == expected_encoding
 
 
 def test_rlp_encode_fails() -> None:
@@ -181,7 +181,7 @@ def test_rlp_encode_fails() -> None:
     ]
     for raw_data in test_cases:
         with pytest.raises(RLPEncodingError):
-            rlp.encode(cast(RLP, raw_data))
+            rlp.encode(cast(Extended, raw_data))
 
 
 #
@@ -338,7 +338,7 @@ def test_roundtrip_encoding_and_decoding() -> None:
         [[b"hello", b"world"], [b"how", b"are"], [b"you", b"doing"]],
     ]
     for raw_data in test_cases:
-        assert rlp.decode(rlp.encode(cast(RLP, raw_data))) == raw_data
+        assert rlp.decode(rlp.encode(cast(Extended, raw_data))) == raw_data
 
 
 #
@@ -348,7 +348,7 @@ def test_roundtrip_encoding_and_decoding() -> None:
 
 def convert_to_rlp_native(
     obj: Union[str, int, Sequence[Union[str, int]]]
-) -> RLP:
+) -> Extended:
     if isinstance(obj, str):
         return bytes(obj, "utf-8")
     elif isinstance(obj, int):
@@ -360,7 +360,7 @@ def convert_to_rlp_native(
 
 def ethtest_fixtures_as_pytest_fixtures(
     *test_files: str,
-) -> List[Tuple[RLP, Bytes]]:
+) -> List[Tuple[Extended, Bytes]]:
     base_path = f"{ETHEREUM_TESTS_PATH}/RLPTests/"
 
     test_data = dict()
@@ -390,7 +390,7 @@ def ethtest_fixtures_as_pytest_fixtures(
     ethtest_fixtures_as_pytest_fixtures("rlptest.json"),
 )
 def test_ethtest_fixtures_for_rlp_encoding(
-    raw_data: RLP, expected_encoded_data: Bytes
+    raw_data: Extended, expected_encoded_data: Bytes
 ) -> None:
     assert rlp.encode(raw_data) == expected_encoded_data
 

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -152,7 +152,7 @@ def test_rlp_encode_nested_sequence() -> None:
 
 
 def test_rlp_encode_successfully() -> None:
-    test_cases = [
+    test_cases: List[Tuple[rlp.Extended, Union[bytes, bytearray]]] = [
         (b"", bytearray([0x80])),
         (b"\x83" * 55, bytearray([0xB7]) + bytearray(b"\x83" * 55)),
         (Uint(0), b"\x80"),
@@ -171,7 +171,7 @@ def test_rlp_encode_successfully() -> None:
         ),
     ]
     for raw_data, expected_encoding in test_cases:
-        assert rlp.encode(cast(Extended, raw_data)) == expected_encoding
+        assert rlp.encode(raw_data) == expected_encoding
 
 
 def test_rlp_encode_fails() -> None:
@@ -324,7 +324,7 @@ def test_rlp_decode_failure_empty_bytes() -> None:
 
 
 def test_roundtrip_encoding_and_decoding() -> None:
-    test_cases = [
+    test_cases: List[Extended] = [
         b"",
         b"h",
         b"hello how are you doing today?",
@@ -338,7 +338,7 @@ def test_roundtrip_encoding_and_decoding() -> None:
         [[b"hello", b"world"], [b"how", b"are"], [b"you", b"doing"]],
     ]
     for raw_data in test_cases:
-        assert rlp.decode(rlp.encode(cast(Extended, raw_data))) == raw_data
+        assert rlp.decode(rlp.encode(raw_data)) == raw_data
 
 
 #


### PR DESCRIPTION
#### Open Questions / Tasks

 - [x] What are better names for `rlp.Serialize` and `rlp.Deserialize`? I was thinking `rlp.Complex` and `rlp.Simple` respectively.
 - [x] Remove uses of `cast` (e.g. [here](https://github.com/ethereum/execution-specs/compare/master...SamWilsn:eth1.0-specs:markdown?expand=1#diff-e5d39c4156d28bf297141c98d404403f2eafd220050fec9a09385204b70d9debR159))

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pawb.social/pictrs/image/9d866a2e-a36e-4ede-b5ca-8838c59b7db3.jpeg)
