### PR TITLE
fix: grammar corrections and minor formatting cleanup

### DIFF
--- a/network-upgrades/mainnet-upgrades/cancun.md
+++ b/network-upgrades/mainnet-upgrades/cancun.md
@@ -4,7 +4,7 @@
 Execution layer changes included in the Network Upgrade.
 
 * [EIP-1153: Transient storage opcodes](https://eips.ethereum.org/EIPS/eip-1153)
-* [EIP-4788: Beacon block root in the EVM ](https://eips.ethereum.org/EIPS/eip-4788)
+* [EIP-4788: Beacon block root in the EVM](https://eips.ethereum.org/EIPS/eip-4788)
 * [EIP-4844: Shard Blob Transactions](https://eips.ethereum.org/EIPS/eip-4844)
 * [EIP-5656: MCOPY - Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656)
 * [EIP-6780: SELFDESTRUCT only in same transaction](https://eips.ethereum.org/EIPS/eip-6780)

--- a/src/ethereum_optimized/fork.py
+++ b/src/ethereum_optimized/fork.py
@@ -9,7 +9,7 @@ Optimized Spec
 Introduction
 ------------
 
-This module contains optimized POW functions can be monkey patched into the
+This module contains optimized POW functions that can be monkey patched into the
 `fork` module of a fork.
 """
 from importlib import import_module

--- a/src/ethereum_optimized/fork.py
+++ b/src/ethereum_optimized/fork.py
@@ -9,8 +9,8 @@ Optimized Spec
 Introduction
 ------------
 
-This module contains optimized POW functions that can be monkey patched into the
-`fork` module of a fork.
+This module contains optimized POW functions that can be monkey patched into
+the `fork` module of a fork.
 """
 from importlib import import_module
 from typing import Any, Dict, cast

--- a/src/ethereum_optimized/state_db.py
+++ b/src/ethereum_optimized/state_db.py
@@ -9,8 +9,8 @@ Optimized State
 Introduction
 ------------
 
-This module contains functions that can be monkey patched into the fork's `state`
-module to use an optimized database backed state.
+This module contains functions that can be monkey patched into the fork's
+`state` module to use an optimized database backed state.
 """
 import logging
 from collections import defaultdict

--- a/src/ethereum_optimized/state_db.py
+++ b/src/ethereum_optimized/state_db.py
@@ -9,7 +9,7 @@ Optimized State
 Introduction
 ------------
 
-This module contains functions can be monkey patched into the fork's `state`
+This module contains functions that can be monkey patched into the fork's `state`
 module to use an optimized database backed state.
 """
 import logging


### PR DESCRIPTION
network-upgrades/mainnet-upgrades/cancun.md: removed extra space in EIP-4788 entry

src/ethereum_optimized/fork.py: fixed grammar in module introduction ("functions that can be…")

src/ethereum_optimized/state_db.py: fixed grammar in module introduction ("functions that can be…")