### PR TITLE
parse `block_hashes` key as hex

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -247,15 +247,21 @@ class Env:
 
         # Read the block hashes
         block_hashes: List[Any] = []
+
+        # The hex key strings provided might not have standard formatting
+        clean_block_hashes: Dict[int, Hash32] = {}
+        if "blockHashes" in data:
+            for key, value in data["blockHashes"].items():
+                int_key = int(key, 16)
+                clean_block_hashes[int_key] = Hash32(hex_to_bytes(value))
+
         # Store a maximum of 256 block hashes.
         max_blockhash_count = min(Uint(256), self.block_number)
         for number in range(
             self.block_number - max_blockhash_count, self.block_number
         ):
-            if "blockHashes" in data and str(number) in data["blockHashes"]:
-                block_hashes.append(
-                    Hash32(hex_to_bytes(data["blockHashes"][str(number)]))
-                )
+            if number in clean_block_hashes.keys():
+                block_hashes.append(clean_block_hashes[number])
             else:
                 block_hashes.append(None)
 


### PR DESCRIPTION
(closes #1078 )

### What was wrong?
The block hashes keys are sent to `t8n` as a string of number but has to be a hex

Related to Issue #1078 

### How was it fixed?
Convert the keys from hex to int.

#### Cute Animal Picture


![](https://upload.wikimedia.org/wikipedia/commons/d/d8/Tunnel_of_ducks.jpg)

