### PR TITLE
Move point at infinity check before curve check for p256 verify

### DIFF
--- a/src/ethereum/osaka/vm/precompiled_contracts/p256verify.py
+++ b/src/ethereum/osaka/vm/precompiled_contracts/p256verify.py
@@ -67,13 +67,13 @@ def p256verify(evm: Evm) -> None:
     if public_key_y < U256(0) or public_key_y >= SECP256R1P:
         return
 
+    # Point should not be at infinity (represented as (0, 0))
+    if public_key_x == U256(0) and public_key_y == U256(0):
+        return
+
     # Point validity: The point (qx, qy) MUST satisfy the curve equation
     # qy^2 ≡ qx^3 + a*qx + b (mod p)
     if not is_on_curve_secp256r1(public_key_x, public_key_y):
-        return
-
-    # Point should not be at infinity (represented as (0, 0))
-    if public_key_x == U256(0) and public_key_y == U256(0):
         return
 
     try:

--- a/src/ethereum/osaka/vm/precompiled_contracts/p256verify.py
+++ b/src/ethereum/osaka/vm/precompiled_contracts/p256verify.py
@@ -62,9 +62,10 @@ def p256verify(evm: Evm) -> None:
 
     # Public key bounds:
     # Both qx and qy MUST satisfy 0 ≤ qx < p and 0 ≤ qy < p
-    if public_key_x < U256(0) or public_key_x >= SECP256R1P:
+    # U256 is unsigned, so we don't need to check for < 0
+    if public_key_x >= SECP256R1P:
         return
-    if public_key_y < U256(0) or public_key_y >= SECP256R1P:
+    if public_key_y >= SECP256R1P:
         return
 
     # Point should not be at infinity (represented as (0, 0))


### PR DESCRIPTION
### What was wrong?

[Code coverage](https://app.codecov.io/gh/ethereum/execution-specs/pull/1388/blob/src/ethereum/osaka/vm/precompiled_contracts/p256verify.py?dropdown=coverage#L76) highlighted that we aren't hitting the point at infinity check because `is_on_curve_secp256r1` catches the point at infinity and returns before it can reach the check for (0, 0).

### How was it fixed?

Moved the point at infinity check ahead of the `is_on_curve...` check, so we don't run through the method if we already know it won't pass. The other option is to remove the check, but I think this makes it more explicit that we're checking that point at infinity, and may be a tiny bit more performant.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://tucsonwildlife.com/wp-content/uploads/bobkitten-copyright-for-website--e1587081030974.jpg)
