### PR TITLE
fix(specs): remove redundant `destroy_storage` call within `process_create_message`

### DIFF
--- a/src/ethereum/forks/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/arrow_glacier/vm/interpreter.py
@@ -172,18 +172,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/arrow_glacier/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/berlin/vm/interpreter.py
+++ b/src/ethereum/forks/berlin/vm/interpreter.py
@@ -171,18 +171,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/berlin/vm/interpreter.py
+++ b/src/ethereum/forks/berlin/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/bpo1/vm/interpreter.py
+++ b/src/ethereum/forks/bpo1/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/bpo1/vm/interpreter.py
+++ b/src/ethereum/forks/bpo1/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/bpo2/vm/interpreter.py
+++ b/src/ethereum/forks/bpo2/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/bpo2/vm/interpreter.py
+++ b/src/ethereum/forks/bpo2/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/bpo3/vm/interpreter.py
+++ b/src/ethereum/forks/bpo3/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/bpo3/vm/interpreter.py
+++ b/src/ethereum/forks/bpo3/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/bpo4/vm/interpreter.py
+++ b/src/ethereum/forks/bpo4/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/bpo4/vm/interpreter.py
+++ b/src/ethereum/forks/bpo4/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/bpo5/vm/interpreter.py
+++ b/src/ethereum/forks/bpo5/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/bpo5/vm/interpreter.py
+++ b/src/ethereum/forks/bpo5/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/byzantium/vm/interpreter.py
+++ b/src/ethereum/forks/byzantium/vm/interpreter.py
@@ -170,14 +170,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
     increment_nonce(state, message.current_target)
     evm = process_message(message)
     if not evm.error:

--- a/src/ethereum/forks/byzantium/vm/interpreter.py
+++ b/src/ethereum/forks/byzantium/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     move_ether,
     rollback_transaction,

--- a/src/ethereum/forks/cancun/vm/interpreter.py
+++ b/src/ethereum/forks/cancun/vm/interpreter.py
@@ -162,18 +162,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/cancun/vm/interpreter.py
+++ b/src/ethereum/forks/cancun/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/constantinople/vm/interpreter.py
+++ b/src/ethereum/forks/constantinople/vm/interpreter.py
@@ -170,15 +170,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
     increment_nonce(state, message.current_target)
     evm = process_message(message)
     if not evm.error:

--- a/src/ethereum/forks/constantinople/vm/interpreter.py
+++ b/src/ethereum/forks/constantinople/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     move_ether,
     rollback_transaction,

--- a/src/ethereum/forks/dao_fork/vm/interpreter.py
+++ b/src/ethereum/forks/dao_fork/vm/interpreter.py
@@ -155,13 +155,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` left empty code.
-    destroy_storage(state, message.current_target)
-
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output

--- a/src/ethereum/forks/dao_fork/vm/interpreter.py
+++ b/src/ethereum/forks/dao_fork/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     move_ether,
     rollback_transaction,
     set_code,

--- a/src/ethereum/forks/frontier/vm/interpreter.py
+++ b/src/ethereum/forks/frontier/vm/interpreter.py
@@ -155,13 +155,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` left empty code.
-    destroy_storage(state, message.current_target)
-
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output

--- a/src/ethereum/forks/frontier/vm/interpreter.py
+++ b/src/ethereum/forks/frontier/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     move_ether,
     rollback_transaction,
     set_code,

--- a/src/ethereum/forks/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/gray_glacier/vm/interpreter.py
@@ -172,18 +172,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/gray_glacier/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/homestead/vm/interpreter.py
+++ b/src/ethereum/forks/homestead/vm/interpreter.py
@@ -155,13 +155,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` left empty code.
-    destroy_storage(state, message.current_target)
-
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output

--- a/src/ethereum/forks/homestead/vm/interpreter.py
+++ b/src/ethereum/forks/homestead/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     move_ether,
     rollback_transaction,
     set_code,

--- a/src/ethereum/forks/istanbul/vm/interpreter.py
+++ b/src/ethereum/forks/istanbul/vm/interpreter.py
@@ -171,18 +171,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/istanbul/vm/interpreter.py
+++ b/src/ethereum/forks/istanbul/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/london/vm/interpreter.py
+++ b/src/ethereum/forks/london/vm/interpreter.py
@@ -172,18 +172,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/london/vm/interpreter.py
+++ b/src/ethereum/forks/london/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/muir_glacier/vm/interpreter.py
@@ -171,18 +171,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/muir_glacier/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/osaka/vm/interpreter.py
+++ b/src/ethereum/forks/osaka/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/osaka/vm/interpreter.py
+++ b/src/ethereum/forks/osaka/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/paris/vm/interpreter.py
+++ b/src/ethereum/forks/paris/vm/interpreter.py
@@ -160,18 +160,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/paris/vm/interpreter.py
+++ b/src/ethereum/forks/paris/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -182,18 +182,8 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
+    # The list of created accounts is used by `get_storage_original`.
+    # Additionally, the list is needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     get_account,
     get_code,
     increment_nonce,

--- a/src/ethereum/forks/shanghai/vm/interpreter.py
+++ b/src/ethereum/forks/shanghai/vm/interpreter.py
@@ -161,18 +161,7 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts.
+    # The list of created accounts is used by `get_storage_original`.
     mark_account_created(state, message.current_target)
 
     increment_nonce(state, message.current_target)

--- a/src/ethereum/forks/shanghai/vm/interpreter.py
+++ b/src/ethereum/forks/shanghai/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     mark_account_created,
     move_ether,

--- a/src/ethereum/forks/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/forks/spurious_dragon/vm/interpreter.py
@@ -169,14 +169,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
     increment_nonce(state, message.current_target)
     evm = process_message(message)
     if not evm.error:

--- a/src/ethereum/forks/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/forks/spurious_dragon/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     increment_nonce,
     move_ether,
     rollback_transaction,

--- a/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
@@ -155,13 +155,6 @@ def process_create_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     begin_transaction(state)
 
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by two `CREATE` calls collide.
-    # * The first `CREATE` left empty code.
-    destroy_storage(state, message.current_target)
-
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output

--- a/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
@@ -36,7 +36,6 @@ from ..state import (
     account_has_storage,
     begin_transaction,
     commit_transaction,
-    destroy_storage,
     move_ether,
     rollback_transaction,
     set_code,


### PR DESCRIPTION
[_This is a copy of PR #1348, which seems to have been closed mistakenly when the `master` branch was deleted_]

### What was wrong?

Related to Issue #1347

### How was it fixed?

Removed the `destroy_storage` call within `process_create_message`.

#### Cute Animal Picture

![Baby Serval](https://img.buzzfeed.com/buzzfeed-static/static/2023-03/7/20/asset/79e51aa4b8af/sub-buzz-670-1678220113-3.jpg?downsize=700%3A%2A&output-quality=auto&output-format=auto)
