### PR TITLE
fix tx parsing on sync

### DIFF
--- a/src/ethereum_spec_tools/sync.py
+++ b/src/ethereum_spec_tools/sync.py
@@ -320,8 +320,8 @@ class BlockDownloader(ForkTracking):
                     self.module("transactions").AccessListTransaction(
                         hex_to_u64(t["chainId"]),
                         hex_to_u256(t["nonce"]),
-                        hex_to_u256(t["gasPrice"]),
-                        hex_to_u256(t["gas"]),
+                        hex_to_uint(t["gasPrice"]),
+                        hex_to_uint(t["gas"]),
                         self.module("utils.hexadecimal").hex_to_address(
                             t["to"]
                         )
@@ -340,9 +340,9 @@ class BlockDownloader(ForkTracking):
                     self.module("transactions").FeeMarketTransaction(
                         hex_to_u64(t["chainId"]),
                         hex_to_u256(t["nonce"]),
-                        hex_to_u256(t["maxPriorityFeePerGas"]),
-                        hex_to_u256(t["maxFeePerGas"]),
-                        hex_to_u256(t["gas"]),
+                        hex_to_uint(t["maxPriorityFeePerGas"]),
+                        hex_to_uint(t["maxFeePerGas"]),
+                        hex_to_uint(t["gas"]),
                         self.module("utils.hexadecimal").hex_to_address(
                             t["to"]
                         )
@@ -359,8 +359,8 @@ class BlockDownloader(ForkTracking):
             else:
                 return self.module("transactions").LegacyTransaction(
                     hex_to_u256(t["nonce"]),
-                    hex_to_u256(t["gasPrice"]),
-                    hex_to_u256(t["gas"]),
+                    hex_to_uint(t["gasPrice"]),
+                    hex_to_uint(t["gas"]),
                     self.module("utils.hexadecimal").hex_to_address(t["to"])
                     if t["to"]
                     else Bytes0(b""),
@@ -373,8 +373,8 @@ class BlockDownloader(ForkTracking):
         else:
             return self.module("transactions").Transaction(
                 hex_to_u256(t["nonce"]),
-                hex_to_u256(t["gasPrice"]),
-                hex_to_u256(t["gas"]),
+                hex_to_uint(t["gasPrice"]),
+                hex_to_uint(t["gas"]),
                 self.module("utils.hexadecimal").hex_to_address(t["to"])
                 if t["to"]
                 else Bytes0(b""),


### PR DESCRIPTION
### What was wrong?

Transaction parsing in the sync tool had incorrect conversions for gas fields

### How was it fixed?
updated the conversion methods

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i2.pickpik.com/photos/474/805/122/cat-animal-cute-pet-preview.jpg)
