### PR TITLE
Remove tracing pollution from spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ packages = [
     "ethereum_spec_tools",
     "ethereum_spec_tools.evm_tools",
     "ethereum_spec_tools.evm_tools.t8n",
+    "ethereum_spec_tools.evm_tools.t8n.evm_trace",
     "ethereum_spec_tools.evm_tools.b11r",
     "ethereum_spec_tools.evm_tools.statetest",
     "ethereum_spec_tools.evm_tools.loaders",

--- a/src/ethereum/arrow_glacier/fork.py
+++ b/src/ethereum/arrow_glacier/fork.py
@@ -771,7 +771,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/arrow_glacier/vm/__init__.py
@@ -93,7 +93,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/berlin/fork.py
+++ b/src/ethereum/berlin/fork.py
@@ -658,7 +658,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/berlin/vm/__init__.py
+++ b/src/ethereum/berlin/vm/__init__.py
@@ -92,7 +92,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/byzantium/fork.py
+++ b/src/ethereum/byzantium/fork.py
@@ -635,7 +635,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/byzantium/vm/__init__.py
+++ b/src/ethereum/byzantium/vm/__init__.py
@@ -90,7 +90,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/cancun/fork.py
+++ b/src/ethereum/cancun/fork.py
@@ -563,7 +563,6 @@ def process_system_transaction(
         blob_versioned_hashes=(),
         index_in_block=None,
         tx_hash=None,
-        traces=[],
     )
 
     system_tx_message = Message(
@@ -755,7 +754,6 @@ def process_transaction(
         blob_versioned_hashes=blob_versioned_hashes,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/cancun/vm/__init__.py
+++ b/src/ethereum/cancun/vm/__init__.py
@@ -104,7 +104,6 @@ class TransactionEnvironment:
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/constantinople/fork.py
+++ b/src/ethereum/constantinople/fork.py
@@ -635,7 +635,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/constantinople/vm/__init__.py
+++ b/src/ethereum/constantinople/vm/__init__.py
@@ -90,7 +90,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/dao_fork/fork.py
+++ b/src/ethereum/dao_fork/fork.py
@@ -647,7 +647,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/dao_fork/vm/__init__.py
+++ b/src/ethereum/dao_fork/vm/__init__.py
@@ -89,7 +89,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -630,7 +630,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -89,7 +89,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/gray_glacier/fork.py
+++ b/src/ethereum/gray_glacier/fork.py
@@ -771,7 +771,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/gray_glacier/vm/__init__.py
+++ b/src/ethereum/gray_glacier/vm/__init__.py
@@ -93,7 +93,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/homestead/fork.py
+++ b/src/ethereum/homestead/fork.py
@@ -630,7 +630,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/homestead/vm/__init__.py
+++ b/src/ethereum/homestead/vm/__init__.py
@@ -89,7 +89,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/istanbul/fork.py
+++ b/src/ethereum/istanbul/fork.py
@@ -635,7 +635,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/istanbul/vm/__init__.py
+++ b/src/ethereum/istanbul/vm/__init__.py
@@ -90,7 +90,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/london/fork.py
+++ b/src/ethereum/london/fork.py
@@ -777,7 +777,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/london/vm/__init__.py
+++ b/src/ethereum/london/vm/__init__.py
@@ -93,7 +93,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/muir_glacier/fork.py
+++ b/src/ethereum/muir_glacier/fork.py
@@ -637,7 +637,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/muir_glacier/vm/__init__.py
+++ b/src/ethereum/muir_glacier/vm/__init__.py
@@ -90,7 +90,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/osaka/fork.py
+++ b/src/ethereum/osaka/fork.py
@@ -616,7 +616,6 @@ def process_system_transaction(
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
-        traces=[],
     )
 
     system_tx_message = Message(
@@ -922,7 +921,6 @@ def process_transaction(
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/osaka/vm/__init__.py
+++ b/src/ethereum/osaka/vm/__init__.py
@@ -108,7 +108,6 @@ class TransactionEnvironment:
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/paris/fork.py
+++ b/src/ethereum/paris/fork.py
@@ -549,7 +549,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/paris/vm/__init__.py
+++ b/src/ethereum/paris/vm/__init__.py
@@ -92,7 +92,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/prague/fork.py
+++ b/src/ethereum/prague/fork.py
@@ -601,7 +601,6 @@ def process_system_transaction(
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
-        traces=[],
     )
 
     system_tx_message = Message(
@@ -907,7 +906,6 @@ def process_transaction(
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/prague/vm/__init__.py
+++ b/src/ethereum/prague/vm/__init__.py
@@ -108,7 +108,6 @@ class TransactionEnvironment:
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -562,7 +562,6 @@ def process_transaction(
         access_list_storage_keys=access_list_storage_keys,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/shanghai/vm/__init__.py
+++ b/src/ethereum/shanghai/vm/__init__.py
@@ -97,7 +97,6 @@ class TransactionEnvironment:
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/spurious_dragon/fork.py
+++ b/src/ethereum/spurious_dragon/fork.py
@@ -631,7 +631,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/spurious_dragon/vm/__init__.py
@@ -90,7 +90,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/tangerine_whistle/fork.py
+++ b/src/ethereum/tangerine_whistle/fork.py
@@ -629,7 +629,6 @@ def process_transaction(
         gas=gas,
         index_in_block=index,
         tx_hash=get_transaction_hash(tx),
-        traces=[],
     )
 
     message = prepare_message(block_env, tx_env, tx)

--- a/src/ethereum/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/tangerine_whistle/vm/__init__.py
@@ -89,7 +89,6 @@ class TransactionEnvironment:
     gas: Uint
     index_in_block: Uint
     tx_hash: Optional[Hash32]
-    traces: List[dict]
 
 
 @dataclass

--- a/src/ethereum/trace.py
+++ b/src/ethereum/trace.py
@@ -172,9 +172,6 @@ All possible types of events that an [`EvmTracer`] is expected to handle.
 def discard_evm_trace(
     evm: object,  # noqa: U100
     event: TraceEvent,  # noqa: U100
-    trace_memory: bool = False,  # noqa: U100
-    trace_stack: bool = True,  # noqa: U100
-    trace_return_data: bool = False,  # noqa: U100
 ) -> None:
     """
     An [`EvmTracer`] that discards all events.
@@ -199,10 +196,6 @@ class EvmTracer(Protocol):
         self,
         evm: object,
         event: TraceEvent,
-        /,
-        trace_memory: bool = False,  # noqa: U100
-        trace_stack: bool = True,  # noqa: U100
-        trace_return_data: bool = False,  # noqa: U100
     ) -> None:
         """
         Call `self` as a function, recording a trace event.
@@ -211,13 +204,6 @@ class EvmTracer(Protocol):
         like [`ethereum.frontier.vm.Evm`][evm].
 
         `event`, a [`TraceEvent`], is the reason why the tracer was triggered.
-
-        `trace_memory` requests a full memory dump in the resulting trace.
-
-        `trace_stack` requests the full stack in the resulting trace.
-
-        `trace_return_data` requests that return data be included in the
-        resulting trace.
 
         See [`discard_evm_trace`] for an example function implementing this
         protocol.
@@ -251,10 +237,6 @@ def set_evm_trace(tracer: EvmTracer) -> EvmTracer:
 def evm_trace(
     evm: object,
     event: TraceEvent,
-    /,
-    trace_memory: bool = False,
-    trace_stack: bool = True,
-    trace_return_data: bool = False,
 ) -> None:
     """
     Emit a trace to the active [`EvmTracer`].
@@ -265,7 +247,4 @@ def evm_trace(
     _evm_trace(
         evm,
         event,
-        trace_memory=trace_memory,
-        trace_stack=trace_stack,
-        trace_return_data=trace_return_data,
     )

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -25,7 +25,7 @@ from ..utils import (
     parse_hex_or_int,
 )
 from .env import Env
-from .evm_trace import evm_trace
+from .evm_trace.eip3155 import evm_trace
 from .t8n_types import Alloc, Result, Txs
 
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -6,7 +6,6 @@ import argparse
 import fnmatch
 import json
 import os
-from functools import partial
 from typing import Any, TextIO
 
 from ethereum_rlp import rlp
@@ -25,7 +24,7 @@ from ..utils import (
     parse_hex_or_int,
 )
 from .env import Env
-from .evm_trace.eip3155 import evm_trace
+from .evm_trace.eip3155 import Eip3155Tracer
 from .t8n_types import Alloc, Result, Txs
 
 
@@ -106,8 +105,7 @@ class T8N(Load):
             trace_stack = not getattr(self.options, "trace.nostack", False)
             trace_return_data = getattr(self.options, "trace.returndata")
             trace.set_evm_trace(
-                partial(
-                    evm_trace,
+                Eip3155Tracer(
                     trace_memory=trace_memory,
                     trace_stack=trace_stack,
                     trace_return_data=trace_return_data,

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/__init__.py
@@ -1,0 +1,5 @@
+"""
+EVM Trace Implementations.
+
+See [`ethereum.trace`](ref:ethereum.trace).
+"""

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
@@ -6,11 +6,12 @@ import json
 import os
 from contextlib import ExitStack
 from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, List, Optional, TextIO, TypeAlias, Union
+from typing import Any, List, Optional, TextIO, Union
 
 from ethereum.exceptions import EthereumException
 from ethereum.trace import (
     EvmStop,
+    EvmTracer,
     GasAndRefund,
     OpEnd,
     OpException,
@@ -69,147 +70,90 @@ class FinalTrace:
             self.error = type(error).__name__
 
 
-_ActiveTraces: TypeAlias = tuple[
-    TransactionEnvironment, list[Trace | FinalTrace]
-]
-_active_traces: _ActiveTraces | None = None
-
-
-def evm_trace(
-    evm: Any,
-    event: TraceEvent,
-    trace_memory: bool = False,
-    trace_stack: bool = True,
-    trace_return_data: bool = False,
-    output_basedir: str | TextIO = ".",
-) -> None:
+class Eip3155Tracer(EvmTracer):
     """
-    Create a trace of the event.
+    EVM trace implementation compatible with EIP-3155.
     """
-    global _active_traces
 
-    # System Transaction do not have a tx_hash or index
-    if (
-        evm.message.tx_env.index_in_block is None
-        or evm.message.tx_env.tx_hash is None
+    transaction_environment: TransactionEnvironment | None
+    active_traces: list[Trace | FinalTrace]
+    trace_memory: bool
+    trace_stack: bool
+    trace_return_data: bool
+    output_basedir: str | TextIO
+
+    def __init__(
+        self,
+        /,
+        trace_memory: bool = False,
+        trace_stack: bool = True,
+        trace_return_data: bool = False,
+        output_basedir: str | TextIO = ".",
     ):
-        return
+        self.transaction_environment = None
+        self.active_traces = []
+        self.trace_memory = trace_memory
+        self.trace_stack = trace_stack
+        self.trace_return_data = trace_return_data
+        self.output_basedir = output_basedir
 
-    assert isinstance(evm, Evm)
-
-    if _active_traces and _active_traces[0] is evm.message.tx_env:
-        traces = _active_traces[1]
-    else:
-        traces = []
-        _active_traces = (evm.message.tx_env, traces)
-
-    last_trace = None
-    if traces:
-        last_trace = traces[-1]
-
-    refund_counter = evm.refund_counter
-    parent_evm = evm.message.parent_evm
-    while parent_evm is not None:
-        refund_counter += parent_evm.refund_counter
-        parent_evm = parent_evm.message.parent_evm
-
-    len_memory = len(evm.memory)
-
-    return_data = None
-    if isinstance(evm, EvmWithReturnData) and trace_return_data:
-        return_data = "0x" + evm.return_data.hex()
-
-    memory = None
-    if trace_memory and len_memory > 0:
-        memory = "0x" + evm.memory.hex()
-
-    stack = None
-    if trace_stack:
-        stack = [hex(i) for i in evm.stack]
-
-    if isinstance(event, TransactionStart):
-        pass
-    elif isinstance(event, TransactionEnd):
-        final_trace = FinalTrace(event.gas_used, event.output, event.error)
-        traces.append(final_trace)
-
-        output_traces(
-            traces,
-            evm.message.tx_env.index_in_block,
-            evm.message.tx_env.tx_hash,
-            output_basedir,
-        )
-    elif isinstance(event, PrecompileStart):
-        new_trace = Trace(
-            pc=int(evm.pc),
-            op="0x" + event.address.hex().lstrip("0"),
-            gas=hex(evm.gas_left),
-            gasCost="0x0",
-            memory=memory,
-            memSize=len_memory,
-            stack=stack,
-            returnData=return_data,
-            depth=int(evm.message.depth) + 1,
-            refund=refund_counter,
-            opName="0x" + event.address.hex().lstrip("0"),
-            precompile=True,
-        )
-
-        traces.append(new_trace)
-    elif isinstance(event, PrecompileEnd):
-        assert isinstance(last_trace, Trace)
-
-        last_trace.gasCostTraced = True
-        last_trace.errorTraced = True
-    elif isinstance(event, OpStart):
-        op = event.op.value
-        if op == "InvalidOpcode":
-            op = "Invalid"
-        new_trace = Trace(
-            pc=int(evm.pc),
-            op=op,
-            gas=hex(evm.gas_left),
-            gasCost="0x0",
-            memory=memory,
-            memSize=len_memory,
-            stack=stack,
-            returnData=return_data,
-            depth=int(evm.message.depth) + 1,
-            refund=refund_counter,
-            opName=str(event.op).split(".")[-1],
-        )
-
-        traces.append(new_trace)
-    elif isinstance(event, OpEnd):
-        assert isinstance(last_trace, Trace)
-
-        last_trace.gasCostTraced = True
-        last_trace.errorTraced = True
-    elif isinstance(event, OpException):
-        if last_trace is not None:
-            assert isinstance(last_trace, Trace)
+    def __call__(self, evm: Any, event: TraceEvent) -> None:
+        """
+        Create a trace of the event.
+        """
+        # System Transaction do not have a tx_hash or index
         if (
-            # The first opcode in the code is an InvalidOpcode.
-            # So we add a new trace with InvalidOpcode as op.
-            not last_trace
-            # The current opcode is an InvalidOpcode. This condition
-            # is true if an InvalidOpcode is found in any location
-            # other than the first opcode.
-            or last_trace.errorTraced
-            # The first opcode in a child message is an InvalidOpcode.
-            # This case has to be explicitly handled since the first
-            # two conditions do not cover it.
-            or last_trace.depth == evm.message.depth
+            evm.message.tx_env.index_in_block is None
+            or evm.message.tx_env.tx_hash is None
         ):
-            if not hasattr(event.error, "code"):
-                name = event.error.__class__.__name__
-                raise TypeError(
-                    f"OpException event error type `{name}` does not have code"
-                ) from event.error
+            return
 
+        assert isinstance(evm, Evm)
+
+        if self.transaction_environment is not evm.message.tx_env:
+            self.active_traces = []
+            self.transaction_environment = evm.message.tx_env
+
+        last_trace = None
+        if self.active_traces:
+            last_trace = self.active_traces[-1]
+
+        refund_counter = evm.refund_counter
+        parent_evm = evm.message.parent_evm
+        while parent_evm is not None:
+            refund_counter += parent_evm.refund_counter
+            parent_evm = parent_evm.message.parent_evm
+
+        len_memory = len(evm.memory)
+
+        return_data = None
+        if isinstance(evm, EvmWithReturnData) and self.trace_return_data:
+            return_data = "0x" + evm.return_data.hex()
+
+        memory = None
+        if self.trace_memory and len_memory > 0:
+            memory = "0x" + evm.memory.hex()
+
+        stack = None
+        if self.trace_stack:
+            stack = [hex(i) for i in evm.stack]
+
+        if isinstance(event, TransactionStart):
+            pass
+        elif isinstance(event, TransactionEnd):
+            final_trace = FinalTrace(event.gas_used, event.output, event.error)
+            self.active_traces.append(final_trace)
+
+            output_traces(
+                self.active_traces,
+                evm.message.tx_env.index_in_block,
+                evm.message.tx_env.tx_hash,
+                self.output_basedir,
+            )
+        elif isinstance(event, PrecompileStart):
             new_trace = Trace(
                 pc=int(evm.pc),
-                op=event.error.code,
+                op="0x" + event.address.hex().lstrip("0"),
                 gas=hex(evm.gas_left),
                 gasCost="0x0",
                 memory=memory,
@@ -218,42 +162,108 @@ def evm_trace(
                 returnData=return_data,
                 depth=int(evm.message.depth) + 1,
                 refund=refund_counter,
-                opName="InvalidOpcode",
-                gasCostTraced=True,
-                errorTraced=True,
-                error=type(event.error).__name__,
+                opName="0x" + event.address.hex().lstrip("0"),
+                precompile=True,
             )
 
-            traces.append(new_trace)
-        elif not last_trace.errorTraced:
-            # If the error for the last trace is not covered
-            # the exception is attributed to the last trace.
-            last_trace.error = type(event.error).__name__
-            last_trace.errorTraced = True
-    elif isinstance(event, EvmStop):
-        if not evm.running:
-            return
-        elif len(evm.code) == 0:
-            return
-        else:
-            evm_trace(
-                evm,
-                OpStart(event.op),
-                trace_memory,
-                trace_stack,
-                trace_return_data,
-            )
-    elif isinstance(event, GasAndRefund):
-        if len(traces) == 0:
-            # In contract creation transactions, there may not be any traces
-            return
+            self.active_traces.append(new_trace)
+        elif isinstance(event, PrecompileEnd):
+            assert isinstance(last_trace, Trace)
 
-        assert isinstance(last_trace, Trace)
-
-        if not last_trace.gasCostTraced:
-            last_trace.gasCost = hex(event.gas_cost)
-            last_trace.refund = refund_counter
             last_trace.gasCostTraced = True
+            last_trace.errorTraced = True
+        elif isinstance(event, OpStart):
+            op = event.op.value
+            if op == "InvalidOpcode":
+                op = "Invalid"
+            new_trace = Trace(
+                pc=int(evm.pc),
+                op=op,
+                gas=hex(evm.gas_left),
+                gasCost="0x0",
+                memory=memory,
+                memSize=len_memory,
+                stack=stack,
+                returnData=return_data,
+                depth=int(evm.message.depth) + 1,
+                refund=refund_counter,
+                opName=str(event.op).split(".")[-1],
+            )
+
+            self.active_traces.append(new_trace)
+        elif isinstance(event, OpEnd):
+            assert isinstance(last_trace, Trace)
+
+            last_trace.gasCostTraced = True
+            last_trace.errorTraced = True
+        elif isinstance(event, OpException):
+            if last_trace is not None:
+                assert isinstance(last_trace, Trace)
+            if (
+                # The first opcode in the code is an InvalidOpcode.
+                # So we add a new trace with InvalidOpcode as op.
+                not last_trace
+                # The current opcode is an InvalidOpcode. This condition
+                # is true if an InvalidOpcode is found in any location
+                # other than the first opcode.
+                or last_trace.errorTraced
+                # The first opcode in a child message is an InvalidOpcode.
+                # This case has to be explicitly handled since the first
+                # two conditions do not cover it.
+                or last_trace.depth == evm.message.depth
+            ):
+                if not hasattr(event.error, "code"):
+                    name = event.error.__class__.__name__
+                    raise TypeError(
+                        f"OpException event error type `{name}` does not "
+                        "have code"
+                    ) from event.error
+
+                new_trace = Trace(
+                    pc=int(evm.pc),
+                    op=event.error.code,
+                    gas=hex(evm.gas_left),
+                    gasCost="0x0",
+                    memory=memory,
+                    memSize=len_memory,
+                    stack=stack,
+                    returnData=return_data,
+                    depth=int(evm.message.depth) + 1,
+                    refund=refund_counter,
+                    opName="InvalidOpcode",
+                    gasCostTraced=True,
+                    errorTraced=True,
+                    error=type(event.error).__name__,
+                )
+
+                self.active_traces.append(new_trace)
+            elif not last_trace.errorTraced:
+                # If the error for the last trace is not covered
+                # the exception is attributed to the last trace.
+                last_trace.error = type(event.error).__name__
+                last_trace.errorTraced = True
+        elif isinstance(event, EvmStop):
+            if not evm.running:
+                return
+            elif len(evm.code) == 0:
+                return
+            else:
+                self(
+                    evm,
+                    OpStart(event.op),
+                )
+        elif isinstance(event, GasAndRefund):
+            if len(self.active_traces) == 0:
+                # In contract creation transactions, there may not be any
+                # traces
+                return
+
+            assert isinstance(last_trace, Trace)
+
+            if not last_trace.gasCostTraced:
+                last_trace.gasCost = hex(event.gas_cost)
+                last_trace.refund = refund_counter
+                last_trace.gasCostTraced = True
 
 
 class _TraceJsonEncoder(json.JSONEncoder):

--- a/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/evm_trace/protocols.py
@@ -1,0 +1,54 @@
+"""
+Protocol definitions for working with EVM trace events.
+"""
+
+from typing import Optional, Protocol, runtime_checkable
+
+from ethereum_types.bytes import Bytes
+from ethereum_types.numeric import U256, Uint
+
+
+@runtime_checkable
+class TransactionEnvironment(Protocol):
+    """
+    The class implements the tx_env interface for trace.
+    """
+
+    index_in_block: Uint | None
+    tx_hash: Bytes | None
+
+
+@runtime_checkable
+class Message(Protocol):
+    """
+    The class implements the message interface for trace.
+    """
+
+    depth: int
+    tx_env: TransactionEnvironment
+    parent_evm: Optional["Evm"]
+
+
+@runtime_checkable
+class Evm(Protocol):
+    """
+    The class describes the EVM interface for pre-byzantium forks trace.
+    """
+
+    pc: Uint
+    stack: list[U256]
+    memory: bytearray
+    code: Bytes
+    gas_left: Uint
+    refund_counter: int
+    running: bool
+    message: Message
+
+
+@runtime_checkable
+class EvmWithReturnData(Evm, Protocol):
+    """
+    The class describes the EVM interface for post-byzantium forks trace.
+    """
+
+    return_data: Bytes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def pytest_configure(config: Config) -> None:
 
     if config.getoption("evm_trace"):
         import ethereum.trace
-        from ethereum_spec_tools.evm_tools.t8n.evm_trace import (
+        from ethereum_spec_tools.evm_tools.t8n.evm_trace.eip3155 import (
             evm_trace as new_trace_function,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,11 +61,11 @@ def pytest_configure(config: Config) -> None:
     if config.getoption("evm_trace"):
         import ethereum.trace
         from ethereum_spec_tools.evm_tools.t8n.evm_trace.eip3155 import (
-            evm_trace as new_trace_function,
+            Eip3155Tracer,
         )
 
         # Replace the function in the module
-        ethereum.trace.set_evm_trace(new_trace_function)
+        ethereum.trace.set_evm_trace(Eip3155Tracer())
 
 
 class _FixturesDownloader:

--- a/tests/helpers/load_vm_tests.py
+++ b/tests/helpers/load_vm_tests.py
@@ -127,7 +127,6 @@ class VmTestLoader:
             gas=tx.gas,
             index_in_block=Uint(0),
             tx_hash=b"56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            traces=[],
         )
 
         return {

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -12,9 +12,6 @@ def test_modify_evm_trace() -> None:
     def tracer1(
         evm: object,  # noqa: U100
         event: ethereum.trace.TraceEvent,
-        trace_memory: bool = False,  # noqa: U100
-        trace_stack: bool = True,  # noqa: U100
-        trace_return_data: bool = False,  # noqa: U100
     ) -> None:
         nonlocal trace1
         trace1 = event
@@ -22,9 +19,6 @@ def test_modify_evm_trace() -> None:
     def tracer2(
         evm: object,  # noqa: U100
         event: ethereum.trace.TraceEvent,
-        trace_memory: bool = False,  # noqa: U100
-        trace_stack: bool = True,  # noqa: U100
-        trace_return_data: bool = False,  # noqa: U100
     ) -> None:
         nonlocal trace2
         trace2 = event

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -9,7 +9,10 @@ from ethereum_spec_tools.evm_tools.loaders.transaction_loader import (
     TransactionLoad,
 )
 from ethereum_spec_tools.evm_tools.t8n.env import Ommer
-from ethereum_spec_tools.evm_tools.t8n.evm_trace import Trace, FinalTrace
+from ethereum_spec_tools.evm_tools.t8n.evm_trace.eip3155 import (
+    Trace,
+    FinalTrace,
+)
 from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
 from ethereum_spec_tools.lint.lints.glacier_forks_hygiene import (
     GlacierForksHygiene,
@@ -87,7 +90,7 @@ TransactionLoad.json_to_s
 # src/ethereum_spec_tools/evm_tools/t8n/env.py
 Ommer.delta
 
-# src/ethereum_spec_tools/evm_tools/t8n/evm_trace.py
+# src/ethereum_spec_tools/evm_tools/t8n/evm_trace/eip3155.py
 Trace.gasCost
 Trace.memSize
 Trace.returnData

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -20,6 +20,7 @@ coincurve
 crypto
 E501
 EIP
+eip3155
 encodings
 endian
 eth


### PR DESCRIPTION
### What was wrong?

Related to Issues #909 & #1351

### How was it fixed?

- Instead of storing traces within the `TransactionEnvironment`, after this PR we store them within the tracer object itself. This removes a bit of unnecessary and single purpose code from the specification.
- Removes the `trace_memory`, `trace_stack`, and `trace_return_data` arguments from the `EvmTracer`. Not all trace implementations need these arguments, so threading them through `ethereum.trace` is overly coupled.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/d1f12378-072a-401b-ac60-e8a437654c95.jpeg?format=webp)
