### PR TITLE
dev: simplify condition in is_account_alive

### DIFF
--- a/src/ethereum/arrow_glacier/state.py
+++ b/src/ethereum/arrow_glacier/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/arrow_glacier/state.py
+++ b/src/ethereum/arrow_glacier/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/berlin/state.py
+++ b/src/ethereum/berlin/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/berlin/state.py
+++ b/src/ethereum/berlin/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/byzantium/state.py
+++ b/src/ethereum/byzantium/state.py
@@ -434,10 +434,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/byzantium/state.py
+++ b/src/ethereum/byzantium/state.py
@@ -437,11 +437,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -496,11 +496,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -493,10 +493,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/constantinople/state.py
+++ b/src/ethereum/constantinople/state.py
@@ -434,10 +434,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/constantinople/state.py
+++ b/src/ethereum/constantinople/state.py
@@ -437,11 +437,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/gray_glacier/state.py
+++ b/src/ethereum/gray_glacier/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/gray_glacier/state.py
+++ b/src/ethereum/gray_glacier/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/istanbul/state.py
+++ b/src/ethereum/istanbul/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/istanbul/state.py
+++ b/src/ethereum/istanbul/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/london/state.py
+++ b/src/ethereum/london/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/london/state.py
+++ b/src/ethereum/london/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/muir_glacier/state.py
+++ b/src/ethereum/muir_glacier/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/muir_glacier/state.py
+++ b/src/ethereum/muir_glacier/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/paris/state.py
+++ b/src/ethereum/paris/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/paris/state.py
+++ b/src/ethereum/paris/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/prague/state.py
+++ b/src/ethereum/prague/state.py
@@ -496,11 +496,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/prague/state.py
+++ b/src/ethereum/prague/state.py
@@ -493,10 +493,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -463,11 +463,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/shanghai/state.py
+++ b/src/ethereum/shanghai/state.py
@@ -460,10 +460,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/spurious_dragon/state.py
+++ b/src/ethereum/spurious_dragon/state.py
@@ -434,10 +434,7 @@ def is_account_alive(state: State, address: Address) -> bool:
         True if the account is alive.
     """
     account = get_account_optional(state, address)
-    if account is None:
-        return False
-    else:
-        return not account == EMPTY_ACCOUNT
+    return account is not None and account != EMPTY_ACCOUNT
 
 
 def modify_state(

--- a/src/ethereum/spurious_dragon/state.py
+++ b/src/ethereum/spurious_dragon/state.py
@@ -437,11 +437,7 @@ def is_account_alive(state: State, address: Address) -> bool:
     if account is None:
         return False
     else:
-        return not (
-            account.nonce == Uint(0)
-            and account.code == b""
-            and account.balance == 0
-        )
+        return not account == EMPTY_ACCOUNT
 
 
 def modify_state(


### PR DESCRIPTION
### What was wrong?

The condition for `is_account_alive` is strictly equivalent to `== EMPTY_ACCOUNT`. Thus, for simplicity, I modified it (and ensuring that if the Account model came to change, this would be properly reflected in this function.
