### PR TITLE
Re-read account code after setting 7702 delegation

### DIFF
--- a/src/ethereum/osaka/vm/eoa_delegation.py
+++ b/src/ethereum/osaka/vm/eoa_delegation.py
@@ -202,4 +202,6 @@ def set_delegation(message: Message) -> U256:
     if message.code_address is None:
         raise InvalidBlock("Invalid type 4 transaction: no target")
 
+    message.code = get_account(state, message.code_address).code
+
     return refund_counter

--- a/src/ethereum/prague/vm/eoa_delegation.py
+++ b/src/ethereum/prague/vm/eoa_delegation.py
@@ -202,4 +202,6 @@ def set_delegation(message: Message) -> U256:
     if message.code_address is None:
         raise InvalidBlock("Invalid type 4 transaction: no target")
 
+    message.code = get_account(state, message.code_address).code
+
     return refund_counter


### PR DESCRIPTION
### What was wrong?
Currently, the 7702 transaction implementation does not read the account code after delegation setting. This means, it could miss if the transaction target received a new delegation.

### How was it fixed?
Re-read the code after delegation setting

