### PR TITLE
Simplified validate_header func in post-merge forks

### DIFF
--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -310,7 +310,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain
+    
     parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)
@@ -337,6 +337,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     if header.difficulty != 0:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
+        raise InvalidBlock
+    if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 
     block_parent_hash = keccak256(rlp.encode(parent_header))

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -349,6 +349,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
         raise InvalidBlock
+     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
     if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -310,19 +310,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    parent_header_number = header.number - Uint(1)
-    first_block_number = chain.blocks[0].header.number
-    last_block_number = chain.blocks[-1].header.number
-
-    if (
-        parent_header_number < first_block_number
-        or parent_header_number > last_block_number
-    ):
-        raise InvalidBlock
-
-    parent_header = chain.blocks[
-        parent_header_number - first_block_number
-    ].header
+    # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain
+    parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)
     if header.excess_blob_gas != excess_blob_gas:
@@ -348,9 +337,6 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     if header.difficulty != 0:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
-        raise InvalidBlock
-     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
-    if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 
     block_parent_hash = keccak256(rlp.encode(parent_header))

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -310,7 +310,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    
+
     parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -284,19 +284,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    parent_header_number = header.number - Uint(1)
-    first_block_number = chain.blocks[0].header.number
-    last_block_number = chain.blocks[-1].header.number
 
-    if (
-        parent_header_number < first_block_number
-        or parent_header_number > last_block_number
-    ):
-        raise InvalidBlock
-
-    parent_header = chain.blocks[
-        parent_header_number - first_block_number
-    ].header
+    parent_header = chain.blocks[-1].header
 
     if header.gas_used > header.gas_limit:
         raise InvalidBlock

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -333,7 +333,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    
+
     parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -333,19 +333,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    parent_header_number = header.number - Uint(1)
-    first_block_number = chain.blocks[0].header.number
-    last_block_number = chain.blocks[-1].header.number
-
-    if (
-        parent_header_number < first_block_number
-        or parent_header_number > last_block_number
-    ):
-        raise InvalidBlock
-
-    parent_header = chain.blocks[
-        parent_header_number - first_block_number
-    ].header
+    
+    parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)
     if header.excess_blob_gas != excess_blob_gas:

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -289,19 +289,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    parent_header_number = header.number - Uint(1)
-    first_block_number = chain.blocks[0].header.number
-    last_block_number = chain.blocks[-1].header.number
-
-    if (
-        parent_header_number < first_block_number
-        or parent_header_number > last_block_number
-    ):
-        raise InvalidBlock
-
-    parent_header = chain.blocks[
-        parent_header_number - first_block_number
-    ].header
+    # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain
+    parent_header = chain.blocks[-1].header
 
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
@@ -323,9 +312,6 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     if header.difficulty != 0:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
-        raise InvalidBlock
-     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
-    if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 
     block_parent_hash = keccak256(rlp.encode(parent_header))

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -289,7 +289,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     """
     if header.number < Uint(1):
         raise InvalidBlock
-    # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain
+
     parent_header = chain.blocks[-1].header
 
     if header.gas_used > header.gas_limit:
@@ -312,6 +312,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     if header.difficulty != 0:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
+        raise InvalidBlock
+    if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 
     block_parent_hash = keccak256(rlp.encode(parent_header))

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -324,6 +324,7 @@ def validate_header(chain: BlockChain, header: Header) -> None:
         raise InvalidBlock
     if header.nonce != b"\x00\x00\x00\x00\x00\x00\x00\x00":
         raise InvalidBlock
+     # Post-merge forks do not allow ommers, so parent_header is always the last header in the chain.
     if header.ommers_hash != EMPTY_OMMER_HASH:
         raise InvalidBlock
 


### PR DESCRIPTION
Related to Issue #1133

### How was it fixed?
Simplified the validate_header function in Cancun, shanghai and Paris forks in the forks.py file since they are the post-merge forks.
Added documentation in the function docstring clarifying that for post-merge forks, the parent header is always the last header in the chain.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR4IoiZyX73T-6i59-D4zDKuGxGtnVHEdLUQA&s)
