### PR TITLE
dev: stricter types for MessageCallOuput

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -441,7 +445,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -748,7 +752,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -343,7 +347,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -642,7 +646,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -632,7 +636,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -49,6 +50,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -81,8 +83,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -50,7 +51,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal
@@ -421,7 +425,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -696,7 +700,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -16,8 +16,9 @@ It consists of a main account trie and storage tries for each contract.
 There is a distinction between an account that does not exist and
 `EMPTY_ACCOUNT`.
 """
+
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
@@ -719,7 +720,7 @@ def set_transient_storage(
 
 
 def destroy_touched_empty_accounts(
-    state: State, touched_accounts: Iterable[Address]
+    state: State, touched_accounts: Set[Address]
 ) -> None:
     """
     Destroy all touched accounts that are empty.
@@ -727,7 +728,7 @@ def destroy_touched_empty_accounts(
     ----------
     state: `State`
         The current state.
-    touched_accounts: `Iterable[Address]`
+    touched_accounts: `Set[Address]`
         All the accounts that have been touched in the current transaction.
     """
     for address in touched_accounts:

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address, VersionedHash
@@ -94,7 +95,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -632,7 +636,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -49,6 +50,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -81,8 +83,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -50,7 +51,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -48,7 +49,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -11,6 +11,7 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
@@ -47,6 +48,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -82,7 +83,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -48,7 +49,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -11,6 +11,7 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
@@ -47,6 +48,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -441,7 +445,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -748,7 +752,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -48,7 +49,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -11,6 +11,7 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
@@ -47,6 +48,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -633,7 +637,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -88,7 +89,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt
@@ -447,7 +451,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -754,7 +758,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -18,8 +18,8 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
-    EthereumException,
     EvmStop,
     OpEnd,
     OpException,

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -11,13 +11,15 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import (
+    EthereumException,
     EvmStop,
     OpEnd,
     OpException,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -633,7 +637,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -88,7 +89,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -18,8 +18,8 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
-    EthereumException,
     EvmStop,
     OpEnd,
     OpException,

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -11,13 +11,15 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import (
+    EthereumException,
     EvmStop,
     OpEnd,
     OpException,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -354,7 +358,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -538,7 +542,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal
@@ -358,7 +362,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -560,7 +564,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -51,7 +52,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -50,6 +51,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidContractPrefix,
     InvalidOpcode,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -85,7 +86,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -11,8 +11,9 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
@@ -49,6 +50,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,
@@ -80,8 +82,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -50,7 +51,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     OutOfGasError,

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -48,7 +49,6 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
-    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -11,6 +11,7 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
@@ -47,6 +48,7 @@ from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Environment, Evm
 from .exceptions import (
     AddressCollision,
+    EthereumException,
     ExceptionalHalt,
     InvalidOpcode,
     StackDepthLimitError,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -20,6 +20,8 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Protocol, Union
 
+from ethereum.exceptions import EthereumException
+
 
 @dataclass
 class TransactionStart:
@@ -44,7 +46,7 @@ class TransactionEnd:
     Return value or revert reason of the outermost frame of execution.
     """
 
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     """
     The exception, if any, that caused the transaction to fail.
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -1,6 +1,7 @@
 """
 The module implements the raw EVM tracer for t8n.
 """
+
 import json
 import os
 from contextlib import ExitStack
@@ -10,6 +11,7 @@ from typing import List, Optional, Protocol, TextIO, Union, runtime_checkable
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     GasAndRefund,
@@ -60,7 +62,7 @@ class FinalTrace:
     error: Optional[str] = None
 
     def __init__(
-        self, gas_used: int, output: bytes, error: Optional[Exception]
+        self, gas_used: int, output: bytes, error: Optional[EthereumException]
     ) -> None:
         self.output = output.hex()
         self.gasUsed = hex(gas_used)


### PR DESCRIPTION
### What was wrong?
Logs, error and touched_accounts can have stricter types 

Related to Issue #1097

### How was it fixed?
Stricter types

* logs: Union[Tuple[()], Tuple[Log, ...] to Tuple[Log, ...] (redundant)
* errors: Option[Exception] to Option[EthereumException]
* touched_accounts: Iterable type to Set 
