### PR TITLE
Suppress daemon log spam

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -29,6 +29,10 @@ def daemon_arguments(subparsers: argparse._SubParsersAction) -> None:
 
 
 class _EvmToolHandler(BaseHTTPRequestHandler):
+    def log_request(self, *args):
+        """Don't log requests"""
+        pass
+
     def do_POST(self) -> None:
         from . import main
 


### PR DESCRIPTION
### What was wrong?

`BaseHTTPRequestHandler` writes a log to stderr for every request processed. This results in annoying stderr spam in our usecase.

### How was it fixed?

Suppress the logging.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/ix49md78dsnd1.jpeg)
