### PR TITLE
docs:fix Documentation for calculate_block_difficulty incorrectly ref…

### DIFF
--- a/src/ethereum/forks/arrow_glacier/fork.py
+++ b/src/ethereum/forks/arrow_glacier/fork.py
@@ -908,7 +908,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/berlin/fork.py
+++ b/src/ethereum/forks/berlin/fork.py
@@ -793,7 +793,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/byzantium/fork.py
+++ b/src/ethereum/forks/byzantium/fork.py
@@ -770,7 +770,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/constantinople/fork.py
+++ b/src/ethereum/forks/constantinople/fork.py
@@ -770,7 +770,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/dao_fork/fork.py
+++ b/src/ethereum/forks/dao_fork/fork.py
@@ -776,7 +776,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/gray_glacier/fork.py
+++ b/src/ethereum/forks/gray_glacier/fork.py
@@ -908,7 +908,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/homestead/fork.py
+++ b/src/ethereum/forks/homestead/fork.py
@@ -758,7 +758,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/istanbul/fork.py
+++ b/src/ethereum/forks/istanbul/fork.py
@@ -770,7 +770,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -914,7 +914,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/muir_glacier/fork.py
+++ b/src/ethereum/forks/muir_glacier/fork.py
@@ -772,7 +772,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/spurious_dragon/fork.py
+++ b/src/ethereum/forks/spurious_dragon/fork.py
@@ -767,7 +767,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------

--- a/src/ethereum/forks/tangerine_whistle/fork.py
+++ b/src/ethereum/forks/tangerine_whistle/fork.py
@@ -758,7 +758,7 @@ def calculate_block_difficulty(
     set for the genesis block since it has no parent. So, a block
     can't be less difficult than the genesis block, therefore each block's
     difficulty is set to the maximum value between the calculated
-    difficulty and the ``GENESIS_DIFFICULTY``.
+    difficulty and the ``MINIMUM_DIFFICULTY``.
 
     Parameters
     ----------


### PR DESCRIPTION
…erences GENESIS_DIFFICULTY

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
fixes #607 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
