### PR TITLE
Fix T8N in London

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -152,11 +152,6 @@ class Env:
                     self.parent_base_fee_per_gas,
                 ]
 
-                # TODO: See if this explicit check can be removed. See
-                # https://github.com/ethereum/execution-specs/issues/740
-                if t8n.fork.fork_module == "london":
-                    parameters.append(t8n.fork_block == self.block_number)
-
                 self.base_fee_per_gas = t8n.fork.calculate_base_fee_per_gas(
                     *parameters
                 )


### PR DESCRIPTION
### What was wrong?

The T8N daemon was failing when spawned on London fork due to an extra parameter that was appended (`t8n.fork_block == self.block_number`), which seems to have been removed in https://github.com/ethereum/execution-specs/commit/8d617fbb424ded118fd29e3fb13d31242d8c38c4.

### How was it fixed?
Removing the lines that added the parameter seems to have done the trick.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/media/EUIBacNWsAAw3EH.jpg:large)
