### PR TITLE
feat(osaka): add eip-7939 count leading zeros opcode

### DIFF
--- a/src/ethereum/osaka/vm/instructions/__init__.py
+++ b/src/ethereum/osaka/vm/instructions/__init__.py
@@ -65,6 +65,7 @@ class Ops(enum.Enum):
     SHL = 0x1B
     SHR = 0x1C
     SAR = 0x1D
+    CLZ = 0x1E
 
     # Keccak Op
     KECCAK = 0x20
@@ -241,6 +242,7 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.SHL: bitwise_instructions.bitwise_shl,
     Ops.SHR: bitwise_instructions.bitwise_shr,
     Ops.SAR: bitwise_instructions.bitwise_sar,
+    Ops.CLZ: bitwise_instructions.count_leading_zeros,
     Ops.KECCAK: keccak_instructions.keccak,
     Ops.SLOAD: storage_instructions.sload,
     Ops.BLOCKHASH: block_instructions.block_hash,

--- a/src/ethereum/osaka/vm/instructions/bitwise.py
+++ b/src/ethereum/osaka/vm/instructions/bitwise.py
@@ -238,3 +238,34 @@ def bitwise_sar(evm: Evm) -> None:
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
+
+
+def count_leading_zeros(evm: Evm) -> None:
+    """
+    Count the number of leading zero bits in a 256-bit word.
+    
+    Pops one value from the stack and pushes the number of leading zero bits.
+    If the input is zero, pushes 256.
+    
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+    """
+    # STACK
+    x = pop(evm.stack)
+    
+    # GAS
+    charge_gas(evm, GAS_VERY_LOW)
+    
+    # OPERATION
+    if x == 0:
+        result = U256(256)
+    else:
+        bit_length = x.bit_length()
+        result = U256(256 - bit_length)
+    
+    push(evm.stack, result)
+    
+    # PROGRAM COUNTER
+    evm.pc += Uint(1)


### PR DESCRIPTION
#### Description

Adds the CLZ (count leading zeros opcode) for [EIP-7939](https://github.com/Vectorized/EIPs/blob/a770f43b7c15e3e217c840253e6bb8025f65c9e3/EIPS/eip-7939.md).

#### Cute Animal Picture

![1269071-cute-pig-wallpapers-1920x1200-for-mac-3717821457](https://github.com/user-attachments/assets/dbbaebf3-b679-4859-9697-e08eed6c39eb)

