### PR TITLE
chore(deps): bump `py-ecc` to match version in forks/prague

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ install_requires =
     pycryptodome>=3,<4
     coincurve>=20,<21
     typing_extensions>=4.2
-    py_ecc @ git+https://github.com/petertdavies/py_ecc.git@127184f4c57b1812da959586d0fe8f43bb1a2389
+    py-ecc >= 8.0.0b2, < 9
     ethereum-types>=0.2.1,<0.3
     ethereum-rlp>=0.1.1,<0.2
 


### PR DESCRIPTION
### What was wrong?

Nothing yet, but if
- https://github.com/petertdavies/ethereum-spec-evm-resolver/pull/9
gets merged, then a similar conflict as described in that PR will occur between execution-specs `main` and the resolver.

### How was it fixed?

Bumped the `py_ecc` version spec to match that of the resolver (and that of `forks/prague`, see https://github.com/ethereum/execution-specs/commit/8d6093a3983dbbf98ebdb84daadef74445050dad).

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/9eff8551-dd87-4206-bb3a-2be4fe2417d6)

