### PR TITLE
Clear specific json files

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/daemon.py
+++ b/src/ethereum_spec_tools/evm_tools/daemon.py
@@ -59,6 +59,24 @@ class _EvmToolHandler(BaseHTTPRequestHandler):
             f"--state.reward={content['state']['reward']}",
         ]
 
+        trace = content.get("trace", False)
+        output_basedir = content.get("output-basedir")
+        if trace:
+            if not output_basedir:
+                raise ValueError(
+                    "`output-basedir` should be provided when `--trace` "
+                    "is enabled."
+                )
+            # send full trace output if ``trace`` is ``True``
+            args.extend(
+                [
+                    "--trace",
+                    "--trace.memory",
+                    "--trace.returndata",
+                    f"--output.basedir={output_basedir}",
+                ]
+            )
+
         query_string = urlparse(self.path).query
         if query_string:
             query = parse_qs(

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -3,6 +3,7 @@ Create a transition tool for the given fork.
 """
 
 import argparse
+import fnmatch
 import json
 import os
 from functools import partial
@@ -251,10 +252,25 @@ class T8N(Load):
 
     def run(self) -> int:
         """Run the transition and provide the relevant outputs"""
-        # Clean out files from the output directory
+        # Clear files that may have been created in a previous
+        # run of the t8n tool.
+        # Define the specific files and pattern to delete
+        files_to_delete = [
+            self.options.output_result,
+            self.options.output_alloc,
+            self.options.output_body,
+        ]
+        pattern_to_delete = "trace-*.jsonl"
+
+        # Iterate through the directory
         for file in os.listdir(self.options.output_basedir):
-            if file.endswith(".json") or file.endswith(".jsonl"):
-                os.remove(os.path.join(self.options.output_basedir, file))
+            file_path = os.path.join(self.options.output_basedir, file)
+
+            # Check if the file matches the specific names or the pattern
+            if file in files_to_delete or fnmatch.fnmatch(
+                file, pattern_to_delete
+            ):
+                os.remove(file_path)
 
         try:
             if self.options.state_test:


### PR DESCRIPTION
(closes #1178 )

### What was wrong?
The `t8n` tool would indiscriminately clear all the json files in the `output.basedir` folder during its run in order to avoid any confusion with output files that my have been created in a previous run with the same parameters. This leads in some specific cases to some config files being deleted.

Related to Issue #1178 

### How was it fixed?

1. Port the commit that updates the daemon from `master` to `forks/prague`
2. Clear files selectively

