### PR TITLE
Encode requests correctly in `t8n`

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -354,6 +354,8 @@ class Result:
             assert self.requests is not None
 
             data["requestsHash"] = encode_to_hex(self.requests_hash)
-            data["requests"] = [encode_to_hex(req) for req in self.requests]
+            # T8N doesn't consider the request type byte to be part of the
+            # request
+            data["requests"] = [encode_to_hex(req[1:]) for req in self.requests]
 
         return data


### PR DESCRIPTION
### What was wrong?

When hashed, requests consist of an identifier byte followed by arbitrary data. Internally EELS considers the identifier byte to be part of the request, but the `t8n` interface does not.

### How was it fixed?

Strip the identifier byte when encoding requests in `t8n`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/yydje0wr3f2e1.jpeg)
