### PR TITLE
docs:fix Documentation for calculate_block_difficulty incorrectly references GENESIS_DIFFICULTY

### DIFF
--- a/src/ethereum/forks/dao_fork/fork.py
+++ b/src/ethereum/forks/dao_fork/fork.py
@@ -776,7 +776,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------


### PR DESCRIPTION


## 🗒️ Description
Documentation: fix documentation for calculate_block_difficulty incorrectly references GENESIS_DIFFICULTY

## 🔗 Related Issues or PRs
#607

## ✅ Checklist
fixes #607 

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
