### PR TITLE
feat: Process `state.reward` in T8N

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -58,6 +58,11 @@ class ForkLoad:
         return self._module("fork").HISTORY_STORAGE_ADDRESS
 
     @property
+    def BLOCK_REWARD(self) -> Any:
+        """BLOCK_REWARD of the given fork."""
+        return self._module("fork").BLOCK_REWARD
+
+    @property
     def process_general_purpose_requests(self) -> Any:
         """process_general_purpose_requests function of the given fork."""
         return self._module("fork").process_general_purpose_requests

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -266,7 +266,7 @@ class ForkLoad:
     def close_state(self) -> Any:
         """close_state function of the fork"""
         return self._module("state").close_state
-    
+
     @property
     def create_ether(self) -> Any:
         """create_ether function of the fork"""

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -261,6 +261,11 @@ class ForkLoad:
     def close_state(self) -> Any:
         """close_state function of the fork"""
         return self._module("state").close_state
+    
+    @property
+    def create_ether(self) -> Any:
+        """create_ether function of the fork"""
+        return self._module("state").create_ether
 
     @property
     def root(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 from typing import Any, TextIO
 
 from ethereum_rlp import rlp
-from ethereum_types.numeric import U256, U64, Uint
+from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum import trace
 from ethereum.exceptions import EthereumException, InvalidBlock
@@ -179,14 +179,22 @@ class T8N(Load):
     def pay_block_rewards(self, block_reward: U256, block_env: Any) -> None:
         """Apply the block rewards to the block coinbase."""
         ommer_count = U256(len(self.env.ommers))
-        miner_reward = block_reward + (ommer_count * (block_reward // U256(32)))
-        self.fork.create_ether(block_env.state, block_env.coinbase, miner_reward)
+        miner_reward = block_reward + (
+            ommer_count * (block_reward // U256(32))
+        )
+        self.fork.create_ether(
+            block_env.state, block_env.coinbase, miner_reward
+        )
 
         for ommer in self.env.ommers:
             # Ommer age with respect to the current block.
             ommer_age = U256(block_env.number - ommer.number)
-            ommer_miner_reward = ((U256(8) - ommer_age) * block_reward) // U256(8)
-            self.fork.create_ether(block_env.state, ommer.coinbase, ommer_miner_reward)
+            ommer_miner_reward = (
+                (U256(8) - ommer_age) * block_reward
+            ) // U256(8)
+            self.fork.create_ether(
+                block_env.state, ommer.coinbase, ommer_miner_reward
+            )
 
     def run_state_test(self) -> Any:
         """
@@ -243,7 +251,9 @@ class T8N(Load):
             if self.options.state_reward is None:
                 self.pay_block_rewards(self.fork.BLOCK_REWARD, block_env)
             elif self.options.state_reward != -1:
-                self.pay_block_rewards(U256(self.options.state_reward), block_env)
+                self.pay_block_rewards(
+                    U256(self.options.state_reward), block_env
+                )
 
         if self.fork.is_after_fork("ethereum.shanghai"):
             self.fork.process_withdrawals(

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -176,6 +176,18 @@ class T8N(Load):
         state = self.alloc.state
         state._main_trie, state._storage_tries = self.alloc.state_backup
 
+    def pay_block_rewards(self, block_reward: U256, block_env: Any) -> None:
+        """Apply the block rewards to the block coinbase."""
+        ommer_count = U256(len(self.env.ommers))
+        miner_reward = block_reward + (ommer_count * (block_reward // U256(32)))
+        self.fork.create_ether(block_env.state, block_env.coinbase, miner_reward)
+
+        for ommer in self.env.ommers:
+            # Ommer age with respect to the current block.
+            ommer_age = U256(block_env.number - ommer.number)
+            ommer_miner_reward = ((U256(8) - ommer_age) * block_reward) // U256(8)
+            self.fork.create_ether(block_env.state, ommer.coinbase, ommer_miner_reward)
+
     def run_state_test(self) -> Any:
         """
         Apply a single transaction on pre-state. No system operations
@@ -228,25 +240,10 @@ class T8N(Load):
                 self.logger.warning(f"Transaction {i} failed: {e!r}")
 
         if not self.fork.is_after_fork("ethereum.paris"):
-            if self.options.state_reward is not None:
-                if self.options.state_reward != -1:
-                    block_reward = U256(self.options.state_reward)
-                    ommer_count = U256(len(self.env.ommers))
-                    miner_reward = block_reward + (ommer_count * (block_reward // U256(32)))
-                    self.fork.create_ether(block_env.state, block_env.coinbase, miner_reward)
-
-                    for ommer in self.env.ommers:
-                        # Ommer age with respect to the current block.
-                        ommer_age = U256(block_env.number - ommer.number)
-                        ommer_miner_reward = ((U256(8) - ommer_age) * block_reward) // U256(8)
-                        self.fork.create_ether(block_env.state, ommer.coinbase, ommer_miner_reward)
-            elif not self.fork.is_after_fork("ethereum.paris"):
-                self.fork.pay_rewards(
-                    block_env.state,
-                    block_env.number,
-                    block_env.coinbase,
-                    self.env.ommers,
-                )
+            if self.options.state_reward is None:
+                self.pay_block_rewards(self.fork.BLOCK_REWARD, block_env)
+            elif self.options.state_reward != -1:
+                self.pay_block_rewards(U256(self.options.state_reward), block_env)
 
         if self.fork.is_after_fork("ethereum.shanghai"):
             self.fork.process_withdrawals(

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -10,7 +10,7 @@ from functools import partial
 from typing import Any, TextIO
 
 from ethereum_rlp import rlp
-from ethereum_types.numeric import U64, Uint
+from ethereum_types.numeric import U256, U64, Uint
 
 from ethereum import trace
 from ethereum.exceptions import EthereumException, InvalidBlock
@@ -64,7 +64,7 @@ def t8n_arguments(subparsers: argparse._SubParsersAction) -> None:
         "--state.fork", dest="state_fork", type=str, default="Frontier"
     )
     t8n_parser.add_argument(
-        "--state.reward", dest="state_reward", type=int, default=0
+        "--state.reward", dest="state_reward", type=int, default=None
     )
     t8n_parser.add_argument("--trace", action="store_true")
     t8n_parser.add_argument("--trace.memory", action="store_true")
@@ -228,12 +228,25 @@ class T8N(Load):
                 self.logger.warning(f"Transaction {i} failed: {e!r}")
 
         if not self.fork.is_after_fork("ethereum.paris"):
-            self.fork.pay_rewards(
-                block_env.state,
-                block_env.number,
-                block_env.coinbase,
-                self.env.ommers,
-            )
+            if self.options.state_reward is not None:
+                if self.options.state_reward != -1:
+                    block_reward = U256(self.options.state_reward)
+                    ommer_count = U256(len(self.env.ommers))
+                    miner_reward = block_reward + (ommer_count * (block_reward // U256(32)))
+                    self.fork.create_ether(block_env.state, block_env.coinbase, miner_reward)
+
+                    for ommer in self.env.ommers:
+                        # Ommer age with respect to the current block.
+                        ommer_age = U256(block_env.number - ommer.number)
+                        ommer_miner_reward = ((U256(8) - ommer_age) * block_reward) // U256(8)
+                        self.fork.create_ether(block_env.state, ommer.coinbase, ommer_miner_reward)
+            elif not self.fork.is_after_fork("ethereum.paris"):
+                self.fork.pay_rewards(
+                    block_env.state,
+                    block_env.number,
+                    block_env.coinbase,
+                    self.env.ommers,
+                )
 
         if self.fork.is_after_fork("ethereum.shanghai"):
             self.fork.process_withdrawals(


### PR DESCRIPTION
### What was wrong?

T8N was not processing the `--state.reward` modifier during the state transition.

### How was it fixed?

I copied the logic from one of the pre-merge forks, and applied it using the custom value (only if `!= -1`).

I had to expose `create_ether` to properly follow the fork logic, let me know if this is not ok.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/DdN8e7c.jpeg)
