### PR TITLE
Update EIP-7883: Change modexp gas calculation

### DIFF
--- a/src/ethereum/osaka/vm/precompiled_contracts/modexp.py
+++ b/src/ethereum/osaka/vm/precompiled_contracts/modexp.py
@@ -19,8 +19,6 @@ from ...vm.exceptions import ExceptionalHalt
 from ...vm.gas import charge_gas
 from ..memory import buffer_read
 
-GQUADDIVISOR = Uint(3)
-
 
 def modexp(evm: Evm) -> None:
     """
@@ -177,5 +175,4 @@ def gas_cost(
     multiplication_complexity = complexity(base_length, modulus_length)
     iteration_count = iterations(exponent_length, exponent_head)
     cost = multiplication_complexity * iteration_count
-    cost //= GQUADDIVISOR
     return max(Uint(500), cost)


### PR DESCRIPTION
### What was wrong?
A proposed change to EIP-7883 updates the mod exp gas calculation

Related to Issue #1316

### How was it fixed?
Update the gas calculation for the precompile
