### PR TITLE
Update the type for `blob_gas_used`

### DIFF
--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -423,7 +423,7 @@ def check_transaction(
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InvalidBlock
 
-        max_gas_fee += calculate_total_blob_gas(tx) * Uint(
+        max_gas_fee += Uint(calculate_total_blob_gas(tx)) * Uint(
             tx.max_fee_per_blob_gas
         )
         blob_versioned_hashes = tx.blob_versioned_hashes

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -76,7 +76,7 @@ BEACON_ROOTS_ADDRESS = hex_to_address(
     "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02"
 )
 SYSTEM_TRANSACTION_GAS = Uint(30000000)
-MAX_BLOB_GAS_PER_BLOCK = Uint(786432)
+MAX_BLOB_GAS_PER_BLOCK = U64(786432)
 VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 
@@ -350,7 +350,7 @@ def check_transaction(
     block_env: vm.BlockEnvironment,
     block_output: vm.BlockOutput,
     tx: Transaction,
-) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], Uint]:
+) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
 

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -69,7 +69,7 @@ class BlockOutput:
         block.
     withdrawals_trie : `ethereum.fork_types.Root`
         Trie root of all the withdrawals in the block.
-    blob_gas_used : `ethereum.base_types.Uint`
+    blob_gas_used : `ethereum.base_types.U64`
         Total blob gas used in the block.
     """
 
@@ -84,7 +84,7 @@ class BlockOutput:
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
-    blob_gas_used: Uint = Uint(0)
+    blob_gas_used: U64 = U64(0)
 
 
 @dataclass

--- a/src/ethereum/cancun/vm/gas.py
+++ b/src/ethereum/cancun/vm/gas.py
@@ -357,6 +357,6 @@ def calculate_data_fee(excess_blob_gas: U64, tx: Transaction) -> Uint:
     data_fee: `Uint`
         The blob data fee.
     """
-    return calculate_total_blob_gas(tx) * calculate_blob_gas_price(
+    return Uint(calculate_total_blob_gas(tx)) * calculate_blob_gas_price(
         excess_blob_gas
     )

--- a/src/ethereum/cancun/vm/gas.py
+++ b/src/ethereum/cancun/vm/gas.py
@@ -69,7 +69,7 @@ GAS_BLOBHASH_OPCODE = Uint(3)
 GAS_POINT_EVALUATION = Uint(50000)
 
 TARGET_BLOB_GAS_PER_BLOCK = U64(393216)
-GAS_PER_BLOB = Uint(2**17)
+GAS_PER_BLOB = U64(2**17)
 MIN_BLOB_GASPRICE = Uint(1)
 BLOB_BASE_FEE_UPDATE_FRACTION = Uint(3338477)
 
@@ -300,7 +300,7 @@ def calculate_excess_blob_gas(parent_header: Header) -> U64:
         return parent_blob_gas - TARGET_BLOB_GAS_PER_BLOCK
 
 
-def calculate_total_blob_gas(tx: Transaction) -> Uint:
+def calculate_total_blob_gas(tx: Transaction) -> U64:
     """
     Calculate the total blob gas for a transaction.
 
@@ -315,9 +315,9 @@ def calculate_total_blob_gas(tx: Transaction) -> Uint:
         The total blob gas for the transaction.
     """
     if isinstance(tx, BlobTransaction):
-        return GAS_PER_BLOB * Uint(len(tx.blob_versioned_hashes))
+        return GAS_PER_BLOB * U64(len(tx.blob_versioned_hashes))
     else:
-        return Uint(0)
+        return U64(0)
 
 
 def calculate_blob_gas_price(excess_blob_gas: U64) -> Uint:

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -446,7 +446,7 @@ def check_transaction(
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
             raise InvalidBlock
 
-        max_gas_fee += calculate_total_blob_gas(tx) * Uint(
+        max_gas_fee += Uint(calculate_total_blob_gas(tx)) * Uint(
             tx.max_fee_per_blob_gas
         )
         blob_versioned_hashes = tx.blob_versioned_hashes

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -85,7 +85,7 @@ BEACON_ROOTS_ADDRESS = hex_to_address(
     "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02"
 )
 SYSTEM_TRANSACTION_GAS = Uint(30000000)
-MAX_BLOB_GAS_PER_BLOCK = Uint(1179648)
+MAX_BLOB_GAS_PER_BLOCK = U64(1179648)
 VERSIONED_HASH_VERSION_KZG = b"\x01"
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
@@ -373,7 +373,7 @@ def check_transaction(
     block_env: vm.BlockEnvironment,
     block_output: vm.BlockOutput,
     tx: Transaction,
-) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], Uint]:
+) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
 

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -69,7 +69,7 @@ class BlockOutput:
         block.
     withdrawals_trie : `ethereum.fork_types.Root`
         Trie root of all the withdrawals in the block.
-    blob_gas_used : `ethereum.base_types.Uint`
+    blob_gas_used : `ethereum.base_types.U64`
         Total blob gas used in the block.
     requests : `Bytes`
         Hash of all the requests in the block.
@@ -86,7 +86,7 @@ class BlockOutput:
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
-    blob_gas_used: Uint = Uint(0)
+    blob_gas_used: U64 = U64(0)
     deposit_requests: Bytes = Bytes(b"")
     requests: List[Bytes] = field(default_factory=list)
 

--- a/src/ethereum/prague/vm/gas.py
+++ b/src/ethereum/prague/vm/gas.py
@@ -69,7 +69,7 @@ GAS_BLOBHASH_OPCODE = Uint(3)
 GAS_POINT_EVALUATION = Uint(50000)
 
 TARGET_BLOB_GAS_PER_BLOCK = U64(786432)
-GAS_PER_BLOB = Uint(2**17)
+GAS_PER_BLOB = U64(2**17)
 MIN_BLOB_GASPRICE = Uint(1)
 BLOB_BASE_FEE_UPDATE_FRACTION = Uint(5007716)
 
@@ -307,7 +307,7 @@ def calculate_excess_blob_gas(parent_header: Header) -> U64:
         return parent_blob_gas - TARGET_BLOB_GAS_PER_BLOCK
 
 
-def calculate_total_blob_gas(tx: Transaction) -> Uint:
+def calculate_total_blob_gas(tx: Transaction) -> U64:
     """
     Calculate the total blob gas for a transaction.
 
@@ -322,9 +322,9 @@ def calculate_total_blob_gas(tx: Transaction) -> Uint:
         The total blob gas for the transaction.
     """
     if isinstance(tx, BlobTransaction):
-        return GAS_PER_BLOB * Uint(len(tx.blob_versioned_hashes))
+        return GAS_PER_BLOB * U64(len(tx.blob_versioned_hashes))
     else:
-        return Uint(0)
+        return U64(0)
 
 
 def calculate_blob_gas_price(excess_blob_gas: U64) -> Uint:

--- a/src/ethereum/prague/vm/gas.py
+++ b/src/ethereum/prague/vm/gas.py
@@ -364,6 +364,6 @@ def calculate_data_fee(excess_blob_gas: U64, tx: Transaction) -> Uint:
     data_fee: `Uint`
         The blob data fee.
     """
-    return calculate_total_blob_gas(tx) * calculate_blob_gas_price(
+    return Uint(calculate_total_blob_gas(tx)) * calculate_blob_gas_price(
         excess_blob_gas
     )


### PR DESCRIPTION
### What was wrong?
The blob_gas_used variable had inconsistent types across the repo. Somewhere U64 and somewhere Uint.

Related to Issue #1125 

### How was it fixed?
I updated the type of blob_gas_used to U64 across all files. Ensured to also update the return types of functions that populated the blob_gas_used variable.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.bornfree.org.uk/wp-content/uploads/2024/10/Image-by-eshan-chandra-from-Pixabay-1536x864.jpg)
