### PR TITLE
Invalid block if system contract is empty on call or call fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ pip-delete-this-directory.txt
 /docs
 
 .coverage
+.coverage.*
 
 /doc/diffs
 /doc/autoapi

--- a/setup.cfg
+++ b/setup.cfg
@@ -171,6 +171,7 @@ test =
     GitPython>=3.1.0,<3.2
     filelock>=3.12.3,<3.13
     requests
+    requests-cache>=1.2.1,<2
 
 lint =
     types-setuptools>=68.1.0.1,<69

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -514,10 +514,16 @@ def make_receipt(
 def process_system_transaction(
     block_env: vm.BlockEnvironment,
     target_address: Address,
+    system_contract_code: Bytes,
     data: Bytes,
 ) -> MessageCallOutput:
     """
-    Process a system transaction.
+    Process a system transaction with the given code.
+
+    Prefer calling `process_checked_system_transaction` or
+    `process_unchecked_system_transaction` depending on
+    whether missing code or an execution error should cause
+    the block to be rejected.
 
     Parameters
     ----------
@@ -525,6 +531,8 @@ def process_system_transaction(
         The block scoped environment.
     target_address :
         Address of the contract to call.
+    system_contract_code :
+        Code of the contract to call.
     data :
         Data to pass to the contract.
 
@@ -533,8 +541,6 @@ def process_system_transaction(
     system_tx_output : `MessageCallOutput`
         Output of processing the system transaction.
     """
-    system_contract_code = get_account(block_env.state, target_address).code
-
     tx_env = vm.TransactionEnvironment(
         origin=SYSTEM_ADDRESS,
         gas_price=block_env.base_fee_per_gas,
@@ -574,6 +580,85 @@ def process_system_transaction(
     return system_tx_output
 
 
+def process_checked_system_transaction(
+    block_env: vm.BlockEnvironment,
+    target_address: Address,
+    data: Bytes,
+) -> MessageCallOutput:
+    """
+    Process a system transaction and raise an error if the contract does not
+    contain code or if the transaction fails.
+
+    Parameters
+    ----------
+    block_env :
+        The block scoped environment.
+    target_address :
+        Address of the contract to call.
+    data :
+        Data to pass to the contract.
+
+    Returns
+    -------
+    system_tx_output : `MessageCallOutput`
+        Output of processing the system transaction.
+    """
+    system_contract_code = get_account(block_env.state, target_address).code
+
+    if len(system_contract_code) == 0:
+        raise InvalidBlock(
+            f"System contract address {target_address.hex()} does not "
+            "contain code"
+        )
+
+    system_tx_output = process_system_transaction(
+        block_env,
+        target_address,
+        system_contract_code,
+        data,
+    )
+
+    if system_tx_output.error:
+        raise InvalidBlock(
+            f"System contract ({target_address.hex()}) call failed: "
+            f"{system_tx_output.error}"
+        )
+
+    return system_tx_output
+
+
+def process_unchecked_system_transaction(
+    block_env: vm.BlockEnvironment,
+    target_address: Address,
+    data: Bytes,
+) -> MessageCallOutput:
+    """
+    Process a system transaction without checking if the contract contains code
+    or if the transaction fails.
+
+    Parameters
+    ----------
+    block_env :
+        The block scoped environment.
+    target_address :
+        Address of the contract to call.
+    data :
+        Data to pass to the contract.
+
+    Returns
+    -------
+    system_tx_output : `MessageCallOutput`
+        Output of processing the system transaction.
+    """
+    system_contract_code = get_account(block_env.state, target_address).code
+    return process_system_transaction(
+        block_env,
+        target_address,
+        system_contract_code,
+        data,
+    )
+
+
 def apply_body(
     block_env: vm.BlockEnvironment,
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
@@ -605,13 +690,13 @@ def apply_body(
     """
     block_output = vm.BlockOutput()
 
-    process_system_transaction(
+    process_unchecked_system_transaction(
         block_env=block_env,
         target_address=BEACON_ROOTS_ADDRESS,
         data=block_env.parent_beacon_block_root,
     )
 
-    process_system_transaction(
+    process_unchecked_system_transaction(
         block_env=block_env,
         target_address=HISTORY_STORAGE_ADDRESS,
         data=block_env.block_hashes[-1],  # The parent hash
@@ -650,7 +735,7 @@ def process_general_purpose_requests(
     if len(deposit_requests) > 0:
         requests_from_execution.append(DEPOSIT_REQUEST_TYPE + deposit_requests)
 
-    system_withdrawal_tx_output = process_system_transaction(
+    system_withdrawal_tx_output = process_checked_system_transaction(
         block_env=block_env,
         target_address=WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS,
         data=b"",
@@ -661,7 +746,7 @@ def process_general_purpose_requests(
             WITHDRAWAL_REQUEST_TYPE + system_withdrawal_tx_output.return_data
         )
 
-    system_consolidation_tx_output = process_system_transaction(
+    system_consolidation_tx_output = process_checked_system_transaction(
         block_env=block_env,
         target_address=CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS,
         data=b"",

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -63,9 +63,9 @@ class ForkLoad:
         return self._module("fork").process_general_purpose_requests
 
     @property
-    def process_system_transaction(self) -> Any:
-        """process_system_transaction function of the given fork."""
-        return self._module("fork").process_system_transaction
+    def process_unchecked_system_transaction(self) -> Any:
+        """process_unchecked_system_transaction function of the given fork."""
+        return self._module("fork").process_unchecked_system_transaction
 
     @property
     def process_withdrawals(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -203,14 +203,14 @@ class T8N(Load):
 
     def _run_blockchain_test(self, block_env: Any, block_output: Any) -> None:
         if self.fork.is_after_fork("ethereum.prague"):
-            self.fork.process_system_transaction(
+            self.fork.process_unchecked_system_transaction(
                 block_env=block_env,
                 target_address=self.fork.HISTORY_STORAGE_ADDRESS,
                 data=block_env.block_hashes[-1],  # The parent hash
             )
 
         if self.fork.is_after_fork("ethereum.cancun"):
-            self.fork.process_system_transaction(
+            self.fork.process_unchecked_system_transaction(
                 block_env=block_env,
                 target_address=self.fork.BEACON_ROOTS_ADDRESS,
                 data=block_env.parent_beacon_block_root,

--- a/tests/cancun/test_evm_tools.py
+++ b/tests/cancun/test_evm_tools.py
@@ -15,11 +15,9 @@ EEST_STATE_TESTS_DIR = f"{EEST_TESTS_PATH}/state_tests/"
 FORK_NAME = "Cancun"
 
 SLOW_TESTS = (
-    "CALLBlake2f_MaxRounds",
-    "CALLCODEBlake2f",
-    "CALLBlake2f",
-    "loopExp",
-    "loopMul",
+    "GeneralStateTests/stTimeConsuming/CALLBlake2f_MaxRounds.json::CALLBlake2f_MaxRounds-fork_[Cancun-Prague]-d0g0v0",
+    "GeneralStateTests/VMTests/vmPerformance/loopExp.json::loopExp-fork_[Cancun-Prague]-d[0-14]g0v0",
+    "GeneralStateTests/VMTests/vmPerformance/loopMul.json::loopMul-fork_[Cancun-Prague]-d[0-2]g0v0",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ try:
     from xdist import get_xdist_worker_id  # type: ignore[import-untyped]
 except ImportError:
 
-    def get_xdist_worker_id(request_or_session: object) -> str:
+    def get_xdist_worker_id(request_or_session: object) -> str:  # noqa: U100
         return "master"
 
 
@@ -185,10 +185,15 @@ def pytest_sessionstart(session: Session) -> None:  # noqa: U100
                     props["url"], fixture_path, props["commit_hash"]
                 )
             else:
-                downloader.fetch_http(props["url"], fixture_path)
+                downloader.fetch_http(
+                    props["url"],
+                    fixture_path,
+                )
 
 
-def pytest_sessionfinish(session: Session, exitstatus: int) -> None:
+def pytest_sessionfinish(
+    session: Session, exitstatus: int  # noqa: U100
+) -> None:
     if get_xdist_worker_id(session) != "master":
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,28 @@
 import os
 import shutil
 import tarfile
-import tempfile
-import urllib.request
+from pathlib import Path
+from typing import Final, Optional, Set
 
 import git
+import requests_cache
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
-from filelock import SoftFileLock
+from filelock import FileLock
 from git.exc import GitCommandError, InvalidGitRepositoryError
-from pytest import Session
+from pytest import Session, StashKey
+from requests_cache import CachedSession
+from requests_cache.backends.sqlite import SQLiteCache
+from typing_extensions import Self
 
 from tests.helpers import TEST_FIXTURES
+
+try:
+    from xdist import get_xdist_worker_id  # type: ignore[import-untyped]
+except ImportError:
+
+    def get_xdist_worker_id(request_or_session: object) -> str:
+        return "master"
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -56,34 +67,54 @@ def pytest_configure(config: Config) -> None:
         ethereum.trace.set_evm_trace(new_trace_function)
 
 
-def download_fixtures(url: str, location: str) -> None:
-    # xdist processes will all try to download the fixtures.
-    # Using lockfile to make it parallel safe
-    with SoftFileLock(f"{location}.lock"):
-        if not os.path.exists(location):
-            print(f"Downloading {location}...")
-            with tempfile.TemporaryFile() as tfile:
-                with urllib.request.urlopen(url) as response:
-                    shutil.copyfileobj(response, tfile)
+class _FixturesDownloader:
+    cache: Final[SQLiteCache]
+    session: Final[CachedSession]
+    root: Final[Path]
+    keep_cache_keys: Final[Set[str]]
 
-                tfile.seek(0)
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.cache = SQLiteCache(use_cache_dir=True, db_path="eels_cache")
+        self.session = requests_cache.CachedSession(
+            backend=self.cache,
+            ignored_parameters=["X-Amz-Signature", "X-Amz-Date"],
+            expire_after=24 * 60 * 60,
+            cache_control=True,
+        )
+        self.keep_cache_keys = set()
 
-                with tarfile.open(fileobj=tfile, mode="r:gz") as tar:
-                    tar.extractall(location)
-        else:
-            print(f"{location} already available.")
+    def fetch_http(self, url: str, location: str) -> None:
+        path = self.root.joinpath(location)
+        print(f"Downloading {location}...")
 
+        with self.session.get(url, stream=True) as response:
+            if response.from_cache:
+                print(f"Cache hit {url}")
+            else:
+                print(f"Cache miss {url} :(")
 
-def git_clone_fixtures(url: str, commit_hash: str, location: str) -> None:
-    # xdist processes will all try to download the fixtures.
-    # Using lockfile to make it parallel safe
-    with SoftFileLock(f"{location}.lock"):
-        if not os.path.exists(location):
+            # Track the cache keys we've hit this session so we don't delete
+            # them.
+            all_responses = [response] + response.history
+            current_keys = set(
+                self.cache.create_key(request=r.request) for r in all_responses
+            )
+            self.keep_cache_keys.update(current_keys)
+
+            with tarfile.open(fileobj=response.raw, mode="r:gz") as tar:
+                shutil.rmtree(path, ignore_errors=True)
+                print(f"Extracting {location}...")
+                tar.extractall(path)
+
+    def fetch_git(self, url: str, location: str, commit_hash: str) -> None:
+        path = self.root.joinpath(location)
+        if not os.path.exists(path):
             print(f"Cloning {location}...")
-            repo = git.Repo.clone_from(url, to_path=location)
+            repo = git.Repo.clone_from(url, to_path=path)
         else:
             print(f"{location} already available.")
-            repo = git.Repo(location)
+            repo = git.Repo(path)
 
         print(f"Checking out the correct commit {commit_hash}...")
         branch = repo.heads["develop"]
@@ -113,19 +144,56 @@ def git_clone_fixtures(url: str, commit_hash: str, location: str) -> None:
             if parent_commit != submodule_head:
                 submodule.update(init=True, recursive=True)
 
+    def __enter__(self) -> Self:
+        assert not self.keep_cache_keys
+        return self
+
+    def __exit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> None:
+        cached = self.cache.filter(expired=True, invalid=True)
+        to_delete = set(x.cache_key for x in cached) - self.keep_cache_keys
+        if to_delete:
+            print(f"Evicting {len(to_delete)} from HTTP cache")
+            self.cache.delete(*to_delete, vacuum=True)
+        self.keep_cache_keys.clear()
+
+
+fixture_lock = StashKey[Optional[FileLock]]()
+
 
 def pytest_sessionstart(session: Session) -> None:  # noqa: U100
-    for _, props in TEST_FIXTURES.items():
-        fixture_path = props["fixture_path"]
+    if get_xdist_worker_id(session) != "master":
+        return
 
-        try:
-            os.makedirs(os.path.dirname(fixture_path))
-        except FileExistsError:
-            pass
+    lock_path = session.config.rootpath.joinpath("tests/fixtures/.lock")
+    stash = session.stash
+    lock_file = FileLock(str(lock_path), timeout=0)
+    lock_file.acquire()
 
-        if "commit_hash" in props:
-            git_clone_fixtures(
-                props["url"], props["commit_hash"], fixture_path
-            )
-        else:
-            download_fixtures(props["url"], fixture_path)
+    assert fixture_lock not in stash
+    stash[fixture_lock] = lock_file
+
+    with _FixturesDownloader(session.config.rootpath) as downloader:
+        for _, props in TEST_FIXTURES.items():
+            fixture_path = props["fixture_path"]
+
+            os.makedirs(os.path.dirname(fixture_path), exist_ok=True)
+
+            if "commit_hash" in props:
+                downloader.fetch_git(
+                    props["url"], fixture_path, props["commit_hash"]
+                )
+            else:
+                downloader.fetch_http(props["url"], fixture_path)
+
+
+def pytest_sessionfinish(session: Session, exitstatus: int) -> None:
+    if get_xdist_worker_id(session) != "master":
+        return
+
+    lock_file = session.stash[fixture_lock]
+    session.stash[fixture_lock] = None
+
+    assert lock_file is not None
+    lock_file.release()

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -12,8 +12,7 @@ TEST_FIXTURES = {
         "fixture_path": "tests/fixtures/ethereum_tests",
     },
     "latest_fork_tests": {
-        "url": "https://github.com/gurukamath/latest_fork_tests.git",
-        "commit_hash": "7a22f8e",
+        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_stable.tar.gz",
         "fixture_path": "tests/fixtures/latest_fork_tests",
     },
 }

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,17 @@
+from typing import Dict, TypedDict
+
+from typing_extensions import NotRequired
+
+
+class _FixtureSource(TypedDict):
+    url: str
+    fixture_path: str
+    commit_hash: NotRequired[str]
+
+
 # Update the links and commit has in order to consume
 # newer/other tests
-TEST_FIXTURES = {
+TEST_FIXTURES: Dict[str, _FixtureSource] = {
     "evm_tools_testdata": {
         "url": "https://github.com/gurukamath/evm-tools-testdata.git",
         "commit_hash": "792422d",
@@ -8,11 +19,11 @@ TEST_FIXTURES = {
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "afed83b",
+        "commit_hash": "3129f16519013b265fa309208f49406b2ef57b13",
         "fixture_path": "tests/fixtures/ethereum_tests",
     },
     "latest_fork_tests": {
-        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_stable.tar.gz",
+        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_stable.tar.gz",
         "fixture_path": "tests/fixtures/latest_fork_tests",
     },
 }

--- a/tests/helpers/load_state_tests.py
+++ b/tests/helpers/load_state_tests.py
@@ -176,11 +176,7 @@ def fetch_state_test_files(
             files_to_iterate.append(os.path.join(test_dir, test_path))
     else:
         # If there isn't a custom list, iterate over the test_dir
-        all_jsons = [
-            y
-            for x in os.walk(test_dir)
-            for y in glob(os.path.join(x[0], "*.json"))
-        ]
+        all_jsons = glob(os.path.join(test_dir, "**/*.json"), recursive=True)
 
         for full_path in all_jsons:
             if not any(x.search(full_path) for x in all_ignore):

--- a/tests/prague/test_evm_tools.py
+++ b/tests/prague/test_evm_tools.py
@@ -16,11 +16,9 @@ FORK_NAME = "Prague"
 
 
 SLOW_TESTS = (
-    "CALLBlake2f_MaxRounds",
-    "CALLCODEBlake2f",
-    "CALLBlake2f",
-    "loopExp",
-    "loopMul",
+    "GeneralStateTests/stTimeConsuming/CALLBlake2f_MaxRounds.json::CALLBlake2f_MaxRounds-fork_[Cancun-Prague]-d0g0v0",
+    "GeneralStateTests/VMTests/vmPerformance/loopExp.json::loopExp-fork_[Cancun-Prague]-d[0-14]g0v0",
+    "GeneralStateTests/VMTests/vmPerformance/loopMul.json::loopMul-fork_[Cancun-Prague]-d[0-2]g0v0",
     "tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py::test_valid[fork_Prague-state_test-bls_pairing_non-degeneracy-]",
     "tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py::test_valid[fork_Prague-state_test-bls_pairing_bilinearity-]",
     "tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py::test_valid[fork_Prague-state_test-bls_pairing_e(G1,-G2)=e(-G1,G2)-]",


### PR DESCRIPTION
### What was wrong?

EIPs 7002 and 7251 have been updated to define the expected outcome in case of execution failure or code absence:

https://github.com/ethereum/EIPs/pull/9508
https://github.com/ethereum/EIPs/pull/9582

### How was it fixed?

Conditions for zero-length code and execution failure have been added to the system contract calls.

I'm not sure if this change affects EIP-2935, although I think we should not cherry-pick which system-contracts invalidate a block and which don't.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/cc9e9400-54be-4f70-8edc-e9f37a2693cb)
