### PR TITLE
EOAs that delegate to a precompile

### DIFF
--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -566,7 +566,7 @@ def process_system_transaction(
         is_static=False,
         accessed_addresses=set(),
         accessed_storage_keys=set(),
-        is_delegated=False,
+        disable_precompiles=False,
         parent_evm=None,
     )
 

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -566,6 +566,7 @@ def process_system_transaction(
         is_static=False,
         accessed_addresses=set(),
         accessed_storage_keys=set(),
+        is_delegated=False,
         parent_evm=None,
     )
 

--- a/src/ethereum/prague/utils/message.py
+++ b/src/ethereum/prague/utils/message.py
@@ -51,6 +51,8 @@ def prepare_message(
     accessed_addresses.update(PRE_COMPILED_CONTRACTS.keys())
     accessed_addresses.update(tx_env.access_list_addresses)
 
+    is_delegated = False
+
     if isinstance(tx.to, Bytes0):
         current_target = compute_contract_address(
             tx_env.origin,
@@ -66,6 +68,7 @@ def prepare_message(
 
         delegated_address = get_delegated_code_address(code)
         if delegated_address is not None:
+            is_delegated = True
             accessed_addresses.add(delegated_address)
             code = get_account(block_env.state, delegated_address).code
 
@@ -91,5 +94,6 @@ def prepare_message(
         is_static=False,
         accessed_addresses=accessed_addresses,
         accessed_storage_keys=set(tx_env.access_list_storage_keys),
+        is_delegated=is_delegated,
         parent_evm=None,
     )

--- a/src/ethereum/prague/utils/message.py
+++ b/src/ethereum/prague/utils/message.py
@@ -51,7 +51,7 @@ def prepare_message(
     accessed_addresses.update(PRE_COMPILED_CONTRACTS.keys())
     accessed_addresses.update(tx_env.access_list_addresses)
 
-    is_delegated = False
+    disable_precompiles = False
 
     if isinstance(tx.to, Bytes0):
         current_target = compute_contract_address(
@@ -68,7 +68,7 @@ def prepare_message(
 
         delegated_address = get_delegated_code_address(code)
         if delegated_address is not None:
-            is_delegated = True
+            disable_precompiles = True
             accessed_addresses.add(delegated_address)
             code = get_account(block_env.state, delegated_address).code
 
@@ -94,6 +94,6 @@ def prepare_message(
         is_static=False,
         accessed_addresses=accessed_addresses,
         accessed_storage_keys=set(tx_env.access_list_storage_keys),
-        is_delegated=is_delegated,
+        disable_precompiles=disable_precompiles,
         parent_evm=None,
     )

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -131,7 +131,7 @@ class Message:
     is_static: bool
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
-    is_delegated: bool
+    disable_precompiles: bool
     parent_evm: Optional["Evm"]
 
 

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -131,6 +131,7 @@ class Message:
     is_static: bool
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
+    is_delegated: bool
     parent_evm: Optional["Evm"]
 
 

--- a/src/ethereum/prague/vm/eoa_delegation.py
+++ b/src/ethereum/prague/vm/eoa_delegation.py
@@ -204,7 +204,7 @@ def set_delegation(message: Message) -> U256:
     message.code = get_account(state, message.code_address).code
 
     if is_valid_delegation(message.code):
-        message.is_delegated = True
+        message.disable_precompiles = True
         message.code_address = Address(
             message.code[EOA_DELEGATION_MARKER_LENGTH:]
         )

--- a/src/ethereum/prague/vm/eoa_delegation.py
+++ b/src/ethereum/prague/vm/eoa_delegation.py
@@ -204,6 +204,7 @@ def set_delegation(message: Message) -> U256:
     message.code = get_account(state, message.code_address).code
 
     if is_valid_delegation(message.code):
+        message.is_delegated = True
         message.code_address = Address(
             message.code[EOA_DELEGATION_MARKER_LENGTH:]
         )

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -133,6 +133,7 @@ def generic_create(
         is_static=False,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
+        is_delegated=False,
         parent_evm=evm,
     )
     child_evm = process_create_message(child_message)
@@ -307,12 +308,6 @@ def generic_call(
     call_data = memory_read_bytes(
         evm.memory, memory_input_start_position, memory_input_size
     )
-    code = get_account(evm.message.block_env.state, code_address).code
-
-    if is_delegated_code and len(code) == 0:
-        evm.gas_left += gas
-        push(evm.stack, U256(1))
-        return
 
     child_message = Message(
         block_env=evm.message.block_env,
@@ -330,6 +325,7 @@ def generic_call(
         is_static=True if is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
+        is_delegated=is_delegated_code,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -133,7 +133,7 @@ def generic_create(
         is_static=False,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        is_delegated=False,
+        disable_precompiles=False,
         parent_evm=evm,
     )
     child_evm = process_create_message(child_message)
@@ -291,7 +291,7 @@ def generic_call(
     memory_output_start_position: U256,
     memory_output_size: U256,
     code: bytes,
-    is_delegated_code: bool,
+    disable_precompiles: bool,
 ) -> None:
     """
     Perform the core logic of the `CALL*` family of opcodes.
@@ -325,7 +325,7 @@ def generic_call(
         is_static=True if is_staticcall else evm.message.is_static,
         accessed_addresses=evm.accessed_addresses.copy(),
         accessed_storage_keys=evm.accessed_storage_keys.copy(),
-        is_delegated=is_delegated_code,
+        disable_precompiles=disable_precompiles,
         parent_evm=evm,
     )
     child_evm = process_message(child_message)
@@ -382,7 +382,7 @@ def call(evm: Evm) -> None:
 
     code_address = to
     (
-        is_delegated_code,
+        disable_precompiles,
         code_address,
         code,
         delegated_access_gas_cost,
@@ -428,7 +428,7 @@ def call(evm: Evm) -> None:
             memory_output_start_position,
             memory_output_size,
             code,
-            is_delegated_code,
+            disable_precompiles,
         )
 
     # PROGRAM COUNTER
@@ -471,7 +471,7 @@ def callcode(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     (
-        is_delegated_code,
+        disable_precompiles,
         code_address,
         code,
         delegated_access_gas_cost,
@@ -512,7 +512,7 @@ def callcode(evm: Evm) -> None:
             memory_output_start_position,
             memory_output_size,
             code,
-            is_delegated_code,
+            disable_precompiles,
         )
 
     # PROGRAM COUNTER
@@ -614,7 +614,7 @@ def delegatecall(evm: Evm) -> None:
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
     (
-        is_delegated_code,
+        disable_precompiles,
         code_address,
         code,
         delegated_access_gas_cost,
@@ -642,7 +642,7 @@ def delegatecall(evm: Evm) -> None:
         memory_output_start_position,
         memory_output_size,
         code,
-        is_delegated_code,
+        disable_precompiles,
     )
 
     # PROGRAM COUNTER
@@ -683,7 +683,7 @@ def staticcall(evm: Evm) -> None:
 
     code_address = to
     (
-        is_delegated_code,
+        disable_precompiles,
         code_address,
         code,
         delegated_access_gas_cost,
@@ -715,7 +715,7 @@ def staticcall(evm: Evm) -> None:
         memory_output_start_position,
         memory_output_size,
         code,
-        is_delegated_code,
+        disable_precompiles,
     )
 
     # PROGRAM COUNTER

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -300,7 +300,7 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            if message.is_delegated:
+            if message.disable_precompiles:
                 return evm
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -300,6 +300,8 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
+            if message.is_delegated:
+                return evm
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())

--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -76,7 +76,7 @@ class TransactionLoad:
     def json_to_access_list(self) -> Any:
         """Get the access list of the transaction."""
         access_list = []
-        for sublist in self.raw.get("accessLists", []):
+        for sublist in self.raw.get("accessList", []):
             access_list.append(
                 self.fork.Access(
                     self.fork.hex_to_address(sublist.get("address")),
@@ -192,7 +192,7 @@ class TransactionLoad:
             elif "maxFeePerGas" in self.raw:
                 tx_cls = self.fork.FeeMarketTransaction
                 tx_byte_prefix = b"\x02"
-            elif "accessLists" in self.raw:
+            elif "accessList" in self.raw:
                 tx_cls = self.fork.AccessListTransaction
                 tx_byte_prefix = b"\x01"
             else:

--- a/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
@@ -107,7 +107,7 @@ def run_test_case(
             tx[k] = value[v]
         elif k == "accessLists":
             if value[d] is not None:
-                tx["accessLists"] = value[d]
+                tx["accessList"] = value[d]
         else:
             tx[k] = value
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -13,7 +13,7 @@ TEST_FIXTURES = {
     },
     "latest_fork_tests": {
         "url": "https://github.com/gurukamath/latest_fork_tests.git",
-        "commit_hash": "bc74af5",
+        "commit_hash": "7a22f8e",
         "fixture_path": "tests/fixtures/latest_fork_tests",
     },
 }

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -95,7 +95,7 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
             tx[k] = value[v]
         elif k == "accessLists":
             if value[d] is not None:
-                tx["accessLists"] = value[d]
+                tx["accessList"] = value[d]
         else:
             tx[k] = value
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -467,3 +467,4 @@ eoa
 
 blockchain
 listdir
+precompiles


### PR DESCRIPTION
### What was wrong?
Currently, the EOA account that delegate to a precompile in 7702 are not handled properly. This PR also updates to 4.2.0 version of the EEST tests

### How was it fixed?
Execute empty code when an EOA delegates to a pre-compile

