### PR TITLE
typo: fix `encode_account` documentation

### DIFF
--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -51,9 +51,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -51,10 +51,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/cancun/fork_types.py
+++ b/src/ethereum/cancun/fork_types.py
@@ -53,9 +53,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/cancun/fork_types.py
+++ b/src/ethereum/cancun/fork_types.py
@@ -53,10 +53,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -52,10 +52,9 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass.
+    Encode `Account` dataclass using RLP.
 
-    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
-    encoded with providing a storage root.
+    Note: Storage is not included in `Account`, so a storage root must be provided.
     """
     return rlp.encode(
         (

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -52,9 +52,10 @@ EMPTY_ACCOUNT = Account(
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass using RLP.
+    Encode `Account` dataclass.
 
-    Note: Storage is not included in `Account`, so a storage root must be provided.
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    encoded without providing a storage root.
     """
     return rlp.encode(
         (


### PR DESCRIPTION
### What was wrong?

Previous documentation was

```
Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
    encoded with providing a storage root.
```

which is incorrect.


### How was it fixed?

Typo fix.

