### PR TITLE
Tune test memory usage; disable index on pypy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: Run pypy3 tests
         run: tox -e pypy3
         env:
-          PYPY_GC_MAX: "10G"
+          PYPY_GC_MAX: "2G"
+          PYPY_GC_MIN: "1G"
 
   json_infra:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ extras =
 commands =
     fill \
         -m "not slow and not zkevm and not benchmark" \
-        -n auto --maxprocesses 6 \
+        -n auto --maxprocesses 10 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
         --clean \
         --until Osaka \
@@ -56,13 +56,16 @@ extras =
     test,fill
 passenv =
     PYPY_GC_MAX
+    PYPY_GC_MIN
 commands =
     fill \
+        --skip-index \
+        --no-html \
         --tb=no \
         --show-capture=no \
         --disable-warnings \
         -m "not slow and not zkevm and not benchmark" \
-        -n auto --maxprocesses 3 \
+        -n auto --maxprocesses 7 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
         --clean \
         --until Osaka \
@@ -74,6 +77,7 @@ extras =
     optimized
 passenv =
     PYPY_GC_MAX
+    PYPY_GC_MIN
 commands =
     pytest \
         -m "not slow and not evm_tools" \


### PR DESCRIPTION
## 🗒️ Description

**This might require waiting until [`11b96b80f1a9dad80766d3fedb51c3cc463b2011`](https://github.com/ethereum/execution-spec-tests/commit/11b96b80f1a9dad80766d3fedb51c3cc463b2011) is pulled in a subtree**

Four notable tweaks in here:

- Switch to `--dist=loadgroup`. See pytest-xdist's [distribution modes](https://pytest-xdist.readthedocs.io/en/latest/distribution.html#distribution-modes).
- Lower the pypy garbage collector limit to 2G (from 10G).
- Increase the max number of workers to 10.
- Disable test index generation in pypy (this takes more than 2G of memory).

On my machine, as measured by `systemd-run`, this 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lemmy.world/pictrs/image/f88facbd-b8fc-49e6-8ef3-eeb46af611e4.jpeg?format=webp)
