### PR TITLE
added address after checks

### DIFF
--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -94,6 +94,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -104,8 +106,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -75,7 +75,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -94,6 +93,7 @@ def generic_create(
         evm.gas_left += create_message_gas
         push(evm.stack, U256(0))
         return
+    
 
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
@@ -105,6 +105,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/arrow_glacier/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -75,7 +76,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
     if evm.message.is_static:
@@ -93,7 +93,6 @@ def generic_create(
         evm.gas_left += create_message_gas
         push(evm.stack, U256(0))
         return
-    
 
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -75,7 +76,6 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -95,6 +95,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -105,8 +107,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/berlin/vm/instructions/system.py
+++ b/src/ethereum/berlin/vm/instructions/system.py
@@ -76,7 +76,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -106,6 +105,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -83,7 +84,6 @@ def generic_create(
     )
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -84,7 +84,6 @@ def generic_create(
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -114,6 +113,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -103,6 +103,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -113,8 +115,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -74,7 +75,6 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -94,6 +94,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -104,8 +106,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/gray_glacier/vm/instructions/system.py
@@ -75,7 +75,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -105,6 +104,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -92,7 +93,6 @@ def generic_create(
         evm.gas_left += create_message_gas
         push(evm.stack, U256(0))
         return
-    
 
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -94,6 +94,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -104,8 +106,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/london/vm/instructions/system.py
+++ b/src/ethereum/london/vm/instructions/system.py
@@ -75,8 +75,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-    evm.accessed_addresses.add(contract_address)
-
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
     if evm.message.is_static:
@@ -94,6 +92,7 @@ def generic_create(
         evm.gas_left += create_message_gas
         push(evm.stack, U256(0))
         return
+    
 
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
@@ -105,6 +104,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -74,7 +75,6 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -94,6 +94,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -104,8 +106,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/paris/vm/instructions/system.py
+++ b/src/ethereum/paris/vm/instructions/system.py
@@ -75,7 +75,6 @@ def generic_create(
         evm.memory, memory_start_position, memory_size
     )
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -105,6 +104,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -84,7 +85,6 @@ def generic_create(
     )
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -85,7 +85,6 @@ def generic_create(
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -115,6 +114,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -104,6 +104,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -114,8 +116,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -11,6 +11,7 @@ Introduction
 
 Implementations of the EVM system related instructions.
 """
+
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint
 
@@ -82,7 +83,6 @@ def generic_create(
     )
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
-
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -83,7 +83,6 @@ def generic_create(
     if len(call_data) > 2 * MAX_CODE_SIZE:
         raise OutOfGasError
 
-    evm.accessed_addresses.add(contract_address)
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))
     evm.gas_left -= create_message_gas
@@ -113,6 +112,8 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
+
+    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -102,6 +102,8 @@ def generic_create(
         push(evm.stack, U256(0))
         return
 
+    evm.accessed_addresses.add(contract_address)
+
     if account_has_code_or_nonce(
         evm.message.block_env.state, contract_address
     ) or account_has_storage(evm.message.block_env.state, contract_address):
@@ -112,8 +114,6 @@ def generic_create(
         return
 
     increment_nonce(evm.message.block_env.state, evm.message.current_target)
-
-    evm.accessed_addresses.add(contract_address)
 
     child_message = Message(
         block_env=evm.message.block_env,


### PR DESCRIPTION
### What was wrong?

contract_address is being added to the accessed_addresses before the checks validating that the sender nonce is small enough, the sender has enough balance, and the call-stack-depth has not overflowed.

### How was it fixed?

Simply added contract_address to accessed_addresses after the checks.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://c02.purpledshub.com/uploads/sites/41/2024/05/Adelie-penguin.jpg?webp=1&w=1200)
