### PR TITLE
fix(consume): consume sync validation relies on FCU only

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,12 +14,14 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `consume`
 
+- 🐞 Fix a bug with `consume sync` tests where some clients don't have JSON-RPC immediately available after syncing and can't yet serve the synced block ([#1670](https://github.com/ethereum/execution-specs/pull/1670)).
+
 ### 📋 Misc
 
 ### 🧪 Test Cases
 
-- 🐞Fix BALs opcode OOG test vectors by updating the Amsterdam commit hash in specs and validating appropriately on the testing side ([#2293](https://github.com/ethereum/execution-spec-tests/pull/2293)).
-- ✨Fix test vector for BALs SSTORE with OOG by pointing to updated specs; add new boundary conditions cases for SSTORE w/ OOG ([#2297](https://github.com/ethereum/execution-spec-tests/pull/2297)).
+- 🐞 Fix BALs opcode OOG test vectors by updating the Amsterdam commit hash in specs and validating appropriately on the testing side ([#2293](https://github.com/ethereum/execution-spec-tests/pull/2293)).
+- ✨ Fix test vector for BALs SSTORE with OOG by pointing to updated specs; add new boundary conditions cases for SSTORE w/ OOG ([#2297](https://github.com/ethereum/execution-spec-tests/pull/2297)).
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/docs/running_tests/test_formats/blockchain_test_sync.md
+++ b/docs/running_tests/test_formats/blockchain_test_sync.md
@@ -48,9 +48,8 @@ For each [`HiveFixture`](#hivefixture) test object in the JSON fixture file, per
     - Send `engine_forkchoiceUpdatedVX` pointing to the last block hash
 
 4. Monitor and verify synchronization:
-    - Wait for the sync client to reach the [`lastblockhash`](#-lastblockhash-hash)
-    - Verify the final state root matches between both clients
-    - If [`post`](#-post-alloc) is provided, verify the final state matches
+    - Wait for the sync client to return `VALID` for `engine_forkchoiceUpdatedVX` with the sync block payload
+    - If RPC is available after sync, retrieve the sync block via `eth_getBlockByHash` for [`lastblockhash`](#-lastblockhash-hash) and check the state root matches on this block for client under test and sync client
 
 ## Structures
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
@@ -55,6 +55,8 @@ def pytest_collection_modifyitems(
 
     for item in items:
         # Auto-mark all verify_sync tests as flaky with 3 reruns
+        # TODO: We can likely remove this as we have more stable sync
+        #  tests now. Leaving this here for now to be safe.
         if item.get_closest_marker("blockchain_test_sync"):
             item.add_marker(pytest.mark.flaky(reruns=3))
 


### PR DESCRIPTION
## 🗒️ Description

RPC is not yet available for some clients during the sync verification. I tried using `eth_getBlockByNumber("safe")` instead of retrieving by `blockhash` but this is also returning `None` after the `VALID` FCU response is returned from the sync client. I don't think sync tests need to test JSON-RPC and I think FCU `VALID` is enough to tell us that the client has validated the payload.

I'm open to other suggestions here but this tests the acceptance of the sync block and with these changes all tests pass for the current sync tests (block rlp limit, EIP-7934) without flakiness. This resolves a very annoying flaky test issue due to some clients not making the block available immediately via JSON-RPC.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fthvnext.bing.com%2Fth%2Fid%2FOIP.Y51P0UC6nw6y7PVbpsu9_AHaEo%3Fcb%3D12%26pid%3DApi&f=1&ipt=0a5a2233eaeb860d0a7dc0a59938abb09b2b83b31f83715b452a3f505c041007&ipo=images)
