### PR TITLE
Run latest ethereum tests

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -8,7 +8,7 @@ TEST_FIXTURES = {
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "a0e8482",
+        "commit_hash": "afed83b",
         "fixture_path": "tests/fixtures/ethereum_tests",
     },
     "latest_fork_tests": {


### PR DESCRIPTION
### What was wrong?

The latest `ethereum/tests` release [v16.0](https://github.com/ethereum/tests/releases/tag/v16.0) which adds support to Prague is not currently running


### How was it fixed?
Update to v16.0

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/user-attachments/assets/3043ba72-c371-49b3-ab9d-7189cd6818bf)


