### PR TITLE
Docs: Update comments for mark_account_created to include EIP-6780

### DIFF
--- a/src/ethereum/cancun/state.py
+++ b/src/ethereum/cancun/state.py
@@ -246,7 +246,8 @@ def mark_account_created(state: State, address: Address) -> None:
     """
     Mark an account as having been created in the current transaction.
     This information is used by `get_storage_original()` to handle an obscure
-    edgecase.
+    edgecase, and to respect the constraints added to SELFDESTRUCT by
+    EIP-6780.
 
     The marker is not removed even if the account creation reverts. Since the
     account cannot have had code prior to its creation and can't call

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -167,7 +167,8 @@ def process_create_message(message: Message) -> Evm:
 
     # In the previously mentioned edge case the preexisting storage is ignored
     # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # accounts. This tracking is also needed to respect the constraints
+    # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)


### PR DESCRIPTION
### What was wrong?

The comments for `mark_account_created` in `src/ethereum/cancun/vm/interpreter.py` and `src/ethereum/cancun/state.py` were incomplete. They did not mention that account creation tracking is also necessary for EIP-6780 `SELFDESTRUCT` constraints, only referencing gas refunds.

Related to Issue #979 

### How was it fixed?

Updated the comments in both `interpreter.py` and `state.py` to include the EIP-6780 `SELFDESTRUCT` constraint as a reason for tracking created accounts.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRXLQYd53EGtBLpkM8VBYshtLLy34F2-t4LYw&s) 
