### PR TITLE
tests: add specific exceptions on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some clarifications were enabled without protocol releases:
 | [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681) | 0 |
 | [EIP-3607](https://eips.ethereum.org/EIPS/eip-3607) | 0 |
 | [EIP-7523](https://eips.ethereum.org/EIPS/eip-7523) | 15537394 |
-| [EIP-7610](https://github.com/ethereum/EIPs/pull/8161) | 0 |
+| [EIP-7610](https://eips.ethereum.org/EIPS/eip-7610) | 0 |
 
 
 ## Execution Specification (work-in-progress)

--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -13,7 +13,11 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -254,15 +258,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -101,3 +101,9 @@ class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
     """
     The priority fee is greater than the maximum fee per gas.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -443,14 +443,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -13,9 +13,13 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
-from .exceptions import TransactionTypeError
+from .exceptions import InitCodeTooLargeError, TransactionTypeError
 from .fork_types import Address, VersionedHash
 
 TX_BASE_COST = Uint(21000)
@@ -439,7 +443,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`. It also raises an
+    `InitCodeTooLargeError` if the code size of a contract creation transaction
+    exceeds the maximum allowed size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -447,11 +455,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
-        raise InvalidTransaction("Code size too large")
+        raise InitCodeTooLargeError("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/cancun/vm/instructions/system.py
+++ b/src/ethereum/cancun/vm/instructions/system.py
@@ -72,7 +72,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -80,7 +80,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/cancun/vm/interpreter.py
+++ b/src/ethereum/cancun/vm/interpreter.py
@@ -62,6 +62,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -60,3 +60,16 @@ class GasUsedExceedsLimitError(InvalidTransaction):
     Thrown when a transaction's gas usage exceeds the gas available in the
     block.
     """
+
+
+class InsufficientTransactionGasError(InvalidTransaction):
+    """
+    Thrown when a transaction does not provide enough gas to cover its
+    intrinsic cost.
+    """
+
+
+class NonceOverflowError(InvalidTransaction):
+    """
+    Thrown when a transaction's nonce is greater than `2**64 - 2`.
+    """

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -105,15 +109,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/osaka/exceptions.py
+++ b/src/ethereum/osaka/exceptions.py
@@ -107,3 +107,19 @@ class EmptyAuthorizationListError(InvalidTransaction):
     """
     The authorization list in the transaction is empty.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """
+
+
+class TransactionGasLimitExceededError(InvalidTransaction):
+    """
+    The transaction has specified a gas limit that is greater than the allowed
+    maximum.
+
+    Note that this is _not_ the exception thrown when bytecode execution runs
+    out of gas.
+    """

--- a/src/ethereum/osaka/transactions.py
+++ b/src/ethereum/osaka/transactions.py
@@ -13,9 +13,17 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
-from .exceptions import TransactionTypeError
+from .exceptions import (
+    InitCodeTooLargeError,
+    TransactionGasLimitExceededError,
+    TransactionTypeError,
+)
 from .fork_types import Address, Authorization, VersionedHash
 
 TX_BASE_COST = Uint(21000)
@@ -536,8 +544,11 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost and the minimum calldata gas cost for the transaction after
-    validation. It throws an `InvalidTransaction` exception
-    if the transaction is invalid.
+    validation. It throws an `InsufficientTransactionGasError` exception if
+    the transaction does not provide enough gas to cover the intrinsic cost,
+    and a `NonceOverflowError` exception if the nonce is greater than
+    `2**64 - 2`. It also raises an `InitCodeTooLargeError` if the code size of
+    a contract creation transaction exceeds the maximum allowed size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
@@ -546,13 +557,13 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
     if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
-        raise InvalidTransaction("Code size too large")
+        raise InitCodeTooLargeError("Code size too large")
     if tx.gas > TX_MAX_GAS_LIMIT:
-        raise InvalidTransaction("Gas limit too high")
+        raise TransactionGasLimitExceededError("Gas limit too high")
 
     return intrinsic_gas, calldata_floor_gas_cost
 

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -107,3 +107,9 @@ class EmptyAuthorizationListError(InvalidTransaction):
     """
     The authorization list in the transaction is empty.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/prague/transactions.py
+++ b/src/ethereum/prague/transactions.py
@@ -540,14 +540,14 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
     if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas, calldata_floor_gas_cost

--- a/src/ethereum/prague/vm/instructions/system.py
+++ b/src/ethereum/prague/vm/instructions/system.py
@@ -73,7 +73,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -81,7 +81,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -64,6 +64,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass

--- a/src/ethereum/shanghai/exceptions.py
+++ b/src/ethereum/shanghai/exceptions.py
@@ -56,3 +56,9 @@ class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
     """
     The priority fee is greater than the maximum fee per gas.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -344,14 +344,14 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
-    from .vm.interpreter import MAX_CODE_SIZE
+    from .vm.interpreter import MAX_INIT_CODE_SIZE
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
         raise InvalidTransaction("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise InvalidTransaction("Nonce too high")
-    if tx.to == Bytes0(b"") and len(tx.data) > 2 * MAX_CODE_SIZE:
+    if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InvalidTransaction("Code size too large")
 
     return intrinsic_gas

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -13,9 +13,13 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
-from .exceptions import TransactionTypeError
+from .exceptions import InitCodeTooLargeError, TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = Uint(21000)
@@ -340,7 +344,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`. It also raises an
+    `InitCodeTooLargeError` if the code size of a contract creation transaction
+    exceeds the maximum allowed size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -348,11 +356,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
-        raise InvalidTransaction("Code size too large")
+        raise InitCodeTooLargeError("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/shanghai/vm/instructions/system.py
+++ b/src/ethereum/shanghai/vm/instructions/system.py
@@ -71,7 +71,7 @@ def generic_create(
     # This import causes a circular import error
     # if it's not moved inside this method
     from ...vm.interpreter import (
-        MAX_CODE_SIZE,
+        MAX_INIT_CODE_SIZE,
         STACK_DEPTH_LIMIT,
         process_create_message,
     )
@@ -79,7 +79,7 @@ def generic_create(
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
     )
-    if len(call_data) > 2 * MAX_CODE_SIZE:
+    if len(call_data) > MAX_INIT_CODE_SIZE:
         raise OutOfGasError
 
     create_message_gas = max_message_call_gas(Uint(evm.gas_left))

--- a/src/ethereum/shanghai/vm/interpreter.py
+++ b/src/ethereum/shanghai/vm/interpreter.py
@@ -62,6 +62,7 @@ from .runtime import get_valid_jump_destinations
 
 STACK_DEPTH_LIMIT = Uint(1024)
 MAX_CODE_SIZE = 0x6000
+MAX_INIT_CODE_SIZE = 2 * MAX_CODE_SIZE
 
 
 @dataclass

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.berlin.transactions import (
     LegacyTransaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -4,7 +4,7 @@ import pytest
 from ethereum_rlp import rlp
 
 from ethereum.byzantium.transactions import Transaction, validate_transaction
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.constantinople.transactions import (
     Transaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.frontier.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.homestead.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.istanbul.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.london.transactions import (
     LegacyTransaction,
     validate_transaction,
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.spurious_dragon.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.tangerine_whistle.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ethereum/execution-specs/issues/1021

### How was it fixed?

- While loading state tests - replaced `InvalidTransaction` on pytest.raises with specific exception type
- Added specific exception (`InsufficientTransactionGasError`, `NonceTooHighError` and `InitCodeTooLargeError`) for transaction validation, extending `InvalidTransaction`

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1535077516733-ad29da1026f6?q=80&w=2425&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
