### PR TITLE
fix(t8n): return the receipts list

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -339,14 +339,6 @@ class Result:
 
             receipt_dict["gasUsed"] = hex(receipt.cumulative_gas_used)
             receipt_dict["bloom"] = "0x" + receipt.bloom.hex()
-            receipt_dict["logs"] = [
-                {
-                    "address": "0x" + log.address.hex(),
-                    "topics": ["0x" + topic.hex() for topic in log.topics],
-                    "data": "0x" + log.data.hex(),
-                }
-                for log in receipt.logs
-            ]
 
             receipts_json.append(receipt_dict)
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -350,7 +350,7 @@ class Result:
 
             receipts_json.append(receipt_dict)
 
-            return receipt_dict
+        return receipts_json
 
     def to_json(self) -> Any:
         """Encode the result to JSON"""


### PR DESCRIPTION
### What was wrong?

v1.17.0 doesn't fill EEST Prague tests; `t8n` returns the incorrect type. It returns the first transaction receipt instead of a list of receipts.
```
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py:207: in test_valid
    state_test(
src/pytest_plugins/filler/filler.py:750: in __init__
    fixture = self.generate(
src/ethereum_test_specs/state.py:252: in generate
    return self.make_state_test_fixture(t8n, fork, eips)
src/ethereum_test_specs/state.py:185: in make_state_test_fixture
    transition_tool_output = t8n.evaluate(
src/ethereum_clis/transition_tool.py:536: in evaluate
    return self._evaluate_server(
src/ethereum_clis/transition_tool.py:357: in _evaluate_server
    output: TransitionToolOutput = TransitionToolOutput.model_validate(
E   pydantic_core._pydantic_core.ValidationError: 1 validation error for TransitionToolOutput
E   result.receipts
E     Input should be a valid list [type=list_type, input_value={'transactionHash': '0xa5...0000000000', 'logs': []}, input_type=dict]
E       For further information visit https://errors.pydantic.dev/2.10/v/list_type
```

### How was it fixed?

Return the list.

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/a4177ed9-3689-4abb-805d-8d7cacdee637)

Required for https://github.com/ethereum/execution-spec-tests/pull/1454