### PR TITLE
Forks/osaka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ tests/fixtures
 tests/t8n_testdata
 
 fixtures
+logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ This specification aims to be:
 - Avoid using EIP numbers in identifiers.
 - If necessary, there is a custom dictionary `whitelist.txt`. 
 
+See [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md) for rules not covered by Black (naming, ensure/assert, and typing ignore policy). 
+
 ### Changes across various Forks
 
 Many contributions require changes across multiple forks, organized under `src/ethereum/*`. When making such changes, please ensure that differences between the forks are minimal and consist only of necessary differences. This will help with getting cleaner [diff outputs](https://ethereum.github.io/execution-specs/diffs/index.html).

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,5 +9,7 @@ strict_bytes = True
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True
+show_error_codes = True
+enable_error_code = ignore-without-code
 
 ignore_missing_imports = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,6 +441,7 @@ select = [
     "D", # pydocstyle
     "C4", # flake8-comprehensions
     "ARG", # flake8-unused-arguments
+    "PGH003", # blanket-type-ignore
 ]
 fixable = [
     "E", # pycodestyle errors

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -51,8 +51,12 @@ from docc.source import Source
 from docc.transform import Transform
 from fladrif.apply import Apply
 from fladrif.treediff import Adapter, Operation, TreeMatcher
-from mistletoe import block_token as blocks  # type: ignore
-from mistletoe import span_token as spans
+from mistletoe import (  # type: ignore[import-untyped]  # Third-party library without types
+    block_token as blocks,
+)
+from mistletoe import (
+    span_token as spans,
+)
 from typing_extensions import assert_never, override
 
 from .forks import Hardfork

--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -130,7 +130,7 @@ class Hardfork:
 
         for criteria, name in config:
             mod = importlib.import_module("ethereum." + name)
-            mod.FORK_CRITERIA = criteria  # type: ignore
+            mod.FORK_CRITERIA = criteria  # type: ignore[attr-defined]  # Dynamic module attribute assignment
             forks.append(cls(mod))
 
         return forks


### PR DESCRIPTION
- Add STYLE_GUIDE.md reference to CONTRIBUTING.md
- Enable mypy error codes and ignore-without-code enforcement
- Add PGH003 (blanket-type-ignore) to ruff linter rules
- Fix type ignore comments to include specific error codes
- Add logs/ to .gitignore to exclude test execution logs

These changes enforce more precise type ignore comments and improve
code quality by requiring specific mypy error codes.

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
