### PR TITLE
chore(pytest): Fix/enable `packages/tests` unit tests

### DIFF
--- a/.github/actions/build-evmone/action.yaml
+++ b/.github/actions/build-evmone/action.yaml
@@ -39,7 +39,7 @@ runs:
     # Restore previously built binaries if cache hit
     - name: Restore build cache
       id: cache-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ${{ github.workspace }}/evmone/build
@@ -92,7 +92,7 @@ runs:
     # Save cache only when we actually built
     - name: Save build cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ${{ github.workspace }}/evmone/build

--- a/.github/actions/build-evmone/action.yaml
+++ b/.github/actions/build-evmone/action.yaml
@@ -1,0 +1,103 @@
+name: 'Build evmone EVM'
+description: 'Builds the evmone EVM binary'
+inputs:
+  repo:
+    description: 'Source repository to use to build the EVM binary'
+    required: true
+    default: 'ethereum/evmone'
+  ref:
+    description: 'Reference to branch, commit, or tag to use to build the EVM binary'
+    required: true
+    default: 'master'
+  targets:
+    description: 'Which targets to build from evmone repo'
+    required: false
+    default: 'all'
+  cache_ttl_days:
+    description: 'Number of days to reuse a cached build before refreshing'
+    required: false
+    default: '3'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute cache bucket (time window)
+      id: bucket
+      shell: bash
+      run: |
+        # Round "today" down to the start of the current N-day bucket in UTC.
+        N=${{ inputs.cache_ttl_days }}
+        SECS=$(( $(date -u +%s) ))
+        DAY=$(( SECS / 86400 ))
+        BUCKET_START_DAY=$(( (DAY / N) * N ))
+        echo "CACHE_BUCKET=$(date -u -d @$(( BUCKET_START_DAY * 86400 )) +%Y-%m-%d)" >> $GITHUB_ENV
+      
+    - name: Prepare cache target dir
+      shell: bash
+      run: mkdir -p "$GITHUB_WORKSPACE/evmone/build"
+
+    # Restore previously built binaries if cache hit
+    - name: Restore build cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ${{ github.workspace }}/evmone/build
+        key: >
+          evmone-build-${{ runner.os }}-${{ runner.arch }}-
+          targets=${{ inputs.targets }}-
+          ref=${{ inputs.ref }}-
+          bucket=${{ env.CACHE_BUCKET }}
+    
+    # Checkout and build evmone if cache miss
+    - name: Checkout evmone
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        repository: ${{ inputs.repo }}
+        ref: ${{ inputs.ref }}
+        path: evmone
+        submodules: true
+
+    - name: Setup cmake
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+      with:
+        cmake-version: '3.x'
+
+    - name: Install GMP Linux
+      if: runner.os == 'Linux' && steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
+
+    - name: Install GMP macOS
+      if: runner.os == 'macOS' && steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        brew update && brew install gmp
+
+    - name: Build evmone binary (skips when cache hit)
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p "$GITHUB_WORKSPACE/bin"
+        cd "$GITHUB_WORKSPACE/evmone"
+        cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
+        cmake --build build --parallel --target ${{ inputs.targets }}
+
+    - name: Add evmone bin to PATH
+      shell: bash
+      run: echo "$GITHUB_WORKSPACE/evmone/build/bin" >> "$GITHUB_PATH"
+
+    # Save cache only when we actually built
+    - name: Save build cache
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ github.workspace }}/evmone/build
+        key: >
+          evmone-build-${{ runner.os }}-${{ runner.arch }}-
+          targets=${{ inputs.targets }}-
+          ref=${{ inputs.ref }}-
+          bucket=${{ env.CACHE_BUCKET }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload Pages Artifact
         id: artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: .tox/docs
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload Pages Artifact
         id: artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
         with:
           path: .tox/docs
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,11 @@ jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - name: Install Tox and any other packages
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'push' || github.ref_name != github.event.repository.default_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - name: Install gitlint
@@ -60,11 +60,11 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
@@ -75,11 +75,11 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "pypy3.11"
       - uses: ./.github/actions/setup-env
@@ -93,18 +93,18 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
       - name: Run json infra tests
         run: tox -e json_infra
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
           files: .tox/coverage.xml
           flags: unittests
@@ -114,11 +114,11 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
@@ -129,11 +129,11 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
@@ -145,11 +145,11 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "pypy3.11"
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,3 +124,38 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Run optimized tests
         run: tox -e optimized
+
+  tests_pytest_py3:
+    runs-on: [self-hosted-ghr, size-xl-x64]
+    needs: static
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-evmone
+      - name: Run py3 tests
+        run: tox -e tests_pytest_py3
+
+  tests_pytest_pypy3:
+    runs-on: [self-hosted-ghr, size-xl-x64]
+    needs: static
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "pypy3.11"
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-evmone
+      - name: Run pypy3 tests
+        run: tox -e tests_pytest_pypy3
+        env:
+          PYPY_GC_MAX: "2G"
+          PYPY_GC_MIN: "1G"

--- a/packages/tests/src/cli/gentest/tests/test_cli.py
+++ b/packages/tests/src/cli/gentest/tests/test_cli.py
@@ -117,7 +117,6 @@ def test_tx_type(
     monkeypatch: Any,
     tx_type: int,
     transaction_hash: str,
-    default_t8n: Any,
 ) -> None:
     """Generates a test case for any transaction type."""
     # This test is run in a CI environment, where connection to a
@@ -159,8 +158,6 @@ def test_tx_type(
         "state_test",
         "--fork",
         "Cancun",
-        "--t8n-server-url",
-        default_t8n.server_url,
     ]
     result = pytester.runpytest("-v", *args)
     assert result.ret == pytest.ExitCode.OK, f"Fill command failed:\n{result}"

--- a/packages/tests/src/cli/tests/test_pytest_fill_command.py
+++ b/packages/tests/src/cli/tests/test_pytest_fill_command.py
@@ -1,70 +1,139 @@
 """Tests for pytest commands (e.g., fill) click CLI."""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any, Generator
+from typing import Callable
 
 import pytest
-from click.testing import CliRunner
-from pytest import MonkeyPatch
+from click.testing import CliRunner, Result
+from pytest import MonkeyPatch, Pytester, RunResult, TempPathFactory
 
 import pytest_plugins.filler.filler
 
 from ..pytest_commands.fill import fill
 
+MINIMAL_TEST_FILE_NAME = "test_example.py"
+MINIMAL_TEST_CONTENTS = """
+from ethereum_test_tools import Transaction
+def test_function(state_test, pre):
+    tx = Transaction(to=0, gas_limit=21_000, sender=pre.fund_eoa())
+    state_test(pre=pre, post={}, tx=tx)
+"""
+
 
 @pytest.fixture
-def runner() -> CliRunner:
-    """Provide a Click CliRunner for invoking command-line interfaces."""
-    return CliRunner()
+def expected_exit_code() -> pytest.ExitCode:
+    return pytest.ExitCode.OK
 
 
-def test_fill_help(runner: CliRunner) -> None:
-    """Test the `--help` option of the `fill` command."""
-    result = runner.invoke(fill, ["--help"])
-    assert result.exit_code == pytest.ExitCode.OK
-    assert "[--evm-bin EVM_BIN]" in result.output
-    assert "[--traces]" in result.output
-    assert "[--evm-code-type EVM_CODE_TYPE]" in result.output
-    assert "--help" in result.output
-    assert "Arguments defining evm executable behavior:" in result.output
-
-
-def test_fill_pytest_help(runner: CliRunner) -> None:
-    """Test the `--pytest-help` option of the `fill` command."""
-    result = runner.invoke(fill, ["--pytest-help"])
-    assert result.exit_code == pytest.ExitCode.OK
-    assert "[options] [file_or_dir] [file_or_dir] [...]" in result.output
-    assert "-k EXPRESSION" in result.output
-
-
-def test_fill_with_invalid_option(runner: CliRunner) -> None:
-    """Test invoking `fill` with an invalid option."""
-    result = runner.invoke(fill, ["--invalid-option"])
-    assert result.exit_code != 0
-    assert "unrecognized arguments" in result.output
-
-
-class TestHtmlReportFlags:
-    """Test html report generation and output options."""
+class TestFillClickCli:
+    """Test fill command using Click CLI."""
 
     @pytest.fixture
-    def fill_args(self, default_t8n: Any) -> list[str]:
-        """
-        Provide default arguments for the `fill` command when testing html
-        report generation.
+    def runner(self) -> CliRunner:
+        """Provide a Click CliRunner for invoking command-line interfaces."""
+        return CliRunner()
 
-        Specifies a single existing example test case for faster fill
-        execution, and to allow for tests to check for the fixture generation
-        location.
+    @pytest.fixture
+    def run_fill(
+        self, runner: CliRunner, expected_exit_code: pytest.ExitCode
+    ) -> Callable[..., Result]:
+        """Provide a Click CliRunner for invoking command-line interfaces."""
+
+        def _run_fill(*args: str) -> Result:
+            result = runner.invoke(fill, args)
+            assert result.exit_code == expected_exit_code, (
+                f"Invalid exit code, {result.exit_code}, "
+                f"expected {expected_exit_code}, "
+                f"stdout: {result.stdout}, "
+                f"stderr: {result.stderr}, "
+                f"command-line args: {args}"
+            )
+            return result
+
+        return _run_fill
+
+    def test_fill_help(self, run_fill: Callable[..., Result]) -> None:
+        """Test the `--help` option of the `fill` command."""
+        result = run_fill("--help")
+        assert "[--evm-bin EVM_BIN]" in result.output
+        assert "[--traces]" in result.output
+        assert "[--evm-code-type EVM_CODE_TYPE]" in result.output
+        assert "--help" in result.output
+        assert "Arguments defining evm executable behavior:" in result.output
+
+    def test_fill_pytest_help(self, run_fill: Callable[..., Result]) -> None:
+        """Test the `--pytest-help` option of the `fill` command."""
+        result = run_fill("--pytest-help")
+        assert "[options] [file_or_dir] [file_or_dir] [...]" in result.output
+        assert "-k EXPRESSION" in result.output
+
+    @pytest.mark.parametrize("expected_exit_code", [pytest.ExitCode.USAGE_ERROR])
+    def test_fill_with_invalid_option(self, run_fill: Callable[..., Result]) -> None:
+        """Test invoking `fill` with an invalid option."""
+        result = run_fill("--invalid-option")
+        assert "unrecognized arguments" in result.output
+
+
+class TestFillPytester:
+    """
+    Test fill command using pytester.
+
+    This mode skips the fill command's Click CLI and uses pytester to run the command.
+
+    Pytester allows to actually fill the python test files.
+    """
+
+    @pytest.fixture
+    def pytester_temp_dir(self, pytester: pytest.Pytester) -> Path:
         """
+        Get the base temporary directory for pytest.
+        """
+        return pytester.path
+
+    @pytest.fixture
+    def minimal_test_path(self, pytester: pytest.Pytester) -> Path:
+        """
+        Minimal test file that's written to a file using pytester and ready to
+        fill.
+        """
+        tests_dir = pytester.mkdir("tests")
+        test_file = tests_dir / MINIMAL_TEST_FILE_NAME
+        test_file.write_text(MINIMAL_TEST_CONTENTS)
+        return test_file
+
+    @pytest.fixture
+    def fill_args(self, minimal_test_path: Path) -> list[str]:
+        """Default fill arguments."""
         return [
-            "-k",
-            "test_dup and state_test-DUP16",
             "--fork",
-            "Frontier",
-            "../../tests/eest/frontier",  # TODO: Should not be necessary.
+            "Cancun",
+            str(minimal_test_path),
         ]
+
+    @pytest.fixture
+    def run_fill(
+        self, pytester: Pytester, expected_exit_code: pytest.ExitCode
+    ) -> Callable[..., RunResult]:
+        """Provide a function to run the fill command with various options."""
+
+        def _run_fill(*args: str) -> RunResult:
+            pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
+            args = (
+                "-c",
+                "pytest-fill.ini",
+                *args,
+            )
+            result = pytester.runpytest(*args)
+            assert result.ret == expected_exit_code, (
+                f"Invalid exit code, {result.ret}, "
+                f"expected {expected_exit_code}, "
+                f"stdout: {result.outlines}, "
+                f"stderr: {result.errlines}, "
+                f"command-line args: {args}"
+            )
+            return result
+
+        return _run_fill
 
     @pytest.fixture()
     def default_html_report_file_path(self) -> str:
@@ -72,15 +141,13 @@ class TestHtmlReportFlags:
         return pytest_plugins.filler.filler.default_html_report_file_path()
 
     @pytest.fixture(scope="function")
-    def temp_dir(self) -> Generator[Path, None, None]:
+    def default_fixtures_output(self, tmp_path_factory: TempPathFactory) -> Path:
         """Provide a temporary directory as a pytest fixture."""
-        temp_dir = TemporaryDirectory()
-        yield Path(temp_dir.name)
-        temp_dir.cleanup()
+        return tmp_path_factory.mktemp("fixtures")
 
     @pytest.fixture(scope="function", autouse=True)
     def monkeypatch_default_output_directory(
-        self, monkeypatch: MonkeyPatch, temp_dir: Path
+        self, monkeypatch: MonkeyPatch, default_fixtures_output: Path
     ) -> None:
         """
         Monkeypatch default output directory for the pytest commands.
@@ -90,7 +157,7 @@ class TestHtmlReportFlags:
         """
 
         def mock_default_output_directory() -> Path:
-            return temp_dir
+            return default_fixtures_output
 
         monkeypatch.setattr(
             pytest_plugins.filler.filler,
@@ -100,8 +167,8 @@ class TestHtmlReportFlags:
 
     def test_fill_default_output_options(
         self,
-        runner: CliRunner,
-        temp_dir: Path,
+        run_fill: Callable[..., RunResult],
+        default_fixtures_output: Path,
         fill_args: list[str],
         default_html_report_file_path: str,
     ) -> None:
@@ -109,55 +176,49 @@ class TestHtmlReportFlags:
         Test default pytest html behavior: Neither `--html` or `--output` is
         specified.
         """
-        default_html_path = temp_dir / default_html_report_file_path
-        result = runner.invoke(fill, fill_args)
-        assert result.exit_code == pytest.ExitCode.OK
+        default_html_path = default_fixtures_output / default_html_report_file_path
+        run_fill(*fill_args)
         assert default_html_path.exists()
 
     def test_fill_no_html_option(
         self,
-        runner: CliRunner,
-        temp_dir: Path,
+        run_fill: Callable[..., RunResult],
+        default_fixtures_output: Path,
         fill_args: list[str],
         default_html_report_file_path: str,
     ) -> None:
         """Test pytest html report is disabled with the `--no-html` flag."""
-        default_html_path = temp_dir / default_html_report_file_path
+        default_html_path = default_fixtures_output / default_html_report_file_path
         fill_args += ["--no-html"]
-        result = runner.invoke(fill, fill_args)
-        assert result.exit_code == pytest.ExitCode.OK
+        run_fill(*fill_args)
         assert not default_html_path.exists()
 
     def test_fill_html_option(
         self,
-        runner: CliRunner,
-        temp_dir: Path,
+        run_fill: Callable[..., RunResult],
+        pytester_temp_dir: Path,
         fill_args: list[str],
     ) -> None:
         """Tests pytest html report generation with only the `--html` flag."""
-        non_default_html_path = (
-            temp_dir / "non_default_output_dir" / "report.html"
-        )
+        non_default_html_path = pytester_temp_dir / "non_default_output_dir" / "report.html"
         fill_args += ["--html", str(non_default_html_path)]
-        result = runner.invoke(fill, fill_args)
-        assert result.exit_code == pytest.ExitCode.OK
+        run_fill(*fill_args)
         assert non_default_html_path.exists()
 
     def test_fill_output_option(
         self,
-        runner: CliRunner,
-        temp_dir: Path,
+        run_fill: Callable[..., RunResult],
+        pytester_temp_dir: Path,
         fill_args: list[str],
         default_html_report_file_path: str,
     ) -> None:
         """
         Tests pytest html report generation with only the `--output` flag.
         """
-        output_dir = temp_dir / "non_default_output_dir"
+        output_dir = pytester_temp_dir / "non_default_output_dir"
         non_default_html_path = output_dir / default_html_report_file_path
         fill_args += ["--output", str(output_dir)]
-        result = runner.invoke(fill, fill_args)
-        assert result.exit_code == pytest.ExitCode.OK
+        run_fill(*fill_args)
         assert non_default_html_path.exists()
         assert (output_dir / "state_tests").exists(), (
             "No fixtures in output directory"
@@ -165,21 +226,18 @@ class TestHtmlReportFlags:
 
     def test_fill_html_and_output_options(
         self,
-        runner: CliRunner,
-        temp_dir: Path,
+        run_fill: Callable[..., RunResult],
+        pytester_temp_dir: Path,
         fill_args: list[str],
     ) -> None:
         """
         Tests pytest html report generation with both `--output` and `--html`
         flags.
         """
-        output_dir = temp_dir / "non_default_output_dir_fixtures"
-        html_path = (
-            temp_dir / "non_default_output_dir_html" / "non_default.html"
-        )
+        output_dir = pytester_temp_dir / "non_default_output_dir_fixtures"
+        html_path = pytester_temp_dir / "non_default_output_dir_html" / "non_default.html"
         fill_args += ["--output", str(output_dir), "--html", str(html_path)]
-        result = runner.invoke(fill, fill_args)
-        assert result.exit_code == pytest.ExitCode.OK
+        run_fill(*fill_args)
         assert html_path.exists()
         assert (output_dir / "state_tests").exists(), (
             "No fixtures in output directory"

--- a/packages/tests/src/cli/tests/test_pytest_fill_command.py
+++ b/packages/tests/src/cli/tests/test_pytest_fill_command.py
@@ -67,8 +67,12 @@ class TestFillClickCli:
         assert "[options] [file_or_dir] [file_or_dir] [...]" in result.output
         assert "-k EXPRESSION" in result.output
 
-    @pytest.mark.parametrize("expected_exit_code", [pytest.ExitCode.USAGE_ERROR])
-    def test_fill_with_invalid_option(self, run_fill: Callable[..., Result]) -> None:
+    @pytest.mark.parametrize(
+        "expected_exit_code", [pytest.ExitCode.USAGE_ERROR]
+    )
+    def test_fill_with_invalid_option(
+        self, run_fill: Callable[..., Result]
+    ) -> None:
         """Test invoking `fill` with an invalid option."""
         result = run_fill("--invalid-option")
         assert "unrecognized arguments" in result.output
@@ -117,7 +121,9 @@ class TestFillPytester:
         """Provide a function to run the fill command with various options."""
 
         def _run_fill(*args: str) -> RunResult:
-            pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
+            pytester.copy_example(
+                name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+            )
             args = (
                 "-c",
                 "pytest-fill.ini",
@@ -141,7 +147,9 @@ class TestFillPytester:
         return pytest_plugins.filler.filler.default_html_report_file_path()
 
     @pytest.fixture(scope="function")
-    def default_fixtures_output(self, tmp_path_factory: TempPathFactory) -> Path:
+    def default_fixtures_output(
+        self, tmp_path_factory: TempPathFactory
+    ) -> Path:
         """Provide a temporary directory as a pytest fixture."""
         return tmp_path_factory.mktemp("fixtures")
 
@@ -176,7 +184,9 @@ class TestFillPytester:
         Test default pytest html behavior: Neither `--html` or `--output` is
         specified.
         """
-        default_html_path = default_fixtures_output / default_html_report_file_path
+        default_html_path = (
+            default_fixtures_output / default_html_report_file_path
+        )
         run_fill(*fill_args)
         assert default_html_path.exists()
 
@@ -188,7 +198,9 @@ class TestFillPytester:
         default_html_report_file_path: str,
     ) -> None:
         """Test pytest html report is disabled with the `--no-html` flag."""
-        default_html_path = default_fixtures_output / default_html_report_file_path
+        default_html_path = (
+            default_fixtures_output / default_html_report_file_path
+        )
         fill_args += ["--no-html"]
         run_fill(*fill_args)
         assert not default_html_path.exists()
@@ -200,7 +212,9 @@ class TestFillPytester:
         fill_args: list[str],
     ) -> None:
         """Tests pytest html report generation with only the `--html` flag."""
-        non_default_html_path = pytester_temp_dir / "non_default_output_dir" / "report.html"
+        non_default_html_path = (
+            pytester_temp_dir / "non_default_output_dir" / "report.html"
+        )
         fill_args += ["--html", str(non_default_html_path)]
         run_fill(*fill_args)
         assert non_default_html_path.exists()
@@ -235,7 +249,11 @@ class TestFillPytester:
         flags.
         """
         output_dir = pytester_temp_dir / "non_default_output_dir_fixtures"
-        html_path = pytester_temp_dir / "non_default_output_dir_html" / "non_default.html"
+        html_path = (
+            pytester_temp_dir
+            / "non_default_output_dir_html"
+            / "non_default.html"
+        )
         fill_args += ["--output", str(output_dir), "--html", str(html_path)]
         run_fill(*fill_args)
         assert html_path.exists()

--- a/packages/tests/src/cli/tests/test_pytest_fill_command.py
+++ b/packages/tests/src/cli/tests/test_pytest_fill_command.py
@@ -63,7 +63,7 @@ class TestHtmlReportFlags:
             "test_dup and state_test-DUP16",
             "--fork",
             "Frontier",
-            f"--t8n-server-url={default_t8n.server_url}",
+            "../../tests/eest/frontier",  # TODO: Should not be necessary.
         ]
 
     @pytest.fixture()

--- a/packages/tests/src/ethereum_clis/clis/execution_specs.py
+++ b/packages/tests/src/ethereum_clis/clis/execution_specs.py
@@ -64,6 +64,7 @@ class ExecutionSpecsTransitionTool(TransitionTool):
             mode="json", **model_dump_config
         )
 
+        temp_dir = tempfile.TemporaryDirectory()
         t8n_args = [
             "t8n",
             "--input.alloc=stdin",
@@ -72,6 +73,7 @@ class ExecutionSpecsTransitionTool(TransitionTool):
             "--output.result=stdout",
             "--output.body=stdout",
             "--output.alloc=stdout",
+            f"--output.basedir={temp_dir.name}",
             f"--state.fork={request_data_json['state']['fork']}",
             f"--state.chainid={request_data_json['state']['chainid']}",
             f"--state.reward={request_data_json['state']['reward']}",
@@ -80,14 +82,12 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         if transition_tool_data.state_test:
             t8n_args.append("--state-test")
 
-        temp_dir = tempfile.TemporaryDirectory()
         if self.trace:
             t8n_args.extend(
                 [
                     "--trace",
                     "--trace.memory",
                     "--trace.returndata",
-                    f"--output.basedir={temp_dir.name}",
                 ]
             )
 
@@ -134,6 +134,11 @@ class ExecutionSpecsTransitionTool(TransitionTool):
         temp_dir.cleanup()
 
         return output
+
+    @classmethod
+    def is_installed(cls, binary_path: Optional[Path] = None) -> bool:
+        """ExecutionSpecs is always installed."""
+        return True
 
 
 class ExecutionSpecsExceptionMapper(ExceptionMapper):

--- a/packages/tests/src/ethereum_clis/tests/test_execution_specs.py
+++ b/packages/tests/src/ethereum_clis/tests/test_execution_specs.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sysconfig
+from os.path import realpath
 from pathlib import Path
 from shutil import which
 from typing import Dict, List, Type
@@ -15,7 +16,8 @@ from ethereum_test_base_types import to_json
 from ethereum_test_forks import Berlin
 from ethereum_test_types import Alloc, Environment, Transaction
 
-FIXTURES_ROOT = Path(os.path.join("src", "ethereum_clis", "tests", "fixtures"))
+CURRENT_FOLDER = Path(realpath(__file__)).parent
+FIXTURES_ROOT = CURRENT_FOLDER / "fixtures"
 DEFAULT_EVM_T8N_BINARY_NAME = "ethereum-spec-evm-resolver"
 
 
@@ -92,9 +94,8 @@ def test_calc_state_root(
 
 
 @pytest.mark.parametrize("evm_tool", [ExecutionSpecsTransitionTool])
-@pytest.mark.parametrize(
-    "binary_arg", ["no_binary_arg", "path_type", "str_type"]
-)
+@pytest.mark.parametrize("binary_arg", ["no_binary_arg", "path_type", "str_type"])
+@pytest.mark.skip(reason="ExecutionSpecsTransitionTool through binary path is not supported")
 def test_evm_tool_binary_arg(
     evm_tool: Type[ExecutionSpecsTransitionTool], binary_arg: str
 ) -> None:

--- a/packages/tests/src/ethereum_clis/tests/test_execution_specs.py
+++ b/packages/tests/src/ethereum_clis/tests/test_execution_specs.py
@@ -94,8 +94,12 @@ def test_calc_state_root(
 
 
 @pytest.mark.parametrize("evm_tool", [ExecutionSpecsTransitionTool])
-@pytest.mark.parametrize("binary_arg", ["no_binary_arg", "path_type", "str_type"])
-@pytest.mark.skip(reason="ExecutionSpecsTransitionTool through binary path is not supported")
+@pytest.mark.parametrize(
+    "binary_arg", ["no_binary_arg", "path_type", "str_type"]
+)
+@pytest.mark.skip(
+    reason="ExecutionSpecsTransitionTool through binary path is not supported"
+)
 def test_evm_tool_binary_arg(
     evm_tool: Type[ExecutionSpecsTransitionTool], binary_arg: str
 ) -> None:

--- a/packages/tests/src/ethereum_clis/tests/test_transition_tool.py
+++ b/packages/tests/src/ethereum_clis/tests/test_transition_tool.py
@@ -37,11 +37,14 @@ def test_default_tool() -> None:
             "evmone-t8n 0.11.0-dev+commit.93997506",
             EvmOneTransitionTool,
         ),
-        (
-            None,
-            "evm",
-            "evm version 1.12.1-unstable-c7b099b2-20230627",
+        pytest.param(
+            Path("ethereum-spec-evm"),
+            "ethereum-spec-evm",
+            "ethereum-spec-evm",
             ExecutionSpecsTransitionTool,
+            marks=pytest.mark.skip(
+                reason="ExecutionSpecsTransitionTool through binary path is not supported"
+            ),
         ),
         (
             Path("t8n"),

--- a/packages/tests/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
+++ b/packages/tests/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py
@@ -60,6 +60,7 @@ def get_all_checklist_ids(obj: Any) -> Set[str]:
     return ids
 
 
+@pytest.mark.skip(reason="Skipping test until ./docs/ folder is subtree'd")
 def test_checklist_template_consistency() -> None:
     """
     Test that all IDs in markdown template match EIPChecklist class exactly.
@@ -100,6 +101,7 @@ def test_checklist_template_consistency() -> None:
         pytest.fail(error_message)
 
 
+@pytest.mark.skip(reason="Skipping test until ./docs/ folder is subtree'd")
 def test_checklist_template_exists() -> None:
     """Test that the checklist template file exists."""
     assert TEMPLATE_PATH.exists(), (

--- a/packages/tests/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/packages/tests/src/ethereum_test_specs/tests/test_fixtures.py
@@ -199,7 +199,9 @@ def test_fill_state_test(
     }
 
     format_name = fixture_format.format_name
-    expected_json_file = f"chainid_{fork.name().lower()}_{format_name}_tx_type_{tx_type}.json"
+    expected_json_file = (
+        f"chainid_{fork.name().lower()}_{format_name}_tx_type_{tx_type}.json"
+    )
     expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
     remove_info_metadata(expected)
 
@@ -546,7 +548,9 @@ class TestFillBlockchainValidTxs:
             ),
         }
 
-        expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
+        expected = json.loads(
+            (FIXTURES_FOLDER / expected_json_file).read_text()
+        )
         remove_info_metadata(expected)
 
         remove_info_metadata(fixture)

--- a/packages/tests/src/ethereum_test_specs/tests/test_fixtures.py
+++ b/packages/tests/src/ethereum_test_specs/tests/test_fixtures.py
@@ -1,7 +1,8 @@
 """Test suite for `ethereum_test_specs` fixture generation."""
 
 import json
-import os
+from os.path import realpath
+from pathlib import Path
 from typing import Any, List, Mapping
 
 import pytest
@@ -40,6 +41,9 @@ from ..blockchain import Block, BlockchainTest, Header
 from ..state import StateTest
 from .helpers import remove_info_metadata
 
+CURRENT_FOLDER = Path(realpath(__file__)).parent
+FIXTURES_FOLDER = CURRENT_FOLDER / "fixtures"
+
 
 @pytest.fixture()
 def fixture_hash(fork: Fork) -> bytes:
@@ -62,7 +66,7 @@ def test_check_helper_fixtures() -> None:
     runner = CliRunner()
     args = [
         "--input",
-        "src/ethereum_test_specs/tests/fixtures",
+        str(FIXTURES_FOLDER),
         "--quiet",
         "--stop-on-error",
     ]
@@ -195,20 +199,9 @@ def test_fill_state_test(
     }
 
     format_name = fixture_format.format_name
-    expected_json_file = (
-        f"chainid_{fork.name().lower()}_{format_name}_tx_type_{tx_type}.json"
-    )
-    with open(
-        os.path.join(
-            "src",
-            "ethereum_test_specs",
-            "tests",
-            "fixtures",
-            expected_json_file,
-        )
-    ) as f:
-        expected = json.load(f)
-        remove_info_metadata(expected)
+    expected_json_file = f"chainid_{fork.name().lower()}_{format_name}_tx_type_{tx_type}.json"
+    expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
+    remove_info_metadata(expected)
 
     remove_info_metadata(fixture)
     assert fixture == expected
@@ -553,17 +546,8 @@ class TestFillBlockchainValidTxs:
             ),
         }
 
-        with open(
-            os.path.join(
-                "src",
-                "ethereum_test_specs",
-                "tests",
-                "fixtures",
-                expected_json_file,
-            )
-        ) as f:
-            expected = json.load(f)
-            remove_info_metadata(expected)
+        expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
+        remove_info_metadata(expected)
 
         remove_info_metadata(fixture)
         assert fixture_name in fixture
@@ -939,17 +923,8 @@ def test_fill_blockchain_invalid_txs(
         fixture_name: generated_fixture.json_dict_with_info(hash_only=True),
     }
 
-    with open(
-        os.path.join(
-            "src",
-            "ethereum_test_specs",
-            "tests",
-            "fixtures",
-            expected_json_file,
-        )
-    ) as f:
-        expected = json.load(f)
-        remove_info_metadata(expected)
+    expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
+    remove_info_metadata(expected)
 
     remove_info_metadata(fixture)
     assert fixture_name in fixture

--- a/packages/tests/src/ethereum_test_specs/tests/test_transaction.py
+++ b/packages/tests/src/ethereum_test_specs/tests/test_transaction.py
@@ -1,7 +1,8 @@
 """Test suite for the transaction spec test generation."""
 
 import json
-import os
+from os.path import realpath
+from pathlib import Path
 
 import pytest
 
@@ -11,6 +12,9 @@ from ethereum_test_types import Transaction
 
 from ..transaction import TransactionTest
 from .helpers import remove_info_metadata
+
+CURRENT_FOLDER = Path(realpath(__file__)).parent
+FIXTURES_FOLDER = CURRENT_FOLDER / "fixtures"
 
 
 @pytest.mark.parametrize(
@@ -37,17 +41,9 @@ def test_transaction_test_filling(
     }
 
     expected_json_file = f"tx_{name}_{fork.name().lower()}.json"
-    with open(
-        os.path.join(
-            "src",
-            "ethereum_test_specs",
-            "tests",
-            "fixtures",
-            expected_json_file,
-        )
-    ) as f:
-        expected = json.load(f)
-        remove_info_metadata(expected)
+
+    expected = json.loads((FIXTURES_FOLDER / expected_json_file).read_text())
+    remove_info_metadata(expected)
 
     remove_info_metadata(fixture)
     assert fixture == expected

--- a/packages/tests/src/pytest_plugins/consume/tests/test_consume_args.py
+++ b/packages/tests/src/pytest_plugins/consume/tests/test_consume_args.py
@@ -9,8 +9,6 @@ import pytest
 from filelock import FileLock
 from pytest import Pytester, TempPathFactory
 
-from ethereum_clis import TransitionTool
-
 MINIMAL_TEST_FILE_NAME = "test_example.py"
 MINIMAL_TEST_CONTENTS = """
 from ethereum_test_tools import Transaction
@@ -70,7 +68,6 @@ def fill_tests(
     fill_fork_from: str,
     fill_fork_until: str,
     minimal_test_path: Path,
-    default_t8n: TransitionTool,
 ) -> None:
     """
     Run fill to generate test fixtures for use with testing consume.
@@ -96,7 +93,6 @@ def fill_tests(
                 f"--from={fill_fork_from}",
                 f"--until={fill_fork_until}",
                 f"--output={str(fixtures_dir)}",
-                f"--t8n-server-url={default_t8n.server_url}",
                 str(minimal_test_path),
             ]
             fill_result = pytester.runpytest(*args)

--- a/packages/tests/src/pytest_plugins/filler/tests/test_eip_checklist.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_eip_checklist.py
@@ -4,7 +4,10 @@ import re
 import textwrap
 from typing import Any
 
+import pytest
 
+
+@pytest.mark.skip(reason="Skipping test until ./docs/ folder is subtree'd")
 def test_eip_checklist_collection(testdir: Any) -> None:
     """Test that checklist markers are collected correctly."""
     # Create the test in an EIP-specific directory

--- a/packages/tests/src/pytest_plugins/filler/tests/test_filler.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_filler.py
@@ -439,7 +439,6 @@ def test_fixture_output_based_on_command_line_args(
     args: list[str],
     expected_fixture_files: list[Path],
     expected_fixture_counts: list[int],
-    default_t8n: TransitionTool,
 ) -> None:
     """
     Test:
@@ -478,9 +477,6 @@ def test_fixture_output_based_on_command_line_args(
     args.append("pytest-fill.ini")
     args.append("-v")
     args.append("--no-html")
-    args.append("--t8n-server-url")
-    assert default_t8n.server_url is not None
-    args.append(default_t8n.server_url)
 
     result = testdir.runpytest(*args)
     result.assert_outcomes(
@@ -542,9 +538,7 @@ def test_fixture_output_based_on_command_line_args(
     )
     config = configparser.ConfigParser()
     ini_file_text = ini_file.read_text()
-    ini_file_text = ini_file_text.replace(
-        default_t8n.server_url, "t8n_server_path"
-    )
+    # ini_file_text = ini_file_text.replace(default_t8n.server_url, "t8n_server_path")
     config.read_string(ini_file_text)
 
     if "--skip-index" not in args:
@@ -612,7 +606,6 @@ def test_fill_variables(
     expected_fixture_files: list[Path],
     expected_fixture_counts: list[int],
     expected_gas_limit: int,
-    default_t8n: TransitionTool,
 ) -> None:
     """
     Test filling tests that depend on variables such as the max block gas limit.
@@ -636,9 +629,6 @@ def test_fill_variables(
     args.append("-m")
     args.append("state_test")
     args.append("--no-html")
-    args.append("--t8n-server-url")
-    assert default_t8n.server_url is not None
-    args.append(default_t8n.server_url)
     result = testdir.runpytest(*args)
     result.assert_outcomes(
         passed=1,
@@ -699,9 +689,7 @@ def test_fill_variables(
     )
     config = configparser.ConfigParser()
     ini_file_text = ini_file.read_text()
-    ini_file_text = ini_file_text.replace(
-        default_t8n.server_url, "t8n_server_path"
-    )
+    # ini_file_text = ini_file_text.replace(default_t8n.server_url, "t8n_server_path")
     config.read_string(ini_file_text)
 
     if "--skip-index" not in args:

--- a/packages/tests/src/pytest_plugins/filler/tests/test_output_directory.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_output_directory.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 import pytest
 from pytest import TempPathFactory
 
-from ethereum_clis import TransitionTool
-
 from ..fixture_output import FixtureOutput
 
 MINIMAL_TEST_FILE_NAME = "test_example.py"
@@ -50,7 +48,6 @@ def run_fill(
     minimal_test_path: Path,
     fill_fork_from: str,
     fill_fork_until: str,
-    default_t8n: TransitionTool,
 ) -> Callable[..., pytest.RunResult]:
     """
     Create a function to run the fill command with various output directory
@@ -78,7 +75,6 @@ def run_fill(
             f"--from={fill_fork_from}",
             f"--until={fill_fork_until}",
             f"--output={str(output_dir)}",
-            f"--t8n-server-url={default_t8n.server_url}",
             str(minimal_test_path),
         ]
         if clean:

--- a/packages/tests/src/pytest_plugins/filler/tests/test_prealloc_group.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_prealloc_group.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from ethereum_clis import TransitionTool
 from ethereum_test_fixtures import BaseFixture, PreAllocGroups
 from ethereum_test_forks import Fork, Prague
 from ethereum_test_specs.base import BaseTest
@@ -419,7 +418,6 @@ class BlockchainTest(FormattedTest):  # noqa: D101
 )
 def test_pre_alloc_grouping_by_test_type(
     pytester: pytest.Pytester,
-    default_t8n: TransitionTool,
     test_definitions: List[FormattedTest],
     expected_different_pre_alloc_groups: int,
 ) -> None:
@@ -439,10 +437,7 @@ def test_pre_alloc_grouping_by_test_type(
         "pytest-fill.ini",
         "--generate-pre-alloc-groups",
         "--fork=Cancun",
-        "--t8n-server-url",
     ]
-    assert default_t8n.server_url is not None
-    args.append(default_t8n.server_url)
     result = pytester.runpytest(*args)
     result.assert_outcomes(
         passed=len(test_definitions),

--- a/packages/tests/src/pytest_plugins/filler/tests/test_slow_marker_pre_alloc.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_slow_marker_pre_alloc.py
@@ -3,12 +3,9 @@
 import textwrap
 from typing import Any
 
-from ethereum_clis import TransitionTool
 
 
-def test_slow_marker_gets_pre_alloc_group(
-    pytester: Any, default_t8n: TransitionTool
-) -> None:
+def test_slow_marker_gets_pre_alloc_group(pytester: Any, default_t8n: TransitionTool) -> None:
     """
     Test that slow tests without benchmark marker get pre_alloc_group
     automatically.
@@ -46,8 +43,6 @@ def test_slow_marker_gets_pre_alloc_group(
         "pytest-fill.ini",
         "--collect-only",
         "-q",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/cancun/test_slow.py",
     ]
 
@@ -56,9 +51,7 @@ def test_slow_marker_gets_pre_alloc_group(
     result.stdout.fnmatch_lines(["*test_slow_without_benchmark*"])
 
 
-def test_slow_with_benchmark_no_pre_alloc(
-    pytester: Any, default_t8n: TransitionTool
-) -> None:
+def test_slow_with_benchmark_no_pre_alloc(pytester: Any, default_t8n: TransitionTool) -> None:
     """
     Test that slow tests WITH benchmark marker do NOT get pre_alloc_group.
     """
@@ -95,8 +88,6 @@ def test_slow_with_benchmark_no_pre_alloc(
         "pytest-fill.ini",
         "--collect-only",
         "-q",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/benchmark/test_slow_benchmark.py",
     ]
 
@@ -105,9 +96,7 @@ def test_slow_with_benchmark_no_pre_alloc(
     result.stdout.fnmatch_lines(["*test_slow_with_benchmark*"])
 
 
-def test_slow_with_existing_pre_alloc_unchanged(
-    pytester: Any, default_t8n: TransitionTool
-) -> None:
+def test_slow_with_existing_pre_alloc_unchanged(pytester: Any) -> None:
     """
     Test that slow tests with existing pre_alloc_group marker are unchanged.
     """
@@ -144,8 +133,6 @@ def test_slow_with_existing_pre_alloc_unchanged(
         "pytest-fill.ini",
         "--collect-only",
         "-q",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/cancun/test_existing_pre_alloc.py",
     ]
 
@@ -154,9 +141,7 @@ def test_slow_with_existing_pre_alloc_unchanged(
     result.stdout.fnmatch_lines(["*test_slow_with_existing_pre_alloc*"])
 
 
-def test_non_slow_no_pre_alloc(
-    pytester: Any, default_t8n: TransitionTool
-) -> None:
+def test_non_slow_no_pre_alloc(pytester: Any, default_t8n: TransitionTool) -> None:
     """Test that tests without slow marker do not get pre_alloc_group."""
     test_module = textwrap.dedent(
         """\
@@ -189,8 +174,6 @@ def test_non_slow_no_pre_alloc(
         "pytest-fill.ini",
         "--collect-only",
         "-q",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/cancun/test_normal.py",
     ]
 
@@ -199,9 +182,7 @@ def test_non_slow_no_pre_alloc(
     result.stdout.fnmatch_lines(["*test_normal_speed*"])
 
 
-def test_integration_with_fill(
-    pytester: Any, default_t8n: TransitionTool
-) -> None:
+def test_integration_with_fill(pytester: Any, default_t8n: TransitionTool) -> None:
     """
     Integration test using actual fill command to verify marker application.
     """
@@ -246,8 +227,6 @@ def test_integration_with_fill(
         "pytest-fill.ini",
         "-v",
         "--no-html",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/cancun/slow_test_module/",
     ]
 

--- a/packages/tests/src/pytest_plugins/filler/tests/test_slow_marker_pre_alloc.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_slow_marker_pre_alloc.py
@@ -4,8 +4,7 @@ import textwrap
 from typing import Any
 
 
-
-def test_slow_marker_gets_pre_alloc_group(pytester: Any, default_t8n: TransitionTool) -> None:
+def test_slow_marker_gets_pre_alloc_group(pytester: Any) -> None:
     """
     Test that slow tests without benchmark marker get pre_alloc_group
     automatically.
@@ -51,7 +50,7 @@ def test_slow_marker_gets_pre_alloc_group(pytester: Any, default_t8n: Transition
     result.stdout.fnmatch_lines(["*test_slow_without_benchmark*"])
 
 
-def test_slow_with_benchmark_no_pre_alloc(pytester: Any, default_t8n: TransitionTool) -> None:
+def test_slow_with_benchmark_no_pre_alloc(pytester: Any) -> None:
     """
     Test that slow tests WITH benchmark marker do NOT get pre_alloc_group.
     """
@@ -141,7 +140,7 @@ def test_slow_with_existing_pre_alloc_unchanged(pytester: Any) -> None:
     result.stdout.fnmatch_lines(["*test_slow_with_existing_pre_alloc*"])
 
 
-def test_non_slow_no_pre_alloc(pytester: Any, default_t8n: TransitionTool) -> None:
+def test_non_slow_no_pre_alloc(pytester: Any) -> None:
     """Test that tests without slow marker do not get pre_alloc_group."""
     test_module = textwrap.dedent(
         """\
@@ -182,7 +181,7 @@ def test_non_slow_no_pre_alloc(pytester: Any, default_t8n: TransitionTool) -> No
     result.stdout.fnmatch_lines(["*test_normal_speed*"])
 
 
-def test_integration_with_fill(pytester: Any, default_t8n: TransitionTool) -> None:
+def test_integration_with_fill(pytester: Any) -> None:
     """
     Integration test using actual fill command to verify marker application.
     """

--- a/packages/tests/src/pytest_plugins/filler/tests/test_verify_sync_marker.py
+++ b/packages/tests/src/pytest_plugins/filler/tests/test_verify_sync_marker.py
@@ -3,8 +3,6 @@
 import textwrap
 from typing import Any
 
-from ethereum_clis import TransitionTool
-
 test_module_with_verify_sync = textwrap.dedent(
     """\
     import pytest
@@ -65,10 +63,7 @@ test_module_with_verify_sync = textwrap.dedent(
 )
 
 
-def test_verify_sync_marker(
-    pytester: Any,
-    default_t8n: TransitionTool,
-) -> None:
+def test_verify_sync_marker(pytester: Any) -> None:
     """
     Test blockchain sync fixture generation with verify_sync marker.
 
@@ -121,8 +116,6 @@ def test_verify_sync_marker(
         "pytest-fill.ini",
         "-v",
         "--no-html",
-        "--t8n-server-url",
-        default_t8n.server_url,
         "tests/cancun/verify_sync_test_module/",
     ]
 

--- a/packages/tests/src/pytest_plugins/forks/tests/test_markers.py
+++ b/packages/tests/src/pytest_plugins/forks/tests/test_markers.py
@@ -212,7 +212,9 @@ def test_fork_markers(
     console output.
     """
     pytester.makepyfile(test_function)
-    pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
+    pytester.copy_example(
+        name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
     result = pytester.runpytest(
         "-c",
         "pytest-fill.ini",

--- a/packages/tests/src/pytest_plugins/forks/tests/test_markers.py
+++ b/packages/tests/src/pytest_plugins/forks/tests/test_markers.py
@@ -4,8 +4,6 @@ from typing import List
 
 import pytest
 
-from ethereum_clis import TransitionTool
-
 
 def generate_test(**kwargs: str) -> str:
     """Generate a test function with the given fork markers."""
@@ -130,6 +128,7 @@ def test_case(state_test):
             ["--until=BPO1"],
             {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_until_bpo_fork_without_bpo_test_marker",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
         pytest.param(
             generate_test(
@@ -140,6 +139,7 @@ def test_case(state_test):
             ["--until=BPO1"],
             {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_until_bpo_fork_with_bpo_test_marker",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
         pytest.param(
             generate_test(
@@ -148,6 +148,7 @@ def test_case(state_test):
             ["--until=BPO1"],
             {"passed": 1, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_at_transition_without_bpo_test_marker",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
         pytest.param(
             generate_test(
@@ -157,6 +158,7 @@ def test_case(state_test):
             ["--until=BPO1"],
             {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_at_transition_with_bpo_test_marker",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
         pytest.param(
             generate_test(
@@ -182,6 +184,7 @@ def test_case(state_test):
             ["--fork=Osaka"],
             {"passed": 0, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_at_transition_with_bpo_test_marker_fork_parent",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
         pytest.param(
             generate_test(
@@ -191,6 +194,7 @@ def test_case(state_test):
             ["--from=Osaka", "--until=Osaka"],
             {"passed": 0, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_at_transition_with_bpo_test_marker_from_parent",
+            marks=pytest.mark.skip(reason="BPO tests are not supported yet"),
         ),
     ],
 )
@@ -199,7 +203,6 @@ def test_fork_markers(
     test_function: str,
     outcomes: dict,
     pytest_args: List[str],
-    default_t8n: TransitionTool,
 ) -> None:
     """
     Test fork markers in an isolated test session, i.e., in
@@ -209,16 +212,11 @@ def test_fork_markers(
     console output.
     """
     pytester.makepyfile(test_function)
-    pytester.copy_example(
-        name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
-    )
-    assert default_t8n.server_url is not None
+    pytester.copy_example(name="src/cli/pytest_commands/pytest_ini_files/pytest-fill.ini")
     result = pytester.runpytest(
         "-c",
         "pytest-fill.ini",
         "-v",
         *pytest_args,
-        "--t8n-server-url",
-        default_t8n.server_url,
     )
     result.assert_outcomes(**outcomes)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 requires =
     tox-uv >=0.2.0
-envlist = py3,pypy3,json_infra,static
+envlist = py3,pypy3,json_infra,static,tests_pytest
 
 [testenv]
 package = uv
@@ -21,6 +21,14 @@ commands =
     mypy
     ethereum-spec-lint
     uv lock --check
+
+
+[testenv:tests_pytest]
+# run inside the package directory so pytest picks up packages/tests/pyproject.toml
+changedir = {toxinidir}/packages/tests
+# install the package in editable mode with its test extras
+deps = -e .[test,lint]  # lint is required because gentest uses ruff format
+commands = pytest src -n auto
 
 [testenv:json_infra]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.0
 requires =
     tox-uv >=0.2.0
-envlist = py3,pypy3,json_infra,static,tests_pytest
+envlist = py3,pypy3,json_infra,static,tests_pytest_py3,tests_pytest_pypy3
 
 [testenv]
 package = uv
@@ -23,12 +23,30 @@ commands =
     uv lock --check
 
 
-[testenv:tests_pytest]
+[testenv:tests_pytest_py3]
 # run inside the package directory so pytest picks up packages/tests/pyproject.toml
 changedir = {toxinidir}/packages/tests
 # install the package in editable mode with its test extras
 deps = -e .[test,lint]  # lint is required because gentest uses ruff format
-commands = pytest src -n auto
+commands =
+    pytest \
+        -n auto --maxprocesses 6 \
+        --basetemp="{temp_dir}/pytest" \
+        src
+
+[testenv:tests_pytest_pypy3]
+passenv =
+    PYPY_GC_MAX
+    PYPY_GC_MIN
+# run inside the package directory so pytest picks up packages/tests/pyproject.toml
+changedir = {toxinidir}/packages/tests
+# install the package in editable mode with its test extras
+deps = -e .[test,lint]  # lint is required because gentest uses ruff format
+commands =
+    pytest \
+        -n auto --maxprocesses 6 \
+        --basetemp="{temp_dir}/pytest" \
+        src 
 
 [testenv:json_infra]
 extras =


### PR DESCRIPTION
## 🗒️ Description
Creates tox workflow to run `packages/tests` unit tests, and fixes/skips failing tests:
- Disable using `--t8n-server-url` flag in unit tests because we no longer support the resolver for unit tests.
- Use a relative path to tests/eest in `packages/tests/src/cli/tests/test_pytest_fill_command.py` (~~Needs issue~~ Now fixed).
- Implements `is_installed` for `ExecutionSpecsTransitionTool` in order for it to work as the default T8N tool for unit tests.
- Always pass `--output.basedir` to T8N in `ExecutionSpecsTransitionTool` (#1652).
- Disables unit tests that require `docs` folder in `packages/tests/src/ethereum_test_checklists/tests/test_checklist_template_consistency.py` and `packages/tests/src/pytest_plugins/filler/tests/test_eip_checklist.py` (#1645).
- Disables BPO tests in `packages/tests/src/pytest_plugins/forks/tests/test_markers.py` (#1646).

## 🔗 Related Issues or PRs
N/A.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/cbc658fa-af47-493e-9766-de55bc62694a)
