### PR TITLE
Default to empty access list when unavailable

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -76,7 +76,7 @@ class TransactionLoad:
     def json_to_access_list(self) -> Any:
         """Get the access list of the transaction."""
         access_list = []
-        for sublist in self.raw["accessList"]:
+        for sublist in self.raw.get("accessLists", []):
             access_list.append(
                 (
                     self.fork.hex_to_address(sublist.get("address")),
@@ -192,7 +192,7 @@ class TransactionLoad:
             elif "maxFeePerGas" in self.raw:
                 tx_cls = self.fork.FeeMarketTransaction
                 tx_byte_prefix = b"\x02"
-            elif "accessList" in self.raw:
+            elif "accessLists" in self.raw:
                 tx_cls = self.fork.AccessListTransaction
                 tx_byte_prefix = b"\x01"
             else:

--- a/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
@@ -107,7 +107,7 @@ def run_test_case(
             tx[k] = value[v]
         elif k == "accessLists":
             if value[d] is not None:
-                tx["accessList"] = value[d]
+                tx["accessLists"] = value[d]
         else:
             tx[k] = value
 

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -95,7 +95,7 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
             tx[k] = value[v]
         elif k == "accessLists":
             if value[d] is not None:
-                tx["accessList"] = value[d]
+                tx["accessLists"] = value[d]
         else:
             tx[k] = value
 


### PR DESCRIPTION
(closes #1146)

### What was wrong?
If any of the typed transactions do not have an explicit `accessLists` field, the transaction parser fails. Ideally, it should accept an empty list as a default.

Related to Issue #1146

### How was it fixed?
Use empty list as a default behavior

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/user-attachments/assets/8b74b9f6-beb7-4405-a837-fa1264793f30)

