### PR TITLE
fix: block difficulty calc frontier

### DIFF
--- a/src/ethereum/frontier/fork.py
+++ b/src/ethereum/frontier/fork.py
@@ -768,7 +768,7 @@ def calculate_block_difficulty(
     # See https://github.com/ethereum/go-ethereum/pull/1588
     num_bomb_periods = (int(block_number) // 100000) - 2
     if num_bomb_periods >= 0:
-        difficulty += 2**num_bomb_periods
+        difficulty += Uint(2**num_bomb_periods)
 
     # Some clients raise the difficulty to `MINIMUM_DIFFICULTY` prior to adding
     # the bomb. This bug does not matter because the difficulty is always much


### PR DESCRIPTION
### What was wrong?

Frontier block difficulty calculation was broken

### How was it fixed?

Type conversion

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/736x/ef/e0/29/efe029d1edf0362c91b5afa9808af63a.jpg)
