### PR TITLE
chore(tooling): add initial vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,23 @@
+{
+    // List of extensions that MUST be used for users of the repo.
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.mypy-type-checker",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "esbenp.prettier-vscode",
+        "njpwerner.autodocstring",
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml",
+        "bierner.markdown-mermaid",
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "DavidAnson.vscode-markdownlint",
+        "soulcode.vscode-unwanted-extensions"
+    ],
+    // List of extensions that MUST NOT be used for users of the repo.
+    "unwantedRecommendations": [
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.isort"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    // Settings that users SHOULD adhere to when developing with the EEST repo.
+    "cSpell.customDictionaries": {
+        "project-words": {
+            "name": "project-words",
+            "path": "${workspaceRoot}/whitelist.txt",
+            "description": "Words used in this project",
+            "addWords": true
+        },
+        "custom": true,
+        "internal-terms": false
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[python]": {
+        "editor.rulers": [79],
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit",
+            "source.fixAll.ruff": "explicit",
+        },
+    },
+    "python.analysis.autoFormatStrings": true,
+    "ruff.enable": true,
+    "ruff.lineLength": 79,
+    "extensions.ignoreRecommendations": false,
+    "search.exclude": {
+        "tests/static": true
+    },
+    "files.watcherExclude": {
+        "tests/static": true
+    }
+}


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Adds some basic `.vscode` settings to the repository. Useful for auto formatting the ruff line length on a save.

Please see EEST's `.vscode` - https://github.com/ethereum/execution-spec-tests/tree/main/.vscode

I've noticed EELS has this in its `.gitignore` so this PR can be used for a discussion point if we don't want it in the repo.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fpeople.com%2Fthmb%2F-BoJd05n2On7S_kGD8ayNKXysro%3D%2F1500x0%2Ffilters%3Ano_upscale()%3Amax_bytes(150000)%3Astrip_icc()%3Afocal(749x0%3A751x2)%2FHow-to-Prevent-a-Shark-Attack-and-What-to-Do-If-Bit-080323-5-37c3c95f4a8c4f4f993f02f2b531bc6c.jpg&f=1&nofb=1&ipt=1ab2a76ce476a785b9e005f7e08b3ea7af2bd18c3b2972f34df48e7e6f8655fb)
