### PR TITLE
Add checks to signature recovery

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -417,7 +418,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:

--- a/src/ethereum/arrow_glacier/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/arrow_glacier/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -335,7 +336,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/berlin/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -329,7 +330,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/byzantium/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/cancun/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/cancun/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -329,7 +330,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/constantinople/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/crypto/__init__.py
+++ b/src/ethereum/crypto/__init__.py
@@ -1,3 +1,11 @@
 """
 Cryptographic primitives used in Ethereum.
 """
+
+
+class InvalidSignature(Exception):
+    """
+    Thrown when a signature is invalid.
+    """
+
+    pass

--- a/src/ethereum/crypto/elliptic_curve.py
+++ b/src/ethereum/crypto/elliptic_curve.py
@@ -8,9 +8,12 @@ from typing import Generic, Type, TypeVar
 import coincurve
 
 from ..base_types import U256, Bytes
+from . import InvalidSignature
 from .finite_field import Field
 from .hash import Hash32
 
+SECP256K1B = 7
+SECP256K1P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
 SECP256K1N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 F = TypeVar("F", bound=Field)
@@ -37,6 +40,13 @@ def secp256k1_recover(r: U256, s: U256, v: U256, msg_hash: Hash32) -> Bytes:
     public_key : `ethereum.base_types.Bytes`
         Recovered public key.
     """
+    is_square = pow(
+        pow(r, 3, SECP256K1P) + SECP256K1B, (SECP256K1P - 1) // 2, SECP256K1P
+    )
+
+    if is_square != 1:
+        raise InvalidSignature("r value is not a square")
+
     r_bytes = r.to_be_bytes32()
     s_bytes = s.to_be_bytes32()
 
@@ -44,9 +54,17 @@ def secp256k1_recover(r: U256, s: U256, v: U256, msg_hash: Hash32) -> Bytes:
     signature[32 - len(r_bytes) : 32] = r_bytes
     signature[64 - len(s_bytes) : 64] = s_bytes
     signature[64] = v
-    public_key = coincurve.PublicKey.from_signature_and_message(
-        bytes(signature), msg_hash, hasher=None
-    )
+
+    # If the recovery algorithm returns the point at infinity,
+    # the signature is considered invalid
+    # the below function will raise a ValueError.
+    try:
+        public_key = coincurve.PublicKey.from_signature_and_message(
+            bytes(signature), msg_hash, hasher=None
+        )
+    except ValueError as e:
+        raise InvalidSignature from e
+
     public_key = public_key.format(compressed=False)[1:]
     return public_key
 

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -338,7 +339,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(tx)
+
+    try:
+        sender_address = recover_sender(tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/dao_fork/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/dao_fork/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -15,6 +15,7 @@ Entry point for the Ethereum specification.
 from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -318,7 +319,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(tx)
+
+    try:
+        sender_address = recover_sender(tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/frontier/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/frontier/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/genesis.py
+++ b/src/ethereum/genesis.py
@@ -263,6 +263,9 @@ def add_genesis_block(
     if has_field(hardfork.Header, "parent_beacon_block_root"):
         fields["parent_beacon_block_root"] = Hash32(b"\0" * 32)
 
+    if has_field(hardfork.Header, "requests_root"):
+        fields["requests_root"] = hardfork.root(hardfork.Trie(False, None))
+
     genesis_header = hardfork.Header(**fields)
 
     block_fields = {
@@ -273,6 +276,9 @@ def add_genesis_block(
 
     if has_field(hardfork.Block, "withdrawals"):
         block_fields["withdrawals"] = ()
+
+    if has_field(hardfork.Block, "requests"):
+        block_fields["requests"] = ()
 
     genesis_block = hardfork.Block(**block_fields)
 

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -417,7 +418,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:

--- a/src/ethereum/gray_glacier/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/gray_glacier/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -320,7 +321,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(tx)
+
+    try:
+        sender_address = recover_sender(tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/homestead/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/homestead/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -329,7 +330,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/istanbul/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple, Union
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -425,7 +426,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:

--- a/src/ethereum/london/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/london/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -329,7 +330,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
 from ethereum.base_types import Bytes0, Bytes32
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import InvalidBlock
@@ -332,7 +333,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:

--- a/src/ethereum/paris/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/paris/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
 from ethereum.base_types import Bytes0, Bytes32
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import InvalidBlock
@@ -402,8 +403,12 @@ def check_transaction(
     if tx.gas > gas_available:
         raise InvalidBlock
 
-    sender = recover_sender(chain_id, tx)
-    sender_account = get_account(state, sender)
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
+
+    sender_account = get_account(state, sender_address)
 
     if isinstance(tx, (FeeMarketTransaction, BlobTransaction)):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
@@ -446,7 +451,7 @@ def check_transaction(
     if sender_account.code != bytearray():
         raise InvalidBlock
 
-    return sender, effective_gas_price, blob_versioned_hashes
+    return sender_address, effective_gas_price, blob_versioned_hashes
 
 
 def make_receipt(

--- a/src/ethereum/prague/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
 from ethereum.base_types import Bytes0, Bytes32
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import InvalidBlock
@@ -337,7 +338,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:

--- a/src/ethereum/shanghai/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/shanghai/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -325,7 +326,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(chain_id, tx)
+
+    try:
+        sender_address = recover_sender(chain_id, tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/spurious_dragon/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/spurious_dragon/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 
 from ethereum.base_types import Bytes0
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
@@ -320,7 +321,11 @@ def check_transaction(
     """
     if tx.gas > gas_available:
         raise InvalidBlock
-    sender_address = recover_sender(tx)
+
+    try:
+        sender_address = recover_sender(tx)
+    except InvalidSignature as e:
+        raise InvalidBlock from e
 
     return sender_address
 

--- a/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ecrecover.py
+++ b/src/ethereum/tangerine_whistle/vm/precompiled_contracts/ecrecover.py
@@ -12,6 +12,7 @@ Introduction
 Implementation of the ECRECOVER precompiled contract.
 """
 from ethereum.base_types import U256
+from ethereum.crypto import InvalidSignature
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.utils.byte import left_pad_zero_bytes
@@ -52,7 +53,7 @@ def ecrecover(evm: Evm) -> None:
 
     try:
         public_key = secp256k1_recover(r, s, v - 27, message_hash)
-    except ValueError:
+    except InvalidSignature:
         # unable to extract public key
         return
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -63,6 +63,8 @@ U32
 U8
 secp256k1
 secp256k1n
+secp256k1p
+secp256k1b
 statetest
 subclasses
 iadd


### PR DESCRIPTION
### What was wrong?
The current sender recovery does not check if the `r` value in the signature is a valid one.

### How was it fixed?
Add a additional check to the `secp256k1_recover` function.

