### PR TITLE
Implement EIP-7805

### DIFF
--- a/src/ethereum/osaka/vm/__init__.py
+++ b/src/ethereum/osaka/vm/__init__.py
@@ -74,6 +74,8 @@ class BlockOutput:
         Total blob gas used in the block.
     requests : `Bytes`
         Hash of all the requests in the block.
+    is_inclusion_list_satisfied : `bool`
+        Whether the block satisfies the inclusion list constraints.
     """
 
     block_gas_used: Uint = Uint(0)
@@ -90,6 +92,7 @@ class BlockOutput:
     )
     blob_gas_used: U64 = U64(0)
     requests: List[Bytes] = field(default_factory=list)
+    is_inclusion_list_satisfied: bool = True
 
 
 @dataclass

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -153,6 +153,11 @@ class ForkLoad:
         return self._module("fork").process_transaction
 
     @property
+    def validate_inclusion_list_transactions(self) -> Any:
+        """validate_inclusion_list_transactions function of the fork"""
+        return self._module("fork").validate_inclusion_list_transactions
+
+    @property
     def MAX_BLOB_GAS_PER_BLOCK(self) -> Any:
         """MAX_BLOB_GAS_PER_BLOCK parameter of the fork"""
         return self._module("fork").MAX_BLOB_GAS_PER_BLOCK

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -255,6 +255,14 @@ class T8N(Load):
                     U256(self.options.state_reward), block_env
                 )
 
+        if self.fork.is_after_fork("ethereum.osaka"):
+            self.fork.validate_inclusion_list_transactions(
+                block_env,
+                block_output,
+                self.txs.transactions,
+                self.env.inclusion_list_transactions,
+            )
+
         if self.fork.is_after_fork("ethereum.shanghai"):
             self.fork.process_withdrawals(
                 block_env, block_output, self.env.withdrawals

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -268,6 +268,7 @@ class Result:
     requests_hash: Optional[Hash32] = None
     requests: Optional[List[Bytes]] = None
     block_exception: Optional[str] = None
+    is_inclusion_list_satisfied: Optional[bool] = None
 
     def get_receipts_from_output(
         self,
@@ -322,6 +323,11 @@ class Result:
         if hasattr(block_output, "requests"):
             self.requests = block_output.requests
             self.requests_hash = t8n.fork.compute_requests_hash(self.requests)
+
+        if hasattr(block_output, "is_inclusion_list_satisfied"):
+            self.is_inclusion_list_satisfied = (
+                block_output.is_inclusion_list_satisfied
+            )
 
     def json_encode_receipts(self) -> Any:
         """
@@ -389,5 +395,8 @@ class Result:
 
         if self.block_exception is not None:
             data["blockException"] = self.block_exception
+
+        if self.is_inclusion_list_satisfied is not None:
+            data["isInclusionListSatisfied"] = self.is_inclusion_list_satisfied
 
         return data


### PR DESCRIPTION
### What was wrong?

This PR implements EIP-7805.

### How was it fixed?

When testing IL validation, we would only need to modify blockchain tests. Hence, t8n's [`run_blockchain_test()`](https://github.com/ethereum/execution-specs/blob/forks/osaka/src/ethereum_spec_tools/evm_tools/t8n/__init__.py#L266) has been updated to validate IL constraints while [`run_state_test()`](https://github.com/ethereum/execution-specs/blob/forks/osaka/src/ethereum_spec_tools/evm_tools/t8n/__init__.py#L199) remains unchanged.

Meanwhile, [`add_block_to_chain()`](https://github.com/ethereum/execution-specs/blob/5a49b2f39a909be6a8c84bb70611febdc2b2fd98/tests/helpers/load_state_tests.py#L100), which runs `state_transition`, effectively performs no-ops for IL validation. It seems it doesn’t differentiate behavior based on the fork, so the modified `state_transition` receives an empty Tuple by default for simplicity.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://a-z-animals.com/media/2021/08/Pembroke-Welsh-Corgi-Leaping-in-the-Field.jpg)
