### PR TITLE
Add tracing support for daemon

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -59,6 +59,24 @@ class _EvmToolHandler(BaseHTTPRequestHandler):
             f"--state.reward={content['state']['reward']}",
         ]
 
+        trace = content.get("trace", False)
+        output_basedir = content.get("output-basedir")
+        if trace:
+            if not output_basedir:
+                raise ValueError(
+                    "`output-basedir` should be provided when `--trace` "
+                    "is enabled."
+                )
+            # send full trace output if ``trace`` is ``True``
+            args.extend(
+                [
+                    "--trace",
+                    "--trace.memory",
+                    "--trace.returndata",
+                    f"--output.basedir={output_basedir}",
+                ]
+            )
+
         query_string = urlparse(self.path).query
         if query_string:
             query = parse_qs(


### PR DESCRIPTION
### What was wrong?

Related to ethereum/execution-spec-tests#1174

Tracing is not currently working via daemon when ``--traces`` is passed via EEST when filling tests.

### How was it fixed?

- If ``trace`` is passed in the POST, turn on full trace in the T8N tool.
- Validate that ``output-basedir`` is also specified as EEST relies on a known location for the trace files. Raise a clarifying 
error if it is not specified.

#### Cute Animal Picture

<img width="1016" alt="Screenshot 2025-02-04 at 08 43 22" src="https://github.com/user-attachments/assets/57dd415e-e024-424f-9f4e-f286eae0d375" />
