### PR TITLE
Refactored AccessListTransaction by hoisting class member into own class for readability

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -733,10 +733,10 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/arrow_glacier/transactions.py
+++ b/src/ethereum/arrow_glacier/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -195,9 +207,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -634,10 +634,10 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     if isinstance(tx, AccessListTransaction):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -167,9 +179,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, AccessListTransaction):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -668,10 +668,10 @@ def process_transaction(
     if isinstance(
         tx, (AccessListTransaction, FeeMarketTransaction, BlobTransaction)
     ):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -100,7 +112,7 @@ class BlobTransaction:
     to: Address
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     max_fee_per_blob_gas: U256
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     y_parity: U256
@@ -234,9 +246,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     if isinstance(
         tx, (AccessListTransaction, FeeMarketTransaction, BlobTransaction)
     ):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -733,10 +733,10 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/gray_glacier/transactions.py
+++ b/src/ethereum/gray_glacier/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -195,9 +207,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -739,10 +739,10 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/london/transactions.py
+++ b/src/ethereum/london/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -195,9 +207,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -512,10 +512,10 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/paris/transactions.py
+++ b/src/ethereum/paris/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -195,9 +207,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -762,10 +762,10 @@ def process_transaction(
             SetCodeTransaction,
         ),
     ):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     authorizations: Tuple[Authorization, ...] = ()
     if isinstance(tx, SetCodeTransaction):

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -100,7 +112,7 @@ class BlobTransaction:
     to: Address
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     max_fee_per_blob_gas: U256
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     y_parity: U256
@@ -123,7 +135,7 @@ class SetCodeTransaction:
     to: Address
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     authorizations: Tuple[Authorization, ...]
     y_parity: U256
     r: U256
@@ -279,9 +291,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             SetCodeTransaction,
         ),
     ):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -525,10 +525,10 @@ def process_transaction(
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for address, keys in tx.access_list:
-            access_list_addresses.add(address)
-            for key in keys:
-                access_list_storage_keys.add((address, key))
+        for access in tx.access_list:
+            access_list_addresses.add(access.account)
+            for slot in access.slots:
+                access_list_storage_keys.add((access.account, slot))
 
     tx_env = vm.TransactionEnvironment(
         origin=sender,

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -46,6 +46,18 @@ class LegacyTransaction:
 
 @slotted_freezable
 @dataclass
+class Access:
+    """
+    A mapping from account address to storage slots that are pre-warmed as part
+    of a transaction.
+    """
+
+    account: Address
+    slots: Tuple[Bytes32, ...]
+
+
+@slotted_freezable
+@dataclass
 class AccessListTransaction:
     """
     The transaction type added in EIP-2930 to support access lists.
@@ -58,7 +70,7 @@ class AccessListTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -79,7 +91,7 @@ class FeeMarketTransaction:
     to: Union[Bytes0, Address]
     value: U256
     data: Bytes
-    access_list: Tuple[Tuple[Address, Tuple[Bytes32, ...]], ...]
+    access_list: Tuple[Access, ...]
     y_parity: U256
     r: U256
     s: U256
@@ -202,9 +214,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
 
     access_list_cost = Uint(0)
     if isinstance(tx, (AccessListTransaction, FeeMarketTransaction)):
-        for _address, keys in tx.access_list:
+        for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += ulen(keys) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            access_list_cost += (
+                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+            )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -193,6 +193,11 @@ class ForkLoad:
         return self._module("transactions").LegacyTransaction
 
     @property
+    def Access(self) -> Any:
+        """Access class of the fork"""
+        return self._module("transactions").Access
+
+    @property
     def AccessListTransaction(self) -> Any:
         """Access List transaction class of the fork"""
         return self._module("transactions").AccessListTransaction

--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -78,7 +78,7 @@ class TransactionLoad:
         access_list = []
         for sublist in self.raw.get("accessLists", []):
             access_list.append(
-                (
+                self.fork.Access(
                     self.fork.hex_to_address(sublist.get("address")),
                     [
                         hex_to_bytes32(key)

--- a/tests/berlin/test_rlp.py
+++ b/tests/berlin/test_rlp.py
@@ -5,6 +5,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.berlin.blocks import Block, Header, Log, Receipt
 from ethereum.berlin.transactions import (
+    Access,
     AccessListTransaction,
     LegacyTransaction,
     Transaction,
@@ -59,7 +60,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),

--- a/tests/cancun/test_rlp.py
+++ b/tests/cancun/test_rlp.py
@@ -5,6 +5,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.cancun.blocks import Block, Header, Log, Receipt, Withdrawal
 from ethereum.cancun.transactions import (
+    Access,
     AccessListTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -60,7 +61,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),
@@ -75,7 +79,10 @@ transaction_1559 = FeeMarketTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),

--- a/tests/london/test_rlp.py
+++ b/tests/london/test_rlp.py
@@ -6,6 +6,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.london.blocks import Block, Header, Log, Receipt
 from ethereum.london.transactions import (
+    Access,
     AccessListTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -60,7 +61,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),
@@ -75,7 +79,10 @@ transaction_1559 = FeeMarketTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),

--- a/tests/paris/test_rlp.py
+++ b/tests/paris/test_rlp.py
@@ -6,6 +6,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.paris.blocks import Block, Header, Log, Receipt
 from ethereum.paris.transactions import (
+    Access,
     AccessListTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -60,7 +61,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),
@@ -75,7 +79,10 @@ transaction_1559 = FeeMarketTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),

--- a/tests/prague/test_rlp.py
+++ b/tests/prague/test_rlp.py
@@ -6,6 +6,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.prague.blocks import Block, Header, Log, Receipt, Withdrawal
 from ethereum.prague.transactions import (
+    Access,
     AccessListTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -61,7 +62,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),
@@ -76,7 +80,10 @@ transaction_1559 = FeeMarketTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),

--- a/tests/shanghai/test_rlp.py
+++ b/tests/shanghai/test_rlp.py
@@ -6,6 +6,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import keccak256
 from ethereum.shanghai.blocks import Block, Header, Log, Receipt, Withdrawal
 from ethereum.shanghai.transactions import (
+    Access,
     AccessListTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -60,7 +61,10 @@ access_list_transaction = AccessListTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),
@@ -75,7 +79,10 @@ transaction_1559 = FeeMarketTransaction(
     Bytes0(),
     U256(4),
     Bytes(b"bar"),
-    ((address1, (hash1, hash2)), (address2, tuple())),
+    (
+        Access(account=address1, slots=(hash1, hash2)),
+        Access(account=address2, slots=()),
+    ),
     U256(27),
     U256(5),
     U256(6),


### PR DESCRIPTION
### What was wrong?

AccessListTransaction had a complex class member which was reducing the acceptable readability of related code.

Related to Issue #947 

### How was it fixed?

The class member was hoisted into its own class called `Access` which simplifies use in the rest of the code 

#### Cute Animal Picture

![white baby fox](https://i.imgur.com/mSM5j8s.jpeg)
