### PR TITLE
chore: remove weld migration warnings

### DIFF
--- a/packages/tests/src/pytest_plugins/consume/consume.py
+++ b/packages/tests/src/pytest_plugins/consume/consume.py
@@ -8,7 +8,7 @@ import tarfile
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Generator, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import platformdirs
@@ -40,45 +40,6 @@ CACHED_DOWNLOADS_DIRECTORY = (
     Path(platformdirs.user_cache_dir("ethereum-execution-spec-tests"))
     / "cached_downloads"
 )
-
-
-def print_migration_warning(terminalreporter: Any = None) -> None:
-    """Print migration warning about repository merge."""
-    lines = [
-        "",
-        "=" * 80,
-        "⚠️  IMPORTANT: Repository Migration in Progress - 'The Weld' ⚠️",
-        "=" * 80,
-        "",
-        "This repository is being merged into ethereum/execution-specs (EELS) during the",
-        "week of October 20-24, 2025.",
-        "",
-        "📅 Timeline:",
-        "  • Week of Oct 13-17: Closing PRs, porting issues to EELS",
-        "  • Week of Oct 20-24: Migration week - fixing CI and fixture building",
-        "  • Oct 24 (ETA): Weld finalized - all development moves to EELS",
-        "",
-        "👉 What This Means:",
-        "  • Test Contributors: After Oct 24, reopen draft PRs in EELS",
-        "  • All future test development happens in EELS after completion",
-        "  • Fixture releases continue as usual during transition",
-        "",
-        "For details: https://steel.ethereum.foundation/blog/blog_posts/2025-09-11_weld-announcement/",
-        "=" * 80,
-        "",
-    ]
-
-    if terminalreporter:
-        for line in lines:
-            if "⚠️" in line or "IMPORTANT" in line:
-                terminalreporter.write_line(line, bold=True, yellow=True)
-            elif line.startswith("="):
-                terminalreporter.write_line(line, yellow=True)
-            else:
-                terminalreporter.write_line(line)
-    else:
-        for line in lines:
-            print(line)
 
 
 def default_input() -> str:
@@ -466,7 +427,6 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: D103
     called before the pytest-html plugin's pytest_configure to ensure that it
     uses the modified `htmlpath` option.
     """
-    print_migration_warning()
     # Validate --extract-to usage
     if config.option.extract_to_folder is not None and "cache" not in sys.argv:
         pytest.exit(
@@ -642,17 +602,3 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 for client in metafunc.config.hive_execution_clients  # type: ignore[attr-defined]
             ],
         )
-
-
-@pytest.hookimpl(hookwrapper=True, trylast=True)
-def pytest_terminal_summary(
-    terminalreporter: Any,
-    exitstatus: int,
-    config: pytest.Config,
-) -> Generator[None, None, None]:
-    """Print migration warning at end of test session."""
-    del exitstatus
-    yield
-
-    if not hasattr(config, "workerinput"):
-        print_migration_warning(terminalreporter)

--- a/packages/tests/src/pytest_plugins/execute/execute.py
+++ b/packages/tests/src/pytest_plugins/execute/execute.py
@@ -30,45 +30,6 @@ from ..spec_version_checker.spec_version_checker import EIPSpecTestItem
 from .pre_alloc import Alloc
 
 
-def print_migration_warning(terminalreporter: Any = None) -> None:
-    """Print migration warning about repository merge."""
-    lines = [
-        "",
-        "=" * 80,
-        "⚠️  IMPORTANT: Repository Migration in Progress - 'The Weld' ⚠️",
-        "=" * 80,
-        "",
-        "This repository is being merged into ethereum/execution-specs (EELS) during the",
-        "week of October 20-24, 2025.",
-        "",
-        "📅 Timeline:",
-        "  • Week of Oct 13-17: Closing PRs, porting issues to EELS",
-        "  • Week of Oct 20-24: Migration week - fixing CI and fixture building",
-        "  • Oct 24 (ETA): Weld finalized - all development moves to EELS",
-        "",
-        "👉 What This Means:",
-        "  • Test Contributors: After Oct 24, reopen draft PRs in ethereum/execution-specs",
-        "  • All future test development happens in EELS after completion",
-        "  • Fixture releases continue as usual during transition",
-        "",
-        "For details: https://steel.ethereum.foundation/blog/blog_posts/2025-09-11_weld-announcement/",
-        "=" * 80,
-        "",
-    ]
-
-    if terminalreporter:
-        for line in lines:
-            if "⚠️" in line or "IMPORTANT" in line:
-                terminalreporter.write_line(line, bold=True, yellow=True)
-            elif line.startswith("="):
-                terminalreporter.write_line(line, yellow=True)
-            else:
-                terminalreporter.write_line(line)
-    else:
-        for line in lines:
-            print(line)
-
-
 def default_html_report_file_path() -> str:
     """
     File (default) to store the generated HTML test report. Defined as a
@@ -186,7 +147,6 @@ def pytest_configure(config: pytest.Config) -> None:
        called before the pytest-html plugin's pytest_configure to ensure that
        it uses the modified `htmlpath` option.
     """
-    print_migration_warning()
     # Modify the block gas limit if specified.
     if config.getoption("transaction_gas_limit"):
         EnvironmentDefaults.gas_limit = config.getoption(

--- a/packages/tests/src/pytest_plugins/filler/filler.py
+++ b/packages/tests/src/pytest_plugins/filler/filler.py
@@ -61,45 +61,6 @@ from ..spec_version_checker.spec_version_checker import (
 from .fixture_output import FixtureOutput
 
 
-def print_migration_warning(terminalreporter: Any = None) -> None:
-    """Print migration warning about repository merge."""
-    lines = [
-        "",
-        "=" * 80,
-        "⚠️  IMPORTANT: Repository Migration in Progress - 'The Weld' ⚠️",
-        "=" * 80,
-        "",
-        "This repository is being merged into ethereum/execution-specs (EELS) during the",
-        "week of October 20-24, 2025.",
-        "",
-        "📅 Timeline:",
-        "  • Week of Oct 13-17: Closing PRs, porting issues to EELS",
-        "  • Week of Oct 20-24: Migration week - fixing CI and fixture building",
-        "  • Oct 24 (ETA): Weld finalized - all development moves to EELS",
-        "",
-        "👉 What This Means:",
-        "  • Test Contributors: After Oct 24, reopen draft PRs in ethereum/execution-specs",
-        "  • All future test development happens in EELS after completion",
-        "  • Fixture releases continue as usual during transition",
-        "",
-        "For details: https://steel.ethereum.foundation/blog/blog_posts/2025-09-11_weld-announcement/",
-        "=" * 80,
-        "",
-    ]
-
-    if terminalreporter:
-        for line in lines:
-            if "⚠️" in line or "IMPORTANT" in line:
-                terminalreporter.write_line(line, bold=True, yellow=True)
-            elif line.startswith("="):
-                terminalreporter.write_line(line, yellow=True)
-            else:
-                terminalreporter.write_line(line)
-    else:
-        for line in lines:
-            print(line)
-
-
 @dataclass(kw_only=True)
 class PhaseManager:
     """
@@ -725,8 +686,6 @@ def pytest_configure(config: pytest.Config) -> None:
        called before the pytest-html plugin's pytest_configure to ensure that
        it uses the modified `htmlpath` option.
     """
-    if not is_help_or_collectonly_mode(config):
-        print_migration_warning()
     # Register custom markers
     # Modify the block gas limit if specified.
     if config.getoption("block_gas_limit"):
@@ -874,7 +833,6 @@ def pytest_terminal_summary(
     yield
     if config.fixture_output.is_stdout or hasattr(config, "workerinput"):  # type: ignore[attr-defined]
         return
-    print_migration_warning(terminalreporter)
     stats = terminalreporter.stats
     if "passed" in stats and stats["passed"]:
         # Custom message for Phase 1 (pre-allocation group generation)


### PR DESCRIPTION
## 🗒️ Description

Removes migration warnings when using `uv` + `execute`, `consume`, `fill`.

Compare with ethereum/execution-spec-tests#2302 for changeset

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.NE-sDG6gJuAQxtrZS3DhTAHaE8%3Fcb%3D12%26pid%3DApi&f=1&ipt=7fe0f7809db5e8883c666985fe1d3c96f7533a2a7f1c87db97261e92af3980e7&ipo=images)
