### PR TITLE
Extract t8n arguments from daemon query string

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -12,6 +12,7 @@ from io import StringIO, TextIOWrapper
 from socket import socket
 from threading import Thread
 from typing import Any, Tuple, Union
+from urllib.parse import parse_qs, urlparse
 
 
 def daemon_arguments(subparsers: argparse._SubParsersAction) -> None:
@@ -57,6 +58,16 @@ class _EvmToolHandler(BaseHTTPRequestHandler):
             f"--state.chainid={content['state']['chainid']}",
             f"--state.reward={content['state']['reward']}",
         ]
+
+        query_string = urlparse(self.path).query
+        if query_string:
+            query = parse_qs(
+                query_string,
+                keep_blank_values=True,
+                strict_parsing=True,
+                errors="strict",
+            )
+            args += query.get("arg", [])
 
         self.send_response(200)
         self.send_header("Content-type", "application/octet-stream")


### PR DESCRIPTION
### What was wrong?

Closes #1029
Closes #1006 

### How was it fixed?

This commit allows daemon clients to pass command line arguments in the query string (under the key `arg`.) To add multiple arguments, use multiple key/value pairs. For example:

```bash
curl --unix-socket /run/user/1000/ethereum-spec-evm/daemon.sock 'http://localhost/?arg=--help'
```

```bash
curl --unix-socket /run/user/1000/ethereum-spec-evm/daemon.sock 'http://localhost/?arg=--help&arg=--state-test'
```

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/2eb7d44d-8bba-44ac-925c-c0d25a0ad89d.jpeg?format=webp)
