### PR TITLE
Optimized bls12 381

### DIFF
--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
@@ -334,7 +334,9 @@ def bytes_to_g1(
     if y >= FQ.field_modulus:
         raise InvalidParameter("y >= field modulus")
 
-    z = 0 if (x == 0 and y == 0) else 1
+    z = 1
+    if x == 0 and y == 0:
+        z = 0
     point = FQ(x), FQ(y), FQ(z)
 
     if not is_on_curve(point, b):
@@ -486,7 +488,10 @@ def bytes_to_g2(
     x = bytes_to_fq2(data[:128])
     y = bytes_to_fq2(data[128:])
 
-    z = (0, 0) if x == FQ2((0, 0)) and y == FQ2((0, 0)) else (1, 0)
+    z = (1, 0)
+    if x == FQ2((0, 0)) and y == FQ2((0, 0)):
+        z = (0, 0)
+
     point = x, y, FQ2(z)
 
     # Check if the point is on the curve

--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
@@ -12,14 +12,13 @@ Introduction
 Precompile for BLS12-381 curve operations.
 """
 
-from typing import Tuple, Union
+from typing import Tuple
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.numeric import U256, Uint
 from py_ecc.optimized_bls12_381.optimized_curve import (
     FQ,
     FQ2,
-    FQP,
     b,
     b2,
     curve_order,
@@ -303,7 +302,7 @@ MULTIPLIER = Uint(1000)
 
 
 def bytes_to_g1(
-    data: bytes,
+    data: Bytes,
 ) -> Point3D[FQ]:
     """
     Decode 128 bytes to a G1 point. Does not perform sub-group check.
@@ -347,7 +346,7 @@ def bytes_to_g1(
 
 def g1_to_bytes(
     g1_point: Point3D[FQ],
-) -> bytes:
+) -> Bytes:
     """
     Encode a G1 point to 128 bytes.
 
@@ -367,7 +366,7 @@ def g1_to_bytes(
 
 
 def decode_g1_scalar_pair(
-    data: bytes,
+    data: Bytes,
 ) -> Tuple[Point3D[FQ], int]:
     """
     Decode 160 bytes to a G1 point and a scalar.
@@ -429,7 +428,7 @@ def bytes_to_fq(data: Bytes) -> FQ:
     return FQ(c)
 
 
-def bytes_to_fq2(data: Bytes) -> Union[FQ2, FQ2]:
+def bytes_to_fq2(data: Bytes) -> FQ2:
     """
     Decode 128 bytes to an FQ2 element.
 
@@ -440,7 +439,7 @@ def bytes_to_fq2(data: Bytes) -> Union[FQ2, FQ2]:
 
     Returns
     -------
-    fq2 : Union[FQ2, FQP]
+    fq2 : FQ2
         The FQ2 element.
 
     Raises
@@ -462,7 +461,7 @@ def bytes_to_fq2(data: Bytes) -> Union[FQ2, FQ2]:
 
 
 def bytes_to_g2(
-    data: bytes,
+    data: Bytes,
 ) -> Point3D[FQ2]:
     """
     Decode 256 bytes to a G2 point. Does not perform sub-group check.
@@ -501,7 +500,7 @@ def bytes_to_g2(
     return point
 
 
-def FQ2_to_bytes(fq2: Union[FQ2, FQP]) -> bytes:
+def FQ2_to_bytes(fq2: FQ2) -> Bytes:
     """
     Encode a FQ2 point to 128 bytes.
 
@@ -526,7 +525,7 @@ def FQ2_to_bytes(fq2: Union[FQ2, FQP]) -> bytes:
 
 def g2_to_bytes(
     g2_point: Point3D[FQ2],
-) -> bytes:
+) -> Bytes:
     """
     Encode a G2 point to 256 bytes.
 
@@ -545,7 +544,7 @@ def g2_to_bytes(
 
 
 def decode_g2_scalar_pair(
-    data: bytes,
+    data: Bytes,
 ) -> Tuple[Point3D[FQ2], int]:
     """
     Decode 288 bytes to a G2 point and a scalar.

--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
@@ -11,11 +11,16 @@ Introduction
 
 Implementation of pre-compiles in G2 (curve over base prime field).
 """
+
 from ethereum_types.numeric import U256, Uint
-from py_ecc.bls12_381.bls12_381_curve import add, multiply
 from py_ecc.bls.hash_to_curve import clear_cofactor_G2, map_to_curve_G2
 from py_ecc.optimized_bls12_381.optimized_curve import FQ2 as OPTIMIZED_FQ2
-from py_ecc.optimized_bls12_381.optimized_curve import normalize
+from py_ecc.optimized_bls12_381.optimized_curve import (
+    add as bls12_add_optimized,
+)
+from py_ecc.optimized_bls12_381.optimized_curve import (
+    multiply as bls12_multiply_optimized,
+)
 
 from ....vm import Evm
 from ....vm.gas import (
@@ -30,10 +35,10 @@ from . import (
     G2_K_DISCOUNT,
     G2_MAX_DISCOUNT,
     MULTIPLIER,
-    G2_to_bytes,
-    bytes_to_FQ2,
-    bytes_to_G2,
-    decode_G2_scalar_pair,
+    bytes_to_fq2,
+    bytes_to_g2,
+    decode_g2_scalar_pair,
+    g2_to_bytes,
 )
 
 LENGTH_PER_PAIR = 288
@@ -61,12 +66,12 @@ def bls12_g2_add(evm: Evm) -> None:
     charge_gas(evm, Uint(GAS_BLS_G2_ADD))
 
     # OPERATION
-    p1 = bytes_to_G2(buffer_read(data, U256(0), U256(256)))
-    p2 = bytes_to_G2(buffer_read(data, U256(256), U256(256)))
+    p1 = bytes_to_g2(buffer_read(data, U256(0), U256(256)))
+    p2 = bytes_to_g2(buffer_read(data, U256(256), U256(256)))
 
-    result = add(p1, p2)
+    result = bls12_add_optimized(p1, p2)
 
-    evm.output = G2_to_bytes(result)
+    evm.output = g2_to_bytes(result)
 
 
 def bls12_g2_msm(evm: Evm) -> None:
@@ -106,15 +111,15 @@ def bls12_g2_msm(evm: Evm) -> None:
         start_index = i * LENGTH_PER_PAIR
         end_index = start_index + LENGTH_PER_PAIR
 
-        p, m = decode_G2_scalar_pair(data[start_index:end_index])
-        product = multiply(p, m)
+        p, m = decode_g2_scalar_pair(data[start_index:end_index])
+        product = bls12_multiply_optimized(p, m)
 
         if i == 0:
             result = product
         else:
-            result = add(result, product)
+            result = bls12_add_optimized(result, product)
 
-    evm.output = G2_to_bytes(result)
+    evm.output = g2_to_bytes(result)
 
 
 def bls12_map_fp2_to_g2(evm: Evm) -> None:
@@ -139,10 +144,10 @@ def bls12_map_fp2_to_g2(evm: Evm) -> None:
     charge_gas(evm, Uint(GAS_BLS_G2_MAP))
 
     # OPERATION
-    field_element = bytes_to_FQ2(data, True)
+    field_element = bytes_to_fq2(data)
     assert isinstance(field_element, OPTIMIZED_FQ2)
 
-    g2_uncompressed = clear_cofactor_G2(map_to_curve_G2(field_element))
-    g2_normalised = normalize(g2_uncompressed)
+    fp2 = bytes_to_fq2(data)
+    g2_optimized_3d = clear_cofactor_G2(map_to_curve_G2(fp2))
 
-    evm.output = G2_to_bytes(g2_normalised)
+    evm.output = g2_to_bytes(g2_optimized_3d)

--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_g2.py
@@ -14,12 +14,10 @@ Implementation of pre-compiles in G2 (curve over base prime field).
 
 from ethereum_types.numeric import U256, Uint
 from py_ecc.bls.hash_to_curve import clear_cofactor_G2, map_to_curve_G2
-from py_ecc.optimized_bls12_381.optimized_curve import FQ2 as OPTIMIZED_FQ2
+from py_ecc.optimized_bls12_381.optimized_curve import FQ2
+from py_ecc.optimized_bls12_381.optimized_curve import add as bls12_add
 from py_ecc.optimized_bls12_381.optimized_curve import (
-    add as bls12_add_optimized,
-)
-from py_ecc.optimized_bls12_381.optimized_curve import (
-    multiply as bls12_multiply_optimized,
+    multiply as bls12_multiply,
 )
 
 from ....vm import Evm
@@ -69,7 +67,7 @@ def bls12_g2_add(evm: Evm) -> None:
     p1 = bytes_to_g2(buffer_read(data, U256(0), U256(256)))
     p2 = bytes_to_g2(buffer_read(data, U256(256), U256(256)))
 
-    result = bls12_add_optimized(p1, p2)
+    result = bls12_add(p1, p2)
 
     evm.output = g2_to_bytes(result)
 
@@ -112,12 +110,12 @@ def bls12_g2_msm(evm: Evm) -> None:
         end_index = start_index + LENGTH_PER_PAIR
 
         p, m = decode_g2_scalar_pair(data[start_index:end_index])
-        product = bls12_multiply_optimized(p, m)
+        product = bls12_multiply(p, m)
 
         if i == 0:
             result = product
         else:
-            result = bls12_add_optimized(result, product)
+            result = bls12_add(result, product)
 
     evm.output = g2_to_bytes(result)
 
@@ -145,9 +143,9 @@ def bls12_map_fp2_to_g2(evm: Evm) -> None:
 
     # OPERATION
     field_element = bytes_to_fq2(data)
-    assert isinstance(field_element, OPTIMIZED_FQ2)
+    assert isinstance(field_element, FQ2)
 
     fp2 = bytes_to_fq2(data)
-    g2_optimized_3d = clear_cofactor_G2(map_to_curve_G2(fp2))
+    g2_3d = clear_cofactor_G2(map_to_curve_G2(fp2))
 
-    evm.output = g2_to_bytes(g2_optimized_3d)
+    evm.output = g2_to_bytes(g2_3d)

--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
@@ -14,7 +14,7 @@ Implementation of the BLS12 381 pairing pre-compile.
 
 from ethereum_types.numeric import Uint
 from py_ecc.optimized_bls12_381 import FQ12, curve_order, is_inf
-from py_ecc.optimized_bls12_381 import multiply as bls12_multiply_optimized
+from py_ecc.optimized_bls12_381 import multiply as bls12_multiply
 from py_ecc.optimized_bls12_381 import pairing
 
 from ....vm import Evm
@@ -53,11 +53,11 @@ def bls12_pairing(evm: Evm) -> None:
         g2_start = Uint(384 * i + 128)
 
         g1_point = bytes_to_g1(data[g1_start : g1_start + Uint(128)])
-        if not is_inf(bls12_multiply_optimized(g1_point, curve_order)):
+        if not is_inf(bls12_multiply(g1_point, curve_order)):
             raise InvalidParameter("Sub-group check failed for G1 point.")
 
         g2_point = bytes_to_g2(data[g2_start : g2_start + Uint(256)])
-        if not is_inf(bls12_multiply_optimized(g2_point, curve_order)):
+        if not is_inf(bls12_multiply(g2_point, curve_order)):
             raise InvalidParameter("Sub-group check failed for G2 point.")
 
         result *= pairing(g2_point, g1_point)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -446,11 +446,17 @@ BLS12
 ECC
 G1
 FQ
+FQP
 Point2
+Point3D
+3d
 msm
 G2
 FQ2
 coeffs
+coord0
+coord1
+coords
 b2
 FQ12
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -448,6 +448,7 @@ G1
 FQ
 FQP
 Point2
+Point3
 Point3D
 3d
 msm


### PR DESCRIPTION
### What was wrong?

While investigating #1258 a bit, I realized that the optimized implementations in `py_ecc` avoid the `FQ.__init__()` overhead both in the `FQP.__init__()`, as well as in `FQP.__mul__() `.

Since specifically the `FQ.__init__()` seems to be where most of the time was hanging, this should help.

### How was it fixed?

I'd implemented the optimized versions of bls12_381 in `py-evm` (heavily basing it off of the EELS implementation 🙂 ) and I figured this can only help with the load. Porting it over to here and hope this is useful!

I wasn't sure how to test here, so I filled the tests successfully with `execution-spec-tests` pointing to my local branch - all tests passing.

---

Note: fwiw it looks like there's still quite a bit of unoptimized `py_ecc` code for bn128 across many forks. That may be where most of the hangup is since bls12_381 is just prague.

#### Cute Animal Picture

![20230402_124811_2](https://github.com/user-attachments/assets/af913ba8-5b5d-42eb-96e1-f31f09214e4e)
