### PR TITLE
chore: remove hardcoded fork reference osaka and fetch latest fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 package-dir = {"" = "src"}
 packages = [
     "ethereum_spec_tools",
+    "ethereum_spec_tools.cli",
     "ethereum_spec_tools.evm_tools",
     "ethereum_spec_tools.evm_tools.t8n",
     "ethereum_spec_tools.evm_tools.b11r",
@@ -198,6 +199,7 @@ ethereum-spec-new-fork = "ethereum_spec_tools.new_fork:main"
 ethereum-spec-patch = "ethereum_spec_tools.patch_tool:main"
 ethereum-spec-evm = "ethereum_spec_tools.evm_tools:main"
 ethereum-spec-fill = "cli.pytest_commands.fill:fill"
+ethereum-spec-forks = "ethereum_spec_tools.cli.forks:main"
 
 [project.entry-points."docc.plugins"]
 "ethereum_spec_tools.docc.discover" = "ethereum_spec_tools.docc:EthereumDiscover"

--- a/src/ethereum_spec_tools/cli/__init__.py
+++ b/src/ethereum_spec_tools/cli/__init__.py
@@ -1,0 +1,3 @@
+"""
+CLI tools for ethereum-execution-specs.
+"""

--- a/src/ethereum_spec_tools/cli/forks.py
+++ b/src/ethereum_spec_tools/cli/forks.py
@@ -1,0 +1,158 @@
+"""
+CLI tool that queries Ethereum hardfork information
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+try:
+    from ethereum_spec_tools.forks import Hardfork
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from hardfork import Hardfork
+
+
+def get_fork_by_index(forks: List[Hardfork], index: int) -> Optional[Hardfork]:
+    """
+    Get fork by index, where 0 being Frontier and -1 being the most recent.
+    """
+    if not forks:
+        return None
+    
+    if index < 0:
+        # Negative indexing: -1 is last, -2 is second last, etc.
+        if abs(index) <= len(forks):
+            return forks[index]
+        else:
+            return None
+    else:
+        # Positive indexing: 0 is first (Frontier), 1 is second, etc.
+        if index < len(forks):
+            return forks[index]
+        else:
+            return None
+
+def format_fork_info(fork: Hardfork, format_type: str) -> str:
+    """
+    Format fork information based on the requested format type.
+    """
+    if format_type == "name":
+        return fork.short_name
+    elif format_type == "title":
+        return fork.title_case_name
+    elif format_type == "full-name":
+        return fork.name
+    elif format_type == "test-name":
+        return f"test_{fork.short_name}"
+    elif format_type == "criteria":
+        return str(fork.criteria)
+    elif format_type == "consensus":
+        return fork.consensus.name.lower()
+    else:
+        return fork.short_name
+
+
+def main() -> None:
+    """
+    Main entry point for the CLI.
+    """
+    parser = argparse.ArgumentParser(
+        prog="ethereum-spec-forks",
+        description="Query Ethereum hardfork information for testing and development",
+    )
+    
+    group = parser.add_mutually_exclusive_group()
+    
+    group.add_argument(
+        "-n", "--fork-number",
+        type=int,
+        help="Fork number (0=Frontier, -1=most recent, etc.)",
+    )
+    
+    # Format options (mutually exclusive)
+    format_group = parser.add_mutually_exclusive_group()
+    
+    format_group.add_argument(
+        "--name",
+        action="store_true",
+        help="Output short name (default)",
+    )
+    
+    format_group.add_argument(
+        "--title",
+        action="store_true",
+        help="Output title case name",
+    )
+    
+    format_group.add_argument(
+        "--full-name",
+        action="store_true",
+        help="Output full module name",
+    )
+    
+    format_group.add_argument(
+        "--test-name",
+        action="store_true",
+        help="Output test name format",
+    )
+    
+    format_group.add_argument(
+        "--criteria",
+        action="store_true",
+        help="Output fork criteria",
+    )
+    
+    format_group.add_argument(
+        "--consensus",
+        action="store_true",
+        help="Output consensus type",
+    )
+    
+    # Base path option for development
+    parser.add_argument(
+        "--base-path",
+        type=Path,
+        help="Base path to ethereum module (for development)",
+    )
+    
+    args = parser.parse_args()
+    
+    try:
+        forks = Hardfork.discover(base=args.base_path)
+    except Exception as e:
+        print(f"Error discovering forks: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    if not forks:
+        print("No forks found", file=sys.stderr)
+        sys.exit(1)
+    
+    if args.fork_number is not None:
+        fork = get_fork_by_index(forks, args.fork_number)
+        if fork is None:
+            print(f"Fork index {args.fork_number} not found", file=sys.stderr)
+            sys.exit(1)
+        
+        if args.title:
+            format_type = "title"
+        elif args.full_name:
+            format_type = "full-name"
+        elif args.test_name:
+            format_type = "test-name"
+        elif args.criteria:
+            format_type = "criteria"
+        elif args.consensus:
+            format_type = "consensus"
+        else:
+            format_type = "name"
+        
+        print(format_fork_info(fork, format_type))
+        return
+    
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,8 @@ commands =
 [testenv:py3_eest]
 extras =
     test
+allowlist_externals = 
+    bash
 commands =
     fill \
         -m "not slow and not zkevm and not benchmark" \
@@ -43,17 +45,19 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --clean \
         eest_tests/execution-spec-tests/tests
-    fill \
+    bash -c 'fill \
         -m "not slow and not zkevm and not benchmark" \
         -n auto --maxprocesses 6 \
         --basetemp="{temp_dir}/pytest" \
         --clean \
-        --fork Osaka \
-        eest_tests/execution-spec-tests/tests/osaka
+        --fork "$(ethereum-spec-forks -n -1 --title)" \
+        "eest_tests/execution-spec-tests/tests/$(ethereum-spec-forks -n -1 --name)"'
 
 [testenv:pypy3]
 extras =
     test
+allowlist_externals = 
+    bash
 passenv =
     PYPY_GC_MAX
 commands =
@@ -66,7 +70,7 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --clean \
         eest_tests/execution-spec-tests/tests
-    fill \
+    bash -c 'fill \
         --tb=no \
         --show-capture=no \
         --disable-warnings \
@@ -74,8 +78,8 @@ commands =
         -n auto --maxprocesses 3 \
         --basetemp="{temp_dir}/pytest" \
         --clean \
-        --fork Osaka \
-        eest_tests/execution-spec-tests/tests/osaka
+        --fork "$(ethereum-spec-forks -n -1 --title)" \
+        "eest_tests/execution-spec-tests/tests/$(ethereum-spec-forks -n -1 --name)"'
 
 [testenv:optimized]
 extras =


### PR DESCRIPTION
### What was wrong?

Related to Issue #1330 
Hardcoded fork reference osaka was being used in `tox.ini`

### How was it fixed?
Implemented a CLI command `ethereum-spec-forks` to fetch hardfork information. Used it in `tox.ini` to fetch the latest fork.

Closes #1330 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2024/05/22/21/51/dog-8781844_1280.jpg)
