### PR TITLE
bls12_381: Cache point generation from raw bytes

### DIFF
--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/__init__.py
@@ -302,13 +302,17 @@ G2_MAX_DISCOUNT = 524
 MULTIPLIER = Uint(1000)
 
 
+# Note: Caching as a way to optimize client performance can create a DoS
+# attack vector for worst-case inputs that trigger only cache misses. This
+# should not be relied upon for client performance optimization in
+# production systems.
 @lru_cache(maxsize=128)
 def _bytes_to_g1_cached(
     data: bytes,
     subgroup_check: bool = False,
 ) -> Point3D[FQ]:
     """
-    Internal cached version of bytes_to_g1 that works with hashable ``bytes``.
+    Internal cached version of `bytes_to_g1` that works with hashable `bytes`.
     """
     if len(data) != 128:
         raise InvalidParameter("Input should be 128 bytes long")
@@ -361,6 +365,8 @@ def bytes_to_g1(
         subgroup check fails.
 
     """
+    # This is needed bc when we slice `Bytes` we get a `bytearray`,
+    # which is not hashable
     return _bytes_to_g1_cached(bytes(data), subgroup_check)
 
 
@@ -478,13 +484,17 @@ def bytes_to_fq2(data: Bytes) -> FQ2:
     return FQ2((c_0, c_1))
 
 
+# Note: Caching as a way to optimize client performance can create a DoS
+# attack vector for worst-case inputs that trigger only cache misses. This
+# should not be relied upon for client performance optimization in
+# production systems.
 @lru_cache(maxsize=128)
 def _bytes_to_g2_cached(
     data: bytes,
     subgroup_check: bool = False,
 ) -> Point3D[FQ2]:
     """
-    Internal cached version of bytes_to_g2 that works with hashable ``bytes``.
+    Internal cached version of `bytes_to_g2` that works with hashable `bytes`.
     """
     if len(data) != 256:
         raise InvalidParameter("G2 should be 256 bytes long")
@@ -532,7 +542,9 @@ def bytes_to_g2(
         If a field element is invalid, the point is not on the curve, or the
         subgroup check fails.
     """
-    return _bytes_to_g2_cached(bytes(data), subgroup_check)
+    # This is needed bc when we slice `Bytes` we get a `bytearray`,
+    # which is not hashable
+    return _bytes_to_g2_cached(data, subgroup_check)
 
 
 def FQ2_to_bytes(fq2: FQ2) -> Bytes:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -381,6 +381,7 @@ sublist
 
 x00
 codehash
+hashable
 
 randao
 prevrandao

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -42,6 +42,7 @@ keccak
 keccak256
 keccak512
 linter
+lru
 mutable256
 mainnet
 memoize


### PR DESCRIPTION
### What was wrong?

We have some new tests in EEST that seem to hang on the subgroup check. I realized a lot of the times we are calling this costly calculation on the same point.

Related to Issues:
- #1268
- ethereum/execution-spec-tests#1894

### How was it fixed?

This PR uses a simple `lru_cache` to cache raw bytes values that we convert to G1 or G2 points, with or without the subgroup check. This should prevent us from having to re-build the same points from raw bytes over and over.

I had to do a bit of dancing around unhashable `bytearray` (`Bytes` after being sliced e.g. `var[:256]`) to use `bytes` instead for the lru cache argument but I don't think it's too bad. This runs all the g2msm tests in 9s as opposed to timing out on a single one of those 4 timeout cases after 20s. I think the biggest bottleneck was those tests are running through the entire g2msm discount table and there were a lot of inefficiencies re-calculating the same values.

#### Cute Animal Picture

![20221102_222308](https://github.com/user-attachments/assets/c33fe950-a89a-4fe7-a87d-2e3c0b9c1485)
