### PR TITLE
Fix typing between bytes and bytearray

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ namespace_packages = True
 strict_optional = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
+strict_bytes = True
 
 warn_unused_ignores = True
 warn_unused_configs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,7 +127,7 @@ install_requires =
     coincurve>=20,<21
     typing_extensions>=4.4
     py-ecc>=8.0.0b2,<9
-    ethereum-types>=0.2.1,<0.3
+    ethereum-types>=0.2.4,<0.3
     ethereum-rlp>=0.1.4,<0.2
 
 [options.package_data]
@@ -176,7 +176,7 @@ test =
 lint =
     types-setuptools>=68.1.0.1,<69
     isort==5.13.2
-    mypy==1.14.1
+    mypy==1.17.0
     black==23.12.0
     flake8==6.1.0
     flake8-bugbear==23.12.2

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/arrow_glacier/utils/address.py
+++ b/src/ethereum/arrow_glacier/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this arrow_glacier version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/arrow_glacier/vm/memory.py
+++ b/src/ethereum/arrow_glacier/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/berlin/utils/address.py
+++ b/src/ethereum/berlin/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this berlin version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/berlin/vm/memory.py
+++ b/src/ethereum/berlin/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -41,7 +41,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/byzantium/vm/memory.py
+++ b/src/ethereum/byzantium/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/cancun/fork_types.py
+++ b/src/ethereum/cancun/fork_types.py
@@ -43,7 +43,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/cancun/utils/address.py
+++ b/src/ethereum/cancun/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this cancun version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/cancun/vm/memory.py
+++ b/src/ethereum/cancun/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/constantinople/utils/address.py
+++ b/src/ethereum/constantinople/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this constantinople version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/constantinople/vm/memory.py
+++ b/src/ethereum/constantinople/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -19,7 +19,7 @@ Hash32 = Bytes32
 Hash64 = Bytes64
 
 
-def keccak256(buffer: Bytes) -> Hash32:
+def keccak256(buffer: Bytes | bytearray) -> Hash32:
     """
     Computes the keccak256 hash of the input `buffer`.
 
@@ -37,7 +37,7 @@ def keccak256(buffer: Bytes) -> Hash32:
     return Hash32(k.update(buffer).digest())
 
 
-def keccak512(buffer: Bytes) -> Hash64:
+def keccak512(buffer: Bytes | bytearray) -> Hash64:
     """
     Computes the keccak512 hash of the input `buffer`.
 

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/dao_fork/vm/memory.py
+++ b/src/ethereum/dao_fork/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/gray_glacier/utils/address.py
+++ b/src/ethereum/gray_glacier/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this gray_glacier version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/gray_glacier/vm/memory.py
+++ b/src/ethereum/gray_glacier/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/homestead/vm/memory.py
+++ b/src/ethereum/homestead/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/istanbul/utils/address.py
+++ b/src/ethereum/istanbul/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this istanbul version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/istanbul/vm/memory.py
+++ b/src/ethereum/istanbul/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/london/utils/address.py
+++ b/src/ethereum/london/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this london version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/london/vm/memory.py
+++ b/src/ethereum/london/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/muir_glacier/utils/address.py
+++ b/src/ethereum/muir_glacier/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this muir_glacier version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/muir_glacier/vm/memory.py
+++ b/src/ethereum/muir_glacier/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/paris/utils/address.py
+++ b/src/ethereum/paris/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this paris version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/paris/vm/memory.py
+++ b/src/ethereum/paris/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/prague/fork_types.py
+++ b/src/ethereum/prague/fork_types.py
@@ -43,7 +43,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/prague/utils/address.py
+++ b/src/ethereum/prague/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this prague version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/prague/vm/memory.py
+++ b/src/ethereum/prague/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
@@ -76,6 +76,5 @@ def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:
     data_bytes :
         Data read from memory.
     """
-    return right_pad_zero_bytes(
-        buffer[start_position : Uint(start_position) + Uint(size)], size
-    )
+    buffer_slice = buffer[start_position : Uint(start_position) + Uint(size)]
+    return right_pad_zero_bytes(bytes(buffer_slice), size)

--- a/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
+++ b/src/ethereum/prague/vm/precompiled_contracts/bls12_381/bls12_381_pairing.py
@@ -52,11 +52,13 @@ def bls12_pairing(evm: Evm) -> None:
         g1_start = Uint(384 * i)
         g2_start = Uint(384 * i + 128)
 
-        g1_point = bytes_to_g1(data[g1_start : g1_start + Uint(128)])
+        g1_slice = data[g1_start : g1_start + Uint(128)]
+        g1_point = bytes_to_g1(bytes(g1_slice))
         if not is_inf(bls12_multiply(g1_point, curve_order)):
             raise InvalidParameter("Sub-group check failed for G1 point.")
 
-        g2_point = bytes_to_g2(data[g2_start : g2_start + Uint(256)])
+        g2_slice = data[g2_start : g2_start + Uint(256)]
+        g2_point = bytes_to_g2(bytes(g2_slice))
         if not is_inf(bls12_multiply(g2_point, curve_order)):
             raise InvalidParameter("Sub-group check failed for G2 point.")
 

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/shanghai/utils/address.py
+++ b/src/ethereum/shanghai/utils/address.py
@@ -13,7 +13,7 @@ Address specific functions used in this shanghai version of
 specification.
 """
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes32
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
@@ -63,7 +63,7 @@ def compute_contract_address(address: Address, nonce: Uint) -> Address:
 
 
 def compute_create2_contract_address(
-    address: Address, salt: Bytes32, call_data: bytearray
+    address: Address, salt: Bytes32, call_data: Bytes
 ) -> Address:
     """
     Computes address of the new account that needs to be created, which is

--- a/src/ethereum/shanghai/vm/memory.py
+++ b/src/ethereum/shanghai/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/spurious_dragon/vm/memory.py
+++ b/src/ethereum/spurious_dragon/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -42,7 +42,7 @@ class Account:
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
-    code=bytearray(),
+    code=b"",
 )
 
 

--- a/src/ethereum/tangerine_whistle/vm/memory.py
+++ b/src/ethereum/tangerine_whistle/vm/memory.py
@@ -37,7 +37,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: U256, size: U256
-) -> bytearray:
+) -> Bytes:
     """
     Read bytes from memory.
 
@@ -55,7 +55,7 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return memory[start_position : Uint(start_position) + Uint(size)]
+    return Bytes(memory[start_position : Uint(start_position) + Uint(size)])
 
 
 def buffer_read(buffer: Bytes, start_position: U256, size: U256) -> Bytes:


### PR DESCRIPTION
### What was wrong?

In rebasing `forks/osaka` on `master`, we ran into an issue where a `bytearray` was being used as a key in a dictionary. This isn't allowed because `bytearray` isn't hashable.

### How was it fixed?


Newer versions of mypy have a check for this, so this PR enables that flag and fixes any issues it uncovered.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/73855d12-631a-4abb-a14d-36c3567f7e1b.jpeg?format=webp)
