### PR TITLE
feat: commit-message-format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,29 @@ jobs:
       - name: Run static checks
         run: tox -e static
 
+  lint-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install gitlint
+        run: pip install gitlint>=0.20.0
+      - name: Lint commits
+        run: |
+          BASE_REF="${{ github.base_ref || github.repository.default_branch }}"
+          BASE_SHA=$(git merge-base HEAD "origin/$BASE_REF")
+          echo "Linting commits from $BASE_SHA to HEAD (base ref: $BASE_REF)"
+          echo "Commits in range:"
+          git log --oneline "$BASE_SHA"..HEAD || echo "No new commits"
+          gitlint --contrib CT1 --commits "$BASE_SHA"..HEAD --ignore body-is-missing
+          echo "Conventional Commits linting PASSED!"
+
   py3:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static


### PR DESCRIPTION
 🗒️ Description

Add commit message validation to enforce conventional commit format in CI using commitlint. 

## 🔗 Related Issues or PRs
 Fixes  #1461 


## ✅ Checklist


- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


#### Cute Animal Picture

![Cute commit-linting owl](https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=300)
