### PR TITLE
EIP-7685: exclude empty requests in requests list

### DIFF
--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -890,7 +890,8 @@ def process_general_purpose_requests(
     """
     # Requests are to be in ascending order of request type
     requests_from_execution: List[Bytes] = []
-    requests_from_execution.append(DEPOSIT_REQUEST_TYPE + deposit_requests)
+    if len(deposit_requests) > 0:
+        requests_from_execution.append(DEPOSIT_REQUEST_TYPE + deposit_requests)
 
     system_withdrawal_tx_output = process_system_transaction(
         WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
@@ -907,9 +908,10 @@ def process_general_purpose_requests(
         excess_blob_gas,
     )
 
-    requests_from_execution.append(
-        WITHDRAWAL_REQUEST_TYPE + system_withdrawal_tx_output.return_data
-    )
+    if len(system_withdrawal_tx_output.return_data) > 0:
+        requests_from_execution.append(
+            WITHDRAWAL_REQUEST_TYPE + system_withdrawal_tx_output.return_data
+        )
 
     system_consolidation_tx_output = process_system_transaction(
         CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
@@ -926,9 +928,11 @@ def process_general_purpose_requests(
         excess_blob_gas,
     )
 
-    requests_from_execution.append(
-        CONSOLIDATION_REQUEST_TYPE + system_consolidation_tx_output.return_data
-    )
+    if len(system_consolidation_tx_output.return_data) > 0:
+        requests_from_execution.append(
+            CONSOLIDATION_REQUEST_TYPE
+            + system_consolidation_tx_output.return_data
+        )
 
     return requests_from_execution
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -356,8 +356,6 @@ class Result:
             data["requestsHash"] = encode_to_hex(self.requests_hash)
             # T8N doesn't consider the request type byte to be part of the
             # request
-            data["requests"] = [
-                encode_to_hex(req) for req in self.requests
-            ]
+            data["requests"] = [encode_to_hex(req) for req in self.requests]
 
         return data

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -357,7 +357,7 @@ class Result:
             # T8N doesn't consider the request type byte to be part of the
             # request
             data["requests"] = [
-                encode_to_hex(req[1:]) for req in self.requests
+                encode_to_hex(req) for req in self.requests
             ]
 
         return data


### PR DESCRIPTION
### What was wrong?

The following PRs include breaking changes in the behavior of requests for devnet-5:

https://github.com/ethereum/execution-apis/pull/599
https://github.com/ethereum/EIPs/pull/8989

### How was it fixed?

Remove requests elements from the requests list if the byte array is empty.

Also do not remove the `request_type` byte in the return list of the T8N result since it's now necessary to calculate the requests commitment.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.lpzoo.org/wp-content/uploads/2023/03/Screen-Shot-2023-02-09-at-7-1-992x797.webp)
