### PR TITLE
Alternate evm trace fix

### DIFF
--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -226,9 +226,44 @@ class EvmTracer(Protocol):
         """
 
 
-evm_trace: EvmTracer = discard_evm_trace
+_evm_trace: EvmTracer = discard_evm_trace
 """
 Active [`EvmTracer`] that is used for generating traces.
 
 [`EvmTracer`]: ref:ethereum.trace.EvmTracer
 """
+
+
+def set_evm_trace(tracer: EvmTracer) -> EvmTracer:
+    """
+    Change the active [`EvmTracer`] that is used for generating traces.
+
+    [`EvmTracer`]: ref:ethereum.trace.EvmTracer
+    """
+    global _evm_trace
+    old = _evm_trace
+    _evm_trace = tracer
+    return old
+
+
+def evm_trace(
+    evm: object,
+    event: TraceEvent,
+    /,
+    trace_memory: bool = False,
+    trace_stack: bool = True,
+    trace_return_data: bool = False,
+) -> None:
+    """
+    Emit a trace to the active [`EvmTracer`].
+
+    [`EvmTracer`]: ref:ethereum.trace.EvmTracer
+    """
+    global _evm_trace
+    _evm_trace(
+        evm,
+        event,
+        trace_memory=trace_memory,
+        trace_stack=trace_stack,
+        trace_return_data=trace_return_data,
+    )

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -105,12 +105,14 @@ class T8N(Load):
             trace_memory = getattr(self.options, "trace.memory", False)
             trace_stack = not getattr(self.options, "trace.nostack", False)
             trace_return_data = getattr(self.options, "trace.returndata")
-            trace.evm_trace = partial(
-                evm_trace,
-                trace_memory=trace_memory,
-                trace_stack=trace_stack,
-                trace_return_data=trace_return_data,
-                output_basedir=self.options.output_basedir,
+            trace.set_evm_trace(
+                partial(
+                    evm_trace,
+                    trace_memory=trace_memory,
+                    trace_stack=trace_stack,
+                    trace_return_data=trace_return_data,
+                    output_basedir=self.options.output_basedir,
+                )
             )
         self.logger = get_stream_logger("T8N")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def pytest_configure(config: Config) -> None:
         )
 
         # Replace the function in the module
-        ethereum.trace.evm_trace = new_trace_function
+        ethereum.trace.set_evm_trace(new_trace_function)
 
 
 def download_fixtures(url: str, location: str) -> None:

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -29,7 +29,7 @@ def test_modify_evm_trace() -> None:
         nonlocal trace2
         trace2 = event
 
-    ethereum.trace.evm_trace = tracer1
+    ethereum.trace.set_evm_trace(tracer1)
 
     from ethereum.prague.vm import Evm, Message
     from ethereum.prague.vm.gas import charge_gas
@@ -60,7 +60,7 @@ def test_modify_evm_trace() -> None:
     assert isinstance(trace1, ethereum.trace.GasAndRefund)
     assert trace1.gas_cost == 5
 
-    ethereum.trace.evm_trace = tracer2
+    ethereum.trace.set_evm_trace(tracer2)
 
     charge_gas(evm, Uint(6))
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,73 @@
+from typing import Optional, cast
+
+from ethereum_types.numeric import Uint
+
+import ethereum.trace
+
+
+def test_modify_evm_trace() -> None:
+    trace1: Optional[ethereum.trace.TraceEvent] = None
+    trace2: Optional[ethereum.trace.TraceEvent] = None
+
+    def tracer1(
+        evm: object,
+        event: ethereum.trace.TraceEvent,
+        trace_memory: bool = False,
+        trace_stack: bool = True,
+        trace_return_data: bool = False,
+    ) -> None:
+        nonlocal trace1
+        trace1 = event
+
+    def tracer2(
+        evm: object,
+        event: ethereum.trace.TraceEvent,
+        trace_memory: bool = False,
+        trace_stack: bool = True,
+        trace_return_data: bool = False,
+    ) -> None:
+        nonlocal trace2
+        trace2 = event
+
+    ethereum.trace.evm_trace = tracer1
+
+    from ethereum.prague.vm import Evm, Message
+    from ethereum.prague.vm.gas import charge_gas
+
+    evm = Evm(
+        pc=Uint(1),
+        stack=[],
+        memory=bytearray(),
+        code=b"",
+        gas_left=Uint(100),
+        valid_jump_destinations=set(),
+        logs=(),
+        refund_counter=0,
+        running=True,
+        message=cast(Message, object()),
+        output=b"",
+        accounts_to_delete=set(),
+        touched_accounts=set(),
+        return_data=b"",
+        error=None,
+        accessed_addresses=set(),
+        accessed_storage_keys=set(),
+    )
+
+    charge_gas(evm, Uint(5))
+
+    assert trace2 is None
+    assert isinstance(trace1, ethereum.trace.GasAndRefund)
+    assert trace1.gas_cost == 5
+
+    ethereum.trace.evm_trace = tracer2
+
+    charge_gas(evm, Uint(6))
+
+    # Check that the old event is unmodified.
+    assert isinstance(trace1, ethereum.trace.GasAndRefund)
+    assert trace1.gas_cost == 5
+
+    # Check that the new event is populated.
+    assert isinstance(trace2, ethereum.trace.GasAndRefund)
+    assert trace2.gas_cost == 6


### PR DESCRIPTION
### What was wrong?

Related to Issue #994

### How was it fixed?

Use functions to set/get `evm_trace` instead of directly manipulating a module-level variable.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/3cab605e-5ae9-4951-93da-9985941e7160.jpeg?format=webp)
