### PR TITLE
bug(tool): update path to include forks folder

### DIFF
--- a/src/ethereum_spec_tools/patch_tool.py
+++ b/src/ethereum_spec_tools/patch_tool.py
@@ -32,7 +32,7 @@ def main() -> None:
     options = parser.parse_args()
 
     if not options.prefix:
-        options.prefix = "src/ethereum/"
+        options.prefix = "src/ethereum/forks/"
 
     source_fork_path = options.prefix + options.source_fork[0]
 


### PR DESCRIPTION
What was wrong?

The path prefix in the patch tool is outdated after all the fork related spec code was moved into the `forks` folder.

How was it fixed?
Add the `forks` folder to the path prefix.

