### PR TITLE
fix: update parameter docstring in address utility function

### DIFF
--- a/src/ethereum/arrow_glacier/utils/address.py
+++ b/src/ethereum/arrow_glacier/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/berlin/utils/address.py
+++ b/src/ethereum/berlin/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/byzantium/utils/address.py
+++ b/src/ethereum/byzantium/utils/address.py
@@ -28,7 +28,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/cancun/utils/address.py
+++ b/src/ethereum/cancun/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/constantinople/utils/address.py
+++ b/src/ethereum/constantinople/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/dao_fork/utils/address.py
+++ b/src/ethereum/dao_fork/utils/address.py
@@ -27,7 +27,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/frontier/utils/address.py
+++ b/src/ethereum/frontier/utils/address.py
@@ -27,7 +27,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/gray_glacier/utils/address.py
+++ b/src/ethereum/gray_glacier/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/homestead/utils/address.py
+++ b/src/ethereum/homestead/utils/address.py
@@ -27,7 +27,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/istanbul/utils/address.py
+++ b/src/ethereum/istanbul/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/london/utils/address.py
+++ b/src/ethereum/london/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/muir_glacier/utils/address.py
+++ b/src/ethereum/muir_glacier/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/osaka/utils/address.py
+++ b/src/ethereum/osaka/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/paris/utils/address.py
+++ b/src/ethereum/paris/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/prague/utils/address.py
+++ b/src/ethereum/prague/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/shanghai/utils/address.py
+++ b/src/ethereum/shanghai/utils/address.py
@@ -29,7 +29,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/spurious_dragon/utils/address.py
+++ b/src/ethereum/spurious_dragon/utils/address.py
@@ -28,7 +28,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------

--- a/src/ethereum/tangerine_whistle/utils/address.py
+++ b/src/ethereum/tangerine_whistle/utils/address.py
@@ -28,7 +28,7 @@ def to_address_masked(data: Uint | U256) -> Address:
     Parameters
     ----------
     data :
-        The string to be converted to bytes.
+        The numeric value to be converted to address.
 
     Returns
     -------


### PR DESCRIPTION
Correct the parameter description for 'data' parameter in to_address_masked()
function to match its actual type (Uint | U256) instead of incorrectly
describing it as a string.