### PR TITLE
Update EIP-2935

### DIFF
--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -41,7 +41,6 @@ from .state import (
     increment_nonce,
     process_withdrawal,
     set_account_balance,
-    set_storage,
     state_root,
 )
 from .transactions import (
@@ -203,13 +202,6 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     validate_header(block.header, parent_header)
     if block.ommers != ():
         raise InvalidBlock
-
-    set_storage(
-        chain.state,
-        HISTORY_STORAGE_ADDRESS,
-        ((block.header.number - 1) % HISTORY_SERVE_WINDOW).to_be_bytes32(),
-        U256.from_be_bytes(block.header.parent_hash),
-    )
 
     apply_body_output = apply_body(
         chain.state,
@@ -716,6 +708,21 @@ def apply_body(
     process_system_transaction(
         BEACON_ROOTS_ADDRESS,
         parent_beacon_block_root,
+        block_hashes,
+        coinbase,
+        block_number,
+        base_fee_per_gas,
+        block_gas_limit,
+        block_time,
+        prev_randao,
+        state,
+        chain_id,
+        excess_blob_gas,
+    )
+
+    process_system_transaction(
+        HISTORY_STORAGE_ADDRESS,
+        block_hashes[-1],  # The parent hash
         block_hashes,
         coinbase,
         block_number,

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -316,20 +316,27 @@ class T8N(Load):
         receipts_trie = self.fork.Trie(secured=False, default=None)
         block_logs = ()
         blob_gas_used = Uint(0)
-        if self.fork.is_after_fork("ethereum.prague"):
+        if (
+            self.fork.is_after_fork("ethereum.prague")
+            and not self.options.state_test
+        ):
             requests_trie = self.fork.Trie(secured=False, default=None)
             requests_from_execution: Tuple[Bytes, ...] = ()
 
-            if not self.options.state_test:
-                self.fork.set_storage(
-                    self.alloc.state,
-                    self.fork.HISTORY_STORAGE_ADDRESS,
-                    (
-                        (self.env.block_number - 1)
-                        % self.fork.HISTORY_SERVE_WINDOW
-                    ).to_be_bytes32(),
-                    U256.from_be_bytes(self.env.parent_hash),
-                )
+            self.fork.process_system_transaction(
+                self.fork.HISTORY_SERVE_WINDOW,
+                self.env.parent_hash,
+                self.env.block_hashes,
+                self.env.coinbase,
+                self.env.block_number,
+                self.env.base_fee_per_gas,
+                self.env.block_gas_limit,
+                self.env.block_timestamp,
+                self.env.prev_randao,
+                self.alloc.state,
+                self.chain_id,
+                self.env.excess_blob_gas,
+            )
 
         if (
             self.fork.is_after_fork("ethereum.cancun")

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -324,7 +324,7 @@ class T8N(Load):
             requests_from_execution: Tuple[Bytes, ...] = ()
 
             self.fork.process_system_transaction(
-                self.fork.HISTORY_SERVE_WINDOW,
+                self.fork.HISTORY_STORAGE_ADDRESS,
                 self.env.parent_hash,
                 self.env.block_hashes,
                 self.env.coinbase,

--- a/tests/prague/test_state_transition.py
+++ b/tests/prague/test_state_transition.py
@@ -105,6 +105,7 @@ test_dirs = (
     "tests/fixtures/latest_fork_tests/blockchain_tests/prague/eip7251_consolidations",
     "tests/fixtures/latest_fork_tests/blockchain_tests/prague/eip7685_general_purpose_el_requests",
     "tests/fixtures/latest_fork_tests/blockchain_tests/prague/eip2537_bls_12_381_precompiles",
+    "tests/fixtures/latest_fork_tests/blockchain_tests/prague/eip2935_historical_block_hashes_from_state",
     # TODO: Current test fixtures don't support EOF along with other
     # EIPs. This will be fixed in the future.
 )


### PR DESCRIPTION
(closes #997 )

### What was wrong?
EIP-2935 implementation was out of date

Related to Issue #997 

### How was it fixed?
The contract address was updated to the latest version in an earlier PR. No change there. This PR uses a contract call instead of `set_storage` to update the storage of the contract. Relevant changes to the `t8n` tool are also included.
