### PR TITLE
feat: add custom exception strings

### DIFF
--- a/src/ethereum/arrow_glacier/exceptions.py
+++ b/src/ethereum/arrow_glacier/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -22,3 +24,35 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -452,16 +452,15 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction is not valid for the sender.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender does not have enough balance to pay for the transaction
-        and gas fees.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is less than the base fee per gas.
     PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee per gas is greater than the maximum fee per gas.
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -449,6 +449,19 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not valid for the sender.
+    InsufficientBalanceError :
+        If the sender does not have enough balance to pay for the transaction
+        and gas fees.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is less than the base fee per gas.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee per gas is greater than the maximum fee per gas.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -23,8 +23,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -445,7 +448,7 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
@@ -467,10 +470,12 @@ def check_transaction(
         effective_gas_price = tx.gas_price
         max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -33,6 +33,10 @@ from ethereum.exceptions import (
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
+from .exceptions import (
+    InsufficientMaxFeePerGasError,
+    PriorityFeeGreaterThanMaxFeeError,
+)
 from .fork_types import Address
 from .state import (
     State,
@@ -454,9 +458,13 @@ def check_transaction(
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise InvalidBlock
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
-            raise InvalidBlock
+            raise InsufficientMaxFeePerGasError(
+                tx.max_fee_per_gas, block_env.base_fee_per_gas
+            )
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -371,8 +371,7 @@ def check_transaction(
     NonceMismatchError :
         If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is not enough to pay for the transaction
-        and gas fees.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -22,8 +22,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -368,16 +371,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -366,8 +366,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction
+        and gas fees.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -361,8 +361,14 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -366,7 +366,7 @@ def check_transaction(
     NonceMismatchError :
         If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is not enough to pay for the transaction
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -21,8 +21,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -363,16 +366,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -24,7 +26,75 @@ class TransactionTypeError(InvalidTransaction):
         self.transaction_type = transaction_type
 
 
+class TransactionTypeContractCreationError(InvalidTransaction):
+    """
+    Transaction type is not allowed for contract creation.
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(
+            f"transaction type `{transaction_type}` not allowed for "
+            "contract creation"
+        )
+        self.transaction_type = transaction_type
+
+
+class BlobGasLimitExceededError(InvalidTransaction):
+    """
+    The blob gas limit for the transaction exceeds the maximum allowed.
+    """
+
+
 class InsufficientMaxFeePerBlobGasError(InvalidTransaction):
     """
     The maximum fee per blob gas is insufficient for the transaction.
+    """
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class InvalidBlobVersionedHashError(InvalidTransaction):
+    """
+    The versioned hash of the blob is invalid.
+    """
+
+
+class NoBlobDataError(InvalidTransaction):
+    """
+    The transaction does not contain any blob data.
+    """
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
     """

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -2,11 +2,14 @@
 Exceptions specific to this fork.
 """
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from ethereum_types.numeric import Uint
 
 from ethereum.exceptions import InvalidTransaction
+
+if TYPE_CHECKING:
+    from .transactions import Transaction
 
 
 class TransactionTypeError(InvalidTransaction):
@@ -28,20 +31,20 @@ class TransactionTypeError(InvalidTransaction):
 
 class TransactionTypeContractCreationError(InvalidTransaction):
     """
-    Transaction type is not allowed for contract creation.
+    Contract creation is not allowed for a transaction type.
     """
 
-    transaction_type: Final[int]
+    transaction: "Transaction"
     """
-    The type byte of the transaction that caused the error.
+    The transaction that caused the error.
     """
 
-    def __init__(self, transaction_type: int):
+    def __init__(self, transaction: "Transaction"):
         super().__init__(
-            f"transaction type `{transaction_type}` not allowed for "
-            "contract creation"
+            f"transaction type `{type(transaction).__name__}` not allowed to "
+            "create contracts"
         )
-        self.transaction_type = transaction_type
+        self.transaction = transaction
 
 
 class BlobGasLimitExceededError(InvalidTransaction):

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -22,3 +22,9 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerBlobGasError(InvalidTransaction):
+    """
+    The maximum fee per blob gas is insufficient for the transaction.
+    """

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -389,6 +389,30 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    BlobGasLimitExceededError :
+        If the blob gas used by the transaction exceeds the block's blob gas
+        limit.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerBlobGasError :
+        If the maximum fee per blob gas is insufficient for the transaction.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
+    InvalidBlobVersionedHashError :
+        If the transaction contains a blob versioned hash with an invalid
+        version.
+    NoBlobDataError :
+        If the transaction is a type 3 but has no blobs.
+    TransactionTypeContractCreationError:
+        If the transaction type is not allowed to create contracts.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -451,7 +451,7 @@ def check_transaction(
 
     if isinstance(tx, BlobTransaction):
         if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx[0])
+            raise TransactionTypeContractCreationError(tx)
         if len(tx.blob_versioned_hashes) == 0:
             raise NoBlobDataError("no blob data in transaction")
         for blob_versioned_hash in tx.blob_versioned_hashes:

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -29,6 +29,7 @@ from ethereum.exceptions import (
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
+from .exceptions import InsufficientMaxFeePerBlobGasError
 from .fork_types import Account, Address, VersionedHash
 from .state import (
     State,
@@ -420,7 +421,7 @@ def check_transaction(
 
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
-            raise InvalidBlock
+            raise InsufficientMaxFeePerBlobGasError("insufficient max fee per blob gas")
 
         max_gas_fee += Uint(calculate_total_blob_gas(tx)) * Uint(
             tx.max_fee_per_blob_gas

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -391,15 +391,21 @@ def check_transaction(
         If the transaction is not includable.
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
+    InsufficientMaxFeePerBlobGasError :
+        If the maximum fee per blob gas is insufficient for the transaction.
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
-    InsufficientMaxFeePerBlobGasError :
-        If the maximum fee per blob gas is insufficient for the transaction.
-    InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is insufficient for the transaction.
     InvalidBlobVersionedHashError :
         If the transaction contains a blob versioned hash with an invalid
         version.
@@ -407,12 +413,6 @@ def check_transaction(
         If the transaction is a type 3 but has no blobs.
     TransactionTypeContractCreationError:
         If the transaction type is not allowed to create contracts.
-    NonceMismatchError :
-        If the nonce of the transaction is not equal to the sender's nonce.
-    InsufficientBalanceError :
-        If the sender's balance is not enough to pay for the transaction
-    InvalidSenderError :
-        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -421,7 +421,9 @@ def check_transaction(
 
         blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
         if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
-            raise InsufficientMaxFeePerBlobGasError("insufficient max fee per blob gas")
+            raise InsufficientMaxFeePerBlobGasError(
+                "insufficient max fee per blob gas"
+            )
 
         max_gas_fee += Uint(calculate_total_blob_gas(tx)) * Uint(
             tx.max_fee_per_blob_gas

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -364,10 +364,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -361,8 +361,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -21,8 +21,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -363,16 +366,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -22,7 +22,13 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
+    InvalidBlock,
+    InvalidSenderError,
+    NonceMismatchError,
+)
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt
@@ -372,16 +378,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -373,8 +373,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -376,10 +376,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -39,3 +39,13 @@ class InvalidSignatureError(InvalidTransaction):
     """
     Thrown when a transaction has an invalid signature.
     """
+
+class InsufficientBalanceError(InvalidTransaction):
+    """
+    Thrown when a transaction cannot be executed due to insufficient sender funds.
+    """
+
+class NonceMismatchError(InvalidTransaction):
+    """
+    Thrown when a transaction's nonce does not match the expected nonce for the sender.
+    """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -43,11 +43,13 @@ class InvalidSignatureError(InvalidTransaction):
 
 class InsufficientBalanceError(InvalidTransaction):
     """
-    Thrown when a transaction cannot be executed due to insufficient sender funds.
+    Thrown when a transaction cannot be executed due to insufficient sender
+    funds.
     """
 
 
 class NonceMismatchError(InvalidTransaction):
     """
-    Thrown when a transaction's nonce does not match the expected nonce for the sender.
+    Thrown when a transaction's nonce does not match the expected nonce for the
+    sender.
     """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -40,10 +40,12 @@ class InvalidSignatureError(InvalidTransaction):
     Thrown when a transaction has an invalid signature.
     """
 
+
 class InsufficientBalanceError(InvalidTransaction):
     """
     Thrown when a transaction cannot be executed due to insufficient sender funds.
     """
+
 
 class NonceMismatchError(InvalidTransaction):
     """

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -53,3 +53,10 @@ class NonceMismatchError(InvalidTransaction):
     Thrown when a transaction's nonce does not match the expected nonce for the
     sender.
     """
+
+
+class GasUsedExceedsLimitError(InvalidTransaction):
+    """
+    Thrown when a transaction's gas usage exceeds the gas available in the
+    block.
+    """

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -359,10 +359,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -356,8 +356,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/gray_glacier/exceptions.py
+++ b/src/ethereum/gray_glacier/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -22,3 +24,35 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -450,21 +450,17 @@ def check_transaction(
     InvalidBlock :
         If the transaction is not includable.
     GasUsedExceedsLimitError :
-        If the gas used by the transaction exceeds the gas limit of the block.
+        If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the expected nonce
-        for the sender.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender does not have enough balance to pay for the gas fee
-        and the value of the transaction.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     PriorityFeeGreaterThanMaxFeeError:
-        If the priority fee per gas is greater than the maximum fee per gas
-        in a 1559 transaction.
+        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is less than the base fee per gas in a
-        1559 transaction.
+        If the maximum fee per gas is insufficient for the transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -449,6 +449,22 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the gas limit of the block.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the expected nonce
+        for the sender.
+    InsufficientBalanceError :
+        If the sender does not have enough balance to pay for the gas fee
+        and the value of the transaction.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    PriorityFeeGreaterThanMaxFeeError:
+        If the priority fee per gas is greater than the maximum fee per gas
+        in a 1559 transaction.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is less than the base fee per gas in a
+        1559 transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -23,13 +23,20 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
+from .exceptions import (
+    InsufficientMaxFeePerGasError,
+    PriorityFeeGreaterThanMaxFeeError,
+)
 from .fork_types import Address
 from .state import (
     State,
@@ -445,15 +452,19 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise InvalidBlock
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
-            raise InvalidBlock
+            raise InsufficientMaxFeePerGasError(
+                tx.max_fee_per_gas, block_env.base_fee_per_gas
+            )
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -467,10 +478,12 @@ def check_transaction(
         effective_gas_price = tx.gas_price
         max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -359,10 +359,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -356,8 +356,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -364,10 +364,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -361,8 +361,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -21,8 +21,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -363,16 +366,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/london/exceptions.py
+++ b/src/ethereum/london/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -22,3 +24,35 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -456,21 +456,17 @@ def check_transaction(
     InvalidBlock :
         If the transaction is not includable.
     GasUsedExceedsLimitError :
-        If the gas used by the transaction exceeds the gas limit of the block.
+        If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the expected nonce
-        for the sender.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender does not have enough balance to pay for the gas fee
-        and the value of the transaction.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     PriorityFeeGreaterThanMaxFeeError:
-        If the priority fee per gas is greater than the maximum fee per gas
-        in a 1559 transaction.
+        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is less than the base fee per gas in a
-        1559 transaction.
+        If the maximum fee per gas is insufficient for the transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -23,13 +23,20 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
 from .bloom import logs_bloom
+from .exceptions import (
+    InsufficientMaxFeePerGasError,
+    PriorityFeeGreaterThanMaxFeeError,
+)
 from .fork_types import Address
 from .state import (
     State,
@@ -451,15 +458,19 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise InvalidBlock
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
-            raise InvalidBlock
+            raise InsufficientMaxFeePerGasError(
+                tx.max_fee_per_gas, block_env.base_fee_per_gas
+            )
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -473,10 +484,12 @@ def check_transaction(
         effective_gas_price = tx.gas_price
         max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -455,6 +455,22 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the gas limit of the block.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the expected nonce
+        for the sender.
+    InsufficientBalanceError :
+        If the sender does not have enough balance to pay for the gas fee
+        and the value of the transaction.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    PriorityFeeGreaterThanMaxFeeError:
+        If the priority fee per gas is greater than the maximum fee per gas
+        in a 1559 transaction.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is less than the base fee per gas in a
+        1559 transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -364,10 +364,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -361,8 +361,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -21,8 +21,11 @@ from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
@@ -363,16 +366,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/paris/exceptions.py
+++ b/src/ethereum/paris/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -22,3 +24,35 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -350,6 +350,22 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the gas limit of the block.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the expected nonce
+        for the sender.
+    InsufficientBalanceError :
+        If the sender does not have enough balance to pay for the gas fee
+        and the value of the transaction.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    PriorityFeeGreaterThanMaxFeeError:
+        If the priority fee per gas is greater than the maximum fee per gas
+        in a 1559 transaction.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is less than the base fee per gas in a
+        1559 transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -351,21 +351,17 @@ def check_transaction(
     InvalidBlock :
         If the transaction is not includable.
     GasUsedExceedsLimitError :
-        If the gas used by the transaction exceeds the gas limit of the block.
+        If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the expected nonce
-        for the sender.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender does not have enough balance to pay for the gas fee
-        and the value of the transaction.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    PriorityFeeGreaterThanMaxFeeError:
-        If the priority fee per gas is greater than the maximum fee per gas
-        in a 1559 transaction.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee is greater than the maximum fee per gas.
     InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is less than the base fee per gas in a
-        1559 transaction.
+        If the maximum fee per gas is insufficient for the transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -2,11 +2,14 @@
 Exceptions specific to this fork.
 """
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from ethereum_types.numeric import Uint
 
 from ethereum.exceptions import InvalidTransaction
+
+if TYPE_CHECKING:
+    from .transactions import Transaction
 
 
 class TransactionTypeError(InvalidTransaction):
@@ -28,20 +31,20 @@ class TransactionTypeError(InvalidTransaction):
 
 class TransactionTypeContractCreationError(InvalidTransaction):
     """
-    Transaction type is not allowed for contract creation.
+    Contract creation is not allowed for a transaction type.
     """
 
-    transaction_type: Final[int]
+    transaction: "Transaction"
     """
-    The type byte of the transaction that caused the error.
+    The transaction that caused the error.
     """
 
-    def __init__(self, transaction_type: int):
+    def __init__(self, transaction: "Transaction"):
         super().__init__(
-            f"transaction type `{transaction_type}` not allowed for "
-            "contract creation"
+            f"transaction type `{type(transaction).__name__}` not allowed to "
+            "create contracts"
         )
-        self.transaction_type = transaction_type
+        self.transaction = transaction
 
 
 class BlobGasLimitExceededError(InvalidTransaction):

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -35,7 +35,10 @@ class TransactionTypeContractCreationError(InvalidTransaction):
     """
 
     def __init__(self, transaction_type: int):
-        super().__init__(f"transaction type `{transaction_type}` not allowed for contract creation")
+        super().__init__(
+            f"transaction type `{transaction_type}` not allowed for "
+            "contract creation"
+        )
         self.transaction_type = transaction_type
 
 

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -23,6 +23,7 @@ class TransactionTypeError(InvalidTransaction):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
 
+
 class TransactionTypeContractCreationError(InvalidTransaction):
     """
     Transaction type is not allowed for contract creation.
@@ -37,35 +38,42 @@ class TransactionTypeContractCreationError(InvalidTransaction):
         super().__init__(f"transaction type `{transaction_type}` not allowed for contract creation")
         self.transaction_type = transaction_type
 
+
 class BlobGasLimitExceededError(InvalidTransaction):
     """
     The blob gas limit for the transaction exceeds the maximum allowed.
     """
+
 
 class InsufficientMaxFeePerBlobGasError(InvalidTransaction):
     """
     The maximum fee per blob gas is insufficient for the transaction.
     """
 
+
 class InsufficientMaxFeePerGasError(InvalidTransaction):
     """
     The maximum fee per gas is insufficient for the transaction.
     """
+
 
 class InvalidBlobVersionedHashError(InvalidTransaction):
     """
     The versioned hash of the blob is invalid.
     """
 
+
 class NoBlobDataError(InvalidTransaction):
     """
     The transaction does not contain any blob data.
     """
 
+
 class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
     """
     The priority fee is greater than the maximum fee per gas.
     """
+
 
 class EmptyAuthorizationListError(InvalidTransaction):
     """

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -59,6 +59,26 @@ class InsufficientMaxFeePerGasError(InvalidTransaction):
     The maximum fee per gas is insufficient for the transaction.
     """
 
+    transaction_max_fee_per_gas: Final[int]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[int]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: int, block_base_fee_per_gas: int
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
 
 class InvalidBlobVersionedHashError(InvalidTransaction):
     """

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -59,18 +61,18 @@ class InsufficientMaxFeePerGasError(InvalidTransaction):
     The maximum fee per gas is insufficient for the transaction.
     """
 
-    transaction_max_fee_per_gas: Final[int]
+    transaction_max_fee_per_gas: Final[Uint]
     """
     The maximum fee per gas specified in the transaction.
     """
 
-    block_base_fee_per_gas: Final[int]
+    block_base_fee_per_gas: Final[Uint]
     """
     The base fee per gas of the block in which the transaction is included.
     """
 
     def __init__(
-        self, transaction_max_fee_per_gas: int, block_base_fee_per_gas: int
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
     ):
         super().__init__(
             f"Insufficient max fee per gas "

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -22,3 +22,52 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+class TransactionTypeContractCreationError(InvalidTransaction):
+    """
+    Transaction type is not allowed for contract creation.
+    """
+
+    transaction_type: Final[int]
+    """
+    The type byte of the transaction that caused the error.
+    """
+
+    def __init__(self, transaction_type: int):
+        super().__init__(f"transaction type `{transaction_type}` not allowed for contract creation")
+        self.transaction_type = transaction_type
+
+class BlobGasLimitExceededError(InvalidTransaction):
+    """
+    The blob gas limit for the transaction exceeds the maximum allowed.
+    """
+
+class InsufficientMaxFeePerBlobGasError(InvalidTransaction):
+    """
+    The maximum fee per blob gas is insufficient for the transaction.
+    """
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+class InvalidBlobVersionedHashError(InvalidTransaction):
+    """
+    The versioned hash of the blob is invalid.
+    """
+
+class NoBlobDataError(InvalidTransaction):
+    """
+    The transaction does not contain any blob data.
+    """
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """
+
+class EmptyAuthorizationListError(InvalidTransaction):
+    """
+    The authorization list in the transaction is empty.
+    """

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -502,7 +502,7 @@ def check_transaction(
 
     if isinstance(tx, (BlobTransaction, SetCodeTransaction)):
         if not isinstance(tx.to, Address):
-            raise TransactionTypeContractCreationError(tx[0])
+            raise TransactionTypeContractCreationError(tx)
 
     if isinstance(tx, SetCodeTransaction):
         if not any(tx.authorizations):

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -415,15 +415,21 @@ def check_transaction(
         If the transaction is not includable.
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
+    InsufficientMaxFeePerBlobGasError :
+        If the maximum fee per blob gas is insufficient for the transaction.
     BlobGasLimitExceededError :
         If the blob gas used by the transaction exceeds the block's blob gas
         limit.
-    PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee is greater than the maximum fee per gas.
-    InsufficientMaxFeePerBlobGasError :
-        If the maximum fee per blob gas is insufficient for the transaction.
-    InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is insufficient for the transaction.
     InvalidBlobVersionedHashError :
         If the transaction contains a blob versioned hash with an invalid
         version.
@@ -431,12 +437,6 @@ def check_transaction(
         If the transaction is a type 3 but has no blobs.
     TransactionTypeContractCreationError:
         If the transaction type is not allowed to create contracts.
-    NonceMismatchError :
-        If the nonce of the transaction is not equal to the sender's nonce.
-    InsufficientBalanceError :
-        If the sender's balance is not enough to pay for the transaction
-    InvalidSenderError :
-        If the transaction is from an address that does not exist anymore.
     EmptyAuthorizationListError :
         If the transaction is a SetCodeTransaction and the authorization list
         is empty.

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -413,6 +413,33 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    BlobGasLimitExceededError :
+        If the blob gas used by the transaction exceeds the block's blob gas
+        limit.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerBlobGasError :
+        If the maximum fee per blob gas is insufficient for the transaction.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
+    InvalidBlobVersionedHashError :
+        If the transaction contains a blob versioned hash with an invalid
+        version.
+    NoBlobDataError :
+        If the transaction is a type 3 but has no blobs.
+    TransactionTypeContractCreationError:
+        If the transaction type is not allowed to create contracts.
+    NonceMismatchError :
+        If the nonce of the transaction is not equal to the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is not enough to pay for the transaction
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    EmptyAuthorizationListError :
+        If the transaction is a SetCodeTransaction and the authorization list
+        is empty.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used

--- a/src/ethereum/shanghai/exceptions.py
+++ b/src/ethereum/shanghai/exceptions.py
@@ -4,6 +4,8 @@ Exceptions specific to this fork.
 
 from typing import Final
 
+from ethereum_types.numeric import Uint
+
 from ethereum.exceptions import InvalidTransaction
 
 
@@ -22,3 +24,35 @@ class TransactionTypeError(InvalidTransaction):
     def __init__(self, transaction_type: int):
         super().__init__(f"unknown transaction type `{transaction_type}`")
         self.transaction_type = transaction_type
+
+
+class InsufficientMaxFeePerGasError(InvalidTransaction):
+    """
+    The maximum fee per gas is insufficient for the transaction.
+    """
+
+    transaction_max_fee_per_gas: Final[Uint]
+    """
+    The maximum fee per gas specified in the transaction.
+    """
+
+    block_base_fee_per_gas: Final[Uint]
+    """
+    The base fee per gas of the block in which the transaction is included.
+    """
+
+    def __init__(
+        self, transaction_max_fee_per_gas: Uint, block_base_fee_per_gas: Uint
+    ):
+        super().__init__(
+            f"Insufficient max fee per gas "
+            f"({transaction_max_fee_per_gas} < {block_base_fee_per_gas})"
+        )
+        self.transaction_max_fee_per_gas = transaction_max_fee_per_gas
+        self.block_base_fee_per_gas = block_base_fee_per_gas
+
+
+class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
+    """
+    The priority fee is greater than the maximum fee per gas.
+    """

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -355,6 +355,19 @@ def check_transaction(
     ------
     InvalidBlock :
         If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction is not valid for the sender.
+    InsufficientBalanceError :
+        If the sender does not have enough balance to pay for the transaction
+        and gas fees.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is less than the base fee per gas.
+    PriorityFeeGreaterThanMaxFeeError :
+        If the priority fee per gas is greater than the maximum fee per gas.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -358,16 +358,15 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction is not valid for the sender.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender does not have enough balance to pay for the transaction
-        and gas fees.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
-    InsufficientMaxFeePerGasError :
-        If the maximum fee per gas is less than the base fee per gas.
     PriorityFeeGreaterThanMaxFeeError :
-        If the priority fee per gas is greater than the maximum fee per gas.
+        If the priority fee is greater than the maximum fee per gas.
+    InsufficientMaxFeePerGasError :
+        If the maximum fee per gas is insufficient for the transaction.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -22,13 +22,20 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import (
     EthereumException,
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
     InvalidBlock,
     InvalidSenderError,
+    NonceMismatchError,
 )
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
+from .exceptions import (
+    InsufficientMaxFeePerGasError,
+    PriorityFeeGreaterThanMaxFeeError,
+)
 from .fork_types import Account, Address
 from .state import (
     State,
@@ -351,15 +358,19 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     if isinstance(tx, FeeMarketTransaction):
         if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-            raise InvalidBlock
+            raise PriorityFeeGreaterThanMaxFeeError(
+                "priority fee greater than max fee"
+            )
         if tx.max_fee_per_gas < block_env.base_fee_per_gas:
-            raise InvalidBlock
+            raise InsufficientMaxFeePerGasError(
+                tx.max_fee_per_gas, block_env.base_fee_per_gas
+            )
 
         priority_fee_per_gas = min(
             tx.max_priority_fee_per_gas,
@@ -373,10 +384,12 @@ def check_transaction(
         effective_gas_price = tx.gas_price
         max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -360,10 +360,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -20,7 +20,13 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
+    InvalidBlock,
+    InvalidSenderError,
+    NonceMismatchError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -356,16 +362,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(block_env.chain_id, tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -357,8 +357,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -358,10 +358,9 @@ def check_transaction(
     GasUsedExceedsLimitError :
         If the gas used by the transaction exceeds the block's gas limit.
     NonceMismatchError :
-        If the nonce of the transaction does not match the sender's nonce.
+        If the nonce of the transaction is not equal to the sender's nonce.
     InsufficientBalanceError :
-        If the sender's balance is insufficient to cover the transaction
-        value and gas fee.
+        If the sender's balance is not enough to pay for the transaction.
     InvalidSenderError :
         If the transaction is from an address that does not exist anymore.
     """

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -20,7 +20,13 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.ethash import dataset_size, generate_cache, hashimoto_light
-from ethereum.exceptions import InvalidBlock, InvalidSenderError
+from ethereum.exceptions import (
+    GasUsedExceedsLimitError,
+    InsufficientBalanceError,
+    InvalidBlock,
+    InvalidSenderError,
+    NonceMismatchError,
+)
 
 from . import vm
 from .blocks import Block, Header, Log, Receipt
@@ -354,16 +360,18 @@ def check_transaction(
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:
-        raise InvalidBlock
+        raise GasUsedExceedsLimitError("gas used exceeds limit")
     sender_address = recover_sender(tx)
     sender_account = get_account(block_env.state, sender_address)
 
     max_gas_fee = tx.gas * tx.gas_price
 
-    if sender_account.nonce != tx.nonce:
-        raise InvalidBlock
+    if sender_account.nonce > Uint(tx.nonce):
+        raise NonceMismatchError("nonce too low")
+    elif sender_account.nonce < Uint(tx.nonce):
+        raise NonceMismatchError("nonce too high")
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
-        raise InvalidBlock
+        raise InsufficientBalanceError("insufficient sender balance")
     if sender_account.code:
         raise InvalidSenderError("not EOA")
 

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -355,8 +355,15 @@ def check_transaction(
 
     Raises
     ------
-    InvalidBlock :
-        If the transaction is not includable.
+    GasUsedExceedsLimitError :
+        If the gas used by the transaction exceeds the block's gas limit.
+    NonceMismatchError :
+        If the nonce of the transaction does not match the sender's nonce.
+    InsufficientBalanceError :
+        If the sender's balance is insufficient to cover the transaction
+        value and gas fee.
+    InvalidSenderError :
+        If the transaction is from an address that does not exist anymore.
     """
     gas_available = block_env.block_gas_limit - block_output.block_gas_used
     if tx.gas > gas_available:


### PR DESCRIPTION
### What was wrong?

Exceptions were not specific, which made matching them in execution-spec-tests difficult

https://github.com/ethereum/execution-specs/issues/1021

### How was it fixed?

Added custom exceptions for the following:

- TransactionException.TYPE_4_TX_CONTRACT_CREATION,

- TransactionException.TYPE_3_TX_CONTRACT_CREATION 

- TransactionException.INSUFFICIENT_ACCOUNT_FUNDS,

- TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED,

- TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS,

- TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS,

- TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH,

- TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED, (same as TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED)

- TransactionException.TYPE_3_TX_ZERO_BLOBS,

- TransactionException.INTRINSIC_GAS_TOO_LOW, (should already be covered by InvalidTransaction("Insufficient gas"))

- TransactionException.INITCODE_SIZE_EXCEEDED (already raised as InvalidTransaction("Code size too large"))

- TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS,

- TransactionException.TYPE_4_EMPTY_AUTHORIZATION_LIST

- TransactionException.NONCE_MISMATCH_TOO_HIGH

- TransactionException.NONCE_MISMATCH_TOO_LOW

#### Reference output
<img width="1504" alt="Screenshot 2025-06-05 at 3 26 17 PM" src="https://github.com/user-attachments/assets/addad4fc-599c-4cec-b19f-41fe93ab809c" />


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/564x/ce/80/f5/ce80f5cdff3aa5ec3eb7072348d41075.jpg)
