### PR TITLE
chore: Use order indexing for multiple Unscheduled forks

### DIFF
--- a/src/ethereum/fork_criteria.py
+++ b/src/ethereum/fork_criteria.py
@@ -188,8 +188,8 @@ class Unscheduled(ForkCriteria):
     Forks that have not been scheduled.
     """
 
-    def __init__(self) -> None:
-        self._internal = (ForkCriteria.UNSCHEDULED, 0)
+    def __init__(self, order_index: int = 0) -> None:
+        self._internal = (ForkCriteria.UNSCHEDULED, order_index)
 
     @override
     def check(self, block_number: Uint, timestamp: U256) -> Literal[False]:
@@ -202,4 +202,4 @@ class Unscheduled(ForkCriteria):
         """
         String representation of this object.
         """
-        return "Unscheduled()"
+        return f"Unscheduled(order_index={self._internal[1]})"

--- a/src/ethereum_spec_tools/new_fork/builder.py
+++ b/src/ethereum_spec_tools/new_fork/builder.py
@@ -331,7 +331,13 @@ class ForkBuilder:
 
         # Try to make a sane guess for the activation criteria.
         if found is forks[-1]:
-            self.fork_criteria = Unscheduled()
+            order_index = 0
+
+            # check template fork's criteria and bump order_index if needed
+            if isinstance(found.criteria, Unscheduled):
+                order_index = found.criteria._internal[1] + 1
+
+            self.fork_criteria = Unscheduled(order_index=order_index)
         elif hasattr(found.criteria, "timestamp"):
             self.fork_criteria = ByTimestamp(
                 U256(found.criteria.timestamp) + U256(1)


### PR DESCRIPTION
## 🗒️ Description

We've approved the `order_index` change before but it was for `forks/amsterdam` so when we recreate it from osaka, it's gone. I went a step further and built this into the new fork tool while rebuilding `forks/amsterdam` this time so that we can preserve the index without manual updates. I think this will be nice to have in `forks/osaka` in case we have to rebuild `forks/amsterdam` again.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
CHANGELOG.md).
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.8GT98mgv8iLszkdr2rpFYQHaFj%3Fpid%3DApi&f=1&ipt=62daca5b04c65121aa149fc2c0499c388389a522821813cae9b58827f4242628&ipo=images)
