### PR TITLE
chore(tests): run latest json_infra tests

### DIFF
--- a/tests/json_infra/__init__.py
+++ b/tests/json_infra/__init__.py
@@ -19,7 +19,7 @@ TEST_FIXTURES: Dict[str, _FixtureSource] = {
     },
     "ethereum_tests": {
         "url": "https://github.com/ethereum/tests.git",
-        "commit_hash": "3129f16519013b265fa309208f49406b2ef57b13",
+        "commit_hash": "c67e485ff8b5be9abc8ad15345ec21aa22e290d9",
         "fixture_path": "tests/json_infra/fixtures/ethereum_tests",
     },
     "latest_fork_tests": {
@@ -27,7 +27,7 @@ TEST_FIXTURES: Dict[str, _FixtureSource] = {
         "fixture_path": "tests/json_infra/fixtures/latest_fork_tests",
     },
     "osaka_tests": {
-        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-3%40v1.0.0/fixtures_fusaka-devnet-3.tar.gz",
+        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-5%40v1.1.0/fixtures_fusaka-devnet-5.tar.gz",
         "fixture_path": "tests/json_infra/fixtures/osaka_tests",
     },
 }

--- a/tests/json_infra/vm/test_control_flow_operations.py
+++ b/tests/json_infra/vm/test_control_flow_operations.py
@@ -59,7 +59,7 @@ TEST_DIR = f"{ETHEREUM_TESTS_PATH}/LegacyTests/Constantinople/VMTests/vmIOandFlo
         ("JDfromStorageDynamicJump1.json", True),
         ("JDfromStorageDynamicJumpInsidePushWithJumpDest.json", True),
         ("JDfromStorageDynamicJumpInsidePushWithoutJumpDest.json", True),
-        ("DyanmicJump0_outOfBoundary.json", True),
+        ("DynamicJump0_outOfBoundary.json", True),
         ("DynamicJump0_AfterJumpdest.json", True),
         ("DynamicJump0_AfterJumpdest3.json", True),
         ("DynamicJump0_withoutJumpdest.json", True),


### PR DESCRIPTION
### What was wrong?
1. The latest osaka devnet tests were not being run
2. The latest commit of `ethereum/tests` was not being pulled in.

Related to Issue #1339

### How was it fixed?
Update the relevant fixture URLs

#### Cute Animal Picture

![Cute Animals - 1 of 1](https://github.com/user-attachments/assets/341d7195-5769-42d2-bb59-dd9a099a7f59)

