### PR TITLE
Import Extended type directly instead of using rlp.Extended

### DIFF
--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -86,7 +86,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -95,26 +95,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -124,13 +124,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,10 +146,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
 
     Returns
     -------
-    encoded : `rlp.Extended`
+    encoded : `Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -489,6 +489,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -82,7 +82,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -91,26 +91,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -120,13 +120,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -145,7 +145,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -487,6 +487,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.RLP`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/prague/trie.py
+++ b/src/ethereum/prague/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -86,7 +86,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -95,26 +95,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -124,13 +124,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,10 +146,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
 
     Returns
     -------
-    encoded : `rlp.Extended`
+    encoded : `Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -489,6 +489,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -86,7 +86,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -95,26 +95,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -124,13 +124,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,10 +146,10 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
 
     Returns
     -------
-    encoded : `rlp.Extended`
+    encoded : `Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -489,6 +489,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-from ethereum_rlp import rlp
+from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
@@ -83,7 +83,7 @@ class LeafNode:
     """Leaf node in the Merkle Trie"""
 
     rest_of_key: Bytes
-    value: rlp.Extended
+    value: Extended
 
 
 @slotted_freezable
@@ -92,26 +92,26 @@ class ExtensionNode:
     """Extension node in the Merkle Trie"""
 
     key_segment: Bytes
-    subnode: rlp.Extended
+    subnode: Extended
 
 
 BranchSubnodes = Tuple[
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
-    rlp.Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
 ]
 
 
@@ -121,13 +121,13 @@ class BranchNode:
     """Branch node in the Merkle Trie"""
 
     subnodes: BranchSubnodes
-    value: rlp.Extended
+    value: Extended
 
 
 InternalNode = Union[LeafNode, ExtensionNode, BranchNode]
 
 
-def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
+def encode_internal_node(node: Optional[InternalNode]) -> Extended:
     """
     Encodes a Merkle Trie node into its RLP form. The RLP will then be
     serialized into a `Bytes` and hashed unless it is less that 32 bytes
@@ -146,7 +146,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
     encoded : `rlp.Extended`
         The node encoded as RLP.
     """
-    unencoded: rlp.Extended
+    unencoded: Extended
     if node is None:
         unencoded = b""
     elif isinstance(node, LeafNode):
@@ -486,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[Extended, ...])),
         value,
     )


### PR DESCRIPTION
### What was wrong?


Solves #1049

### How was it fixed?

As proposed in the issue, I added the `Extended` type to the `Node` union in `trie.py`.
