### PR TITLE
T8N fixes

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
@@ -135,6 +135,7 @@ def run_test_case(
         "stdin",
         "--state.fork",
         f"{test_case.fork_name}",
+        "--state-test",
     ]
 
     if t8n_extra is not None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -109,6 +109,7 @@ class T8N(Load):
                 trace_memory=trace_memory,
                 trace_stack=trace_stack,
                 trace_return_data=trace_return_data,
+                output_basedir=self.options.output_basedir,
             )
         self.logger = get_stream_logger("T8N")
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -32,7 +32,6 @@ from ethereum.trace import (
 )
 
 EXCLUDE_FROM_OUTPUT = ["gasCostTraced", "errorTraced", "precompile"]
-OUTPUT_DIR = "."
 
 
 @dataclass
@@ -141,6 +140,7 @@ def evm_trace(
     trace_memory: bool = False,
     trace_stack: bool = True,
     trace_return_data: bool = False,
+    output_basedir: str | TextIO = ".",
 ) -> None:
     """
     Create a trace of the event.
@@ -189,6 +189,7 @@ def evm_trace(
             traces,
             evm.message.tx_env.index_in_block,
             evm.message.tx_env.tx_hash,
+            output_basedir,
         )
     elif isinstance(event, PrecompileStart):
         new_trace = Trace(
@@ -349,6 +350,7 @@ def output_traces(
     traces: List[Union[Trace, FinalTrace]],
     index_in_block: int,
     tx_hash: bytes,
+    output_basedir: str | TextIO,
 ) -> None:
     """
     Output the traces to a json file.
@@ -356,15 +358,15 @@ def output_traces(
     with ExitStack() as stack:
         json_file: TextIO
 
-        if isinstance(OUTPUT_DIR, str):
+        if isinstance(output_basedir, str):
             tx_hash_str = "0x" + tx_hash.hex()
             output_path = os.path.join(
-                OUTPUT_DIR, f"trace-{index_in_block}-{tx_hash_str}.jsonl"
+                output_basedir, f"trace-{index_in_block}-{tx_hash_str}.jsonl"
             )
             json_file = open(output_path, "w")
             stack.push(json_file)
         else:
-            json_file = OUTPUT_DIR
+            json_file = output_basedir
 
         for trace in traces:
             if getattr(trace, "precompile", False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,17 +47,13 @@ def pytest_configure(config: Config) -> None:
         ethereum_optimized.monkey_patch(None)
 
     if config.getoption("evm_trace"):
-        path = config.getoption("evm_trace")
         import ethereum.trace
-        import ethereum_spec_tools.evm_tools.t8n.evm_trace as evm_trace_module
         from ethereum_spec_tools.evm_tools.t8n.evm_trace import (
             evm_trace as new_trace_function,
         )
 
         # Replace the function in the module
         ethereum.trace.evm_trace = new_trace_function
-        # Set the output directory for traces
-        evm_trace_module.OUTPUT_DIR = path
 
 
 def download_fixtures(url: str, location: str) -> None:


### PR DESCRIPTION
(closes #1146)

### What was wrong?

1. The `statetest` command in `ethereum-spec-evm` should receive the `--state-test` flag in its arguments but currently does not
2. The `t8n` command in `ethereum-spec-evm` does not output traces to the location defined in `output_basedir`

Related to Issue #1146

### How was it fixed?
1. The `--state-test` argument was added to the `statetest` command
2. The path provided in `--output.basedir` to the `t8n` tool is passed on to the `evm_trace` function such that the traces are created in the appropriate location.

#### Cute Animal Picture

![All Photos - 1 of 1](https://github.com/user-attachments/assets/9778990d-b12f-4b26-9af0-7f9a447a9861)

