### PR TITLE
Fix EVM Tracing

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -26,6 +26,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -546,7 +547,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -675,6 +678,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -698,6 +702,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -746,7 +752,7 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/arrow_glacier/vm/gas.py
+++ b/src/ethereum/arrow_glacier/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -108,7 +108,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/arrow_glacier/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -265,6 +265,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -287,9 +288,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -298,18 +299,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -25,6 +25,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -453,7 +454,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -582,6 +585,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -605,6 +609,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -647,7 +653,7 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -89,7 +90,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/berlin/vm/gas.py
+++ b/src/ethereum/berlin/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -109,7 +109,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/berlin/vm/interpreter.py
+++ b/src/ethereum/berlin/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -104,6 +103,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -135,7 +135,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -261,6 +261,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -283,9 +284,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -294,18 +295,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/byzantium/vm/gas.py
+++ b/src/ethereum/byzantium/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -108,7 +108,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/byzantium/vm/interpreter.py
+++ b/src/ethereum/byzantium/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -103,6 +102,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -134,7 +134,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -254,6 +254,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -274,9 +275,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -285,18 +286,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Address, VersionedHash
@@ -102,7 +103,7 @@ class TransactionEnvironment:
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/cancun/vm/gas.py
+++ b/src/ethereum/cancun/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U64, U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
@@ -118,7 +118,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -267,6 +267,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -289,9 +290,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -300,18 +301,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/constantinople/vm/gas.py
+++ b/src/ethereum/constantinople/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -109,7 +109,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -23,6 +23,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.trace import BaseEvmTracer
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt
@@ -454,7 +455,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(transactions):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -583,6 +586,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -606,6 +610,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(block_output.transactions_trie, rlp.encode(Uint(index)), tx)
     intrinsic_gas = validate_transaction(tx)
@@ -633,7 +639,7 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -86,7 +87,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/dao_fork/vm/gas.py
+++ b/src/ethereum/dao_fork/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from ..fork_types import Address
@@ -107,7 +107,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/dao_fork/vm/interpreter.py
+++ b/src/ethereum/dao_fork/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -96,6 +95,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -121,7 +121,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -235,6 +235,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -253,9 +254,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -264,14 +265,14 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
     return evm

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -22,6 +22,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -437,7 +438,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(transactions):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -566,6 +569,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -589,6 +593,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(block_output.transactions_trie, rlp.encode(Uint(index)), tx)
     intrinsic_gas = validate_transaction(tx)
@@ -616,7 +622,7 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -86,7 +87,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from ..fork_types import Address
@@ -107,7 +107,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -96,6 +95,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -121,7 +121,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -233,6 +233,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -251,9 +252,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -262,14 +263,14 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
     return evm

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -26,6 +26,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -546,7 +547,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -675,6 +678,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -698,6 +702,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -746,7 +752,7 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/gray_glacier/vm/gas.py
+++ b/src/ethereum/gray_glacier/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -108,7 +108,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/gray_glacier/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -265,6 +265,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -287,9 +288,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -298,18 +299,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -22,6 +22,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -437,7 +438,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(transactions):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -566,6 +569,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -589,6 +593,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(block_output.transactions_trie, rlp.encode(Uint(index)), tx)
     intrinsic_gas = validate_transaction(tx)
@@ -616,7 +622,7 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -86,7 +87,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/homestead/vm/gas.py
+++ b/src/ethereum/homestead/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from ..fork_types import Address
@@ -107,7 +107,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/homestead/vm/interpreter.py
+++ b/src/ethereum/homestead/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -96,6 +95,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -121,7 +121,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -235,6 +235,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -253,9 +254,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -264,14 +265,14 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
     return evm

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/istanbul/vm/gas.py
+++ b/src/ethereum/istanbul/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -111,7 +111,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/istanbul/vm/interpreter.py
+++ b/src/ethereum/istanbul/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -104,6 +103,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -135,7 +135,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -261,6 +261,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -281,9 +282,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -292,18 +293,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -26,6 +26,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -552,7 +553,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -681,6 +684,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -704,6 +708,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -752,7 +758,7 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/london/vm/gas.py
+++ b/src/ethereum/london/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -108,7 +108,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/london/vm/interpreter.py
+++ b/src/ethereum/london/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -265,6 +265,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -287,9 +288,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -298,18 +299,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -24,6 +24,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -447,7 +448,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(transactions):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -576,6 +579,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -599,6 +603,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(block_output.transactions_trie, rlp.encode(Uint(index)), tx)
     intrinsic_gas = validate_transaction(tx)
@@ -626,7 +632,7 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/muir_glacier/vm/gas.py
+++ b/src/ethereum/muir_glacier/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -111,7 +111,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/muir_glacier/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -104,6 +103,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -135,7 +135,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -261,6 +261,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -281,9 +282,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -292,18 +293,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -25,6 +25,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -444,7 +445,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     return block_output
 
@@ -454,6 +457,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -477,6 +481,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -525,7 +531,7 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -90,7 +91,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/paris/vm/gas.py
+++ b/src/ethereum/paris/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -108,7 +108,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/paris/vm/interpreter.py
+++ b/src/ethereum/paris/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -265,6 +265,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -287,9 +288,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -298,18 +299,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -25,6 +25,7 @@ from ethereum.exceptions import (
     InvalidBlock,
     InvalidSenderError,
 )
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
@@ -547,7 +548,7 @@ def process_system_transaction(
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
-        traces=[],
+        tracer=BaseEvmTracer(),
     )
 
     system_tx_message = Message(
@@ -628,7 +629,9 @@ def apply_body(
     )
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     process_withdrawals(block_env, block_output, withdrawals)
 
@@ -689,6 +692,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -712,6 +716,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(
         block_output.transactions_trie,
@@ -783,7 +789,7 @@ def process_transaction(
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Address, Authorization, VersionedHash
@@ -107,7 +108,7 @@ class TransactionEnvironment:
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/prague/vm/gas.py
+++ b/src/ethereum/prague/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U64, U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32, taylor_exponential
 
 from ..blocks import Header
@@ -125,7 +125,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -26,7 +26,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -107,6 +106,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -146,7 +146,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -278,6 +278,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -302,9 +303,9 @@ def execute_code(message: Message) -> Evm:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             if message.disable_precompiles:
                 return evm
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -313,18 +314,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Address
@@ -95,7 +96,7 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/shanghai/vm/gas.py
+++ b/src/ethereum/shanghai/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -109,7 +109,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -105,6 +104,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -136,7 +136,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -265,6 +265,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -287,9 +288,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -298,18 +299,18 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.output = b""
         evm.error = error
     except Revert as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.error = error
     return evm

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -87,7 +88,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/spurious_dragon/vm/gas.py
+++ b/src/ethereum/spurious_dragon/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -107,7 +107,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/spurious_dragon/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -102,6 +101,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -133,7 +133,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -252,6 +252,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -271,9 +272,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -282,14 +283,14 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
     return evm

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.trace import BaseEvmTracer
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -436,7 +437,9 @@ def apply_body(
     block_output = vm.BlockOutput()
 
     for i, tx in enumerate(transactions):
-        process_transaction(block_env, block_output, tx, Uint(i))
+        process_transaction(
+            block_env, block_output, tx, Uint(i), BaseEvmTracer()
+        )
 
     pay_rewards(block_env.state, block_env.number, block_env.coinbase, ommers)
 
@@ -565,6 +568,7 @@ def process_transaction(
     block_output: vm.BlockOutput,
     tx: Transaction,
     index: Uint,
+    tracer: BaseEvmTracer,
 ) -> None:
     """
     Execute a transaction against the provided environment.
@@ -588,6 +592,8 @@ def process_transaction(
         Transaction to execute.
     index:
         Index of the transaction in the block.
+    tracer:
+        Evm tracer for the transaction.
     """
     trie_set(block_output.transactions_trie, rlp.encode(Uint(index)), tx)
     intrinsic_gas = validate_transaction(tx)
@@ -615,7 +621,7 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
+        tracer=tracer,
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -21,6 +21,7 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.trace import BaseEvmTracer
 
 from ..blocks import Log, Receipt
 from ..fork_types import Address
@@ -86,7 +87,7 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
+    tracer: BaseEvmTracer
 
 
 @dataclass

--- a/src/ethereum/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/tangerine_whistle/vm/gas.py
@@ -16,7 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U256, Uint
 
-from ethereum.trace import GasAndRefund, evm_trace
+from ethereum.trace import GasAndRefund
 from ethereum.utils.numeric import ceil32
 
 from . import Evm
@@ -107,7 +107,8 @@ def charge_gas(evm: Evm, amount: Uint) -> None:
         The amount of gas the current operation requires.
 
     """
-    evm_trace(evm, GasAndRefund(int(amount)))
+    tracer = evm.message.tx_env.tracer
+    tracer.capture(evm, GasAndRefund(int(amount)))
 
     if evm.gas_left < amount:
         raise OutOfGasError

--- a/src/ethereum/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/tangerine_whistle/vm/interpreter.py
@@ -27,7 +27,6 @@ from ethereum.trace import (
     PrecompileEnd,
     PrecompileStart,
     TransactionEnd,
-    evm_trace,
 )
 
 from ..blocks import Log
@@ -96,6 +95,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
     """
     block_env = message.block_env
+    tx_env = message.tx_env
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
@@ -121,7 +121,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
     )
-    evm_trace(evm, tx_end)
+    tx_env.tracer.capture(evm, tx_end)
 
     return MessageCallOutput(
         gas_left=evm.gas_left,
@@ -235,6 +235,7 @@ def execute_code(message: Message) -> Evm:
     """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
+    tracer = message.tx_env.tracer
 
     evm = Evm(
         pc=Uint(0),
@@ -253,9 +254,9 @@ def execute_code(message: Message) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
+            tracer.capture(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
+            tracer.capture(evm, PrecompileEnd())
             return evm
 
         while evm.running and evm.pc < ulen(evm.code):
@@ -264,14 +265,14 @@ def execute_code(message: Message) -> Evm:
             except ValueError:
                 raise InvalidOpcode(evm.code[evm.pc])
 
-            evm_trace(evm, OpStart(op))
+            tracer.capture(evm, OpStart(op))
             op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+            tracer.capture(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+        tracer.capture(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
-        evm_trace(evm, OpException(error))
+        tracer.capture(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
     return evm

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -17,8 +17,8 @@ See [EIP-3155] for more details on EVM traces.
 """
 
 import enum
-from dataclasses import dataclass
-from typing import Optional, Protocol, Union
+from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from ethereum.exceptions import EthereumException
 
@@ -167,40 +167,29 @@ All possible types of events that an [`EvmTracer`] is expected to handle.
 """
 
 
-def discard_evm_trace(
-    evm: object,
-    event: TraceEvent,
-    trace_memory: bool = False,
-    trace_stack: bool = True,
-    trace_return_data: bool = False,
-) -> None:
+@dataclass
+class BaseTrace:
     """
-    An [`EvmTracer`] that discards all events.
-
-    [`EvmTracer`]: ref:ethereum.trace.EvmTracer
+    A basic trace.
     """
 
 
-class EvmTracer(Protocol):
+@dataclass
+class BaseEvmTracer:
     """
-    [`Protocol`] that describes tracer functions.
-
-    See [`ethereum.trace`] for details about tracing in general, and
-    [`__call__`] for more on how to implement a tracer.
-
-    [`Protocol`]: https://docs.python.org/3/library/typing.html#typing.Protocol
-    [`ethereum.trace`]: ref:ethereum.trace
-    [`__call__`]: ref:ethereum.trace.EvmTracer.__call__
+    Default tracer for an EVM.
     """
 
-    def __call__(
+    traces: list[BaseTrace] = field(default_factory=list)
+    trace_memory: bool = False
+    trace_stack: bool = True
+    trace_return_data: bool = False
+    output_basedir: str = "."
+
+    def capture(
         self,
         evm: object,
         event: TraceEvent,
-        /,
-        trace_memory: bool = False,
-        trace_stack: bool = True,
-        trace_return_data: bool = False,
     ) -> None:
         """
         Call `self` as a function, recording a trace event.
@@ -210,13 +199,6 @@ class EvmTracer(Protocol):
 
         `event`, a [`TraceEvent`], is the reason why the tracer was triggered.
 
-        `trace_memory` requests a full memory dump in the resulting trace.
-
-        `trace_stack` requests the full stack in the resulting trace.
-
-        `trace_return_data` requests that return data be included in the
-        resulting trace.
-
         See [`discard_evm_trace`] for an example function implementing this
         protocol.
 
@@ -224,11 +206,4 @@ class EvmTracer(Protocol):
         [evm]: ref:ethereum.frontier.vm.Evm
         [`TraceEvent`]: ref:ethereum.trace.TraceEvent
         """
-
-
-evm_trace: EvmTracer = discard_evm_trace
-"""
-Active [`EvmTracer`] that is used for generating traces.
-
-[`EvmTracer`]: ref:ethereum.trace.EvmTracer
-"""
+        pass

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
@@ -196,6 +196,10 @@ class FullEvmTracer(BaseEvmTracer):
                 evm.message.tx_env.tx_hash,
                 self.output_basedir,
             )
+        
+            # Empty the traces after output
+            self.traces.clear()
+
         elif isinstance(event, PrecompileStart):
             new_trace = Trace(
                 pc=int(evm.pc),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,12 +48,10 @@ def pytest_configure(config: Config) -> None:
 
     if config.getoption("evm_trace"):
         import ethereum.trace
-        from ethereum_spec_tools.evm_tools.t8n.evm_trace import (
-            evm_trace as new_trace_function,
-        )
+        from ethereum_spec_tools.evm_tools.t8n.evm_trace import FullEvmTracer
 
         # Replace the function in the module
-        ethereum.trace.evm_trace = new_trace_function
+        ethereum.trace.BaseEvmTracer = FullEvmTracer  # type: ignore[misc]
 
 
 def download_fixtures(url: str, location: str) -> None:

--- a/tests/helpers/load_vm_tests.py
+++ b/tests/helpers/load_vm_tests.py
@@ -13,7 +13,7 @@ from ethereum.utils.hexadecimal import (
     hex_to_u256,
     hex_to_uint,
 )
-
+from ethereum.trace import BaseEvmTracer
 
 class VmTestLoader:
     """
@@ -127,7 +127,7 @@ class VmTestLoader:
             gas=tx.gas,
             index_in_block=Uint(0),
             tx_hash=b"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            traces=[],
+            tracer=BaseEvmTracer(),
         )
 
         return {


### PR DESCRIPTION
(closes #994 )

### What was wrong?
The assigning of the `output_basedir` via `functools.partial` in t8n was not working as intended. As a result EEST is not able to fill tests with traces.

Related to Issue #994 

### How was it fixed?
Instead of patching the trace via `functools.partial`, this PR creates tracer classes which can be incorporated into the `TransactionEnvironment` and be switched as desired.

PS: This PR has many files changed simply because this feature needs to be backported to earlier forks.

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/user-attachments/assets/04d1a21c-d98b-401b-996e-6dfa90493d0b)

