### PR TITLE
dev: make refund counter a `Uint`

### DIFF
--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -779,7 +779,7 @@ def process_transaction(
     output = process_message_call(message, env)
 
     gas_used = tx.gas - output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(output.refund_counter))
+    gas_refund = min(gas_used // Uint(5), output.refund_counter)
     gas_refund_amount = (output.gas_left + gas_refund) * env.gas_price
 
     # For non-1559 transactions env.gas_price == tx.gas_price

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -87,7 +87,7 @@ class Evm:
     env: Environment
     valid_jump_destinations: Set[Uint]
     logs: Tuple[Log, ...]
-    refund_counter: int
+    refund_counter: Uint
     running: bool
     message: Message
     output: Bytes

--- a/src/ethereum/cancun/vm/instructions/storage.py
+++ b/src/ethereum/cancun/vm/instructions/storage.py
@@ -103,20 +103,20 @@ def sstore(evm: Evm) -> None:
     if current_value != new_value:
         if original_value != 0 and current_value != 0 and new_value == 0:
             # Storage is cleared for the first time in the transaction
-            evm.refund_counter += int(GAS_STORAGE_CLEAR_REFUND)
+            evm.refund_counter += GAS_STORAGE_CLEAR_REFUND
 
         if original_value != 0 and current_value == 0:
             # Gas refund issued earlier to be reversed
-            evm.refund_counter -= int(GAS_STORAGE_CLEAR_REFUND)
+            evm.refund_counter -= GAS_STORAGE_CLEAR_REFUND
 
         if original_value == new_value:
             # Storage slot being restored to its original value
             if original_value == 0:
                 # Slot was originally empty and was SET earlier
-                evm.refund_counter += int(GAS_STORAGE_SET - GAS_WARM_ACCESS)
+                evm.refund_counter += (GAS_STORAGE_SET - GAS_WARM_ACCESS)
             else:
                 # Slot was originally non-empty and was UPDATED earlier
-                evm.refund_counter += int(
+                evm.refund_counter += (
                     GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS
                 )
 

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -79,7 +79,7 @@ class MessageCallOutput:
     """
 
     gas_left: Uint
-    refund_counter: U256
+    refund_counter: Uint
     logs: Union[Tuple[()], Tuple[Log, ...]]
     accounts_to_delete: Set[Address]
     touched_accounts: Iterable[Address]
@@ -112,7 +112,7 @@ def process_message_call(
         )
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                Uint(0), Uint(0), tuple(), set(), set(), AddressCollision()
             )
         else:
             evm = process_create_message(message, env)
@@ -125,12 +125,12 @@ def process_message_call(
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
         touched_accounts = set()
-        refund_counter = U256(0)
+        refund_counter = Uint(0)
     else:
         logs = evm.logs
         accounts_to_delete = evm.accounts_to_delete
         touched_accounts = evm.touched_accounts
-        refund_counter = U256(evm.refund_counter)
+        refund_counter = evm.refund_counter
 
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error


### PR DESCRIPTION
### What was wrong?

Related to Issue #1067

### How was it fixed?
I modified refund_counter to be a Uint. It cannot go negative, nor can it go beyond the gas_used, which is itself a Uint

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1453608829/photo/serious-bengal-cat-is-the-boss-in-a-tie-and-shirt-in-the-office.jpg?s=612x612&w=0&k=20&c=5Ra2I1gMp3qJD6EpH3nhveKv_t-rVho_9Qm7W5S6AU8=)
