### PR TITLE
Closes two long-pending minor issues #630 and #752

### DIFF
--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -805,41 +805,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -704,41 +704,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -681,41 +681,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -768,41 +768,6 @@ def process_withdrawals(
             destroy_account(block_env.state, wd.address)
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -681,41 +681,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -685,41 +685,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -668,41 +668,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -805,41 +805,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -668,41 +668,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -681,41 +681,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -811,41 +811,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -683,41 +683,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -584,41 +584,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -622,41 +622,6 @@ def process_withdrawals(
             destroy_account(block_env.state, wd.address)
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -676,41 +676,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -667,41 +667,6 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
 
-def compute_header_hash(header: Header) -> Hash32:
-    """
-    Computes the hash of a block header.
-
-    The header hash of a block is the canonical hash that is used to refer
-    to a specific block and completely distinguishes a block from another.
-
-    ``keccak256`` is a function that produces a 256 bit hash of any input.
-    It also takes in any number of bytes as an input and produces a single
-    hash for them. A hash is a completely unique output for a single input.
-    So an input corresponds to one unique hash that can be used to identify
-    the input exactly.
-
-    Prior to using the ``keccak256`` hash function, the header must be
-    encoded using the Recursive-Length Prefix. See :ref:`rlp`.
-    RLP encoding the header converts it into a space-efficient format that
-    allows for easy transfer of data between nodes. The purpose of RLP is to
-    encode arbitrarily nested arrays of binary data, and RLP is the primary
-    encoding method used to serialize objects in Ethereum's execution layer.
-    The only purpose of RLP is to encode structure; encoding specific data
-    types (e.g. strings, floats) is left up to higher-order protocols.
-
-    Parameters
-    ----------
-    header :
-        Header of interest.
-
-    Returns
-    -------
-    hash : `ethereum.crypto.hash.Hash32`
-        Hash of the header.
-    """
-    return keccak256(rlp.encode(header))
-
-
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
     """
     Validates the gas limit for a block.


### PR DESCRIPTION
### What was wrong?
The `compute_header_hash() ` function in fork.py is never used in any file. 
Some variables were still using 'bytes' instead of 'Bytes'.

Related to Issue #
#630 and #752
### How was it fixed?
Removed `compute_header_hash()` from fork.py, and
converted 'bytes'  to 'Bytes' in blocks.py and fork_types.py ( I couldn't find them anywhere else )


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://factanimal.com/wp-content/uploads/2021/12/quokka-facts.jpg)
