### PR TITLE
feat: Implement PEP 673 Self Type for improved type annotations

### DIFF
--- a/src/ethereum/crypto/blake2.py
+++ b/src/ethereum/crypto/blake2.py
@@ -4,7 +4,7 @@ The Blake2 Implementation
 """
 import struct
 from dataclasses import dataclass
-from typing import Final, List, Tuple
+from typing import Final, List, Tuple, Self
 
 from ethereum_types.numeric import Uint
 
@@ -151,7 +151,7 @@ class Blake2:
 
     def G(
         self, v: List, a: Uint, b: Uint, c: Uint, d: Uint, x: Uint, y: Uint
-    ) -> List:
+    ) -> Self:
         """
         The mixing function used in Blake2
         https://datatracker.ietf.org/doc/html/rfc7693#section-3.1
@@ -185,7 +185,7 @@ class Blake2:
             (v[b] ^ v[c]) << self.w_R4
         ) % self.max_word
 
-        return v
+        return self
 
     def compress(
         self,

--- a/src/ethereum/crypto/elliptic_curve.py
+++ b/src/ethereum/crypto/elliptic_curve.py
@@ -3,7 +3,7 @@ Elliptic Curves
 ^^^^^^^^^^^^^^^
 """
 
-from typing import Generic, Type, TypeVar
+from typing import Generic, Type, TypeVar, Self
 
 import coincurve
 from ethereum_types.bytes import Bytes
@@ -17,7 +17,6 @@ SECP256K1N = U256(
 )
 
 F = TypeVar("F", bound=Field)
-T = TypeVar("T", bound="EllipticCurve")
 
 
 def secp256k1_recover(r: U256, s: U256, v: U256, msg_hash: Hash32) -> Bytes:
@@ -69,7 +68,7 @@ class EllipticCurve(Generic[F]):
     x: F
     y: F
 
-    def __new__(cls: Type[T], x: F, y: F) -> T:
+    def __new__(cls, x: F, y: F) -> Self:
         """
         Make new point on the curve. The point is not checked to see if it is
         on the curve.
@@ -104,7 +103,7 @@ class EllipticCurve(Generic[F]):
         return str((self.x, self.y))
 
     @classmethod
-    def point_at_infinity(cls: Type[T]) -> T:
+    def point_at_infinity(cls) -> Self:
         """
         Return the point at infinity. This is the identity element of the group
         operation.
@@ -114,7 +113,7 @@ class EllipticCurve(Generic[F]):
         """
         return cls.__new__(cls, cls.FIELD.zero(), cls.FIELD.zero())
 
-    def double(self: T) -> T:
+    def double(self) -> Self:
         """
         Add a point to itself.
         """
@@ -126,7 +125,7 @@ class EllipticCurve(Generic[F]):
         new_y = lam * (x - new_x) - y
         return self.__new__(type(self), new_x, new_y)
 
-    def __add__(self: T, other: T) -> T:
+    def __add__(self, other: "EllipticCurve") -> Self:
         """
         Add two points together.
         """
@@ -146,7 +145,7 @@ class EllipticCurve(Generic[F]):
         y = lam * (self_x - x) - self_y
         return self.__new__(type(self), x, y)
 
-    def mul_by(self: T, n: int) -> T:
+    def mul_by(self, n: int) -> Self:
         """
         Multiply `self` by `n` using the double and add algorithm.
         """

--- a/src/ethereum/crypto/finite_field.py
+++ b/src/ethereum/crypto/finite_field.py
@@ -5,7 +5,7 @@ Finite Fields
 
 # flake8: noqa: D102, D105
 
-from typing import Iterable, List, Tuple, Type, TypeVar, cast
+from typing import Iterable, List, Tuple, Type, TypeVar, cast, Self
 
 from ethereum_types.bytes import Bytes, Bytes32
 from typing_extensions import Protocol
@@ -28,44 +28,41 @@ class Field(Protocol):
     def from_int(cls: Type[F], n: int) -> F:
         ...
 
-    def __radd__(self: F, left: F) -> F:
+    def __radd__(self, left: "Field") -> Self:
         ...
 
-    def __add__(self: F, right: F) -> F:
+    def __add__(self, right: "Field") -> Self:
         ...
 
-    def __iadd__(self: F, right: F) -> F:
+    def __iadd__(self, right: "Field") -> Self:
         ...
 
-    def __sub__(self: F, right: F) -> F:
+    def __sub__(self, right: "Field") -> Self:
         ...
 
-    def __rsub__(self: F, left: F) -> F:
+    def __rsub__(self, left: "Field") -> Self:
         ...
 
-    def __mul__(self: F, right: F) -> F:
+    def __mul__(self, right: "Field") -> Self:
         ...
 
-    def __rmul__(self: F, left: F) -> F:
+    def __rmul__(self, left: "Field") -> Self:
         ...
 
-    def __imul__(self: F, right: F) -> F:
+    def __imul__(self, right: "Field") -> Self:
         ...
 
-    def __pow__(self: F, exponent: int) -> F:
+    def __pow__(self, exponent: int) -> Self:
         ...
 
-    def __ipow__(self: F, right: int) -> F:
+    def __ipow__(self, right: int) -> Self:
         ...
 
-    def __neg__(self: F) -> F:
+    def __neg__(self) -> Self:
         ...
 
-    def __truediv__(self: F, right: F) -> F:
+    def __truediv__(self, right: "Field") -> Self:
         ...
-
-
-T = TypeVar("T", bound="PrimeField")
 
 
 class PrimeField(int, Field):
@@ -78,7 +75,7 @@ class PrimeField(int, Field):
     PRIME: int
 
     @classmethod
-    def from_be_bytes(cls: Type[T], buffer: "Bytes") -> T:
+    def from_be_bytes(cls, buffer: "Bytes") -> Self:
         """
         Converts a sequence of bytes into a element of the field.
         Parameters
@@ -87,56 +84,56 @@ class PrimeField(int, Field):
             Bytes to decode.
         Returns
         -------
-        self : `T`
+        self : `Self`
             Unsigned integer decoded from `buffer`.
         """
         return cls(int.from_bytes(buffer, "big"))
 
     @classmethod
-    def zero(cls: Type[T]) -> T:
+    def zero(cls) -> Self:
         return cls.__new__(cls, 0)
 
     @classmethod
-    def from_int(cls: Type[T], n: int) -> T:
+    def from_int(cls, n: int) -> Self:
         return cls(n)
 
-    def __new__(cls: Type[T], value: int) -> T:
+    def __new__(cls, value: int) -> Self:
         return int.__new__(cls, value % cls.PRIME)
 
-    def __radd__(self: T, left: T) -> T:  # type: ignore[override]
+    def __radd__(self, left: "PrimeField") -> Self:  # type: ignore[override]
         return self.__add__(left)
 
-    def __add__(self: T, right: T) -> T:  # type: ignore[override]
+    def __add__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         if not isinstance(right, int):
             return NotImplemented
 
         return self.__new__(type(self), int.__add__(self, right))
 
-    def __iadd__(self: T, right: T) -> T:  # type: ignore[override]
+    def __iadd__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         return self.__add__(right)
 
-    def __sub__(self: T, right: T) -> T:  # type: ignore[override]
+    def __sub__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         if not isinstance(right, int):
             return NotImplemented
 
         return self.__new__(type(self), int.__sub__(self, right))
 
-    def __rsub__(self: T, left: T) -> T:  # type: ignore[override]
+    def __rsub__(self, left: "PrimeField") -> Self:  # type: ignore[override]
         if not isinstance(left, int):
             return NotImplemented
 
         return self.__new__(type(self), int.__rsub__(self, left))
 
-    def __mul__(self: T, right: T) -> T:  # type: ignore[override]
+    def __mul__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         if not isinstance(right, int):
             return NotImplemented
 
         return self.__new__(type(self), int.__mul__(self, right))
 
-    def __rmul__(self: T, left: T) -> T:  # type: ignore[override]
+    def __rmul__(self, left: "PrimeField") -> Self:  # type: ignore[override]
         return self.__mul__(left)
 
-    def __imul__(self: T, right: T) -> T:  # type: ignore[override]
+    def __imul__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         return self.__mul__(right)
 
     __floordiv__ = None  # type: ignore
@@ -145,7 +142,7 @@ class PrimeField(int, Field):
     __divmod__ = None  # type: ignore
     __rdivmod__ = None  # type: ignore
 
-    def __pow__(self: T, exponent: int) -> T:  # type: ignore[override]
+    def __pow__(self, exponent: int) -> Self:  # type: ignore[override]
         # For reasons that are unclear, self must be cast to int here under
         # PyPy.
         return self.__new__(
@@ -154,7 +151,7 @@ class PrimeField(int, Field):
 
     __rpow__ = None  # type: ignore
 
-    def __ipow__(self: T, right: int) -> T:  # type: ignore[override]
+    def __ipow__(self, right: int) -> Self:  # type: ignore[override]
         return self.__pow__(right)
 
     __and__ = None  # type: ignore
@@ -167,13 +164,13 @@ class PrimeField(int, Field):
     __irshift__ = None
     __ilshift__ = None
 
-    def __neg__(self: T) -> T:
+    def __neg__(self) -> Self:
         return self.__new__(type(self), int.__neg__(self))
 
-    def __truediv__(self: T, right: T) -> T:  # type: ignore[override]
+    def __truediv__(self, right: "PrimeField") -> Self:  # type: ignore[override]
         return self * right.multiplicative_inverse()
 
-    def multiplicative_inverse(self: T) -> T:
+    def multiplicative_inverse(self) -> Self:
         return self ** (-1)
 
     def to_be_bytes32(self) -> "Bytes32":
@@ -186,9 +183,6 @@ class PrimeField(int, Field):
             Big endian (most significant bits first) representation.
         """
         return Bytes32(self.to_bytes(32, "big"))
-
-
-U = TypeVar("U", bound="GaloisField")
 
 
 class GaloisField(tuple, Field):
@@ -211,19 +205,19 @@ class GaloisField(tuple, Field):
     FROBENIUS_COEFFICIENTS: Tuple["GaloisField", ...]
 
     @classmethod
-    def zero(cls: Type[U]) -> U:
+    def zero(cls) -> Self:
         return cls.__new__(cls, [0] * len(cls.MODULUS))
 
     @classmethod
-    def from_int(cls: Type[U], n: int) -> U:
+    def from_int(cls, n: int) -> Self:
         return cls.__new__(cls, [n] + [0] * (len(cls.MODULUS) - 1))
 
-    def __new__(cls: Type[U], iterable: Iterable[int]) -> U:
+    def __new__(cls, iterable: Iterable[int]) -> Self:
         self = tuple.__new__(cls, (x % cls.PRIME for x in iterable))
         assert len(self) == len(cls.MODULUS)
         return self
 
-    def __add__(self: U, right: U) -> U:  # type: ignore[override]
+    def __add__(self, right: "GaloisField") -> Self:  # type: ignore[override]
         if not isinstance(right, type(self)):
             return NotImplemented
 
@@ -235,13 +229,13 @@ class GaloisField(tuple, Field):
             ),
         )
 
-    def __radd__(self: U, left: U) -> U:
+    def __radd__(self, left: "GaloisField") -> Self:
         return self.__add__(left)
 
-    def __iadd__(self: U, right: U) -> U:  # type: ignore[override]
+    def __iadd__(self, right: "GaloisField") -> Self:  # type: ignore[override]
         return self.__add__(right)
 
-    def __sub__(self: U, right: U) -> U:
+    def __sub__(self, right: "GaloisField") -> Self:
         if not isinstance(right, type(self)):
             return NotImplemented
 
@@ -255,7 +249,7 @@ class GaloisField(tuple, Field):
             ),
         )
 
-    def __rsub__(self: U, left: U) -> U:
+    def __rsub__(self, left: "GaloisField") -> Self:
         if not isinstance(left, type(self)):
             return NotImplemented
 
@@ -267,7 +261,7 @@ class GaloisField(tuple, Field):
             ),
         )
 
-    def __mul__(self: U, right: U) -> U:  # type: ignore[override]
+    def __mul__(self, right: "GaloisField") -> Self:  # type: ignore[override]
         modulus = self.MODULUS
         degree = len(modulus)
         prime = self.PRIME
@@ -286,26 +280,26 @@ class GaloisField(tuple, Field):
             mul[:degree],
         )
 
-    def __rmul__(self: U, left: U) -> U:  # type: ignore[override]
+    def __rmul__(self, left: "GaloisField") -> Self:  # type: ignore[override]
         return self.__mul__(left)
 
-    def __imul__(self: U, right: U) -> U:  # type: ignore[override]
+    def __imul__(self, right: "GaloisField") -> Self:  # type: ignore[override]
         return self.__mul__(right)
 
-    def __truediv__(self: U, right: U) -> U:
+    def __truediv__(self, right: "GaloisField") -> Self:
         return self * right.multiplicative_inverse()
 
-    def __neg__(self: U) -> U:
+    def __neg__(self) -> Self:
         return self.__new__(type(self), (-a for a in self))
 
-    def scalar_mul(self: U, x: int) -> U:
+    def scalar_mul(self, x: int) -> Self:
         """
         Multiply a field element by a integer. This is faster than using
         `from_int()` and field multiplication.
         """
         return self.__new__(type(self), (x * n for n in self))
 
-    def deg(self: U) -> int:
+    def deg(self) -> int:
         """
         This is a support function for `multiplicative_inverse()`.
         """
@@ -314,7 +308,7 @@ class GaloisField(tuple, Field):
                 return i
         raise ValueError("deg() does not support zero")
 
-    def multiplicative_inverse(self: U) -> U:
+    def multiplicative_inverse(self) -> Self:
         """
         Calculate the multiplicative inverse. Uses the Euclidean algorithm.
         """
@@ -359,7 +353,7 @@ class GaloisField(tuple, Field):
                     d1 -= 1
         return self.__new__(type(self), ans)
 
-    def __pow__(self: U, exponent: int) -> U:
+    def __pow__(self, exponent: int) -> Self:
         degree = len(self.MODULUS)
         if exponent < 0:
             self = self.multiplicative_inverse()
@@ -374,11 +368,11 @@ class GaloisField(tuple, Field):
             exponent //= 2
         return res
 
-    def __ipow__(self: U, right: int) -> U:
+    def __ipow__(self, right: int) -> Self:
         return self.__pow__(right)
 
     @classmethod
-    def calculate_frobenius_coefficients(cls: Type[U]) -> Tuple[U, ...]:
+    def calculate_frobenius_coefficients(cls) -> Tuple["GaloisField", ...]:
         """
         Calculate the coefficients needed by `frobenius()`.
         """
@@ -389,7 +383,7 @@ class GaloisField(tuple, Field):
             coefficients.append(cls.__new__(cls, x) ** cls.PRIME)
         return tuple(coefficients)
 
-    def frobenius(self: U) -> U:
+    def frobenius(self) -> Self:
         """
         Returns `self ** p`. This function is known as the Frobenius
         endomorphism and has many special mathematical properties. In
@@ -399,5 +393,5 @@ class GaloisField(tuple, Field):
         ans = self.from_int(0)
         a: int
         for i, a in enumerate(self):
-            ans += cast(U, self.FROBENIUS_COEFFICIENTS[i]).scalar_mul(a)
+            ans += self.FROBENIUS_COEFFICIENTS[i].scalar_mul(a)
         return ans

--- a/src/ethereum_optimized/state_db.py
+++ b/src/ethereum_optimized/state_db.py
@@ -15,7 +15,7 @@ module to use an optimized database backed state.
 import logging
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Any, ClassVar, Dict, List, Optional, Set, cast
+from typing import Any, ClassVar, Dict, List, Optional, Set, Self, cast
 
 try:
     import rust_pyspec_glue
@@ -105,7 +105,7 @@ def get_optimized_state_patches(fork: str) -> Dict[str, Any]:
                 return NotImplemented
             return state_root(self) == state_root(other)
 
-        def __enter__(self) -> "State":
+        def __enter__(self) -> Self:
             """Support with statements"""
             return self
 


### PR DESCRIPTION
- Add `Self` import from `typing` module to affected files
- Replace `TypeVar` used for self-references with `Self` type
- Update method return type annotations in:
  - Field protocol and implementations in finite_field.py
  - EllipticCurve class in elliptic_curve.py
  - State class in state_db.py
  - Blake2 class in blake2.py

Related to #1167

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/127027/pexels-photo-127027.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2)
