### PR TITLE
Refactor transaction validation to use MAX_INIT_CODE_SIZE instead of MAX_CODE_SIZE across multiple modules

### DIFF
--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -191,14 +191,14 @@ def validate_transaction(tx: Transaction) -> Uint:
     InvalidTransaction :
         If the transaction is not valid.
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -80,7 +80,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -62,6 +62,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -221,14 +221,14 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     InvalidBlock :
         If the transaction is not valid.
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
     if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -73,7 +73,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -81,7 +81,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -62,6 +62,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -161,14 +161,14 @@ def validate_transaction(tx: Transaction) -> Uint:
     InvalidTransaction :
         If the transaction is not valid.
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -71,7 +71,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -79,7 +79,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -62,6 +62,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass


### PR DESCRIPTION
### What was wrong?

Related to Issue #1232 

### How was it fixed?

1.  Explicitly defined `MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE` as a new constant in the `vm/interpreter.py` files for the Shanghai, Cancun, and Prague forks.
2.  Updated relevant code in `transactions.py` and `vm/instructions/system.py` for these forks to use the new `MAX_INIT_CODE_SIZE` constant when validating initcode sizes, replacing direct usage of `2 * MAX_CODE_SIZE`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/474x/5e/34/26/5e342664134995cb79a4b2069d1a3419.jpg)