### PR TITLE
Detect state tests via "parentHash" field

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -61,6 +61,12 @@ class Env:
             with open(t8n.options.input_env, "r") as f:
                 data = json.load(f)
 
+        if "parentHash" not in data:
+            # Sometimes we are given a state test without the --state-test
+            # flag being set. This hack detects those cases and treats them
+            # as state tests.
+            t8n.options.state_test = True
+
         self.coinbase = t8n.fork.hex_to_address(data["currentCoinbase"])
         self.block_gas_limit = parse_hex_or_int(data["currentGasLimit"], Uint)
         self.block_number = parse_hex_or_int(data["currentNumber"], Uint)


### PR DESCRIPTION
### What was wrong?

EEST is feeding t8n state tests with telling us they are state tests. There is no standardised way to detect them.

### How was it fixed?

Add a hack that assumes any test missing the `"parentHash"` field is a state test.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/yg8gtmbc0vnd1.jpeg)
