### PR TITLE
type:refactor Change `is_after_fork` method 

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -14,7 +14,7 @@ class ForkLoad:
     """
 
     _fork_module: str
-    _forks: Any
+    _forks: list[Hardfork]
 
     def __init__(self, fork_module: str):
         self._fork_module = fork_module
@@ -40,12 +40,17 @@ class ForkLoad:
         raise Exception(f"fork {self._fork_module} not discovered")
 
     def is_after_fork(self, target_fork_name: str) -> bool:
-        """Check if the fork is after the target fork."""
+        """
+        Check if the fork is after the target fork.
+
+        Accepts short fork names (e.g. "cancun") instead of full module paths.
+        """
         return_value = False
         for fork in self._forks:
-            if fork.name == target_fork_name:
+            short_name = fork.short_name
+            if short_name == target_fork_name:
                 return_value = True
-            if fork.name == "ethereum.forks." + self._fork_module:
+            if short_name == self._fork_module:
                 break
         return return_value
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -174,15 +174,15 @@ class T8N(Load):
             "chain_id": self.chain_id,
         }
 
-        if self.fork.is_after_fork("ethereum.forks.london"):
+        if self.fork.is_after_fork("london"):
             kw_arguments["base_fee_per_gas"] = self.env.base_fee_per_gas
 
-        if self.fork.is_after_fork("ethereum.forks.paris"):
+        if self.fork.is_after_fork("paris"):
             kw_arguments["prev_randao"] = self.env.prev_randao
         else:
             kw_arguments["difficulty"] = self.env.block_difficulty
 
-        if self.fork.is_after_fork("ethereum.forks.cancun"):
+        if self.fork.is_after_fork("cancun"):
             kw_arguments["parent_beacon_block_root"] = (
                 self.env.parent_beacon_block_root
             )
@@ -252,14 +252,14 @@ class T8N(Load):
         self.result.rejected = self.txs.rejected_txs
 
     def _run_blockchain_test(self, block_env: Any, block_output: Any) -> None:
-        if self.fork.is_after_fork("ethereum.forks.prague"):
+        if self.fork.is_after_fork("prague"):
             self.fork.process_unchecked_system_transaction(
                 block_env=block_env,
                 target_address=self.fork.HISTORY_STORAGE_ADDRESS,
                 data=block_env.block_hashes[-1],  # The parent hash
             )
 
-        if self.fork.is_after_fork("ethereum.forks.cancun"):
+        if self.fork.is_after_fork("cancun"):
             self.fork.process_unchecked_system_transaction(
                 block_env=block_env,
                 target_address=self.fork.BEACON_ROOTS_ADDRESS,
@@ -281,7 +281,7 @@ class T8N(Load):
                 self.restore_state()
                 self.logger.warning(f"Transaction {i} failed: {e!r}")
 
-        if not self.fork.is_after_fork("ethereum.forks.paris"):
+        if not self.fork.is_after_fork("paris"):
             if self.options.state_reward is None:
                 self.pay_block_rewards(self.fork.BLOCK_REWARD, block_env)
             elif self.options.state_reward != -1:
@@ -289,12 +289,12 @@ class T8N(Load):
                     U256(self.options.state_reward), block_env
                 )
 
-        if self.fork.is_after_fork("ethereum.forks.shanghai"):
+        if self.fork.is_after_fork("shanghai"):
             self.fork.process_withdrawals(
                 block_env, block_output, self.env.withdrawals
             )
 
-        if self.fork.is_after_fork("ethereum.forks.prague"):
+        if self.fork.is_after_fork("prague"):
             self.fork.process_general_purpose_requests(block_env, block_output)
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -77,7 +77,7 @@ class Env:
         self.read_withdrawals(data, t8n)
 
         self.parent_beacon_block_root = None
-        if t8n.fork.is_after_fork("ethereum.forks.cancun"):
+        if t8n.fork.is_after_fork("cancun"):
             if not t8n.options.state_test:
                 parent_beacon_block_root_hex = data["parentBeaconBlockRoot"]
                 self.parent_beacon_block_root = (
@@ -96,7 +96,7 @@ class Env:
         self.parent_excess_blob_gas = U64(0)
         self.excess_blob_gas = None
 
-        if not t8n.fork.is_after_fork("ethereum.forks.cancun"):
+        if not t8n.fork.is_after_fork("cancun"):
             return
 
         if "currentExcessBlobGas" in data:
@@ -131,7 +131,7 @@ class Env:
         else:
             self.excess_blob_gas = parent_blob_gas - target_blob_gas_per_block
 
-            if t8n.fork.is_after_fork("ethereum.forks.osaka"):
+            if t8n.fork.is_after_fork("osaka"):
                 # Under certain conditions specified in EIP-7918, the
                 # the excess_blob_gas is calculated differently in osaka
                 assert self.parent_base_fee_per_gas is not None
@@ -170,7 +170,7 @@ class Env:
         self.parent_base_fee_per_gas = None
         self.base_fee_per_gas = None
 
-        if t8n.fork.is_after_fork("ethereum.forks.london"):
+        if t8n.fork.is_after_fork("london"):
             if "currentBaseFee" in data:
                 self.base_fee_per_gas = parse_hex_or_int(
                     data["currentBaseFee"], Uint
@@ -212,7 +212,7 @@ class Env:
         Read the randao from the data.
         """
         self.prev_randao = None
-        if t8n.fork.is_after_fork("ethereum.forks.paris"):
+        if t8n.fork.is_after_fork("paris"):
             # tf tool might not always provide an
             # even number of nibbles in the randao
             # This could create issues in the
@@ -233,7 +233,7 @@ class Env:
         Read the withdrawals from the data.
         """
         self.withdrawals = None
-        if t8n.fork.is_after_fork("ethereum.forks.shanghai"):
+        if t8n.fork.is_after_fork("shanghai"):
             self.withdrawals = tuple(
                 t8n.json_to_withdrawals(wd) for wd in data["withdrawals"]
             )
@@ -248,7 +248,7 @@ class Env:
         self.parent_timestamp = None
         self.parent_difficulty = None
         self.parent_ommers_hash = None
-        if t8n.fork.is_after_fork("ethereum.forks.paris"):
+        if t8n.fork.is_after_fork("paris"):
             return
         elif "currentDifficulty" in data:
             self.block_difficulty = parse_hex_or_int(
@@ -267,7 +267,7 @@ class Env:
                 self.parent_timestamp,
                 self.parent_difficulty,
             ]
-            if t8n.fork.is_after_fork("ethereum.forks.byzantium"):
+            if t8n.fork.is_after_fork("byzantium"):
                 if "parentUncleHash" in data:
                     EMPTY_OMMER_HASH = keccak256(rlp.encode([]))  # noqa N806
                     self.parent_ommers_hash = Hash32(
@@ -286,10 +286,7 @@ class Env:
         Read the block hashes. Returns a maximum of 256 block hashes.
         """
         self.parent_hash = None
-        if (
-            t8n.fork.is_after_fork("ethereum.forks.prague")
-            and not t8n.options.state_test
-        ):
+        if t8n.fork.is_after_fork("prague") and not t8n.options.state_test:
             self.parent_hash = Hash32(hex_to_bytes(data["parentHash"]))
 
         # Read the block hashes

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -137,7 +137,7 @@ class Txs:
         t8n = self.t8n
 
         tx_rlp = rlp.encode(raw_tx)
-        if t8n.fork.is_after_fork("ethereum.forks.berlin"):
+        if t8n.fork.is_after_fork("berlin"):
             if isinstance(raw_tx, Bytes):
                 transaction = t8n.fork.decode_transaction(raw_tx)
                 self.all_txs.append(raw_tx)
@@ -180,7 +180,7 @@ class Txs:
         tx = TransactionLoad(raw_tx, t8n.fork).read()
         self.all_txs.append(tx)
 
-        if t8n.fork.is_after_fork("ethereum.forks.berlin"):
+        if t8n.fork.is_after_fork("berlin"):
             transaction = t8n.fork.decode_transaction(tx)
         else:
             transaction = tx
@@ -205,14 +205,14 @@ class Txs:
             tx_decoded = tx
 
         secret_key = hex_to_uint(json_tx["secretKey"][2:])
-        if t8n.fork.is_after_fork("ethereum.forks.berlin"):
+        if t8n.fork.is_after_fork("berlin"):
             Transaction = t8n.fork.LegacyTransaction  # noqa N806
         else:
             Transaction = t8n.fork.Transaction  # noqa N806
 
         v_addend: U256
         if isinstance(tx_decoded, Transaction):
-            if t8n.fork.is_after_fork("ethereum.forks.spurious_dragon"):
+            if t8n.fork.is_after_fork("spurious_dragon"):
                 if protected:
                     signing_hash = t8n.fork.signing_hash_155(
                         tx_decoded, U64(1)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
This PR refactors the `ForkLoad.is_after_fork` method to accept **fork short names** (e.g. `"Paris"`, `"Shanghai"`) instead of full module paths (e.g. `"ethereum.forks.paris"`).

<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

Fixes #1424 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
