### PR TITLE
evm_tools: Parse `state_test` in daemon as t8n option

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -57,6 +57,8 @@ class _EvmToolHandler(BaseHTTPRequestHandler):
             f"--state.chainid={content['state']['chainid']}",
             f"--state.reward={content['state']['reward']}",
         ]
+        if 'state_test' in content and content['state_test']:
+            args.append("--state-test")
 
         self.send_response(200)
         self.send_header("Content-type", "application/octet-stream")


### PR DESCRIPTION
### What was wrong?

T8N's option `--state-test` could not be passed to the t8n handler if we were running in daemon mode.

### How was it fixed?

Added parsing for a `state_test` field in the daemon and, if present, the argument is added to the T8N call.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/rabd5zqi6l961.jpg)
