### PR TITLE
fix(config): implement robust project root detection for env.yaml (#1674)

### DIFF
--- a/packages/testing/src/execution_testing/config/env.py
+++ b/packages/testing/src/execution_testing/config/env.py
@@ -20,22 +20,38 @@ Usage:
 - Access configuration values via properties (e.g., EnvConfig().remote_nodes).
 """
 
+import os
 from pathlib import Path
 from typing import Dict, List
 
 import yaml
 from pydantic import BaseModel, HttpUrl, ValidationError
 
-
 def get_project_root() -> Path:
-    """Find project root by locating .git directory."""
+    """
+    Find project root by locating .git directory, or use alternatives when missing.
+
+    Priority:
+    1. Use EEST_PROJECT_ROOT environment variable if set.
+    2. Traverse upward to find .git directory (development use).
+    3. Fallback to current working directory if no .git found (e.g., in packages or CI).
+    """
+    
+    # 1. Environment Variable Check
+    env_root = os.environ.get("EEST_PROJECT_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+
+    # 2. .git Directory Check
     current = Path(__file__).resolve().parent
     while current != current.parent:
         if (current / ".git").exists():
             return current
         current = current.parent
-    raise FileNotFoundError("Could not find project root (no .git directory)")
-
+    
+    # 3. Fallback to CWD
+    print("Warning: .git directory not found. Falling back to current working directory.")
+    return Path.cwd().resolve()
 
 ENV_PATH = get_project_root() / "env.yaml"
 


### PR DESCRIPTION
## 🗒️ Description

The function `get_project_root()` in `packages/testing/src/execution_testing/config/env.py` previously relied only on traversing the directory tree to find the `.git` directory. This caused failures when running the `eest make env` command in environments where Git metadata is absent (e.g., in distributed Python packages or CI environments).

This PR introduces two fallback mechanisms to ensure the project root (where `env.yaml` is placed) can always be determined:

1.  It checks for the high-priority **`EEST_PROJECT_ROOT` environment variable**.
2.  If the variable is unset and `.git` is not found, it **falls back to the Current Working Directory (`Path.cwd()`)** and emits a warning.

## 🔗 Related Issues or PRs

**Fixes \#1674**

## ✅ Checklist

  - [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
        ` console     uvx tox -e static      `
  - [x] All: PR title adheres to the [[repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles)](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
  - [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
  - [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
  - [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
  - [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
  - [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
  - [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture
![cute](https://github.com/user-attachments/assets/1071ad7a-6422-4d1d-9057-4b9a81b0b833)

