### PR TITLE
lower vulture min confidence from 100 to 60

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*" --namespace-packages
     ethereum-spec-lint
-    vulture src tests setup.py --exclude "*/tests/fixtures/*" --min-confidence 100
+    vulture src tests setup.py --exclude "*/tests/fixtures/*" --min-confidence 60
 
 [testenv:py3]
 extras =


### PR DESCRIPTION
This PR lowers the minimum confidence threshold for Vulture from 100 to 60, allowing it to detect more potentially unused code. This change will help identify dead code that might otherwise be missed with the stricter setting.

Fixes #1239