### PR TITLE
Remove redundant set_account call in json_to_state

### DIFF
--- a/tests/helpers/load_vm_tests.py
+++ b/tests/helpers/load_vm_tests.py
@@ -199,8 +199,6 @@ class VmTestLoader:
                     U256.from_be_bytes(hex_to_bytes32(v)),
                 )
 
-            self.set_account(state, addr, account)
-
         return state
 
     def json_to_addrs(self, raw: Any) -> List[Any]:


### PR DESCRIPTION
### What was wrong?
Fixed a performance issue in the json_to_state method by removing a redundant call to set_account. The account is already set before updating its storage, making the second call unnecessary. This change improves performance when processing large test datasets and follows the DRY principle
