### PR TITLE
Run EEST 4.2.0 tests

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -13,7 +13,7 @@ TEST_FIXTURES = {
     },
     "latest_fork_tests": {
         "url": "https://github.com/gurukamath/latest_fork_tests.git",
-        "commit_hash": "bc74af5",
+        "commit_hash": "7a22f8e",
         "fixture_path": "tests/fixtures/latest_fork_tests",
     },
 }


### PR DESCRIPTION
What was wrong?

Currently, EELS runs version 4.0.0 of the EEST tests

How was it fixed?

Update to 4.2.0