### PR TITLE
Update signature type list for EIP-7702

### DIFF
--- a/lists/signature-types/README.md
+++ b/lists/signature-types/README.md
@@ -16,7 +16,8 @@ Reserved or Tentative.
 | 0x01  | Reserved: [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) *(available in Berlin)* |
 | 0x02  | Reserved: [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) *(available in London)* |
 | 0x03  | Reserved: [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) *(available in Cancun)* |
-| 0x04  | Reserved: [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) |
+| 0x04  | Reserved: [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) *(available in Prague)* |
+| 0x05  | Reserved: prevents collision with [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) authorizations |
 | 0x19  | Reserved: prevents collision with [EIP-191](https://eips.ethereum.org/EIPS/eip-191) |
 | 0xc0 - 0xff  | Invalid; collides with the initial byte of valid RLP encoded transactions |
 


### PR DESCRIPTION
EIP-7702 defines transaction type 0x04, and also uses magic 0x05 for signing authorizations.

Discussion about 0x05 is here:
- https://github.com/ethereum/EIPs/pull/8835
