### PR TITLE
Upgrade pypy/python version to 3.11

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Tox
         run: pip install tox

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        py: [ "3.10", "pypy3.10" ]
+        py: [ "3.11", "pypy3.11" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ This specification aims to be:
 
 Running the tests necessary to merge into the repository requires:
 
- * Python 3.10.x, and
- * [PyPy 7.3.12](https://www.pypy.org/) or later.
+ * Python 3.11.x, and
+ * [PyPy](https://www.pypy.org/) [7.3.19](https://downloads.python.org/pypy/) or later.
  * `geth` installed and present in `$PATH`
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The execution specification is a python implementation of Ethereum that prioriti
 
 The Ethereum specification is maintained as a Python library, for better integration with tooling and testing.
 
-Requires Python 3.10+
+Requires Python 3.11+
 
 ### Building
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license_files =
 classifiers =
     License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: Implementation :: CPython
     Intended Audience :: Developers
@@ -121,7 +121,7 @@ packages =
 package_dir =
     =src
 
-python_requires = >=3.10
+python_requires = >=3.11
 install_requires =
     pycryptodome>=3,<4
     coincurve>=20,<21
@@ -189,7 +189,7 @@ tools =
     platformdirs>=4.2,<5
 
 doc =
-    docc>=0.2.2,<0.3.0
+    docc>=0.3.0,<0.4.0
     fladrif>=0.2.0,<0.3.0
 
 optimized =


### PR DESCRIPTION
### What was wrong?

Pypy was out of date. It now handles python 3.11 so we should too.

Related to Issue #1144

### How was it fixed?

Updated a bunch of config files, the README, etc

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/6046/6360538957_efdd7269ac_b.jpg)
