### PR TITLE
Parse deposit requests after all transactions

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -793,9 +793,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -62,6 +62,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -74,6 +76,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -692,9 +692,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -669,9 +669,12 @@ def process_transaction(
         tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -731,9 +731,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -64,6 +64,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -80,6 +82,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -669,9 +669,12 @@ def process_transaction(
         tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -673,9 +673,12 @@ def process_transaction(
         tx_output.logs,
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -60,6 +60,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -72,6 +74,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -656,9 +656,12 @@ def process_transaction(
         tx_output.logs,
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -60,6 +60,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -72,6 +74,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -793,9 +793,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -62,6 +62,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -74,6 +76,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -656,9 +656,12 @@ def process_transaction(
         tx_output.logs,
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -60,6 +60,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -72,6 +74,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -669,9 +669,12 @@ def process_transaction(
         tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -799,9 +799,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -62,6 +62,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -74,6 +76,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -671,9 +671,12 @@ def process_transaction(
         tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -572,9 +572,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -62,6 +62,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -74,6 +76,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -35,7 +35,7 @@ from .requests import (
     DEPOSIT_REQUEST_TYPE,
     WITHDRAWAL_REQUEST_TYPE,
     compute_requests_hash,
-    parse_deposit_requests_from_receipt,
+    parse_deposit_requests_from_receipts,
 )
 from .state import (
     State,
@@ -655,7 +655,9 @@ def process_general_purpose_requests(
         The block output for the current block.
     """
     # Requests are to be in ascending order of request type
-    deposit_requests = block_output.deposit_requests
+    deposit_requests = parse_deposit_requests_from_receipts(
+        block_output.receipts
+    )
     requests_from_execution = block_output.requests
     if len(deposit_requests) > 0:
         requests_from_execution.append(DEPOSIT_REQUEST_TYPE + deposit_requests)
@@ -848,9 +850,7 @@ def process_transaction(
 
     block_output.block_logs += tx_output.logs
 
-    block_output.deposit_requests += parse_deposit_requests_from_receipt(
-        receipt
-    )
+    block_output.receipts += (receipt,)
 
 
 def process_withdrawals(

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -35,7 +35,7 @@ from .requests import (
     DEPOSIT_REQUEST_TYPE,
     WITHDRAWAL_REQUEST_TYPE,
     compute_requests_hash,
-    parse_deposit_requests_from_receipts,
+    parse_deposit_requests,
 )
 from .state import (
     State,
@@ -655,9 +655,7 @@ def process_general_purpose_requests(
         The block output for the current block.
     """
     # Requests are to be in ascending order of request type
-    deposit_requests = parse_deposit_requests_from_receipts(
-        block_output.receipts
-    )
+    deposit_requests = parse_deposit_requests(block_output)
     requests_from_execution = block_output.requests
     if len(deposit_requests) > 0:
         requests_from_execution.append(DEPOSIT_REQUEST_TYPE + deposit_requests)
@@ -842,15 +840,16 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 
     block_output.block_logs += tx_output.logs
-
-    block_output.receipts += (receipt,)
 
 
 def process_withdrawals(

--- a/src/ethereum/prague/requests.py
+++ b/src/ethereum/prague/requests.py
@@ -9,7 +9,7 @@ then process each one.
 """
 
 from hashlib import sha256
-from typing import List, Union
+from typing import List, Tuple, Union
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import Uint, ulen
@@ -146,22 +146,23 @@ def extract_deposit_data(data: Bytes) -> Bytes:
     return pubkey + withdrawal_credentials + amount + signature + index
 
 
-def parse_deposit_requests_from_receipt(
-    receipt: Union[Bytes, Receipt],
+def parse_deposit_requests_from_receipts(
+    receipts: Tuple[Union[Bytes, Receipt], ...],
 ) -> Bytes:
     """
     Parse deposit requests from a receipt.
     """
     deposit_requests: Bytes = b""
-    decoded_receipt = decode_receipt(receipt)
-    for log in decoded_receipt.logs:
-        if log.address == DEPOSIT_CONTRACT_ADDRESS:
-            if (
-                len(log.topics) > 0
-                and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH
-            ):
-                request = extract_deposit_data(log.data)
-                deposit_requests += request
+    for receipt in receipts:
+        decoded_receipt = decode_receipt(receipt)
+        for log in decoded_receipt.logs:
+            if log.address == DEPOSIT_CONTRACT_ADDRESS:
+                if (
+                    len(log.topics) > 0
+                    and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH
+                ):
+                    request = extract_deposit_data(log.data)
+                    deposit_requests += request
 
     return deposit_requests
 

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -64,6 +64,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipts :
+        Receipts of all the transactions in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -82,12 +84,12 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipts: Tuple[Union[Bytes, Receipt], ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
     blob_gas_used: U64 = U64(0)
-    deposit_requests: Bytes = Bytes(b"")
     requests: List[Bytes] = field(default_factory=list)
 
 

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -64,8 +64,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
-    receipts :
-        Receipts of all the transactions in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -84,7 +84,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
-    receipts: Tuple[Union[Bytes, Receipt], ...] = field(default_factory=tuple)
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -585,9 +585,12 @@ def process_transaction(
         tx, tx_output.error, block_output.block_gas_used, tx_output.logs
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -62,6 +62,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -76,6 +78,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Union[Bytes, Receipt]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
     withdrawals_trie: Trie[Bytes, Optional[Union[Bytes, Withdrawal]]] = field(
         default_factory=lambda: Trie(secured=False, default=None)

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -664,9 +664,12 @@ def process_transaction(
         tx_output.logs,
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -61,6 +61,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -73,6 +75,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -655,9 +655,12 @@ def process_transaction(
         tx_output.logs,
     )
 
+    receipt_key = rlp.encode(Uint(index))
+    block_output.receipt_keys += (receipt_key,)
+
     trie_set(
         block_output.receipts_trie,
-        rlp.encode(Uint(index)),
+        receipt_key,
         receipt,
     )
 

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -60,6 +60,8 @@ class BlockOutput:
         Trie of all the transactions in the block.
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
+    receipt_keys :
+        Key of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.
@@ -72,6 +74,7 @@ class BlockOutput:
     receipts_trie: Trie[Bytes, Optional[Receipt]] = field(
         default_factory=lambda: Trie(secured=False, default=None)
     )
+    receipt_keys: Tuple[Bytes, ...] = field(default_factory=tuple)
     block_logs: Tuple[Log, ...] = field(default_factory=tuple)
 
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -268,6 +268,11 @@ class ForkLoad:
         return self._module("trie").copy_trie
 
     @property
+    def trie_get(self) -> Any:
+        """trie_get function of the fork"""
+        return self._module("trie").trie_get
+
+    @property
     def hex_to_address(self) -> Any:
         """hex_to_address function of the fork"""
         return self._module("utils.hexadecimal").hex_to_address


### PR DESCRIPTION
(closes #1196 )

### What was wrong?
The deposit requests from each transaction were being parsed immediately after that transaction. The specification is to parse the requests after all the transactions. Although this should not be an issue when it comes to the final block processing, it is best to align the EELS code with the spec.

Related to Issue #1196 

### How was it fixed?
Parse deposit requests at the end of block processing, after all the transactions and withdrawals have been processed.
