### PR TITLE
Update EIP-7623 according to spec

### DIFF
--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -1030,12 +1030,12 @@ def process_transaction(
     execution_gas_used -= gas_refund
 
     # EIP-7623 floor price (note: no EVM costs)
-    floor = Uint(tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST)
+    floor_gas_cost = Uint(
+        tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
+    )
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
-    total_gas_used = execution_gas_used
-    if total_gas_used < floor:
-        total_gas_used = floor
+    total_gas_used = max(execution_gas_used, floor_gas_cost)
 
     output.gas_left = tx.gas - total_gas_used
     gas_refund_amount = output.gas_left * env.gas_price


### PR DESCRIPTION
### What was wrong?

EIP-7623 Spec needs update to latest version changed by this PR: https://github.com/ethereum/EIPs/pull/9227

Calldata floor gas cost is now compared to the execution gas cost minus the refund, instead of the refund being applied to the floor data cost in case it was higher than the execution gas cost.

### How was it fixed?

I updated the logic and moved some of the variables to make the change easier and more readable. Let me know if this is ok, or rather we should leave the original structure.

I'm writing the EEST tests tomorrow and will run them to verify the changes.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://stevegettle.com/wp-content/uploads/2019/06/D504875-670x447.jpg)
