### PR TITLE
bug(pytest): fixed repository root getting cluttered with logs/ directory when running with tox 

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/custom_logging/plugin_logging.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/custom_logging/plugin_logging.py
@@ -59,6 +59,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: D103
             "CRITICAL, default - INFO. An integer in [0, 50] may be also provided."
         ),
     )
+    logging_group.addoption(
+        "--log-to",
+        action="store",
+        default=None,
+        dest="eest_log_dir",
+        help="Directory to write log files. Defaults to ./logs if not specified.",
+    )
 
 
 @functools.cache
@@ -108,9 +115,10 @@ def pytest_configure(config: pytest.Config) -> None:
 
     worker_id = os.getenv("PYTEST_XDIST_WORKER", "main")
     log_filename = f"{log_stem}-{worker_id}.log"
-    log_path = Path("logs")
-    log_path.mkdir(exist_ok=True)
-    log_file_path = log_path / log_filename
+    log_dir = getattr(config.option, "eest_log_dir", None)
+    base_logs_dir = Path("logs") if log_dir is None else Path(log_dir)
+    base_logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file_path = base_logs_dir / log_filename
 
     # Store the log file path in the pytest config
     config.option.eest_log_file_path = log_file_path

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ commands =
         -m "not slow and not zkevm and not benchmark" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
         --clean \
         --until Osaka \
         tests
@@ -86,6 +87,7 @@ commands =
         -m "not slow and not zkevm and not benchmark" \
         -n auto --maxprocesses 7 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
         --clean \
         --until Osaka \
         tests


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #1456 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
