### PR TITLE
dev: change type of branch node subnodes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,7 @@ python_requires = >=3.10
 install_requires =
     pycryptodome>=3,<4
     coincurve>=20,<21
-    typing_extensions>=4
+    typing_extensions>=4.2
     py_ecc @ git+https://github.com/petertdavies/py_ecc.git@127184f4c57b1812da959586d0fe8f43bb1a2389
     ethereum-types>=0.2.1,<0.3
 

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -33,6 +33,7 @@ from typing import (
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.london import trie as previous_trie
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.muir_glacier import trie as previous_trie

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.spurious_dragon import trie as previous_trie

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -464,7 +464,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -482,10 +483,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.shanghai import trie as previous_trie

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -101,7 +102,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -97,10 +97,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -100,7 +101,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -140,7 +141,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -462,9 +463,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -97,12 +97,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -488,6 +489,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -102,7 +102,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.byzantium import trie as previous_trie
 from ethereum.crypto.hash import keccak256

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.homestead import trie as previous_trie

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/dao_fork/trie.py
+++ b/src/ethereum/dao_fork/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -486,6 +487,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -96,7 +97,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -136,7 +137,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -460,9 +461,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -98,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -462,7 +462,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -93,12 +93,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -480,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -93,10 +93,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.hexadecimal import hex_to_bytes

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.arrow_glacier import trie as previous_trie
 from ethereum.crypto.hash import keccak256

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.frontier import trie as previous_trie

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.constantinople import trie as previous_trie
 from ethereum.crypto.hash import keccak256

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.berlin import trie as previous_trie
 from ethereum.crypto.hash import keccak256

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.istanbul import trie as previous_trie

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.gray_glacier import trie as previous_trie

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -464,7 +464,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -482,10 +483,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -101,7 +102,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -97,10 +97,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -100,7 +101,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -140,7 +141,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -462,9 +463,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -97,12 +97,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.paris import trie as previous_trie

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -488,6 +489,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -102,7 +102,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.tangerine_whistle import trie as previous_trie

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -16,7 +16,6 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
-    Annotated,
     Callable,
     Dict,
     Generic,

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -461,7 +461,7 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        (
+        tuple(
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
         ),

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -16,6 +16,7 @@ The state trie is the structure responsible for storing
 import copy
 from dataclasses import dataclass, field
 from typing import (
+    Annotated,
     Callable,
     Dict,
     Generic,
@@ -98,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Tuple[rlp.Extended, ...]
+    subnodes: Annotated[Tuple[rlp.Extended], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -27,13 +27,13 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    assert_type,
     cast,
 )
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.dao_fork import trie as previous_trie

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -94,10 +94,25 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
-BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
-                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_types.bytes import Bytes
@@ -479,10 +480,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        tuple(
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ),
+        cast(BranchSubnodes, subnodes),
         value,
     )

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -99,7 +99,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended], 16]
+    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
     value: rlp.Extended
 
 

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -27,6 +27,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    assert_type,
     cast,
 )
 
@@ -485,6 +486,6 @@ def patricialize(
         for k in range(16)
     )
     return BranchNode(
-        cast(BranchSubnodes, subnodes),
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -24,6 +24,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
 )
@@ -97,7 +98,7 @@ class ExtensionNode:
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: Tuple[rlp.Extended, ...]
     value: rlp.Extended
 
 
@@ -137,7 +138,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,9 +460,9 @@ def patricialize(
             branches[key[level]][key] = obj[key]
 
     return BranchNode(
-        [
+        (
             encode_internal_node(patricialize(branches[k], level + Uint(1)))
             for k in range(16)
-        ],
+        ),
         value,
     )

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -94,12 +94,17 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended,
+                      rlp.Extended, rlp.Extended, rlp.Extended, rlp.Extended]
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: Annotated[Tuple[rlp.Extended, ...], 16]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 


### PR DESCRIPTION
### What was wrong?
The type for the BranchNode's subnodes was `List[rlp.Extended]`. While this is not inherently wrong, a more suitable type would be a tuple with 16 rlp.Extended elements, each representing a BranchNode of the trie, as there's no intent to mutate the subnodes after instantiation.

Related to Issue #

### How was it fixed?

Changed to `Annotated[Tuple[rlp.Extended, ...], 16]`. Also open to just repeating 16 times the rlp.Extended argument, but using an annotation sounds more convenient rather than repeating. The annotation conveys at type hint that the tuple is of size 16. 

#### Cute Animal Picture
Our beloved moodeng friend
![Put a link to a cute animal picture inside the parenthesis-->](https://static.news.bitcoin.com/wp-content/uploads/2024/09/moo-deng123dd34.jpg)
