### PR TITLE
More post Prague re-factors

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -753,15 +753,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -787,7 +789,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -156,8 +156,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -209,14 +207,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -255,8 +251,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -155,8 +155,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -205,14 +203,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -251,8 +247,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -631,13 +631,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -663,7 +665,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -154,8 +154,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -198,14 +196,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -244,8 +240,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -680,15 +680,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -712,7 +714,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
     block_output.blob_gas_used += tx_blob_gas_used
 
     receipt = make_receipt(

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -145,8 +145,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -199,14 +197,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -244,8 +240,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -631,13 +631,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -663,7 +665,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/constantinople/vm/interpreter.py
+++ b/src/ethereum/constantinople/vm/interpreter.py
@@ -154,8 +154,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -199,14 +197,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -245,8 +241,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -640,13 +640,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -665,7 +667,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         state_root(block_env.state),

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -140,8 +140,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -179,14 +177,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -225,8 +221,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -623,13 +623,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -648,7 +650,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         state_root(block_env.state),

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -140,8 +140,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -177,14 +175,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -223,8 +219,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -753,15 +753,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -787,7 +789,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -156,8 +156,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -209,14 +207,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -255,8 +251,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -623,13 +623,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -648,7 +650,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         state_root(block_env.state),

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -140,8 +140,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -179,14 +177,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -225,8 +221,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -631,13 +631,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -663,7 +665,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -155,8 +155,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -205,14 +203,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -251,8 +247,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -759,15 +759,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -793,7 +795,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -156,8 +156,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -209,14 +207,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -255,8 +251,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -633,13 +633,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -665,7 +667,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -155,8 +155,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -205,14 +203,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -251,8 +247,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -531,15 +531,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -563,7 +565,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -145,8 +145,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -198,14 +196,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -242,8 +238,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -782,22 +782,24 @@ def process_transaction(
 
     # For EIP-7623 we first calculate the execution_gas_used, which includes
     # the execution gas refund.
-    execution_gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(
-        execution_gas_used // Uint(5), Uint(tx_output.refund_counter)
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
     )
-    execution_gas_used -= gas_refund
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
 
     # Transactions with less execution_gas_used than the floor pay at the
     # floor cost.
-    tx_gas_used = max(execution_gas_used, calldata_floor_gas_cost)
+    tx_gas_used_after_refund = max(
+        tx_gas_used_after_refund, calldata_floor_gas_cost
+    )
 
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -821,7 +823,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
     block_output.blob_gas_used += tx_blob_gas_used
 
     receipt = make_receipt(

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -155,8 +155,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -209,14 +207,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -254,8 +250,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -544,15 +544,17 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(5), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * effective_gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(5), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * effective_gas_price
 
     # For non-1559 transactions effective_gas_price == tx.gas_price
     priority_fee_per_gas = effective_gas_price - block_env.base_fee_per_gas
-    transaction_fee = tx_gas_used * priority_fee_per_gas
+    transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -576,7 +578,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -145,8 +145,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -198,14 +196,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -242,8 +238,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -624,13 +624,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -656,7 +658,7 @@ def process_transaction(
 
     destroy_touched_empty_accounts(block_env.state, tx_output.touched_accounts)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         state_root(block_env.state),

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -153,8 +153,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -196,14 +194,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -242,8 +238,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -622,13 +622,15 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
-    gas_used = tx.gas - tx_output.gas_left
-    gas_refund = min(gas_used // Uint(2), Uint(tx_output.refund_counter))
-    tx_gas_used = gas_used - gas_refund
-    tx_output.gas_left = tx.gas - tx_gas_used
-    gas_refund_amount = tx_output.gas_left * tx.gas_price
+    tx_gas_used_before_refund = tx.gas - tx_output.gas_left
+    tx_gas_refund = min(
+        tx_gas_used_before_refund // Uint(2), Uint(tx_output.refund_counter)
+    )
+    tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+    tx_gas_left = tx.gas - tx_gas_used_after_refund
+    gas_refund_amount = tx_gas_left * tx.gas_price
 
-    transaction_fee = tx_gas_used * tx.gas_price
+    transaction_fee = tx_gas_used_after_refund * tx.gas_price
 
     # refund gas
     sender_balance_after_refund = get_account(
@@ -647,7 +649,7 @@ def process_transaction(
     for address in tx_output.accounts_to_delete:
         destroy_account(block_env.state, address)
 
-    block_output.block_gas_used += tx_gas_used
+    block_output.block_gas_used += tx_gas_used_after_refund
 
     receipt = make_receipt(
         state_root(block_env.state),

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -140,8 +140,6 @@ def process_create_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -179,14 +177,12 @@ def process_create_message(message: Message) -> Evm:
 
 def process_message(message: Message) -> Evm:
     """
-    Executes a call to create a smart contract.
+    Move ether and execute the relevant code.
 
     Parameters
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------
@@ -225,8 +221,6 @@ def execute_code(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
-    env :
-        External items required for EVM execution.
 
     Returns
     -------


### PR DESCRIPTION
(closes #1126 )
(closes #992 )
(closes #1012 )

### What was wrong?
Some of the updates from Prague need to be back-ported to other forks. Also, some planned code refactoring needs to be implemented before the Osaka fork creation.


### How was it fixed?
Implement the following planned re-factors / back-ports

- Update gas variable names to use `tx_gas_used_before_refund` and `tx_gas_used_after_refund`
- Correct the documentation of functions in `interpreter.py`
- Add additional receipt fields into the output of `t8n`

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/user-attachments/assets/42213dea-38b4-43e9-8b85-dd9d4a09b747)

