### PR TITLE
Update EIP-7825: update tx gas limit

### DIFF
--- a/src/ethereum/osaka/transactions.py
+++ b/src/ethereum/osaka/transactions.py
@@ -55,7 +55,7 @@ TX_ACCESS_LIST_STORAGE_KEY_COST = Uint(1900)
 Gas cost for including a storage key in the access list of a transaction.
 """
 
-TX_MAX_GAS_LIMIT = Uint(30_000_000)
+TX_MAX_GAS_LIMIT = Uint(16_777_216)
 
 
 @slotted_freezable


### PR DESCRIPTION
### What was wrong?
The transaction gas limit has to be updated to `16_777_216`

Related to Issue #1315

### How was it fixed?
Update the limit

