### PR TITLE
chore(packages/tests): update bal mappers

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -296,26 +296,6 @@ class BesuExceptionMapper(ExceptionMapper):
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
             r"Block size of \d+ bytes exceeds limit of \d+ bytes"
         ),
-        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BAL_HASH: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INVALID_BLOCK_ACCESS_LIST: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
-        BlockException.INCORRECT_BLOCK_FORMAT: (
-            r"Block access list hash mismatch, "
-            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
-        ),
         TransactionException.INITCODE_SIZE_EXCEEDED: (
             r"transaction invalid Initcode size of \d+ exceeds maximum size of \d+"
         ),
@@ -344,5 +324,26 @@ class BesuExceptionMapper(ExceptionMapper):
         ),
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob transaction has too many blobs: \d+|Invalid Blob Count: \d+"
+        ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block access list hash mismatch, "
+            r"calculated:\s*(0x[a-f0-9]+)\s+header:\s*(0x[a-f0-9]+)"
         ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -117,9 +117,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
             r"invalid block access list:"
         ),
-        BlockException.INVALID_BAL_HASH: (
-            r"invalid block access list:"
-        ),
+        BlockException.INVALID_BAL_HASH: (r"invalid block access list:"),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             r"computed state diff contained mutated accounts which weren't reported in BAL"
         ),
@@ -127,9 +125,7 @@ class GethExceptionMapper(ExceptionMapper):
             r"difference between computed state diff and BAL entry for account"
             r"|invalid block access list:"
         ),
-        BlockException.INCORRECT_BLOCK_FORMAT: (
-            r"invalid block access list:"
-        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list:"),
     }
 
 

--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -87,9 +87,6 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system call failed to execute:",
         BlockException.INVALID_BLOCK_HASH: "blockhash mismatch",
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: "block RLP-encoded size exceeds maximum",
-        BlockException.INVALID_BAL_EXTRA_ACCOUNT: "BAL change not reported in computed",
-        BlockException.INVALID_BAL_MISSING_ACCOUNT: "additional mutations compared to BAL",
-        BlockException.INVALID_BLOCK_ACCESS_LIST: "unequal",
     }
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
@@ -116,6 +113,23 @@ class GethExceptionMapper(ExceptionMapper):
         #
         # EELS definition for `is_valid_deposit_event_data`:
         # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"invalid block access list:"
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"invalid block access list:"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"computed state diff contained mutated accounts which weren't reported in BAL"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"difference between computed state diff and BAL entry for account"
+            r"|invalid block access list:"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"invalid block access list:"
+        ),
     }
 
 

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -455,4 +455,21 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
         ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"could not be parsed as a block: Could not decode block access list."
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"InvalidBlockLevelAccessListRoot:"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"InvalidBlockLevelAccessListRoot:"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"InvalidBlockLevelAccessListRoot:"
+            r"|could not be parsed as a block: Could not decode block access list."
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"could not be parsed as a block: Could not decode block access list."
+        ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -459,9 +459,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
             r"could not be parsed as a block: Could not decode block access list."
         ),
-        BlockException.INVALID_BAL_HASH: (
-            r"InvalidBlockLevelAccessListRoot:"
-        ),
+        BlockException.INVALID_BAL_HASH: (r"InvalidBlockLevelAccessListRoot:"),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             r"InvalidBlockLevelAccessListRoot:"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -78,9 +78,7 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
             r"Block BAL contains an account change that is not present in the computed BAL."
         ),
-        BlockException.INVALID_BAL_HASH: (
-            r"Block's access list is invalid."
-        ),
+        BlockException.INVALID_BAL_HASH: (r"Block's access list is invalid."),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             r"Block BAL is missing an account change that is present in the computed BAL."
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -74,4 +74,20 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_GAS_USED_ABOVE_LIMIT: (
             r"block used gas \(\d+\) is greater than gas limit \(\d+\)"
         ),
+        # BAL Exceptions: TODO - review once all clients completed.
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"Block BAL contains an account change that is not present in the computed BAL."
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            r"Block's access list is invalid."
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"Block BAL is missing an account change that is present in the computed BAL."
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block's access list is invalid."
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block's access list is invalid."
+        ),
     }


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
**Note**: must be rebased once https://github.com/ethereum/execution-specs/pull/1654 is merged. 

This PR should make all ELs (BAL enabled) pass all the consume engine tests. I'm not sure we need to be super strict on the exception checking for BAL. I think we should only have a single BAL exception based on what the clients are returning. More granularity would be nice for debugging, but if clients are failing for the BAL hash mismatch at the highest level (i.e not stating why) I feel this is enough. This PR is also to prompt discussion.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwallpapertag.com%2Fwallpaper%2Ffull%2F1%2F0%2F5%2F468498-gorgerous-cute-baby-animal-wallpaper-2560x1600-xiaomi.jpg&f=1&nofb=1&ipt=003085dc6bdfa9ee7ff1cae76b8dceacb94b1ca440ba7f64423b34b6ea8103a3)
