### PR TITLE
New lint

### DIFF
--- a/src/ethereum/arrow_glacier/blocks.py
+++ b/src/ethereum/arrow_glacier/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/arrow_glacier/fork_types.py
+++ b/src/ethereum/arrow_glacier/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/berlin/blocks.py
+++ b/src/ethereum/berlin/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import AccessListTransaction, LegacyTransaction, Transaction
 

--- a/src/ethereum/berlin/fork_types.py
+++ b/src/ethereum/berlin/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/byzantium/blocks.py
+++ b/src/ethereum/byzantium/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/byzantium/fork_types.py
+++ b/src/ethereum/byzantium/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/cancun/blocks.py
+++ b/src/ethereum/cancun/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/cancun/fork_types.py
+++ b/src/ethereum/cancun/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/constantinople/blocks.py
+++ b/src/ethereum/constantinople/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/constantinople/fork_types.py
+++ b/src/ethereum/constantinople/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/dao_fork/blocks.py
+++ b/src/ethereum/dao_fork/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/dao_fork/fork_types.py
+++ b/src/ethereum/dao_fork/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/frontier/blocks.py
+++ b/src/ethereum/frontier/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/frontier/fork_types.py
+++ b/src/ethereum/frontier/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/gray_glacier/blocks.py
+++ b/src/ethereum/gray_glacier/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/gray_glacier/fork_types.py
+++ b/src/ethereum/gray_glacier/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/homestead/blocks.py
+++ b/src/ethereum/homestead/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/homestead/fork_types.py
+++ b/src/ethereum/homestead/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/istanbul/blocks.py
+++ b/src/ethereum/istanbul/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/istanbul/fork_types.py
+++ b/src/ethereum/istanbul/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/london/blocks.py
+++ b/src/ethereum/london/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/london/fork_types.py
+++ b/src/ethereum/london/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/muir_glacier/blocks.py
+++ b/src/ethereum/muir_glacier/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/muir_glacier/fork_types.py
+++ b/src/ethereum/muir_glacier/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/osaka/blocks.py
+++ b/src/ethereum/osaka/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/osaka/fork_types.py
+++ b/src/ethereum/osaka/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U8, U64, U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/paris/blocks.py
+++ b/src/ethereum/paris/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/paris/fork_types.py
+++ b/src/ethereum/paris/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/prague/blocks.py
+++ b/src/ethereum/prague/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/prague/fork_types.py
+++ b/src/ethereum/prague/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U8, U64, U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/shanghai/blocks.py
+++ b/src/ethereum/shanghai/blocks.py
@@ -16,7 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/spurious_dragon/blocks.py
+++ b/src/ethereum/spurious_dragon/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/spurious_dragon/fork_types.py
+++ b/src/ethereum/spurious_dragon/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum/tangerine_whistle/blocks.py
+++ b/src/ethereum/tangerine_whistle/blocks.py
@@ -15,7 +15,8 @@ from ethereum_types.bytes import Bytes, Bytes8, Bytes32
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32
+from ethereum.crypto.hash import Hash32
+
 from .fork_types import Address, Bloom, Root
 from .transactions import Transaction
 

--- a/src/ethereum/tangerine_whistle/fork_types.py
+++ b/src/ethereum/tangerine_whistle/fork_types.py
@@ -19,7 +19,7 @@ from ethereum_types.bytes import Bytes, Bytes20, Bytes256
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
-from ..crypto.hash import Hash32, keccak256
+from ethereum.crypto.hash import Hash32, keccak256
 
 Address = Bytes20
 Root = Hash32

--- a/src/ethereum_spec_tools/lint/__init__.py
+++ b/src/ethereum_spec_tools/lint/__init__.py
@@ -12,7 +12,8 @@ import pkgutil
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from itertools import zip_longest
-from typing import Generator, List, Optional, Sequence, Tuple
+from pathlib import Path
+from typing import Generator, List, Optional, Sequence, Tuple, TypeVar
 
 from ..forks import Hardfork
 
@@ -78,6 +79,9 @@ class Diagnostic:
     message: str
 
 
+V = TypeVar("V", bound=ast.NodeVisitor)
+
+
 class Lint(metaclass=ABCMeta):
     """
     A single check which may be performed against the specifications.
@@ -98,15 +102,13 @@ class Lint(metaclass=ABCMeta):
             The particular hardfork to lint.
         """
 
-    def _parse(
-        self, source: str, visitor: ast.NodeVisitor, attr: str
-    ) -> Sequence[str]:
+    def _parse(self, source: str, visitor: V) -> V:
         """
-        Walks the source string and extracts a sequence of identifiers.
+        Walks the source string.
         """
         parsed = ast.parse(source)
         visitor.visit(parsed)
-        return getattr(visitor, attr)
+        return visitor
 
 
 class Linter:

--- a/src/ethereum_spec_tools/lint/__init__.py
+++ b/src/ethereum_spec_tools/lint/__init__.py
@@ -12,7 +12,6 @@ import pkgutil
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from itertools import zip_longest
-from pathlib import Path
 from typing import Generator, List, Optional, Sequence, Tuple, TypeVar
 
 from ..forks import Hardfork

--- a/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
@@ -95,13 +95,11 @@ class GlacierForksHygiene(Lint):
                 )
                 continue
 
-            current_node = self._parse(all_current[file], _Visitor(), "items")
-            previous_node = self._parse(
-                all_previous[file], _Visitor(), "items"
-            )
+            current_node = self._parse(all_current[file], _Visitor()).items
+            previous_node = self._parse(all_previous[file], _Visitor()).items
 
             diagnostics += self.compare(
-                fork_name, file, current_node, previous_node  # type: ignore
+                fork_name, file, current_node, previous_node
             )
 
         return diagnostics

--- a/src/ethereum_spec_tools/lint/lints/import_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/import_hygiene.py
@@ -55,7 +55,7 @@ class ImportHygiene(Lint):
             else tuple()
         )
 
-        current_imports = self._parse(source, _Visitor(), "item_imports")
+        current_imports = self._parse(source, _Visitor()).item_imports
 
         for item in current_imports:
             if item is None:

--- a/src/ethereum_spec_tools/lint/lints/patch_hygiene.py
+++ b/src/ethereum_spec_tools/lint/lints/patch_hygiene.py
@@ -50,11 +50,11 @@ class PatchHygiene(Lint):
             # Entire file is new, so nothing to compare!
             return []
 
-        current_nodes = self._parse(current_source, _Visitor(), "items")
+        current_nodes = self._parse(current_source, _Visitor()).items
         previous_nodes = {
             item: idx
             for (idx, item) in enumerate(
-                self._parse(previous_source, _Visitor(), "items")
+                self._parse(previous_source, _Visitor()).items
             )
         }
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #1357

There are relative imports that reach outside of the current fork. In my next PR, I'll be moving the forks into new directories.

### How was it fixed?

Added a check to the import hygiene lint that prevents relative imports like, for example, `..crypto.hash`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/b7bbc157-5562-442c-ab5a-5fca2d5ced73.jpeg?format=webp)
