### PR TITLE
run pectra-devnet-6@v1.0.0 tests

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -17,7 +17,7 @@ TEST_FIXTURES = {
     },
     "latest_fork_tests": {
         "url": "https://github.com/gurukamath/latest_fork_tests.git",
-        "commit_hash": "e7ccbb6",
+        "commit_hash": "e15efcb",
         "fixture_path": "tests/fixtures/latest_fork_tests",
     },
 }


### PR DESCRIPTION
### What was wrong?
Devnets 6 tests are not currently running on CI


### How was it fixed?
Update to pectra-devnet-6@v1.0.0 fixtures


#### Cute Animal Picture

![](https://upload.wikimedia.org/wikipedia/commons/a/a6/Parrulo_-Muscovy_duckling.jpg)
