### PR TITLE
fix: add misisng y parity check on SetCodeTransaction

### DIFF
--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -376,6 +376,8 @@ def recover_sender(chain_id: U64, tx: Transaction) -> Address:
             r, s, tx.y_parity, signing_hash_4844(tx)
         )
     elif isinstance(tx, SetCodeTransaction):
+        if tx.y_parity not in (U256(0), U256(1)):
+            raise InvalidSignatureError("bad y_parity")
         public_key = secp256k1_recover(
             r, s, tx.y_parity, signing_hash_7702(tx)
         )


### PR DESCRIPTION
### What was wrong?

Closes #1269

### How was it fixed?

Added a check on tx.y_parity for SetCodeTransaction

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://critterstop.com/nitropack_static/wuKUaxqsmqLhAYRpfOaXVBNknEpAdAKp/assets/images/optimized/rev-dda9674/critterstop.com/wp-content/uploads/2024/05/01-why-are-animals-so-cute-1024x538.webp)
