### PR TITLE
fix: type 4 transaction accessed address addition in wrong place

### DIFF
--- a/src/ethereum/prague/utils/message.py
+++ b/src/ethereum/prague/utils/message.py
@@ -12,6 +12,7 @@ Introduction
 Message specific functions used in this prague version of
 specification.
 """
+
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import Uint
 
@@ -51,8 +52,6 @@ def prepare_message(
     accessed_addresses.update(PRE_COMPILED_CONTRACTS.keys())
     accessed_addresses.update(tx_env.access_list_addresses)
 
-    disable_precompiles = False
-
     if isinstance(tx.to, Bytes0):
         current_target = compute_contract_address(
             tx_env.origin,
@@ -65,13 +64,6 @@ def prepare_message(
         current_target = tx.to
         msg_data = tx.data
         code = get_account(block_env.state, tx.to).code
-
-        delegated_address = get_delegated_code_address(code)
-        if delegated_address is not None:
-            disable_precompiles = True
-            accessed_addresses.add(delegated_address)
-            code = get_account(block_env.state, delegated_address).code
-
         code_address = tx.to
     else:
         raise AssertionError("Target must be address or empty bytes")
@@ -94,6 +86,6 @@ def prepare_message(
         is_static=False,
         accessed_addresses=accessed_addresses,
         accessed_storage_keys=set(tx_env.access_list_storage_keys),
-        disable_precompiles=disable_precompiles,
+        disable_precompiles=False,
         parent_evm=None,
     )

--- a/src/ethereum/prague/utils/message.py
+++ b/src/ethereum/prague/utils/message.py
@@ -20,7 +20,6 @@ from ..fork_types import Address
 from ..state import get_account
 from ..transactions import Transaction
 from ..vm import BlockEnvironment, Message, TransactionEnvironment
-from ..vm.eoa_delegation import get_delegated_code_address
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from .address import compute_contract_address
 

--- a/src/ethereum/prague/vm/eoa_delegation.py
+++ b/src/ethereum/prague/vm/eoa_delegation.py
@@ -201,15 +201,5 @@ def set_delegation(message: Message) -> U256:
 
     if message.code_address is None:
         raise InvalidBlock("Invalid type 4 transaction: no target")
-    message.code = get_account(state, message.code_address).code
-
-    if is_valid_delegation(message.code):
-        message.disable_precompiles = True
-        message.code_address = Address(
-            message.code[EOA_DELEGATION_MARKER_LENGTH:]
-        )
-        message.accessed_addresses.add(message.code_address)
-
-        message.code = get_account(state, message.code_address).code
 
     return refund_counter

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -124,7 +124,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
     else:
         if message.tx_env.authorizations != ():
             refund_counter += set_delegation(message)
-        
+
         delegated_address = get_delegated_code_address(message.code)
         if delegated_address is not None:
             message.disable_precompiles = True
@@ -142,7 +142,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
         accounts_to_delete = evm.accounts_to_delete
         refund_counter += U256(evm.refund_counter)
 
-    tx_end = TransactionEnd(int(message.gas) - int(evm.gas_left), evm.output, evm.error)
+    tx_end = TransactionEnd(
+        int(message.gas) - int(evm.gas_left), evm.output, evm.error
+    )
     evm_trace(evm, tx_end)
 
     return MessageCallOutput(
@@ -236,7 +238,9 @@ def process_message(message: Message) -> Evm:
     begin_transaction(state, transient_storage)
 
     if message.should_transfer_value and message.value != 0:
-        move_ether(state, message.caller, message.current_target, message.value)
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
 
     evm = execute_code(message)
     if evm.error:


### PR DESCRIPTION
### What was wrong?

- An account was being added to `accessed_addresses` when it shouldn't have been there. If a type 4 transaction replaces the delegated contract of an account then the replaced one shouldn't be in `accessed_addresses`. This becomes clear when we call this previous contract in the same transaction that replaced it and the gas consumption for it being warm is 100, when instead it should've been 2600 because it should be cold.

We detected this with our EVM implementation (LEVM, from [ethrex](https://github.com/lambdaclass/ethrex)) while syncing with Holesky. We had trouble with [this transaction](https://holesky.etherscan.io/tx/0xab66c137ce82b6d122296d68f83bd2b476344b9a53e7a476bca0246f781126ff), but after [this fix](https://github.com/lambdaclass/ethrex/pull/2859) (which has more information about the problem) we could keep on syncing.
There is currently no `state_test` that tests this behavior so I made [this one](https://github.com/ethereum/execution-spec-tests/pull/1648). After this change to the spec gets merged we'll be able to merge the new test, mainly because the test passes with Geth and Reth but the behavior with the specs is different regarding this, and the filler that's usually used is the `ethereum-spec-evm-resolver`.

### How was it fixed?

- Setting message attributes related to EIP 7702 only after having processed the authorization list.

Closes https://github.com/ethereum/execution-specs/issues/1256

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](
https://github.com/user-attachments/assets/4dd7217d-0612-4418-b9bc-6031ca6c3149
)
