### PR TITLE
prague: update `chain_id` in 7702 set code txs to u256

### DIFF
--- a/src/ethereum/prague/fork_types.py
+++ b/src/ethereum/prague/fork_types.py
@@ -77,7 +77,7 @@ class Authorization:
     The authorization for a set code transaction.
     """
 
-    chain_id: U64
+    chain_id: U256
     address: Address
     nonce: U64
     y_parity: U8

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -117,7 +117,7 @@ class SetCodeTransaction:
     The transaction type added in EIP-7702.
     """
 
-    chain_id: U256
+    chain_id: U64
     nonce: U64
     max_priority_fee_per_gas: Uint
     max_fee_per_gas: Uint

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -117,7 +117,7 @@ class SetCodeTransaction:
     The transaction type added in EIP-7702.
     """
 
-    chain_id: U64
+    chain_id: U256
     nonce: U64
     max_priority_fee_per_gas: Uint
     max_fee_per_gas: Uint

--- a/src/ethereum/prague/vm/eoa_delegation.py
+++ b/src/ethereum/prague/vm/eoa_delegation.py
@@ -163,7 +163,7 @@ def set_delegation(message: Message, env: Environment) -> U256:
     """
     refund_counter = U256(0)
     for auth in message.authorizations:
-        if auth.chain_id not in (env.chain_id, U64(0)):
+        if auth.chain_id not in (env.chain_id, U256(0)):
             continue
 
         if auth.nonce >= U64.MAX_VALUE:

--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -92,7 +92,7 @@ class TransactionLoad:
         for sublist in self.raw["authorizationList"]:
             authorizations.append(
                 self.fork.Authorization(
-                    chain_id=hex_to_u64(sublist.get("chainId")),
+                    chain_id=hex_to_u256(sublist.get("chainId")),
                     nonce=hex_to_u64(sublist.get("nonce")),
                     address=self.fork.hex_to_address(sublist.get("address")),
                     y_parity=hex_to_u8(sublist.get("v")),


### PR DESCRIPTION
Updates the EIP-7702 set code transaction type to have a nonce of type u256 instead of u64, see:
- ethereum/EIPs#9143.

Please check that no other instances were missed.

Corresponding change in EEST:
- ethereum/execution-spec-tests#1026

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/52277c39-8690-47b1-a647-d1edae78a5fc)
