### PR TITLE
chore: remove unnecessary flag from tox commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ N/A.
 
 - [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
     ```console
-    uvx --with=tox-uv tox -e static
+    uvx tox -e static
     ```
 - [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
 - [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -19,7 +19,7 @@ uv run mkdocs build --strict
 Perform all docs related checks via `tox` in parallel:
 
 ```console
-uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs --parallel
+uvx tox -e spellcheck,markdownlint,mkdocs --parallel
 ```
 
 ### Local Deployment and Test

--- a/docs/getting_started/code_standards.md
+++ b/docs/getting_started/code_standards.md
@@ -8,15 +8,15 @@ Code pushed to @ethereum/execution-spec-tests must fulfill the following checks 
 
 | Type                   | Tox Command                                     | Explanation                                                                                                 |
 | ---------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Lint & code formatting | `uvx --with=tox-uv tox -e lint`                 | Python lint, format and module import check via `ruff`                                                      |
-| Typecheck              | `uvx --with=tox-uv tox -e typecheck`            | Objects that provide typehints pass type-checking via `mypy`.                                               |
-| Framework unit tests   | `uvx --with=tox-uv tox -e pytest`               | All framework unit tests must execute correctly.                                                            |
-| EL Client test cases   | `uvx --with=tox-uv tox -e tests-deployed`       | All client test cases for deployed forks can be generated.                                                  |
-| Benchmark EL Test cases    | `uvx --with=tox-uv tox -e tests-deployed-benchmark` | All client test cases specific to benchmarks for deployed forks can be generated.                               |
-| HTML doc build         | `uvx --with=tox-uv tox -e mkdocs`               | Documentation generated without warnings.                                                                   |
-| Spellcheck             | `uvx --with=tox-uv tox -e spellcheck`           | Code and documentation spell-check using codespell. |
-| Markdown lint          | `uvx --with=tox-uv tox -e markdownlint`         | Markdown lint (requires [additional dependency](code_standards_details.md#additional-dependencies)).        |
-| Changelog validation   | `uvx --with=tox-uv tox -e changelog`            | Validates changelog entries format and structure in `docs/CHANGELOG.md`.                                    |
+| Lint & code formatting | `uvx tox -e lint`                 | Python lint, format and module import check via `ruff`                                                      |
+| Typecheck              | `uvx tox -e typecheck`            | Objects that provide typehints pass type-checking via `mypy`.                                               |
+| Framework unit tests   | `uvx tox -e pytest`               | All framework unit tests must execute correctly.                                                            |
+| EL Client test cases   | `uvx tox -e tests-deployed`       | All client test cases for deployed forks can be generated.                                                  |
+| Benchmark EL Test cases    | `uvx tox -e tests-deployed-benchmark` | All client test cases specific to benchmarks for deployed forks can be generated.                               |
+| HTML doc build         | `uvx tox -e mkdocs`               | Documentation generated without warnings.                                                                   |
+| Spellcheck             | `uvx tox -e spellcheck`           | Code and documentation spell-check using codespell. |
+| Markdown lint          | `uvx tox -e markdownlint`         | Markdown lint (requires [additional dependency](code_standards_details.md#additional-dependencies)).        |
+| Changelog validation   | `uvx tox -e changelog`            | Validates changelog entries format and structure in `docs/CHANGELOG.md`.                                    |
 
 !!! important "Avoid CI surprises - Use pre-commit hooks!"
     **We strongly encourage all contributors to install and use pre-commit hooks!** This will run fast checks (lint, typecheck, spellcheck) automatically before each commit, helping you catch issues early and avoid frustrating CI failures after pushing your changes.
@@ -33,25 +33,25 @@ Code pushed to @ethereum/execution-spec-tests must fulfill the following checks 
     Add an alias:
 
     ```console
-    alias tox="uvx --with=tox-uv tox"
+    alias tox="uvx tox"
     ```
 
     Run all checks in parallel:
 
     ```console
-    uvx --with=tox-uv tox run-parallel
+    uvx tox run-parallel
     ```
 
     Run sequentially:
 
     ```console
-    uvx --with=tox-uv tox
+    uvx tox
     ```
 
     Run specific, faster checks:
 
     ```console
-    uvx --with=tox-uv tox -e lint,typecheck
+    uvx tox -e lint,typecheck
     ```
 
 !!! tip "Lint & code formatting: Using `ruff` and VS Code to help autoformat and fix module imports"

--- a/docs/getting_started/code_standards_details.md
+++ b/docs/getting_started/code_standards_details.md
@@ -9,19 +9,19 @@ This page provides in-depth information about the code standards and verificatio
 Run all `tox` environments in parallel:
 
 ```console
-uvx --with=tox-uv tox run-parallel
+uvx tox run-parallel
 ```
 
 Run environments sequentially with verbose output:
 
 ```console
-uvx --with=tox-uv tox -v
+uvx tox -v
 ```
 
 List all available environments:
 
 ```console
-uvx --with=tox-uv tox -av
+uvx tox -av
 ```
 
 ### Specific Environment Commands
@@ -29,25 +29,25 @@ uvx --with=tox-uv tox -av
 Run specific environments using the `-e` flag:
 
 ```console
-uvx --with=tox-uv tox -e lint,typecheck,spellcheck
+uvx tox -e lint,typecheck,spellcheck
 ```
 
 #### For Test Case Changes (`./tests/`)
 
 ```console
-uvx --with=tox-uv tox -e lint,typecheck,spellcheck,tests-deployed
+uvx tox -e lint,typecheck,spellcheck,tests-deployed
 ```
 
 #### For Framework and Library Changes (`./src/`)
 
 ```console
-uvx --with=tox-uv tox -e lint,typecheck,spellcheck,pytest
+uvx tox -e lint,typecheck,spellcheck,pytest
 ```
 
 #### For Documentation Changes (`./docs/`)
 
 ```console
-uvx --with=tox-uv tox -e spellcheck,markdownlint,mkdocs,changelog
+uvx tox -e spellcheck,markdownlint,mkdocs,changelog
 ```
 
 !!! note "Tox Virtual Environment"

--- a/packages/tests/src/cli/tox_helpers.py
+++ b/packages/tests/src/cli/tox_helpers.py
@@ -44,7 +44,7 @@ def write_github_summary(
         f.write(f"{error_message}\n\n")
         f.write("### To reproduce this check locally:\n")
         f.write("```bash\n")
-        f.write(f"uvx --with=tox-uv tox -e {tox_env}\n")
+        f.write(f"uvx tox -e {tox_env}\n")
         f.write("```\n\n")
 
         if fix_commands:


### PR DESCRIPTION
## 🗒️ Description

With ethereum/execution-specs#1657, we no longer need to specify the flag ``--with=tox-uv`` for ``tox`` commands as the default runner uses ``tox`` with ``tox-uv``.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx --with=tox-uv tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="559" height="650" alt="Screenshot 2025-10-23 at 13 04 18" src="https://github.com/user-attachments/assets/d2e637a4-23c7-48f1-b926-2773d1ef752a" />
