### PR TITLE
Simplified validate_header func in post-merge forks

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload Pages Artifact
         id: artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: .tox/docs
 
@@ -46,6 +46,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      actions: read
 
     environment:
       name: github-pages
@@ -54,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/EIP_AUTHORS_MANUAL.md
+++ b/EIP_AUTHORS_MANUAL.md
@@ -65,4 +65,4 @@ Please refer the following tutorial for writing new EIP. It takes you through a 
 
 In addition to having a reference implementation, it is also very useful for the community and core development if the EIP author concieves and writes test vectors for the EIP. There is a very user friendly framework for writing ethereum tests in the `execution-spec-tests` repository. Please refer to the following guide for writing tests to your EIP.
 
-[Writing Tests with `execution-spec-tests`](https://ethereum.github.io/execution-spec-tests/main/getting_started/quick_start/)
+[Writing Tests with `execution-spec-tests`](https://ethereum.github.io/execution-spec-tests/getting_started/quick_start/)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,192 @@
+# Execution Specification Releases
+
+## About Versions
+
+EELS' versioning scheme is intended to be compatible with Python's
+[Version Specifiers], and is not compatible with [SemVer] (although it does
+borrow some of SemVer's concepts.)
+
+[Version Specifiers]: https://packaging.python.org/en/latest/specifications/version-specifiers/
+[SemVer]: https://semver.org/
+
+### Format
+
+The general format of EELS version numbers is as follows:
+
+```
+COMPAT "." HARDFORK ( "." PATCH | ".0rc" DEVNET [ ".post" PATCH ] ) [ ".dev" DEV ]
+```
+
+Where:
+
+- `COMPAT` is incremented when a release contains a backwards-incompatible change to an EELS' interface (Python API, command line tools, etc.)
+- `HARDFORK` is the number of hardforks included in the release after Frontier.
+- `DEVNET`, if present, is incremented when a release targets a new devnet.
+- `DEV`, if present, indicates a pre-release preview and is incremented for each pre-release before the final release.
+- `PATCH`, if present, is incremented for each release that does not increment any of `COMPAT`, `HARDFORK`, `DEV`, or `DEVNET`. It is reset to zero when any of `COMPAT`, `HARDFORK`, or `DEVNET` is incremented.
+
+### Examples
+
+The following table is a hypothetical complete example of all of the releases between `1.15.0rc1.dev1` and `2.16.0`, in order from oldest at the top to the newest at the bottom.
+
+| Fork   | Description        | Version Number    |
+| ------ | ------------------ | ----------------- |
+| cancun | preview of devnet1 | `1.15.0rc1.dev1`  |
+| cancun | preview of devnet1 | `1.15.0rc1.dev2`  |
+| cancun | preview of devnet1 | `1.15.0rc1.dev3`  |
+|        |                    |                   |
+| cancun | finalize devnet1   | `1.15.0rc1`       |
+|        |                    |                   |
+| cancun | devnet1 bugfix     | `1.15.0rc1.post1` |
+| cancun | devnet1 bugfix     | `1.15.0rc1.post2` |
+| cancun | devnet1 bugfix     | `1.15.0rc1.post3` |
+|        |                    |                   |
+| cancun | finalize devnet2   | `1.15.0rc2`       |
+|        |                    |                   |
+| cancun | finalize mainnet   | `1.15.0`          |
+|        |                    |                   |
+| cancun | mainnet bugfix     | `1.15.1`          |
+|        |                    |                   |
+| cancun | breaking change    | `2.15.0`          |
+|        |                    |                   |
+| prague | preview of devnet1 | `2.16.0rc1.dev1`  |
+|        |                    |                   |
+| prague | finalize devnet1   | `2.16.0rc1`       |
+|        |                    |                   |
+| prague | finalize mainnet   | `2.16.0`          |
+
+
+## Creating a Release
+
+### Overview
+
+1. Choose a version number.
+1. Update version in source code.
+1. Create a pull request.
+1. Wait for it to get merged.
+1. Create a tag.
+1. Create GitHub release.
+1. Publish to PyPI.
+
+### Choosing a Version Number
+
+To choose the next version number, find the format matching the current version
+number in the table below, then choose the new version according to the reason
+for the new release.
+
+| Current Version           | Action               | New Version            |
+| ------------------------- | -------------------- | ---------------------- |
+| **`1.3.5`**               |                      |                        |
+|                           | Mainnet Release      | `1.4.0`                |
+|                           | Devnet Release       | `1.4.0rc1`             |
+|                           | Bug Fix Release      | `1.3.6`                |
+|                           | Breaking Release     | `2.3.0`                |
+|                           |                      |                        |
+| **`1.3.0rc5`**            |                      |                        |
+|                           | Mainnet Release      | `1.3.0`                |
+|                           | Devnet Release       | `1.3.0rc6`             |
+|                           | Bug Fix Release      | `1.3.0rc5.post1`       |
+|                           | Breaking Release     | `2.3.0rc5`             |
+|                           |                      |                        |
+| **`1.3.0rc5.post7`**      |                      |                        |
+|                           | Mainnet Release      | `1.3.0`                |
+|                           | Devnet Release       | `1.3.0rc6`             |
+|                           | Bug Fix Release      | `1.3.0rc5.post8`       |
+|                           | Breaking Release     | `2.3.0rc5`             |
+|                           |                      |                        |
+| **`1.3.5.dev7`**          |                      |                        |
+|                           | Mainnet Release      | `1.3.5`                |
+|                           | Another Preview      | `1.3.5.dev8`           |
+|                           |                      |                        |
+| **`1.3.0rc5.dev7`**       |                      |                        |
+|                           | Devnet Release       | `1.3.0rc5`             |
+|                           | Another Preview      | `1.3.0rc5.dev8`        |
+|                           |                      |                        |
+| **`1.3.0rc5.post7.dev9`** |                      |                        |
+|                           | Devnet Release       | `1.3.0rc5.post7`       |
+|                           | Another Preview      | `1.3.0rc5.post7.dev10` |
+
+> [!NOTE]
+> Append `.dev1` to any new version number to make it a pre-release, unless it
+> already contained a `.devN` suffix. If it did, increment `N` to make another
+> pre-release instead.
+
+### Updating Version in Source Code
+
+The version number is set in `src/ethereum/__init__.py`. Change it there. For
+example:
+
+```patch
+diff --git a/src/ethereum/__init__.py b/src/ethereum/__init__.py
+index 252f2f317..8cdd89a55 100644
+--- a/src/ethereum/__init__.py
++++ b/src/ethereum/__init__.py
+@@ -18,7 +18,7 @@ possible, to aid in defining the behavior of Ethereum clients.
+ """
+ import sys
+ 
+-__version__ = "1.15.0"
++__version__ = "1.16.0rc1"
+ 
+ #
+ #  Ensure we can reach 1024 frames of recursion
+```
+
+### Creating the Pull Request
+
+The usual. `git checkout -b release-vX.Y.Z`, `git commit -a`, and `git push`.
+
+### Waiting
+
+```
+  ______________________________________
+/ Just because the message may never be  \\
+| received does not mean it is not worth |
+\\ sending.                               /
+  --------------------------------------
+         \   ^__^ 
+          \  (oo)\_______
+             (__)\       )\/\\
+                 ||----w |
+                 ||     ||
+```
+
+### Creating the Tag
+
+> [!WARNING]
+> Do not create the tag from the `HEAD` branch of the pull request.
+>
+> GitHub can rewrite commits when merging pull requests, and tagging the
+> original commit will make the git history messier than necessary.
+
+The tag name should be the letter `v` followed by the version number (eg.
+`1.15.0rc5.post3` becomes `v1.15.0rc5.post3`.)
+
+To create and push the tag:
+
+```bash
+git checkout master     # Replace `master` with the pull request's base branch.
+git pull
+git tag -a -s v1.15.0   # Replace `v1.15.0` with the tag name from earlier.
+git push origin v1.15.0 # Replace the tag name here too.
+```
+
+> [!IMPORTANT]
+> If `git tag` complains about a missing GPG/PGP key, follow
+> [this guide][keygen] to generate one. It's best to add the key to your GitHub
+> account as well.
+
+[keygen]: https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key
+
+### Creating the GitHub Release
+
+Go [here][release], choose the newly created tag, and generate some release
+notes.
+
+[release]: https://github.com/ethereum/execution-specs/releases/new
+
+### Publishing to PyPI
+
+See the [Python Packaging User Guide][ppug]
+
+[ppug]: https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,7 @@ python_requires = >=3.10
 install_requires =
     pycryptodome>=3,<4
     coincurve>=20,<21
-    typing_extensions>=4
+    typing_extensions>=4.2
     py_ecc @ git+https://github.com/petertdavies/py_ecc.git@127184f4c57b1812da959586d0fe8f43bb1a2389
     ethereum-types>=0.2.1,<0.3
     ethereum-rlp>=0.1.1,<0.2

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -441,7 +445,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -748,7 +752,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/arrow_glacier/state.py
+++ b/src/ethereum/arrow_glacier/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -241,10 +241,14 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )

--- a/src/ethereum/arrow_glacier/trie.py
+++ b/src/ethereum/arrow_glacier/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.london import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -343,7 +347,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -642,7 +646,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/berlin/state.py
+++ b/src/ethereum/berlin/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -213,6 +213,8 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )

--- a/src/ethereum/berlin/trie.py
+++ b/src/ethereum/berlin/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.muir_glacier import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -632,7 +636,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/byzantium/state.py
+++ b/src/ethereum/byzantium/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/byzantium/trie.py
+++ b/src/ethereum/byzantium/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.spurious_dragon import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -81,8 +83,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -300,7 +300,9 @@ def validate_header(header: Header, parent_header: Header) -> None:
     header :
         Header to check for correctness.
     parent_header :
-        Parent Header of the header to check for correctness
+        Parent Header of the header to check for correctness. For post-merge forks,
+        this is always the last header in the chain since ommers are
+        not allowed.
     """
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
@@ -323,6 +325,7 @@ def validate_header(header: Header, parent_header: Header) -> None:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
         raise InvalidBlock
+     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
     if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal
@@ -421,7 +425,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -696,7 +700,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -16,8 +16,9 @@ It consists of a main account trie and storage tries for each contract.
 There is a distinction between an account that does not exist and
 `EMPTY_ACCOUNT`.
 """
+
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
@@ -719,7 +720,7 @@ def set_transient_storage(
 
 
 def destroy_touched_empty_accounts(
-    state: State, touched_accounts: Iterable[Address]
+    state: State, touched_accounts: Set[Address]
 ) -> None:
     """
     Destroy all touched accounts that are empty.
@@ -727,7 +728,7 @@ def destroy_touched_empty_accounts(
     ----------
     state: `State`
         The current state.
-    touched_accounts: `Iterable[Address]`
+    touched_accounts: `Set[Address]`
         All the accounts that have been touched in the current transaction.
     """
     for address in touched_accounts:

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -37,12 +37,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -55,8 +56,8 @@ class TransientStorage:
     within a transaction.
     """
 
-    _tries: Dict[Address, Trie[Bytes, U256]] = field(default_factory=dict)
-    _snapshots: List[Dict[Address, Trie[Bytes, U256]]] = field(
+    _tries: Dict[Address, Trie[Bytes32, U256]] = field(default_factory=dict)
+    _snapshots: List[Dict[Address, Trie[Bytes32, U256]]] = field(
         default_factory=list
     )
 
@@ -261,7 +262,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -291,7 +292,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -626,7 +627,7 @@ def set_code(state: State, address: Address, code: Bytes) -> None:
     modify_state(state, address, write_code)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken
@@ -660,7 +661,7 @@ def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
 
 
 def get_transient_storage(
-    transient_storage: TransientStorage, address: Address, key: Bytes
+    transient_storage: TransientStorage, address: Address, key: Bytes32
 ) -> U256:
     """
     Get a value at a storage key on an account from transient storage.
@@ -691,7 +692,7 @@ def get_transient_storage(
 def set_transient_storage(
     transient_storage: TransientStorage,
     address: Address,
-    key: Bytes,
+    key: Bytes32,
     value: U256,
 ) -> None:
     """

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -280,14 +280,20 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )
     elif isinstance(tx, BlobTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_4844(tx)
         )

--- a/src/ethereum/cancun/trie.py
+++ b/src/ethereum/cancun/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.shanghai import trie as previous_trie
@@ -95,12 +98,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -140,7 +163,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -461,10 +484,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address, VersionedHash
@@ -94,7 +95,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -632,7 +636,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/constantinople/state.py
+++ b/src/ethereum/constantinople/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/constantinople/trie.py
+++ b/src/ethereum/constantinople/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.byzantium import trie as previous_trie
 from ethereum.crypto.hash import keccak256
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -81,8 +83,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/dao_fork/state.py
+++ b/src/ethereum/dao_fork/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/frontier/state.py
+++ b/src/ethereum/frontier/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/frontier/trie.py
+++ b/src/ethereum/frontier/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.utils.hexadecimal import hex_to_bytes
@@ -91,12 +94,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -136,7 +159,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -459,10 +482,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -82,7 +83,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -441,7 +445,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -748,7 +752,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/gray_glacier/state.py
+++ b/src/ethereum/gray_glacier/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -241,10 +241,14 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )

--- a/src/ethereum/gray_glacier/trie.py
+++ b/src/ethereum/gray_glacier/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.arrow_glacier import trie as previous_trie
 from ethereum.crypto.hash import keccak256
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/homestead/state.py
+++ b/src/ethereum/homestead/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/homestead/trie.py
+++ b/src/ethereum/homestead/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.frontier import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -633,7 +637,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/istanbul/state.py
+++ b/src/ethereum/istanbul/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/istanbul/trie.py
+++ b/src/ethereum/istanbul/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.constantinople import trie as previous_trie
 from ethereum.crypto.hash import keccak256
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -88,7 +89,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt
@@ -447,7 +451,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -754,7 +758,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/london/state.py
+++ b/src/ethereum/london/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -241,10 +241,14 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )

--- a/src/ethereum/london/trie.py
+++ b/src/ethereum/london/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.berlin import trie as previous_trie
 from ethereum.crypto.hash import keccak256
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -83,8 +85,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -21,7 +21,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -339,7 +343,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Receipt:
@@ -633,7 +637,7 @@ def pay_rewards(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/muir_glacier/state.py
+++ b/src/ethereum/muir_glacier/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -599,7 +600,7 @@ def create_ether(state: State, address: Address, amount: U256) -> None:
     modify_state(state, address, increase_balance)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/muir_glacier/trie.py
+++ b/src/ethereum/muir_glacier/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.istanbul import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -88,7 +89,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -82,8 +84,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -270,7 +270,9 @@ def validate_header(header: Header, parent_header: Header) -> None:
     header :
         Header to check for correctness.
     parent_header :
-        Parent Header of the header to check for correctness
+        Parent Header of the header to check for correctness. For post-merge forks,
+        this is always the last header in the chain since ommers are
+        not allowed.
     """
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
@@ -293,6 +295,7 @@ def validate_header(header: Header, parent_header: Header) -> None:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
         raise InvalidBlock
+    # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
     if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -354,7 +358,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -538,7 +542,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/paris/state.py
+++ b/src/ethereum/paris/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -228,7 +229,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -258,7 +259,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -579,7 +580,7 @@ def set_code(state: State, address: Address, code: Bytes) -> None:
     modify_state(state, address, write_code)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -241,10 +241,14 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )

--- a/src/ethereum/paris/trie.py
+++ b/src/ethereum/paris/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.gray_glacier import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -20,7 +20,11 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    EthereumException,
+    InvalidBlock,
+    InvalidSenderError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal
@@ -358,7 +362,7 @@ def check_transaction(
 
 def make_receipt(
     tx: Transaction,
-    error: Optional[Exception],
+    error: Optional[EthereumException],
     cumulative_gas_used: Uint,
     logs: Tuple[Log, ...],
 ) -> Union[Bytes, Receipt]:
@@ -560,7 +564,7 @@ def apply_body(
 
 def process_transaction(
     env: vm.Environment, tx: Transaction
-) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
+) -> Tuple[Uint, Tuple[Log, ...], Optional[EthereumException]]:
     """
     Execute a transaction against the provided environment.
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -274,7 +274,9 @@ def validate_header(header: Header, parent_header: Header) -> None:
     header :
         Header to check for correctness.
     parent_header :
-        Parent Header of the header to check for correctness
+        Parent Header of the header to check for correctness. For post-merge forks,
+        this is always the last header in the chain since ommers are
+        not allowed.
     """
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
@@ -297,6 +299,7 @@ def validate_header(header: Header, parent_header: Header) -> None:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
         raise InvalidBlock
+     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain
     if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -37,12 +37,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
     created_accounts: Set[Address] = field(default_factory=set)
@@ -229,7 +230,7 @@ def mark_account_created(state: State, address: Address) -> None:
     state.created_accounts.add(address)
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -259,7 +260,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes
@@ -594,7 +595,7 @@ def set_code(state: State, address: Address, code: Bytes) -> None:
     modify_state(state, address, write_code)
 
 
-def get_storage_original(state: State, address: Address, key: Bytes) -> U256:
+def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current
     transaction began. This function reads the value from the snapshots taken

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -248,10 +248,14 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
                 signing_hash_155(tx, chain_id),
             )
     elif isinstance(tx, AccessListTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_2930(tx)
         )
     elif isinstance(tx, FeeMarketTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_1559(tx)
         )

--- a/src/ethereum/shanghai/trie.py
+++ b/src/ethereum/shanghai/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.paris import trie as previous_trie
@@ -95,12 +98,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -140,7 +163,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -461,10 +484,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -91,7 +92,7 @@ class Evm:
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
     return_data: Bytes
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
 

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple, Union
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -81,10 +83,10 @@ class MessageCallOutput:
 
     gas_left: Uint
     refund_counter: U256
-    logs: Union[Tuple[()], Tuple[Log, ...]]
+    logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/spurious_dragon/state.py
+++ b/src/ethereum/spurious_dragon/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/spurious_dragon/trie.py
+++ b/src/ethereum/spurious_dragon/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.tangerine_whistle import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -85,7 +86,7 @@ class Evm:
     output: Bytes
     accounts_to_delete: Set[Address]
     touched_accounts: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -80,8 +82,8 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    touched_accounts: Iterable[Address]
-    error: Optional[Exception]
+    touched_accounts: Set[Address]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/tangerine_whistle/state.py
+++ b/src/ethereum/tangerine_whistle/state.py
@@ -19,7 +19,7 @@ There is a distinction between an account that does not exist and
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
@@ -36,12 +36,13 @@ class State:
     _main_trie: Trie[Address, Optional[Account]] = field(
         default_factory=lambda: Trie(secured=True, default=None)
     )
-    _storage_tries: Dict[Address, Trie[Bytes, U256]] = field(
+    _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
     _snapshots: List[
         Tuple[
-            Trie[Address, Optional[Account]], Dict[Address, Trie[Bytes, U256]]
+            Trie[Address, Optional[Account]],
+            Dict[Address, Trie[Bytes32, U256]],
         ]
     ] = field(default_factory=list)
 
@@ -202,7 +203,7 @@ def destroy_storage(state: State, address: Address) -> None:
         del state._storage_tries[address]
 
 
-def get_storage(state: State, address: Address, key: Bytes) -> U256:
+def get_storage(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get a value at a storage key on an account. Returns `U256(0)` if the
     storage key has not been set previously.
@@ -232,7 +233,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 
 
 def set_storage(
-    state: State, address: Address, key: Bytes, value: U256
+    state: State, address: Address, key: Bytes32, value: U256
 ) -> None:
     """
     Set a value at a storage key on an account. Setting to `U256(0)` deletes

--- a/src/ethereum/tangerine_whistle/trie.py
+++ b/src/ethereum/tangerine_whistle/trie.py
@@ -24,14 +24,17 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.dao_fork import trie as previous_trie
@@ -92,12 +95,32 @@ class ExtensionNode:
     subnode: rlp.Extended
 
 
+BranchSubnodes = Tuple[
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+    rlp.Extended,
+]
+
+
 @slotted_freezable
 @dataclass
 class BranchNode:
     """Branch node in the Merkle Trie"""
 
-    subnodes: List[rlp.Extended]
+    subnodes: BranchSubnodes
     value: rlp.Extended
 
 
@@ -137,7 +160,7 @@ def encode_internal_node(node: Optional[InternalNode]) -> rlp.Extended:
             node.subnode,
         )
     elif isinstance(node, BranchNode):
-        unencoded = node.subnodes + [node.value]
+        unencoded = list(node.subnodes) + [node.value]
     else:
         raise AssertionError(f"Invalid internal node type {type(node)}!")
 
@@ -458,10 +481,11 @@ def patricialize(
         else:
             branches[key[level]][key] = obj[key]
 
+    subnodes = tuple(
+        encode_internal_node(patricialize(branches[k], level + Uint(1)))
+        for k in range(16)
+    )
     return BranchNode(
-        [
-            encode_internal_node(patricialize(branches[k], level + Uint(1)))
-            for k in range(16)
-        ],
+        cast(BranchSubnodes, assert_type(subnodes, Tuple[rlp.Extended, ...])),
         value,
     )

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -20,6 +20,7 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.exceptions import EthereumException
 
 from ..blocks import Log
 from ..fork_types import Address
@@ -83,7 +84,7 @@ class Evm:
     message: Message
     output: Bytes
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -11,12 +11,14 @@ Introduction
 
 A straightforward interpreter that executes EVM code.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes0
 from ethereum_types.numeric import U256, Uint, ulen
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -75,7 +77,7 @@ class MessageCallOutput:
     refund_counter: U256
     logs: Tuple[Log, ...]
     accounts_to_delete: Set[Address]
-    error: Optional[Exception]
+    error: Optional[EthereumException]
 
 
 def process_message_call(

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -20,6 +20,8 @@ import enum
 from dataclasses import dataclass
 from typing import Optional, Protocol, Union
 
+from ethereum.exceptions import EthereumException
+
 
 @dataclass
 class TransactionStart:
@@ -44,7 +46,7 @@ class TransactionEnd:
     Return value or revert reason of the outermost frame of execution.
     """
 
-    error: Optional[Exception]
+    error: Optional[EthereumException]
     """
     The exception, if any, that caused the transaction to fail.
 

--- a/src/ethereum_optimized/state_db.py
+++ b/src/ethereum_optimized/state_db.py
@@ -26,7 +26,7 @@ except ImportError as e:
         "package"
     )
 
-from ethereum_types.bytes import Bytes, Bytes20
+from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
@@ -76,7 +76,7 @@ def get_optimized_state_patches(fork: str) -> Dict[str, Any]:
 
         db: Any
         dirty_accounts: Dict[Address, Optional[Account_]]
-        dirty_storage: Dict[Address, Dict[Bytes, U256]]
+        dirty_storage: Dict[Address, Dict[Bytes32, U256]]
         destroyed_accounts: Set[Address]
         tx_restore_points: List[int]
         journal: List[Any]
@@ -328,7 +328,7 @@ def get_optimized_state_patches(fork: str) -> Dict[str, Any]:
             _rollback_transaction(state)
 
     @add_item(patches)
-    def get_storage(state: State, address: Address, key: Bytes) -> U256:
+    def get_storage(state: State, address: Address, key: Bytes32) -> U256:
         """
         See `state`.
         """
@@ -345,7 +345,7 @@ def get_optimized_state_patches(fork: str) -> Dict[str, Any]:
 
     @add_item(patches)
     def get_storage_original(
-        state: State, address: Address, key: Bytes
+        state: State, address: Address, key: Bytes32
     ) -> U256:
         """
         See `state`.
@@ -357,7 +357,7 @@ def get_optimized_state_patches(fork: str) -> Dict[str, Any]:
 
     @add_item(patches)
     def set_storage(
-        state: State, address: Address, key: Bytes, value: U256
+        state: State, address: Address, key: Bytes32, value: U256
     ) -> None:
         """
         See `state`.

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -1,6 +1,7 @@
 """
 The module implements the raw EVM tracer for t8n.
 """
+
 import json
 import os
 from contextlib import ExitStack
@@ -10,6 +11,7 @@ from typing import List, Optional, Protocol, TextIO, Union, runtime_checkable
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 
+from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
     GasAndRefund,
@@ -60,7 +62,7 @@ class FinalTrace:
     error: Optional[str] = None
 
     def __init__(
-        self, gas_used: int, output: bytes, error: Optional[Exception]
+        self, gas_used: int, output: bytes, error: Optional[EthereumException]
     ) -> None:
         self.output = output.hex()
         self.gasUsed = hex(gas_used)


### PR DESCRIPTION
Related to Issue #1133 

### How was it fixed?
Simplified the validate_header function in Cancun, shanghai and Paris forks in the forks.py file since they are the post-merge forks.
Added documentation in the function docstring clarifying that for post-merge forks, the parent header is always the last header in the chain.


#### Cute Animal Picture


![image](https://github.com/user-attachments/assets/54d9c059-2c30-4196-bb5e-071e7f5ba5b4)

