### PR TITLE
refactor: modexp exponent_head stricter type

### DIFF
--- a/src/ethereum/arrow_glacier/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/arrow_glacier/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/berlin/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/berlin/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/byzantium/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -101,7 +101,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
         )
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -114,7 +114,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -156,7 +156,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/cancun/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/cancun/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/constantinople/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/constantinople/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -101,7 +101,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
         )
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -114,7 +114,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -156,7 +156,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/gray_glacier/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/gray_glacier/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/istanbul/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/istanbul/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -101,7 +101,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
         )
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -114,7 +114,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -156,7 +156,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/london/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/london/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/muir_glacier/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/muir_glacier/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -101,7 +101,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
         )
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -114,7 +114,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -156,7 +156,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/paris/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/paris/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------

--- a/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/shanghai/vm/precompiled_contracts/modexp.py
@@ -35,7 +35,7 @@ def modexp(evm: Evm) -> None:
 
     exp_start = U256(96) + base_length
 
-    exp_head = Uint.from_be_bytes(
+    exp_head = U256.from_be_bytes(
         buffer_read(data, exp_start, min(U256(32), exp_length))
     )
 
@@ -89,7 +89,7 @@ def complexity(base_length: U256, modulus_length: U256) -> Uint:
     return words ** Uint(2)
 
 
-def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
+def iterations(exponent_length: U256, exponent_head: U256) -> Uint:
     """
     Calculate the number of iterations required to perform a modular
     exponentiation.
@@ -102,7 +102,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------
@@ -113,7 +113,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
     if exponent_length <= U256(32) and exponent_head == U256(0):
         count = Uint(0)
     elif exponent_length <= U256(32):
-        bit_length = Uint(exponent_head.bit_length())
+        bit_length = exponent_head.bit_length()
 
         if bit_length > Uint(0):
             bit_length -= Uint(1)
@@ -121,7 +121,7 @@ def iterations(exponent_length: U256, exponent_head: Uint) -> Uint:
         count = bit_length
     else:
         length_part = Uint(8) * (Uint(exponent_length) - Uint(32))
-        bits_part = Uint(exponent_head.bit_length())
+        bits_part = exponent_head.bit_length()
 
         if bits_part > Uint(0):
             bits_part -= Uint(1)
@@ -135,7 +135,7 @@ def gas_cost(
     base_length: U256,
     modulus_length: U256,
     exponent_length: U256,
-    exponent_head: Uint,
+    exponent_head: U256,
 ) -> Uint:
     """
     Calculate the gas cost of performing a modular exponentiation.
@@ -154,7 +154,7 @@ def gas_cost(
 
     exponent_head :
         First 32 bytes of the exponent (with leading zero padding if it is
-        shorter than 32 bytes), as an unsigned integer.
+        shorter than 32 bytes), as a U256.
 
     Returns
     -------


### PR DESCRIPTION
### What was wrong?

exponent_head can have a stricter type

### How was it fixed?
Change from Uint to U256:  exponent_head are the first 32 bytes of the exponent given by `buffer_read(data, exp_start, min(U256(32), exp_length))`. There is no need for an unbound type as it should fit into a U256.
