### PR TITLE
t8n: Return `InvalidBlock` exception in `result.blockException`

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -248,10 +248,11 @@ class T8N(Load):
             if self.fork.is_after_fork("ethereum.prague"):
                 self.fork.process_general_purpose_requests(block_env, block_output)
 
-            self.result.update(self, block_env, block_output)
-            self.result.rejected = self.txs.rejected_txs
         except InvalidBlock as e:
             self.result.block_exception = f"{e}"
+        
+        self.result.update(self, block_env, block_output)
+        self.result.rejected = self.txs.rejected_txs
 
     def run(self) -> int:
         """Run the transition and provide the relevant outputs"""

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -267,6 +267,7 @@ class Result:
     blob_gas_used: Optional[Uint] = None
     requests_hash: Optional[Hash32] = None
     requests: Optional[List[Bytes]] = None
+    block_exception: Optional[str] = None
 
     def get_receipts_from_tries(
         self, t8n: Any, tx_trie: Any, receipts_trie: Any
@@ -372,5 +373,8 @@ class Result:
             # T8N doesn't consider the request type byte to be part of the
             # request
             data["requests"] = [encode_to_hex(req) for req in self.requests]
+        
+        if self.block_exception is not None:
+            data["blockException"] = self.block_exception
 
         return data

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -373,7 +373,7 @@ class Result:
             # T8N doesn't consider the request type byte to be part of the
             # request
             data["requests"] = [encode_to_hex(req) for req in self.requests]
-        
+
         if self.block_exception is not None:
             data["blockException"] = self.block_exception
 


### PR DESCRIPTION
### What was wrong?

Block-level exceptions, such the ones raised when the system contract calls failed, resulted in t8n returning an empty response instead of parseable JSON.

### How was it fixed?

Added a new field in the T8N's response's field `result` that is called `blockException`, which is populated in case of an error.

In this PR only an exception in `process_general_purpose_requests` will be caught and populate the extra field, so every other exception is not caught and will still result in the same behavior, but I think each case should be analyzed separately.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/3503e3ae-6c52-4c72-bee1-c88987e6f967)
