### PR TITLE
add vulture to static analysis suite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -169,6 +169,7 @@ lint =
     flake8-bugbear==23.12.2
     flake8-docstrings==1.7.0
     flake8-spellcheck==0.28.0
+    vulture==2.14.0
 
 tools =
     platformdirs>=4.2,<5

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
     ethereum-spec-lint
+    vulture src tests setup.py --exclude "tests/fixtures/*" --min-confidence 100
 
 [testenv:py3]
 extras =


### PR DESCRIPTION
### What was wrong?

Related to Issue #1122

### How was it fixed?
Added `vulture` (version 2.14.0) to the project's lint dependencies and integrated it into the static analysis suite in `tox.ini`.
Currently configured vulture with a 100% confidence threshold to minimize false positives

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://c.media-amazon.com/images/I/81RQ9EvYi2L._SL1500_.jpg)