### PR TITLE
utilize pydantic models from eest on t8n

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -105,7 +105,7 @@ def main(
         in_file = sys.stdin
 
     if options.evm_tool == "t8n":
-        t8n_tool = T8N(options, out_file, in_file)
+        t8n_tool = T8N(options, in_file, out_file)
         return t8n_tool.run()
     elif options.evm_tool == "b11r":
         b11r_tool = B11R(options, out_file, in_file)

--- a/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/statetest/__init__.py
@@ -146,7 +146,7 @@ def run_test_case(
     if output_basedir is not None:
         t8n_options.output_basedir = output_basedir
 
-    t8n = T8N(t8n_options, out_stream, in_stream)
+    t8n = T8N(t8n_options, in_stream, out_stream)
     t8n.run_state_test()
     return t8n.result
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -15,7 +15,7 @@ from ethereum import trace
 from ethereum.exceptions import EthereumException, InvalidBlock
 from ethereum_clis.types import TransitionToolRequest
 from ethereum_spec_tools.forks import Hardfork
-from ethereum_clis.types import Result as TransitionToolOutput
+from ethereum_clis.types import TransitionToolOutput
 from ethereum_clis.clis.execution_specs import ExecutionSpecsExceptionMapper
 
 from ..loaders.fixture_loader import Load
@@ -93,6 +93,7 @@ class T8N(Load):
             self.forks, self.options, in_file.input.env
         )
         self.fork = ForkLoad(fork_module)
+        self.exception_mapper = ExecutionSpecsExceptionMapper()
 
         if self.options.trace:
             trace_memory = getattr(self.options, "trace.memory", False)
@@ -108,7 +109,6 @@ class T8N(Load):
                 )
             )
         self.logger = get_stream_logger("T8N")
-        self.exception_mapper = ExecutionSpecsExceptionMapper()
 
         super().__init__(
             self.options.state_fork,

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -88,13 +88,13 @@ class Env:
         if not t8n.fork.is_after_fork("ethereum.cancun"):
             return
 
-        if hasattr(data, "excess_blob_gas") and data.excess_blob_gas is not None:
+        if data.excess_blob_gas is not None:
             self.excess_blob_gas = U64(data.excess_blob_gas)
 
-        if hasattr(data, "parent_excess_blob_gas") and data.parent_excess_blob_gas is not None:
+        if data.parent_excess_blob_gas is not None:
             self.parent_excess_blob_gas = U64(data.parent_excess_blob_gas)
 
-        if hasattr(data, "parent_blob_gas_used") and data.parent_blob_gas_used is not None:
+        if data.parent_blob_gas_used is not None:
             self.parent_blob_gas_used = U64(data.parent_blob_gas_used)
 
         if self.excess_blob_gas is not None:
@@ -154,16 +154,16 @@ class Env:
         self.base_fee_per_gas = None
 
         if t8n.fork.is_after_fork("ethereum.london"):
-            if hasattr(data, "base_fee_per_gas") and data.base_fee_per_gas is not None:
+            if data.base_fee_per_gas is not None:
                 self.base_fee_per_gas = Uint(data.base_fee_per_gas)
 
-            if hasattr(data, "parent_gas_used") and data.parent_gas_used is not None:
+            if data.parent_gas_used is not None:
                 self.parent_gas_used = Uint(data.parent_gas_used)
 
-            if hasattr(data, "parent_gas_limit") and data.parent_gas_limit is not None:
+            if data.parent_gas_limit is not None:
                 self.parent_gas_limit = Uint(data.parent_gas_limit)
 
-            if hasattr(data, "parent_base_fee_per_gas") and data.parent_base_fee_per_gas is not None:
+            if data.parent_base_fee_per_gas is not None:
                 self.parent_base_fee_per_gas = Uint(data.parent_base_fee_per_gas)
 
             if self.base_fee_per_gas is None:
@@ -221,7 +221,7 @@ class Env:
         self.parent_ommers_hash = None
         if t8n.fork.is_after_fork("ethereum.paris"):
             return
-        elif hasattr(data, "difficulty") and data.difficulty is not None:
+        elif data.difficulty is not None:
             self.block_difficulty = Uint(data.difficulty)
         else:
             self.parent_timestamp = U256(data.parent_timestamp)
@@ -233,7 +233,7 @@ class Env:
                 self.parent_difficulty,
             ]
             if t8n.fork.is_after_fork("ethereum.byzantium"):
-                if hasattr(data, "parent_ommers_hash") and data.parent_ommers_hash is not None:
+                if data.parent_ommers_hash is not None:
                     EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
                     self.parent_ommers_hash = Hash32(
                         data.parent_ommers_hash
@@ -281,7 +281,7 @@ class Env:
         needed to obtain the Header.
         """
         ommers = []
-        if hasattr(data, "ommers") and data.ommers is not None:
+        if data.ommers is not None:
             for ommer in data.ommers:
                 ommers.append(
                     Ommer(

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -3,14 +3,18 @@ Define t8n Env class
 """
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum_test_types.block_types import Environment
+from ethereum.utils.hexadecimal import hex_to_bytes
+
+from ..utils import parse_hex_or_int
 
 if TYPE_CHECKING:
     from ethereum_spec_tools.evm_tools.t8n import T8N
@@ -52,18 +56,24 @@ class Env:
     excess_blob_gas: Optional[U64]
     requests: Any
 
-    def __init__(self, t8n: "T8N", stdin: Environment):
+    def __init__(self, t8n: "T8N", stdin: Optional[Union[Environment, Dict]] = None):
+        if isinstance(stdin, Environment):
+            self._init_from_pydantic(t8n, stdin)
+        else:
+            self._init_from_json(t8n, stdin)
+
+    def _init_from_pydantic(self, t8n: "T8N", stdin: Environment) -> None:
         self.coinbase = stdin.fee_recipient
         self.block_gas_limit = Uint(stdin.gas_limit)
         self.block_number = Uint(stdin.number)
         self.block_timestamp = U256(stdin.timestamp)
 
-        self.read_block_difficulty(stdin, t8n)
-        self.read_base_fee_per_gas(stdin, t8n)
-        self.read_randao(stdin, t8n)
-        self.read_block_hashes(stdin, t8n)
-        self.read_ommers(stdin, t8n)
-        self.read_withdrawals(stdin, t8n)
+        self.read_block_difficulty_pydantic(stdin, t8n)
+        self.read_base_fee_per_gas_pydantic(stdin, t8n)
+        self.read_randao_pydantic(stdin, t8n)
+        self.read_block_hashes_pydantic(stdin, t8n)
+        self.read_ommers_pydantic(stdin, t8n)
+        self.read_withdrawals_pydantic(stdin, t8n)
 
         self.parent_beacon_block_root = None
         if t8n.fork.is_after_fork("ethereum.cancun"):
@@ -74,9 +84,40 @@ class Env:
                     if parent_beacon_block_root_bytes is not None
                     else None
                 )
-            self.read_excess_blob_gas(stdin, t8n)
+            self.read_excess_blob_gas_pydantic(stdin, t8n)
 
-    def read_excess_blob_gas(self, data: Any, t8n: "T8N") -> None:
+    def _init_from_json(self, t8n: "T8N", stdin: Optional[Dict] = None) -> None:
+        if t8n.options.input_env == "stdin":
+            assert stdin is not None
+            data = stdin["env"]
+        else:
+            with open(t8n.options.input_env, "r") as f:
+                data = json.load(f)
+
+        self.coinbase = t8n.fork.hex_to_address(data["currentCoinbase"])
+        self.block_gas_limit = parse_hex_or_int(data["currentGasLimit"], Uint)
+        self.block_number = parse_hex_or_int(data["currentNumber"], Uint)
+        self.block_timestamp = parse_hex_or_int(data["currentTimestamp"], U256)
+
+        self.read_block_difficulty(data, t8n)
+        self.read_base_fee_per_gas(data, t8n)
+        self.read_randao(data, t8n)
+        self.read_block_hashes(data, t8n)
+        self.read_ommers(data, t8n)
+        self.read_withdrawals(data, t8n)
+
+        self.parent_beacon_block_root = None
+        if t8n.fork.is_after_fork("ethereum.cancun"):
+            if not t8n.options.state_test:
+                parent_beacon_block_root_hex = data["parentBeaconBlockRoot"]
+                self.parent_beacon_block_root = (
+                    Bytes32(hex_to_bytes(parent_beacon_block_root_hex))
+                    if parent_beacon_block_root_hex is not None
+                    else None
+                )
+            self.read_excess_blob_gas(data, t8n)
+
+    def read_excess_blob_gas_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the excess_blob_gas from the data. If the excess blob gas is
         not present, it is calculated from the parent block parameters.
@@ -143,7 +184,80 @@ class Env:
                         // BLOB_SCHEDULE_MAX
                     )
 
-    def read_base_fee_per_gas(self, data: Any, t8n: "T8N") -> None:
+    def read_excess_blob_gas(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the excess_blob_gas from the data. If the excess blob gas is
+        not present, it is calculated from the parent block parameters.
+        """
+        self.parent_blob_gas_used = U64(0)
+        self.parent_excess_blob_gas = U64(0)
+        self.excess_blob_gas = None
+
+        if not t8n.fork.is_after_fork("ethereum.cancun"):
+            return
+
+        if "currentExcessBlobGas" in data:
+            self.excess_blob_gas = parse_hex_or_int(
+                data["currentExcessBlobGas"], U64
+            )
+
+        if "parentExcessBlobGas" in data:
+            self.parent_excess_blob_gas = parse_hex_or_int(
+                data["parentExcessBlobGas"], U64
+            )
+
+        if "parentBlobGasUsed" in data:
+            self.parent_blob_gas_used = parse_hex_or_int(
+                data["parentBlobGasUsed"], U64
+            )
+
+        if self.excess_blob_gas is not None:
+            return
+
+        assert self.parent_excess_blob_gas is not None
+        assert self.parent_blob_gas_used is not None
+
+        parent_blob_gas = (
+            self.parent_excess_blob_gas + self.parent_blob_gas_used
+        )
+
+        target_blob_gas_per_block = t8n.fork.TARGET_BLOB_GAS_PER_BLOCK
+
+        if parent_blob_gas < target_blob_gas_per_block:
+            self.excess_blob_gas = U64(0)
+        else:
+            self.excess_blob_gas = parent_blob_gas - target_blob_gas_per_block
+
+            if t8n.fork.is_after_fork("ethereum.osaka"):
+                # Under certain conditions specified in EIP-7918, the
+                # the excess_blob_gas is calculated differently in osaka
+                assert self.parent_base_fee_per_gas is not None
+
+                GAS_PER_BLOB = t8n.fork.GAS_PER_BLOB
+                BLOB_BASE_COST = t8n.fork.BLOB_BASE_COST
+                BLOB_SCHEDULE_MAX = t8n.fork.BLOB_SCHEDULE_MAX
+                BLOB_SCHEDULE_TARGET = t8n.fork.BLOB_SCHEDULE_TARGET
+
+                target_blob_gas_price = Uint(GAS_PER_BLOB)
+                target_blob_gas_price *= t8n.fork.calculate_blob_gas_price(
+                    self.parent_excess_blob_gas
+                )
+
+                base_blob_tx_price = (
+                    BLOB_BASE_COST * self.parent_base_fee_per_gas
+                )
+                if base_blob_tx_price > target_blob_gas_price:
+                    blob_schedule_delta = (
+                        BLOB_SCHEDULE_MAX - BLOB_SCHEDULE_TARGET
+                    )
+                    self.excess_blob_gas = (
+                        self.parent_excess_blob_gas
+                        + self.parent_blob_gas_used
+                        * blob_schedule_delta
+                        // BLOB_SCHEDULE_MAX
+                    )
+
+    def read_base_fee_per_gas_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the base_fee_per_gas from the data. If the base fee is
         not present, it is calculated from the parent block parameters.
@@ -182,7 +296,54 @@ class Env:
                     *parameters
                 )
 
-    def read_randao(self, data: Any, t8n: "T8N") -> None:
+    def read_base_fee_per_gas(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the base_fee_per_gas from the data. If the base fee is
+        not present, it is calculated from the parent block parameters.
+        """
+        self.parent_gas_used = None
+        self.parent_gas_limit = None
+        self.parent_base_fee_per_gas = None
+        self.base_fee_per_gas = None
+
+        if t8n.fork.is_after_fork("ethereum.london"):
+            if "currentBaseFee" in data:
+                self.base_fee_per_gas = parse_hex_or_int(
+                    data["currentBaseFee"], Uint
+                )
+
+            if "parentGasUsed" in data:
+                self.parent_gas_used = parse_hex_or_int(
+                    data["parentGasUsed"], Uint
+                )
+
+            if "parentGasLimit" in data:
+                self.parent_gas_limit = parse_hex_or_int(
+                    data["parentGasLimit"], Uint
+                )
+
+            if "parentBaseFee" in data:
+                self.parent_base_fee_per_gas = parse_hex_or_int(
+                    data["parentBaseFee"], Uint
+                )
+
+            if self.base_fee_per_gas is None:
+                assert self.parent_gas_limit is not None
+                assert self.parent_gas_used is not None
+                assert self.parent_base_fee_per_gas is not None
+
+                parameters: List[object] = [
+                    self.block_gas_limit,
+                    self.parent_gas_limit,
+                    self.parent_gas_used,
+                    self.parent_base_fee_per_gas,
+                ]
+
+                self.base_fee_per_gas = t8n.fork.calculate_base_fee_per_gas(
+                    *parameters
+                )
+
+    def read_randao_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the randao from the data.
         """
@@ -190,7 +351,28 @@ class Env:
         if t8n.fork.is_after_fork("ethereum.paris"):
             self.prev_randao = Bytes32(data.prev_randao.to_bytes(32, "big"))
 
-    def read_withdrawals(self, data: Any, t8n: "T8N") -> None:
+    def read_randao(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the randao from the data.
+        """
+        self.prev_randao = None
+        if t8n.fork.is_after_fork("ethereum.paris"):
+            # tf tool might not always provide an
+            # even number of nibbles in the randao
+            # This could create issues in the
+            # hex_to_bytes function
+            current_random = data["currentRandom"]
+            if current_random.startswith("0x"):
+                current_random = current_random[2:]
+
+            if len(current_random) % 2 == 1:
+                current_random = "0" + current_random
+
+            self.prev_randao = Bytes32(
+                left_pad_zero_bytes(hex_to_bytes(current_random), 32)
+            )
+
+    def read_withdrawals_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the withdrawals from the data.
         """
@@ -209,7 +391,17 @@ class Env:
             else:
                 self.withdrawals = ()
 
-    def read_block_difficulty(self, data: Any, t8n: "T8N") -> None:
+    def read_withdrawals(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the withdrawals from the data.
+        """
+        self.withdrawals = None
+        if t8n.fork.is_after_fork("ethereum.shanghai"):
+            self.withdrawals = tuple(
+                t8n.json_to_withdrawals(wd) for wd in data["withdrawals"]
+            )
+
+    def read_block_difficulty_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the block difficulty from the data.
         If `currentDifficulty` is present, it is used. Otherwise,
@@ -246,7 +438,50 @@ class Env:
                     args.append(False)
             self.block_difficulty = t8n.fork.calculate_block_difficulty(*args)
 
-    def read_block_hashes(self, data: Any, t8n: "T8N") -> None:
+    def read_block_difficulty(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the block difficulty from the data.
+        If `currentDifficulty` is present, it is used. Otherwise,
+        the difficulty is calculated from the parent block.
+        """
+        self.block_difficulty = None
+        self.parent_timestamp = None
+        self.parent_difficulty = None
+        self.parent_ommers_hash = None
+        if t8n.fork.is_after_fork("ethereum.paris"):
+            return
+        elif "currentDifficulty" in data:
+            self.block_difficulty = parse_hex_or_int(
+                data["currentDifficulty"], Uint
+            )
+        else:
+            self.parent_timestamp = parse_hex_or_int(
+                data["parentTimestamp"], U256
+            )
+            self.parent_difficulty = parse_hex_or_int(
+                data["parentDifficulty"], Uint
+            )
+            args: List[object] = [
+                self.block_number,
+                self.block_timestamp,
+                self.parent_timestamp,
+                self.parent_difficulty,
+            ]
+            if t8n.fork.is_after_fork("ethereum.byzantium"):
+                if "parentUncleHash" in data:
+                    EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
+                    self.parent_ommers_hash = Hash32(
+                        hex_to_bytes(data["parentUncleHash"])
+                    )
+                    parent_has_ommers = (
+                        self.parent_ommers_hash != EMPTY_OMMER_HASH
+                    )
+                    args.append(parent_has_ommers)
+                else:
+                    args.append(False)
+            self.block_difficulty = t8n.fork.calculate_block_difficulty(*args)
+
+    def read_block_hashes_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the block hashes. Returns a maximum of 256 block hashes.
         """
@@ -275,7 +510,40 @@ class Env:
 
         self.block_hashes = block_hashes
 
-    def read_ommers(self, data: Any, t8n: "T8N") -> None:
+    def read_block_hashes(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the block hashes. Returns a maximum of 256 block hashes.
+        """
+        self.parent_hash = None
+        if (
+            t8n.fork.is_after_fork("ethereum.prague")
+            and not t8n.options.state_test
+        ):
+            self.parent_hash = Hash32(hex_to_bytes(data["parentHash"]))
+
+        # Read the block hashes
+        block_hashes: List[Any] = []
+
+        # The hex key strings provided might not have standard formatting
+        clean_block_hashes: Dict[int, Hash32] = {}
+        if "blockHashes" in data:
+            for key, value in data["blockHashes"].items():
+                int_key = int(key, 16)
+                clean_block_hashes[int_key] = Hash32(hex_to_bytes(value))
+
+        # Store a maximum of 256 block hashes.
+        max_blockhash_count = min(Uint(256), self.block_number)
+        for number in range(
+            self.block_number - max_blockhash_count, self.block_number
+        ):
+            if number in clean_block_hashes.keys():
+                block_hashes.append(clean_block_hashes[number])
+            else:
+                block_hashes.append(None)
+
+        self.block_hashes = block_hashes
+
+    def read_ommers_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the ommers. The ommers data might not have all the details
         needed to obtain the Header.
@@ -287,6 +555,22 @@ class Env:
                     Ommer(
                         ommer.delta,
                         ommer.address,
+                    )
+                )
+        self.ommers = ommers
+
+    def read_ommers(self, data: Any, t8n: "T8N") -> None:
+        """
+        Read the ommers. The ommers data might not have all the details
+        needed to obtain the Header.
+        """
+        ommers = []
+        if "ommers" in data:
+            for ommer in data["ommers"]:
+                ommers.append(
+                    Ommer(
+                        ommer["delta"],
+                        t8n.fork.hex_to_address(ommer["address"]),
                     )
                 )
         self.ommers = ommers

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -196,7 +196,7 @@ class Env:
         """
         self.withdrawals = None
         if t8n.fork.is_after_fork("ethereum.shanghai"):
-            raw_withdrawals = getattr(data, "withdrawals", None)
+            raw_withdrawals = data.withdrawals
             if raw_withdrawals:
                 def to_canonical_withdrawal(raw):
                     return t8n.fork.Withdrawal(

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -372,6 +372,15 @@ class Env:
                 left_pad_zero_bytes(hex_to_bytes(current_random), 32)
             )
 
+    def _to_canonical_withdrawal(self, raw, fork):
+        """Convert raw withdrawal to canonical format."""
+        return fork.Withdrawal(
+            index=U64(raw.index),
+            validator_index=U64(raw.validator_index),
+            address=raw.address,
+            amount=U256(raw.amount),
+        )
+
     def read_withdrawals_pydantic(self, data: Any, t8n: "T8N") -> None:
         """
         Read the withdrawals from the data.
@@ -387,7 +396,10 @@ class Env:
                         address=raw.address,
                         amount=U256(raw.amount),
                     )
-                self.withdrawals = tuple(to_canonical_withdrawal(wd) for wd in raw_withdrawals)
+                self.withdrawals = tuple(
+                    self._to_canonical_withdrawal(wd, t8n.fork)
+                    for wd in raw_withdrawals
+                )
             else:
                 self.withdrawals = ()
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -42,18 +42,16 @@ class Alloc:
             )
 
             if t8n.fork.proof_of_stake and canonical_account == EMPTY_ACCOUNT:
-                addr_hex = addr_bytes.hex() if isinstance(addr_bytes, bytes) else str(addr_bytes)
-                raise StateWithEmptyAccount(f"Empty account at {addr_hex}.")
-
+                raise StateWithEmptyAccount(
+                    f"Empty account at {addr_bytes.hex()}."
+                )
             t8n.fork.set_account(state, addr_bytes, canonical_account)
 
             if account.storage and account.storage.root:
                 for storage_key, storage_value in account.storage.root.items():
-                    if isinstance(storage_key, int):
-                        storage_key_bytes = storage_key.to_bytes(32, byteorder='big')
-                    else:
-                        storage_key_bytes = storage_key
-
+                    storage_key_bytes = storage_key.to_bytes(
+                        32, byteorder='big'
+                    )
                     set_storage(
                         state,
                         addr_bytes,
@@ -260,17 +258,12 @@ class Txs:
 def convert_pydantic_tx_to_canonical(tx, fork):
     """
     Convert a Pydantic Transaction to the canonical transaction class for the given fork.
-    fork: The fork object (e.g., self.fork from ForkLoad)
     """
-    if isinstance(tx, list):
-        return [convert_pydantic_tx_to_canonical(t, fork) for t in tx]
 
     def convert_access_list(access_list):
         if not access_list:
             return []
         AccessCls = getattr(fork, "Access", None)
-        if AccessCls is None:
-            from ethereum.arrow_glacier.transactions import Access as AccessCls
         return [
             AccessCls(
                 account=entry.address,
@@ -283,11 +276,9 @@ def convert_pydantic_tx_to_canonical(tx, fork):
         if not auth_list:
             return []
         AuthorizationCls = getattr(fork, "Authorization", None)
-        if AuthorizationCls is None:
-            from ethereum.osaka.fork_types import Authorization as AuthorizationCls
         result = []
         for entry in auth_list:
-            d = entry.dict() if hasattr(entry, "dict") else dict(entry)
+            d = entry.model_dump()
             result.append(
                 AuthorizationCls(
                     chain_id=U256(d.get("chain_id", 0)),
@@ -318,15 +309,7 @@ def convert_pydantic_tx_to_canonical(tx, fork):
     def to_bytes20(val):
         if val is None:
             return Bytes0()
-        if isinstance(val, Bytes20):
-            return val
-        if isinstance(val, (bytes, bytearray)) and len(val) == 20:
-            return Bytes20(val)
-        if isinstance(val, (bytes, bytearray)) and len(val) == 0:
-            return Bytes20(b"\x00" * 20)
-        if isinstance(val, (bytes, bytearray)):
-            return Bytes20(val.rjust(20, b"\x00"))
-        return Bytes20(bytes(val).rjust(20, b"\x00"))
+        return Bytes20(val)
 
     # build the canonical transaction
     if tx_cls.__name__ == "FeeMarketTransaction":

--- a/src/ethereum_spec_tools/evm_tools/t8n/transition_tool.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/transition_tool.py
@@ -85,17 +85,10 @@ class EELST8N(TransitionTool):
         parser = create_parser()
         t8n_options = parser.parse_args(t8n_args)
 
-        out_stream = StringIO()
-
         in_stream = request_data
 
-        t8n = T8N(t8n_options, out_stream, in_stream)
+        t8n = T8N(t8n_options, in_stream)
         output = t8n.run()
-
-        # output_dict = json.loads(out_stream.getvalue())
-        # output: TransitionToolOutput = TransitionToolOutput.model_validate(
-        #     output_dict, context={"exception_mapper": self.exception_mapper}
-        # )
 
         if debug_output_path:
             dump_files_to_directory(

--- a/src/ethereum_spec_tools/evm_tools/t8n/transition_tool.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/transition_tool.py
@@ -2,7 +2,6 @@
 Implementation of the EELS T8N for execution-spec-tests.
 """
 
-import json
 import tempfile
 from io import StringIO
 from typing import Any, Dict, Optional
@@ -88,15 +87,15 @@ class EELST8N(TransitionTool):
 
         out_stream = StringIO()
 
-        in_stream = StringIO(json.dumps(request_data_json["input"]))
+        in_stream = request_data
 
         t8n = T8N(t8n_options, out_stream, in_stream)
-        t8n.run()
+        output = t8n.run()
 
-        output_dict = json.loads(out_stream.getvalue())
-        output: TransitionToolOutput = TransitionToolOutput.model_validate(
-            output_dict, context={"exception_mapper": self.exception_mapper}
-        )
+        # output_dict = json.loads(out_stream.getvalue())
+        # output: TransitionToolOutput = TransitionToolOutput.model_validate(
+        #     output_dict, context={"exception_mapper": self.exception_mapper}
+        # )
 
         if debug_output_path:
             dump_files_to_directory(

--- a/src/ethereum_spec_tools/evm_tools/utils.py
+++ b/src/ethereum_spec_tools/evm_tools/utils.py
@@ -82,7 +82,7 @@ class FatalException(Exception):
 
 
 def get_module_name(
-    forks: Sequence[Hardfork], options: Any, stdin: Any
+    forks: Sequence[Hardfork], options: Any, env: Any
 ) -> Tuple[str, int]:
     """
     Get the module name and the fork block for the given state fork.
@@ -97,14 +97,7 @@ def get_module_name(
         pass
 
     if exception_config:
-        if options.input_env == "stdin":
-            assert stdin is not None
-            data = stdin["env"]
-        else:
-            with open(options.input_env, "r") as f:
-                data = json.load(f)
-
-        block_number = parse_hex_or_int(data["currentNumber"], Uint)
+        block_number = parse_hex_or_int(env.number, Uint)
 
         for fork, fork_block in exception_config["fork_blocks"]:
             if block_number >= Uint(fork_block):

--- a/tests/helpers/load_evm_tools_tests.py
+++ b/tests/helpers/load_evm_tools_tests.py
@@ -125,7 +125,7 @@ def load_evm_tools_test(test_case: Dict[str, str], fork_name: str) -> None:
     t8n_options = parser.parse_args(t8n_args)
 
     try:
-        t8n = T8N(t8n_options, sys.stdout, in_stream)
+        t8n = T8N(t8n_options, in_stream, sys.stdout)
     except StateWithEmptyAccount as e:
         pytest.xfail(str(e))
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #https://github.com/ethereum/execution-specs/issues/1124

### How was it fixed?
- Pydantic models from eest are input/output for t8n
- utilize these models to run t8n


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pixnio.com/free-images/2017/09/26/2017-09-26-09-49-16-1536x1024.jpg)
