### PR TITLE
(hotfix) New exception types

### DIFF
--- a/src/ethereum/berlin/transactions.py
+++ b/src/ethereum/berlin/transactions.py
@@ -13,7 +13,11 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .exceptions import TransactionTypeError
 from .fork_types import Address
@@ -254,15 +258,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/byzantium/transactions.py
+++ b/src/ethereum/byzantium/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/cancun/exceptions.py
+++ b/src/ethereum/cancun/exceptions.py
@@ -101,3 +101,9 @@ class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
     """
     The priority fee is greater than the maximum fee per gas.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/cancun/transactions.py
+++ b/src/ethereum/cancun/transactions.py
@@ -13,9 +13,13 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
-from .exceptions import TransactionTypeError
+from .exceptions import InitCodeTooLargeError, TransactionTypeError
 from .fork_types import Address, VersionedHash
 
 TX_BASE_COST = Uint(21000)
@@ -439,7 +443,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`. It also raises an
+    `InitCodeTooLargeError` if the code size of a contract creation transaction
+    exceeds the maximum allowed size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -447,11 +455,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
-        raise InvalidTransaction("Code size too large")
+        raise InitCodeTooLargeError("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/constantinople/transactions.py
+++ b/src/ethereum/constantinople/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/dao_fork/transactions.py
+++ b/src/ethereum/dao_fork/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/exceptions.py
+++ b/src/ethereum/exceptions.py
@@ -60,3 +60,16 @@ class GasUsedExceedsLimitError(InvalidTransaction):
     Thrown when a transaction's gas usage exceeds the gas available in the
     block.
     """
+
+
+class InsufficientTransactionGasError(InvalidTransaction):
+    """
+    Thrown when a transaction does not provide enough gas to cover its
+    intrinsic cost.
+    """
+
+
+class NonceOverflowError(InvalidTransaction):
+    """
+    Thrown when a transaction's nonce is greater than `2**64 - 2`.
+    """

--- a/src/ethereum/frontier/transactions.py
+++ b/src/ethereum/frontier/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -105,15 +109,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/homestead/transactions.py
+++ b/src/ethereum/homestead/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/istanbul/transactions.py
+++ b/src/ethereum/istanbul/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/muir_glacier/transactions.py
+++ b/src/ethereum/muir_glacier/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/prague/exceptions.py
+++ b/src/ethereum/prague/exceptions.py
@@ -107,3 +107,9 @@ class EmptyAuthorizationListError(InvalidTransaction):
     """
     The authorization list in the transaction is empty.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/shanghai/exceptions.py
+++ b/src/ethereum/shanghai/exceptions.py
@@ -56,3 +56,9 @@ class PriorityFeeGreaterThanMaxFeeError(InvalidTransaction):
     """
     The priority fee is greater than the maximum fee per gas.
     """
+
+
+class InitCodeTooLargeError(InvalidTransaction):
+    """
+    The init code of the transaction is too large.
+    """

--- a/src/ethereum/shanghai/transactions.py
+++ b/src/ethereum/shanghai/transactions.py
@@ -13,9 +13,13 @@ from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
-from .exceptions import TransactionTypeError
+from .exceptions import InitCodeTooLargeError, TransactionTypeError
 from .fork_types import Address
 
 TX_BASE_COST = Uint(21000)
@@ -340,7 +344,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`. It also raises an
+    `InitCodeTooLargeError` if the code size of a contract creation transaction
+    exceeds the maximum allowed size.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
@@ -348,11 +356,11 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
-        raise InvalidTransaction("Code size too large")
+        raise InitCodeTooLargeError("Code size too large")
 
     return intrinsic_gas
 

--- a/src/ethereum/spurious_dragon/transactions.py
+++ b/src/ethereum/spurious_dragon/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/src/ethereum/tangerine_whistle/transactions.py
+++ b/src/ethereum/tangerine_whistle/transactions.py
@@ -12,7 +12,11 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
-from ethereum.exceptions import InvalidSignatureError, InvalidTransaction
+from ethereum.exceptions import (
+    InsufficientTransactionGasError,
+    InvalidSignatureError,
+    NonceOverflowError,
+)
 
 from .fork_types import Address
 
@@ -110,15 +114,17 @@ def validate_transaction(tx: Transaction) -> Uint:
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction after validation. It throws an
-    `InvalidTransaction` exception if the transaction is invalid.
+    `InsufficientTransactionGasError` exception if the transaction does not
+    provide enough gas to cover the intrinsic cost, and a `NonceOverflowError`
+    exception if the nonce is greater than `2**64 - 2`.
 
     [EIP-2681]: https://eips.ethereum.org/EIPS/eip-2681
     """
     intrinsic_gas = calculate_intrinsic_cost(tx)
     if intrinsic_gas > tx.gas:
-        raise InvalidTransaction("Insufficient gas")
+        raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
-        raise InvalidTransaction("Nonce too high")
+        raise NonceOverflowError("Nonce too high")
     return intrinsic_gas
 
 

--- a/tests/berlin/test_transaction.py
+++ b/tests/berlin/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.berlin.transactions import (
     LegacyTransaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/byzantium/test_transaction.py
+++ b/tests/byzantium/test_transaction.py
@@ -4,7 +4,7 @@ import pytest
 from ethereum_rlp import rlp
 
 from ethereum.byzantium.transactions import Transaction, validate_transaction
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/constantinople/test_transaction.py
+++ b/tests/constantinople/test_transaction.py
@@ -7,7 +7,7 @@ from ethereum.constantinople.transactions import (
     Transaction,
     validate_transaction,
 )
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
 
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/frontier/test_transaction.py
+++ b/tests/frontier/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.frontier.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/homestead/test_transaction.py
+++ b/tests/homestead/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.homestead.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -32,7 +32,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/istanbul/test_transaction.py
+++ b/tests/istanbul/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.istanbul.transactions import Transaction, validate_transaction
 from ethereum.utils.hexadecimal import hex_to_uint
 from tests.helpers import TEST_FIXTURES
@@ -30,7 +30,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/london/test_transaction.py
+++ b/tests/london/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.london.transactions import (
     LegacyTransaction,
     validate_transaction,
@@ -33,7 +33,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(LegacyTransaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/spurious_dragon/test_transaction.py
+++ b/tests/spurious_dragon/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.spurious_dragon.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 

--- a/tests/tangerine_whistle/test_transaction.py
+++ b/tests/tangerine_whistle/test_transaction.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 from ethereum_rlp import rlp
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import NonceOverflowError
 from ethereum.tangerine_whistle.transactions import (
     Transaction,
     validate_transaction,
@@ -35,7 +35,7 @@ def test_high_nonce(test_file_high_nonce: str) -> None:
 
     tx = rlp.decode_to(Transaction, test["tx_rlp"])
 
-    with pytest.raises(InvalidTransaction):
+    with pytest.raises(NonceOverflowError):
         validate_transaction(tx)
 
 


### PR DESCRIPTION
### What was wrong?

We are missing some specific exception types in master that would be useful to have there before we merge forks/osaka in during release. This set of changes are not identical to the changes in the PR it was cannibalized from, as that included adding those exception types in `forks/osaka` folders that do not yet exist in master.

Because we want these exception types in master now, but do not want to re-write commit history for the default branch, we are making this PR which adds all of the historical fork exception types without including code for which there is no folder yet. 

:warning:  Therefore, this is a **temporary** addition to master, which will need to be removed before merging `forks/osaka` back into master during the next release. :warning: 

Related to Issue #1021

Cannibalized from PR #1286 

### How was it fixed?


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/7189/6774773288_147e34f489_b.jpg)

“<a href="https://www.flickr.com/photos/andreaskay/6774773288" title="[Glasswing Butterfly](https://www.flickr.com/photos/andreaskay/6774773288)">Glasswing Butterfly</a>” by <a href="https://www.flickr.com/photos/andreaskay/">[Andreas Kay](https://www.flickr.com/photos/andreaskay/)</a>, <a href="https://creativecommons.org/licenses/by-nc-sa/2.0/deed.en" rel="license noopener noreferrer">[CC BY-NC-SA 2.0](https://creativecommons.org/licenses/by-nc-sa/2.0/deed.en)</a>
