### PR TITLE
Update to use CodeCov v5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,9 +49,10 @@ jobs:
         env:
           PYPY_GC_MAX: "10G"
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage reports to Codecov
         if: "${{ !startsWith(matrix.py, 'pypy') }}"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
           files: .tox/coverage.xml
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### What was wrong?

Code coverage reports were not being uploaded to Codecov

Related to Issue #1140 

### How was it fixed?

Updated the `test.yml` file inside the `.github` folder to align with version 5 best practices

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://a-z-animals.com/media/2023/12/shutterstock-176412728-huge-licensed-scaled.jpg)
