### PR TITLE
Fix: Redundant `destroy_storage` call within `process_create_message`

### DIFF
--- a/src/ethereum/prague/vm/interpreter.py
+++ b/src/ethereum/prague/vm/interpreter.py
@@ -177,18 +177,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)


### PR DESCRIPTION
### What was wrong?

Related to Issue #1347 

### How was it fixed?

Removed the `destroy_storage` call within `process_create_message`.

#### Cute Animal Picture

![Baby serval](https://img.buzzfeed.com/buzzfeed-static/static/2023-03/7/20/asset/79e51aa4b8af/sub-buzz-670-1678220113-3.jpg?downsize=700%3A%2A&output-quality=auto&output-format=auto)
