### PR TITLE
chore(tooling): silence 2 mypy errors

### DIFF
--- a/packages/tests/src/ethereum_clis/transition_tool.py
+++ b/packages/tests/src/ethereum_clis/transition_tool.py
@@ -16,7 +16,7 @@ from urllib.parse import urlencode
 from requests import Response
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
-from requests_unixsocket import Session
+from requests_unixsocket import Session  # type: ignore[import-untyped,unused-ignore]
 
 from ethereum_test_base_types import BlobSchedule
 from ethereum_test_base_types.composite_types import ForkBlobSchedule

--- a/packages/tests/src/ethereum_clis/transition_tool.py
+++ b/packages/tests/src/ethereum_clis/transition_tool.py
@@ -16,7 +16,7 @@ from urllib.parse import urlencode
 from requests import Response
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
-from requests_unixsocket import Session  # type: ignore[import-untyped,unused-ignore]
+from requests_unixsocket import Session  # type: ignore[import-untyped, unused-ignore]
 
 from ethereum_test_base_types import BlobSchedule
 from ethereum_test_base_types.composite_types import ForkBlobSchedule

--- a/packages/tests/src/ethereum_test_types/transaction_types.py
+++ b/packages/tests/src/ethereum_test_types/transaction_types.py
@@ -17,7 +17,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
-from trie import HexaryTrie  # type: ignore[import-untyped,unused-ignore]
+from trie import HexaryTrie  # type: ignore[import-untyped, unused-ignore]
 
 from ethereum_test_base_types import (
     AccessList,
@@ -172,7 +172,7 @@ class TransactionGeneric(BaseModel, Generic[NumberBoundTypeVar]):
     """
 
     ty: NumberBoundTypeVar = Field(0, alias="type")  # type: ignore
-    chain_id: NumberBoundTypeVar = Field( # type: ignore[assignment]
+    chain_id: NumberBoundTypeVar = Field(  # type: ignore[assignment, unused-ignore]
         default_factory=lambda: ChainConfigDefaults.chain_id, validate_default=True
     )
     nonce: NumberBoundTypeVar = Field(0)  # type: ignore

--- a/packages/tests/src/ethereum_test_types/transaction_types.py
+++ b/packages/tests/src/ethereum_test_types/transaction_types.py
@@ -17,7 +17,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
-from trie import HexaryTrie
+from trie import HexaryTrie  # type: ignore[import-untyped,unused-ignore]
 
 from ethereum_test_base_types import (
     AccessList,
@@ -172,7 +172,7 @@ class TransactionGeneric(BaseModel, Generic[NumberBoundTypeVar]):
     """
 
     ty: NumberBoundTypeVar = Field(0, alias="type")  # type: ignore
-    chain_id: NumberBoundTypeVar = Field(
+    chain_id: NumberBoundTypeVar = Field( # type: ignore[assignment]
         default_factory=lambda: ChainConfigDefaults.chain_id, validate_default=True
     )
     nonce: NumberBoundTypeVar = Field(0)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -386,6 +386,8 @@ exclude = [
     "^\\.tox/",
     "^\\.venv/",
     "^\\.vscode/",
+    "^build/",
+    ".*/build/",
     "^fixtures/",
     "^logs/",
     "^site/",


### PR DESCRIPTION
## 🗒️ Description
Title

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e lint,typecheck,spellcheck,markdownlint
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT-J20p3H30XMNPbXlXpgeiUvk_bTw9056JZA&s)
