### PR TITLE
Exception strings: `TYPE_NOT_SUPPORTED`

### DIFF
--- a/src/ethereum/arrow_glacier/exceptions.py
+++ b/src/ethereum/arrow_glacier/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -794,7 +794,7 @@ def process_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     effective_gas_fee = tx.gas * env.gas_price
 

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -110,6 +110,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 2:
             return rlp.decode_to(FeeMarketTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/berlin/exceptions.py
+++ b/src/ethereum/berlin/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -683,7 +683,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -81,7 +81,7 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
     """
     if isinstance(tx, Bytes):
         if tx[0] != 1:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
         return rlp.decode_to(AccessListTransaction, tx[1:])
     else:
         return tx

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -671,7 +671,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -20,7 +20,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -427,7 +427,7 @@ def check_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     return sender, effective_gas_price, blob_versioned_hashes
 

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address, VersionedHash
 
 TX_BASE_COST = 21000
@@ -140,6 +140,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 3:
             return rlp.decode_to(BlobTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -671,7 +671,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -23,7 +23,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import FORK_CRITERIA, vm
@@ -677,7 +677,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -32,3 +32,10 @@ class RLPEncodingError(EthereumException):
     """
     Indicates that RLP encoding failed.
     """
+
+
+class InvalidSenderError(InvalidTransaction):
+    """
+    Thrown when a transaction originates from an account that cannot send
+    transactions.
+    """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -22,7 +22,7 @@ class InvalidTransaction(EthereumException):
     """
 
 
-class RLPDecodingError(InvalidBlock):
+class RLPDecodingError(EthereumException):
     """
     Indicates that RLP decoding failed.
     """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -16,6 +16,12 @@ class InvalidBlock(EthereumException):
     """
 
 
+class InvalidTransaction(EthereumException):
+    """
+    Thrown when a transaction being processed is found to be invalid.
+    """
+
+
 class RLPDecodingError(InvalidBlock):
     """
     Indicates that RLP decoding failed.

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -658,7 +658,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/gray_glacier/exceptions.py
+++ b/src/ethereum/gray_glacier/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -794,7 +794,7 @@ def process_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     effective_gas_fee = tx.gas * env.gas_price
 

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -110,6 +110,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 2:
             return rlp.decode_to(FeeMarketTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -659,7 +659,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -672,7 +672,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/london/exceptions.py
+++ b/src/ethereum/london/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import FORK_CRITERIA, vm
@@ -800,7 +800,7 @@ def process_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     effective_gas_fee = tx.gas * env.gas_price
 

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -110,6 +110,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 2:
             return rlp.decode_to(FeeMarketTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -672,7 +672,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/paris/exceptions.py
+++ b/src/ethereum/paris/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -20,7 +20,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -584,7 +584,7 @@ def process_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     effective_gas_fee = tx.gas * env.gas_price
 

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -110,6 +110,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 2:
             return rlp.decode_to(FeeMarketTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/shanghai/exceptions.py
+++ b/src/ethereum/shanghai/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exceptions specific to this fork.
+"""
+
+from typing import Final
+
+from ethereum.exceptions import InvalidTransaction
+
+
+class TransactionTypeError(InvalidTransaction):
+    """
+    Unknown [EIP-2718] transaction type byte.
+
+    [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"unknown transaction type `{transaction_type}`")
+        self.transaction_type = transaction_type

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -20,7 +20,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -607,7 +607,7 @@ def process_transaction(
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     effective_gas_fee = tx.gas * env.gas_price
 

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -11,7 +11,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from .. import rlp
-from ..exceptions import InvalidBlock
+from .exceptions import TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = 21000
@@ -110,6 +110,6 @@ def decode_transaction(tx: Union[LegacyTransaction, Bytes]) -> Transaction:
         elif tx[0] == 2:
             return rlp.decode_to(FeeMarketTransaction, tx[1:])
         else:
-            raise InvalidBlock
+            raise TransactionTypeError(tx[0])
     else:
         return tx

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -667,7 +667,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -21,7 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidSenderError
 
 from .. import rlp
 from . import vm
@@ -659,7 +659,7 @@ def process_transaction(
     if Uint(sender_account.balance) < gas_fee + Uint(tx.value):
         raise InvalidBlock
     if sender_account.code != bytearray():
-        raise InvalidBlock
+        raise InvalidSenderError("not EOA")
 
     gas = tx.gas - calculate_intrinsic_cost(tx)
     increment_nonce(env.state, sender)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -385,9 +385,9 @@ class T8N(Load):
             except EthereumException as e:
                 # The tf tools expects some non-blank error message
                 # even in case e is blank.
-                self.txs.rejected_txs[tx_idx] = f"Failed transaction: {str(e)}"
+                self.txs.rejected_txs[tx_idx] = f"Failed transaction: {e!r}"
                 self.restore_state()
-                self.logger.warning(f"Transaction {tx_idx} failed: {str(e)}")
+                self.logger.warning(f"Transaction {tx_idx} failed: {e!r}")
             else:
                 self.txs.add_transaction(tx)
                 gas_consumed = process_transaction_return[0]

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -11,7 +11,7 @@ from _pytest.mark.structures import ParameterSet
 from ethereum_types.numeric import U64
 
 from ethereum import rlp
-from ethereum.exceptions import InvalidBlock, InvalidTransaction
+from ethereum.exceptions import EthereumException
 from ethereum.utils.hexadecimal import hex_to_bytes
 from ethereum_spec_tools.evm_tools.loaders.fixture_loader import Load
 
@@ -72,7 +72,7 @@ def run_blockchain_st_test(test_case: Dict, load: Load) -> None:
             # TODO: Once all the specific exception types are thrown,
             #       only `pytest.raises` the correct exception type instead of
             #       all of them.
-            with pytest.raises((InvalidBlock, InvalidTransaction)):
+            with pytest.raises(EthereumException):
                 add_block_to_chain(chain, json_block, load, mock_pow)
             return
         else:

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -11,7 +11,7 @@ from _pytest.mark.structures import ParameterSet
 from ethereum_types.numeric import U64
 
 from ethereum import rlp
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidBlock, InvalidTransaction
 from ethereum.utils.hexadecimal import hex_to_bytes
 from ethereum_spec_tools.evm_tools.loaders.fixture_loader import Load
 
@@ -69,7 +69,10 @@ def run_blockchain_st_test(test_case: Dict, load: Load) -> None:
                 break
 
         if block_exception:
-            with pytest.raises(InvalidBlock):
+            # TODO: Once all the specific exception types are thrown,
+            #       only `pytest.raises` the correct exception type instead of
+            #       all of them.
+            with pytest.raises((InvalidBlock, InvalidTransaction)):
                 add_block_to_chain(chain, json_block, load, mock_pow)
             return
         else:


### PR DESCRIPTION
### What was wrong?

Related to Issue #1021

### How was it (partially) fixed?

Adding a new exception type to match `TransactionException.TYPE_NOT_SUPPORTED`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/6d3f443d-2a08-4ee1-8d67-848e4a116745.jpeg?format=webp)
