### PR TITLE
validate_transaction now raises InvalidTransaction  exception

### DIFF
--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -151,7 +151,7 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas") 
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
     return intrinsic_gas

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -151,9 +151,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction 
+        raise InvalidTransaction("Insufficient gas") 
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -146,14 +146,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction 
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -118,14 +118,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -123,9 +123,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address, VersionedHash
@@ -176,18 +176,18 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     from .vm.interpreter import MAX_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidBlock
+        raise InvalidTransaction
 
     return intrinsic_gas
 

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -183,11 +183,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidTransaction
+        raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address, VersionedHash

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -72,9 +72,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 
@@ -67,14 +67,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -151,9 +151,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -146,14 +146,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -151,9 +151,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -146,14 +146,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -151,9 +151,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -146,14 +146,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address, Authorization, VersionedHash

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -213,11 +213,11 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
     if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidTransaction
+        raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas, calldata_floor_gas_cost
 

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address, Authorization, VersionedHash
@@ -213,11 +213,11 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
     if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidBlock
+        raise InvalidTransaction
 
     return intrinsic_gas, calldata_floor_gas_cost
 

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -155,7 +155,7 @@ def validate_transaction(tx: Transaction) -> Uint:
     if intrinsic_gas > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction( "Nonce too high")
+        raise InvalidTransaction("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -153,11 +153,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction( "Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidTransaction
+        raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -146,18 +146,18 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     from .vm.interpreter import MAX_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
-        raise InvalidBlock
+        raise InvalidTransaction
 
     return intrinsic_gas
 

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
+from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
 
 from .fork_types import Address
 

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -73,9 +73,9 @@ def validate_transaction(tx: Transaction) -> Uint:
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction
+        raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction
+        raise InvalidTransaction("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -13,7 +13,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.exceptions import InvalidTransaction, InvalidSignatureError
 
 from .fork_types import Address
 
@@ -68,14 +68,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     Raises
     ------
-    InvalidBlock :
+    InvalidTransaction :
         If the transaction is not valid.
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidBlock
+        raise InvalidTransaction
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidBlock
+        raise InvalidTransaction
     return intrinsic_gas
 
 

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.berlin.transactions import (
     LegacyTransaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -4,7 +4,7 @@ import pytest
 from ethereum_rlp import rlp
 
 from ethereum.byzantium.transactions import Transaction, validate_transaction
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.constantinople.transactions import (
     Transaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.frontier.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.homestead.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.istanbul.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.london.transactions import (
     LegacyTransaction,
     validate_transaction,
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.spurious_dragon.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidBlock
+from ethereum.exceptions import InvalidTransaction
 from ethereum.tangerine_whistle.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidBlock):
+    with pytest.raises(InvalidTransaction):
         validate_transaction(tx)
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,9 @@ import ast
 from textwrap import dedent
 
 from ethereum_spec_tools.lint import Diagnostic
-from ethereum_spec_tools.lint.lints.patch_hygiene import PatchHygiene
+from ethereum_spec_tools.lint.lints.patch_hygiene import (
+    PatchHygiene,
+)
 from ethereum_spec_tools.lint.lints.patch_hygiene import (
     _Visitor as PatchHygieneVisitor,
 )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,9 +2,7 @@ import ast
 from textwrap import dedent
 
 from ethereum_spec_tools.lint import Diagnostic
-from ethereum_spec_tools.lint.lints.patch_hygiene import (
-    PatchHygiene,
-)
+from ethereum_spec_tools.lint.lints.patch_hygiene import PatchHygiene
 from ethereum_spec_tools.lint.lints.patch_hygiene import (
     _Visitor as PatchHygieneVisitor,
 )


### PR DESCRIPTION
### What was wrong?
On failing some checks, the validate_transaction function used to raise InvalidBlock exception instead of InvalidTransaction.
Related to Issue #1117

### How was it fixed?
Simply replaced InvalidBlock  exception with InvalidTransaction excpetion in the context of validate_transaction.

#### Cute Animal Picture

![cute pic](https://images.pexels.com/photos/50577/hedgehog-animal-baby-cute-50577.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1)


