### PR TITLE
feat(tests): Add missing OOG tests: EXP, LOG and constant gas generally

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,7 +39,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for ecadd/ecmul/ecpairing constant gas repricing ([#1738](https://github.com/ethereum/execution-specs/pull/1738)).
 - ✨ Add tests that EIP-1559 and EIP-2930 typed txs are invalid and void before their fork ([#1754](https://github.com/ethereum/execution-specs/pull/1754)).
 - ✨ Add tests for an old validation rule for gas limit above 5000 ([#1731](https://github.com/ethereum/execution-specs/pull/1731)).
-- ✨ Add tests for OOG in EXP, LOG and others ([#1686](https://github.com/ethereum/execution-specs/pull/1686))
+- ✨ Add tests for OOG in EXP, LOG and others ([#1686](https://github.com/ethereum/execution-specs/pull/1686)).
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests for ecadd/ecmul/ecpairing constant gas repricing ([#1738](https://github.com/ethereum/execution-specs/pull/1738)).
 - ✨ Add tests that EIP-1559 and EIP-2930 typed txs are invalid and void before their fork ([#1754](https://github.com/ethereum/execution-specs/pull/1754)).
 - ✨ Add tests for an old validation rule for gas limit above 5000 ([#1731](https://github.com/ethereum/execution-specs/pull/1731)).
+- ✨ Add tests for OOG in EXP, LOG and others ([#1686](https://github.com/ethereum/execution-specs/pull/1686))
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/packages/testing/src/execution_testing/__init__.py
+++ b/packages/testing/src/execution_testing/__init__.py
@@ -95,6 +95,7 @@ from .tools import (
     Switch,
     While,
     extend_with_defaults,
+    gas_test,
     generate_system_contract_deploy_test,
     generate_system_contract_error_test,
 )
@@ -207,6 +208,7 @@ __all__ = (
     "compute_create2_address",
     "compute_eofcreate_address",
     "extend_with_defaults",
+    "gas_test",
     "generate_system_contract_deploy_test",
     "generate_system_contract_error_test",
     "keccak256",

--- a/packages/testing/src/execution_testing/tools/__init__.py
+++ b/packages/testing/src/execution_testing/tools/__init__.py
@@ -14,6 +14,7 @@ from .tools_code import (
 )
 from .utility.generators import (
     DeploymentTestType,
+    gas_test,
     generate_system_contract_deploy_test,
     generate_system_contract_error_test,
 )
@@ -31,6 +32,7 @@ __all__ = (
     "Switch",
     "While",
     "extend_with_defaults",
+    "gas_test",
     "generate_system_contract_deploy_test",
     "generate_system_contract_error_test",
     "get_current_commit_hash_or_tag",

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -13,7 +13,7 @@ from execution_testing.exceptions import BlockException
 from execution_testing.forks import Berlin, Fork
 from execution_testing.specs import BlockchainTestFiller, StateTestFiller
 from execution_testing.specs.blockchain import Block
-from execution_testing.test_types import Alloc, Environment, Transaction
+from execution_testing.test_types import Alloc, Transaction
 from execution_testing.vm import Bytecode, Op
 
 
@@ -443,7 +443,6 @@ def gas_test(
     *,
     fork: Fork,
     state_test: StateTestFiller,
-    env: Environment,
     pre: Alloc,
     setup_code: Bytecode,
     subject_code: Bytecode,
@@ -455,6 +454,7 @@ def gas_test(
     oog_difference: int = 1,
     out_of_gas_testing: bool = True,
     prelude_code: Bytecode | None = None,
+    tx_gas: int | None = None,
 ) -> None:
     """
     Create State Test to check the gas cost of a sequence of EOF code.
@@ -606,8 +606,10 @@ def gas_test(
             LEGACY_CALL_SUCCESS
         )
 
+    if tx_gas is None:
+        tx_gas = gas_single_gas_run + cold_gas + 500_000
     tx = Transaction(
-        to=address_legacy_harness, gas_limit=env.gas_limit, sender=sender
+        to=address_legacy_harness, gas_limit=tx_gas, sender=sender
     )
 
-    state_test(env=env, pre=pre, tx=tx, post=post)
+    state_test(pre=pre, tx=tx, post=post)

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -495,7 +495,7 @@ def gas_test(
         2 * OPCODE_GAS_COST
         + OPCODE_POP_COST
         + gas_costs.G_WARM_ACCOUNT_ACCESS
-        + OPCODE_PUSH_COST * 3
+        + 6 * OPCODE_PUSH_COST
     )
     address_legacy_harness = pre.deploy_contract(
         code=(

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -447,7 +447,7 @@ def gas_test(
     pre: Alloc,
     setup_code: Bytecode,
     subject_code: Bytecode,
-    tear_down_code: Bytecode,
+    tear_down_code: Bytecode | None = None,
     cold_gas: int,
     warm_gas: int | None = None,
     subject_address: Address | None = None,
@@ -476,7 +476,8 @@ def gas_test(
         warm_gas = cold_gas
 
     sender = pre.fund_eoa()
-
+    if tear_down_code is None:
+        tear_down_code = Op.STOP
     address_baseline = pre.deploy_contract(setup_code + tear_down_code)
     code_subject = setup_code + subject_code + tear_down_code
     address_subject = pre.deploy_contract(

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -1,5 +1,6 @@
 """Test generator decorators."""
 
+import itertools
 import json
 from enum import StrEnum
 from pathlib import Path
@@ -9,10 +10,10 @@ import pytest
 
 from execution_testing.base_types import Account, Address, Hash
 from execution_testing.exceptions import BlockException
-from execution_testing.forks import Fork
-from execution_testing.specs import BlockchainTestFiller
+from execution_testing.forks import Berlin, Fork
+from execution_testing.specs import BlockchainTestFiller, StateTestFiller
 from execution_testing.specs.blockchain import Block
-from execution_testing.test_types import Alloc, Transaction
+from execution_testing.test_types import Alloc, Environment, Transaction
 from execution_testing.vm import Bytecode, Op
 
 
@@ -425,3 +426,187 @@ def generate_system_contract_error_test(
         return wrapper
 
     return decorator
+
+
+"""Storage addresses for common testing fields"""
+_slot = itertools.count()
+slot_cold_gas = next(_slot)
+slot_warm_gas = next(_slot)
+slot_oog_call_result = next(_slot)
+slot_sanity_call_result = next(_slot)
+
+LEGACY_CALL_FAILURE = 0
+LEGACY_CALL_SUCCESS = 1
+
+
+def gas_test(
+    *,
+    fork: Fork,
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    setup_code: Bytecode,
+    subject_code: Bytecode,
+    tear_down_code: Bytecode,
+    cold_gas: int,
+    warm_gas: int | None = None,
+    subject_address: Address | None = None,
+    subject_balance: int = 0,
+    oog_difference: int = 1,
+    out_of_gas_testing: bool = True,
+    prelude_code: Bytecode | None = None,
+) -> None:
+    """
+    Create State Test to check the gas cost of a sequence of EOF code.
+
+    `setup_code` and `tear_down_code` are called multiple times during the
+    test, and MUST NOT have any side-effects which persist across message
+    calls, and in particular, any effects on the gas usage of `subject_code`.
+    """
+    if fork < Berlin:
+        raise ValueError(
+            "Gas tests before Berlin are not supported due to CALL gas changes"
+        )
+
+    if cold_gas <= 0:
+        raise ValueError(
+            f"Target gas allocations (cold_gas) must be > 0, got {cold_gas}"
+        )
+    if warm_gas is None:
+        warm_gas = cold_gas
+
+    sender = pre.fund_eoa()
+
+    address_baseline = pre.deploy_contract(setup_code + tear_down_code)
+    code_subject = setup_code + subject_code + tear_down_code
+    address_subject = pre.deploy_contract(
+        code_subject,
+        balance=subject_balance,
+        address=subject_address,
+    )
+    # 2 times GAS, POP, CALL, 6 times PUSH1 - instructions charged for at every
+    # gas run
+    gas_costs = fork.gas_costs()
+    OPCODE_GAS_COST = gas_costs.G_BASE
+    OPCODE_POP_COST = gas_costs.G_BASE
+    OPCODE_PUSH_COST = gas_costs.G_VERY_LOW
+    gas_single_gas_run = (
+        2 * OPCODE_GAS_COST
+        + OPCODE_POP_COST
+        + gas_costs.G_WARM_ACCOUNT_ACCESS
+        + OPCODE_PUSH_COST * 3
+    )
+    address_legacy_harness = pre.deploy_contract(
+        code=(
+            # warm subject and baseline without executing
+            (
+                Op.BALANCE(address_subject)
+                + Op.POP
+                + Op.BALANCE(address_baseline)
+                + Op.POP
+            )
+            # run any "prelude" code that may have universal side effects
+            + prelude_code
+            # Baseline gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_baseline, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # cold gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_subject, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # warm gas run
+            + (
+                Op.GAS
+                + Op.CALL(address=address_subject, gas=Op.GAS)
+                + Op.POP
+                + Op.GAS
+                + Op.SWAP1
+                + Op.SUB
+            )
+            # Store warm gas: DUP3 is the gas of the baseline gas run
+            + (
+                Op.DUP3
+                + Op.SWAP1
+                + Op.SUB
+                + Op.PUSH2(slot_warm_gas)
+                + Op.SSTORE
+            )
+            # store cold gas: DUP2 is the gas of the baseline gas run
+            + (
+                Op.DUP2
+                + Op.SWAP1
+                + Op.SUB
+                + Op.PUSH2(slot_cold_gas)
+                + Op.SSTORE
+            )
+            + (
+                (
+                    # do an oog gas run, unless skipped with
+                    # `out_of_gas_testing=False`:
+                    #
+                    # - DUP7 is the gas of the baseline gas run, after other
+                    #   CALL args were pushed
+                    # - subtract the gas charged by the harness
+                    # - add warm gas charged by the subject
+                    # - subtract `oog_difference` to cause OOG exception
+                    #   (1 by default)
+                    Op.SSTORE(
+                        slot_oog_call_result,
+                        Op.CALL(
+                            gas=Op.ADD(
+                                warm_gas - gas_single_gas_run - oog_difference,
+                                Op.DUP7,
+                            ),
+                            address=address_subject,
+                        ),
+                    )
+                    # sanity gas run: not subtracting 1 to see if enough gas
+                    # makes the call succeed
+                    + Op.SSTORE(
+                        slot_sanity_call_result,
+                        Op.CALL(
+                            gas=Op.ADD(warm_gas - gas_single_gas_run, Op.DUP7),
+                            address=address_subject,
+                        ),
+                    )
+                    + Op.STOP
+                )
+                if out_of_gas_testing
+                else Op.STOP
+            )
+        ),
+    )
+
+    post = {
+        address_legacy_harness: Account(
+            storage={
+                slot_warm_gas: warm_gas,
+                slot_cold_gas: cold_gas,
+            },
+        ),
+    }
+
+    if out_of_gas_testing:
+        post[address_legacy_harness].storage[slot_oog_call_result] = (
+            LEGACY_CALL_FAILURE
+        )
+        post[address_legacy_harness].storage[slot_sanity_call_result] = (
+            LEGACY_CALL_SUCCESS
+        )
+
+    tx = Transaction(
+        to=address_legacy_harness, gas_limit=env.gas_limit, sender=sender
+    )
+
+    state_test(env=env, pre=pre, tx=tx, post=post)

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -18,6 +18,7 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
     UndefinedOpcodes,
+    gas_test,
 )
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 from execution_testing.forks import Byzantium
@@ -25,7 +26,6 @@ from execution_testing.forks import Byzantium
 from tests.unscheduled.eip7692_eof_v1.eip3540_eof_v1.opcodes import (
     V1_EOF_ONLY_OPCODES,
 )
-from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -364,14 +364,13 @@ def test_constant_gas(
         + (code_increment_counter if opcode == Op.CREATE2 else Bytecode())
     )
     gas_test(
-        fork,
-        state_test,
-        env,
-        pre,
+        fork=fork,
+        state_test=state_test,
+        env=env,
+        pre=pre,
         setup_code=setup_code,
         subject_code=opcode,
         tear_down_code=prepare_suffix(opcode),
         cold_gas=cold_gas,
         warm_gas=warm_gas,
-        eof=False,
     )

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -364,6 +364,7 @@ def test_constant_gas(
         + (code_increment_counter if opcode == Op.CREATE2 else Bytecode())
     )
     gas_test(
+        fork,
         state_test,
         env,
         pre,

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -19,7 +19,13 @@ from execution_testing import (
     Transaction,
     UndefinedOpcodes,
 )
+from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 from execution_testing.forks import Byzantium
+
+from tests.unscheduled.eip7692_eof_v1.eip3540_eof_v1.opcodes import (
+    V1_EOF_ONLY_OPCODES,
+)
+from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -192,4 +198,179 @@ def test_stack_overflow(
         pre=pre,
         tx=tx,
         post={contract: Account(storage=expected_storage)},
+    )
+
+
+opcode_to_gas = {
+    Op.ADD: 3,
+    Op.MUL: 5,
+    Op.SUB: 3,
+    Op.DIV: 5,
+    Op.SDIV: 5,
+    Op.MOD: 5,
+    Op.SMOD: 5,
+    Op.ADDMOD: 8,
+    Op.MULMOD: 8,
+    Op.EXP: 10,
+    Op.SIGNEXTEND: 5,
+    Op.LT: 3,
+    Op.GT: 3,
+    Op.SLT: 3,
+    Op.SGT: 3,
+    Op.EQ: 3,
+    Op.ISZERO: 3,
+    Op.AND: 3,
+    Op.OR: 3,
+    Op.XOR: 3,
+    Op.NOT: 3,
+    Op.BYTE: 3,
+    Op.SHL: 3,
+    Op.SHR: 3,
+    Op.SAR: 3,
+    Op.CLZ: 5,
+    Op.SHA3: 30,
+    Op.ADDRESS: 2,
+    Op.BALANCE: 100,
+    Op.ORIGIN: 2,
+    Op.CALLER: 2,
+    Op.CALLVALUE: 2,
+    Op.CALLDATALOAD: 3,
+    Op.CALLDATASIZE: 2,
+    Op.CALLDATACOPY: 3,
+    Op.CODESIZE: 2,
+    Op.CODECOPY: 3,
+    Op.GASPRICE: 2,
+    Op.EXTCODESIZE: 100,
+    Op.EXTCODECOPY: 100,
+    Op.RETURNDATASIZE: 2,
+    Op.RETURNDATACOPY: 3,
+    Op.EXTCODEHASH: 100,
+    Op.BLOCKHASH: 20,
+    Op.COINBASE: 2,
+    Op.TIMESTAMP: 2,
+    Op.NUMBER: 2,
+    Op.PREVRANDAO: 2,
+    Op.GASLIMIT: 2,
+    Op.CHAINID: 2,
+    Op.SELFBALANCE: 5,
+    Op.BASEFEE: 2,
+    Op.BLOBHASH: 3,
+    Op.BLOBBASEFEE: 2,
+    Op.POP: 2,
+    Op.MLOAD: 3,
+    Op.MSTORE: 3,
+    Op.MSTORE8: 3,
+    Op.SLOAD: 100,
+    Op.JUMP: 8,
+    Op.JUMPI: 10,
+    Op.PC: 2,
+    Op.MSIZE: 2,
+    Op.GAS: 2,
+    Op.JUMPDEST: 1,
+    Op.TLOAD: 100,
+    Op.TSTORE: 100,
+    Op.MCOPY: 3,
+    Op.PUSH0: 2,
+    Op.LOG0: 375,
+    Op.LOG1: 2 * 375,
+    Op.LOG2: 3 * 375,
+    Op.LOG3: 4 * 375,
+    Op.LOG4: 5 * 375,
+    Op.CREATE: 32000,
+    Op.CALL: 100,
+    Op.CALLCODE: 100,
+    Op.DELEGATECALL: 100,
+    Op.CREATE2: 32000,
+    Op.STATICCALL: 100,
+    Op.SELFDESTRUCT: 5000,
+}
+
+# PUSHx, SWAPx, DUPx have uniform gas costs
+for opcode in set(Op):
+    if 0x60 <= opcode.int() <= 0x9F:
+        opcode_to_gas[opcode] = 3
+
+constant_gas_opcodes = (
+    set(Op)
+    -
+    # zero constant gas opcodes - untestable
+    {Op.STOP, Op.RETURN, Op.REVERT, Op.INVALID}
+    -
+    # TODO: EOF opcodes. Remove once EOF is removed
+    set(V1_EOF_ONLY_OPCODES)
+    -
+    # SSTORE - untestable due to 2300 gas stipend rule
+    {Op.SSTORE}
+)
+
+
+def prepare_stack_constant_gas_oog(opcode: Opcode) -> Bytecode:
+    """Prepare valid stack for opcode."""
+    if opcode == Op.JUMPI:
+        return Op.PUSH1(1) + Op.PUSH1(3) + Op.PC + Op.ADD
+    if opcode == Op.JUMP:
+        return Op.PUSH1(3) + Op.PC + Op.ADD
+    if opcode == Op.BLOCKHASH:
+        return Op.PUSH1(0x01)
+    return Op.PUSH1(0x00) * 32
+
+
+# NOTE: Gas costs varying across forks not being supported yet would make this
+# test very complex.
+@pytest.mark.valid_at("Osaka")
+@pytest.mark.parametrize("opcode", sorted(constant_gas_opcodes))
+def test_constant_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    fork: Fork,
+    env: Environment,
+) -> None:
+    """Test that constant gas opcodes work as expected."""
+    warm_gas = opcode_to_gas[opcode]
+    cold_gas = warm_gas + (
+        2500
+        if opcode
+        in [
+            Op.BALANCE,
+            Op.EXTCODESIZE,
+            Op.EXTCODECOPY,
+            Op.EXTCODEHASH,
+            Op.CALL,
+            Op.CALLCODE,
+            Op.DELEGATECALL,
+            Op.STATICCALL,
+        ]
+        else 2600
+        if opcode == Op.SELFDESTRUCT
+        else 2000
+        if opcode == Op.SLOAD
+        else 0
+    )
+
+    if cap := fork.transaction_gas_limit_cap():
+        env.gas_limit = ZeroPaddedHexNumber(cap)
+
+    # Using `TLOAD` / `TSTORE` to work around warm/cold gas differences. We
+    # need a counter to pick a distinct salt on each `CREATE2` and avoid
+    # running into address conflicts.
+    code_increment_counter = (
+        Op.TLOAD(1234) + Op.DUP1 + Op.TSTORE(1234, Op.PUSH1(1) + Op.ADD)
+    )
+    setup_code = (
+        Op.MLOAD(0)
+        + Op.POP
+        + prepare_stack_constant_gas_oog(opcode)
+        + (code_increment_counter if opcode == Op.CREATE2 else Bytecode())
+    )
+    gas_test(
+        state_test,
+        env,
+        pre,
+        setup_code=setup_code,
+        subject_code=opcode,
+        tear_down_code=prepare_suffix(opcode),
+        cold_gas=cold_gas,
+        warm_gas=warm_gas,
+        eof=False,
     )

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -3,7 +3,7 @@ Call every possible opcode and test that the subcall is successful if the
 opcode is supported by the fork supports and fails otherwise.
 """
 
-from typing import Dict, Iterator
+from typing import Dict, Generator, Iterator
 
 import pytest
 from execution_testing import (
@@ -15,16 +15,13 @@ from execution_testing import (
     Fork,
     Op,
     Opcode,
+    ParameterSet,
     StateTestFiller,
     Transaction,
     UndefinedOpcodes,
     gas_test,
 )
 from execution_testing.forks import Byzantium
-
-from tests.unscheduled.eip7692_eof_v1.eip3540_eof_v1.opcodes import (
-    V1_EOF_ONLY_OPCODES,
-)
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -200,109 +197,6 @@ def test_stack_overflow(
     )
 
 
-opcode_to_gas = {
-    Op.ADD: 3,
-    Op.MUL: 5,
-    Op.SUB: 3,
-    Op.DIV: 5,
-    Op.SDIV: 5,
-    Op.MOD: 5,
-    Op.SMOD: 5,
-    Op.ADDMOD: 8,
-    Op.MULMOD: 8,
-    Op.EXP: 10,
-    Op.SIGNEXTEND: 5,
-    Op.LT: 3,
-    Op.GT: 3,
-    Op.SLT: 3,
-    Op.SGT: 3,
-    Op.EQ: 3,
-    Op.ISZERO: 3,
-    Op.AND: 3,
-    Op.OR: 3,
-    Op.XOR: 3,
-    Op.NOT: 3,
-    Op.BYTE: 3,
-    Op.SHL: 3,
-    Op.SHR: 3,
-    Op.SAR: 3,
-    Op.CLZ: 5,
-    Op.SHA3: 30,
-    Op.ADDRESS: 2,
-    Op.BALANCE: 100,
-    Op.ORIGIN: 2,
-    Op.CALLER: 2,
-    Op.CALLVALUE: 2,
-    Op.CALLDATALOAD: 3,
-    Op.CALLDATASIZE: 2,
-    Op.CALLDATACOPY: 3,
-    Op.CODESIZE: 2,
-    Op.CODECOPY: 3,
-    Op.GASPRICE: 2,
-    Op.EXTCODESIZE: 100,
-    Op.EXTCODECOPY: 100,
-    Op.RETURNDATASIZE: 2,
-    Op.RETURNDATACOPY: 3,
-    Op.EXTCODEHASH: 100,
-    Op.BLOCKHASH: 20,
-    Op.COINBASE: 2,
-    Op.TIMESTAMP: 2,
-    Op.NUMBER: 2,
-    Op.PREVRANDAO: 2,
-    Op.GASLIMIT: 2,
-    Op.CHAINID: 2,
-    Op.SELFBALANCE: 5,
-    Op.BASEFEE: 2,
-    Op.BLOBHASH: 3,
-    Op.BLOBBASEFEE: 2,
-    Op.POP: 2,
-    Op.MLOAD: 3,
-    Op.MSTORE: 3,
-    Op.MSTORE8: 3,
-    Op.SLOAD: 100,
-    Op.JUMP: 8,
-    Op.JUMPI: 10,
-    Op.PC: 2,
-    Op.MSIZE: 2,
-    Op.GAS: 2,
-    Op.JUMPDEST: 1,
-    Op.TLOAD: 100,
-    Op.TSTORE: 100,
-    Op.MCOPY: 3,
-    Op.PUSH0: 2,
-    Op.LOG0: 375,
-    Op.LOG1: 2 * 375,
-    Op.LOG2: 3 * 375,
-    Op.LOG3: 4 * 375,
-    Op.LOG4: 5 * 375,
-    Op.CREATE: 32000,
-    Op.CALL: 100,
-    Op.CALLCODE: 100,
-    Op.DELEGATECALL: 100,
-    Op.CREATE2: 32000,
-    Op.STATICCALL: 100,
-    Op.SELFDESTRUCT: 5000,
-}
-
-# PUSHx, SWAPx, DUPx have uniform gas costs
-for opcode in set(Op):
-    if 0x60 <= opcode.int() <= 0x9F:
-        opcode_to_gas[opcode] = 3
-
-constant_gas_opcodes = (
-    set(Op)
-    -
-    # zero constant gas opcodes - untestable
-    {Op.STOP, Op.RETURN, Op.REVERT, Op.INVALID}
-    -
-    # TODO: EOF opcodes. Remove once EOF is removed
-    set(V1_EOF_ONLY_OPCODES)
-    -
-    # SSTORE - untestable due to 2300 gas stipend rule
-    {Op.SSTORE}
-)
-
-
 def prepare_stack_constant_gas_oog(opcode: Opcode) -> Bytecode:
     """Prepare valid stack for opcode."""
     if opcode == Op.JUMPI:
@@ -311,26 +205,119 @@ def prepare_stack_constant_gas_oog(opcode: Opcode) -> Bytecode:
         return Op.PUSH1(3) + Op.PC + Op.ADD
     if opcode == Op.BLOCKHASH:
         return Op.PUSH1(0x01)
-    return Op.PUSH1(0x00) * 32
+    return Op.PUSH1(0x00) * opcode.min_stack_height
 
 
-# NOTE: Gas costs varying across forks not being supported yet would make this
-# test very complex.
-@pytest.mark.valid_at("Osaka")
-@pytest.mark.parametrize("opcode", sorted(constant_gas_opcodes))
-def test_constant_gas(
-    state_test: StateTestFiller,
-    pre: Alloc,
-    opcode: Op,
-    fork: Fork,
-    env: Environment,
-) -> None:
-    """Test that constant gas opcodes work as expected."""
-    warm_gas = opcode_to_gas[opcode]
-    cold_gas = warm_gas + (
-        2500
-        if opcode
-        in [
+def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
+    """
+    Return the list of opcodes that are constant gas and their warm gas cost
+    per fork.
+    """
+    valid_opcodes = set(fork.valid_opcodes())
+    gas_costs = fork.gas_costs()
+    opcode_floor_gas = {
+        Op.ADD: gas_costs.G_VERY_LOW,
+        Op.MUL: gas_costs.G_LOW,
+        Op.SUB: gas_costs.G_VERY_LOW,
+        Op.DIV: gas_costs.G_LOW,
+        Op.SDIV: gas_costs.G_LOW,
+        Op.MOD: gas_costs.G_LOW,
+        Op.SMOD: gas_costs.G_LOW,
+        Op.ADDMOD: gas_costs.G_MID,
+        Op.MULMOD: gas_costs.G_MID,
+        Op.EXP: gas_costs.G_HIGH,
+        Op.SIGNEXTEND: gas_costs.G_LOW,
+        Op.LT: gas_costs.G_VERY_LOW,
+        Op.GT: gas_costs.G_VERY_LOW,
+        Op.SLT: gas_costs.G_VERY_LOW,
+        Op.SGT: gas_costs.G_VERY_LOW,
+        Op.EQ: gas_costs.G_VERY_LOW,
+        Op.ISZERO: gas_costs.G_VERY_LOW,
+        Op.AND: gas_costs.G_VERY_LOW,
+        Op.OR: gas_costs.G_VERY_LOW,
+        Op.XOR: gas_costs.G_VERY_LOW,
+        Op.NOT: gas_costs.G_VERY_LOW,
+        Op.BYTE: gas_costs.G_VERY_LOW,
+        Op.SHL: gas_costs.G_VERY_LOW,
+        Op.SHR: gas_costs.G_VERY_LOW,
+        Op.SAR: gas_costs.G_VERY_LOW,
+        Op.CLZ: gas_costs.G_LOW,
+        Op.SHA3: gas_costs.G_KECCAK_256,
+        Op.ADDRESS: gas_costs.G_BASE,
+        Op.BALANCE: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.ORIGIN: gas_costs.G_BASE,
+        Op.CALLER: gas_costs.G_BASE,
+        Op.CALLVALUE: gas_costs.G_BASE,
+        Op.CALLDATALOAD: gas_costs.G_VERY_LOW,
+        Op.CALLDATASIZE: gas_costs.G_BASE,
+        Op.CALLDATACOPY: gas_costs.G_COPY,
+        Op.CODESIZE: gas_costs.G_BASE,
+        Op.CODECOPY: gas_costs.G_COPY,
+        Op.GASPRICE: gas_costs.G_BASE,
+        Op.EXTCODESIZE: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.EXTCODECOPY: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.RETURNDATASIZE: gas_costs.G_BASE,
+        Op.RETURNDATACOPY: gas_costs.G_COPY,
+        Op.EXTCODEHASH: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.BLOCKHASH: gas_costs.G_BLOCKHASH,
+        Op.COINBASE: gas_costs.G_BASE,
+        Op.TIMESTAMP: gas_costs.G_BASE,
+        Op.NUMBER: gas_costs.G_BASE,
+        Op.PREVRANDAO: gas_costs.G_BASE,
+        Op.GASLIMIT: gas_costs.G_BASE,
+        Op.CHAINID: gas_costs.G_BASE,
+        Op.SELFBALANCE: gas_costs.G_LOW,
+        Op.BASEFEE: gas_costs.G_BASE,
+        Op.BLOBHASH: gas_costs.G_VERY_LOW,
+        Op.BLOBBASEFEE: gas_costs.G_BASE,
+        Op.POP: gas_costs.G_BASE,
+        Op.MLOAD: gas_costs.G_VERY_LOW,
+        Op.MSTORE: gas_costs.G_VERY_LOW,
+        Op.MSTORE8: gas_costs.G_VERY_LOW,
+        Op.SLOAD: gas_costs.G_WARM_SLOAD,
+        Op.JUMP: gas_costs.G_MID,
+        Op.JUMPI: gas_costs.G_HIGH,
+        Op.PC: gas_costs.G_BASE,
+        Op.MSIZE: gas_costs.G_BASE,
+        Op.GAS: gas_costs.G_BASE,
+        Op.JUMPDEST: gas_costs.G_JUMPDEST,
+        Op.TLOAD: gas_costs.G_WARM_SLOAD,
+        Op.TSTORE: gas_costs.G_WARM_SLOAD,
+        Op.MCOPY: gas_costs.G_VERY_LOW,
+        Op.PUSH0: gas_costs.G_BASE,
+        Op.LOG0: gas_costs.G_LOG + (0 * gas_costs.G_LOG_TOPIC),
+        Op.LOG1: gas_costs.G_LOG + (1 * gas_costs.G_LOG_TOPIC),
+        Op.LOG2: gas_costs.G_LOG + (2 * gas_costs.G_LOG_TOPIC),
+        Op.LOG3: gas_costs.G_LOG + (3 * gas_costs.G_LOG_TOPIC),
+        Op.LOG4: gas_costs.G_LOG + (4 * gas_costs.G_LOG_TOPIC),
+        Op.CREATE: gas_costs.G_TRANSACTION_CREATE,
+        Op.CALL: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.CALLCODE: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.DELEGATECALL: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.CREATE2: gas_costs.G_TRANSACTION_CREATE,
+        Op.STATICCALL: gas_costs.G_WARM_ACCOUNT_ACCESS,
+        Op.SELFDESTRUCT: gas_costs.G_SELF_DESTRUCT,
+        Op.STOP: 0,
+        Op.RETURN: 0,
+        Op.REVERT: 0,
+        Op.INVALID: 0,
+    }
+
+    # PUSHx, SWAPx, DUPx have uniform gas costs
+    for opcode in valid_opcodes:
+        if 0x60 <= opcode.int() <= 0x9F:
+            opcode_floor_gas[opcode] = gas_costs.G_VERY_LOW
+
+    for opcode in sorted(valid_opcodes):
+        # SSTORE - untestable due to 2300 gas stipend rule
+        if opcode == Op.SSTORE:
+            continue
+        warm_gas = opcode_floor_gas[opcode]
+        if warm_gas == 0:
+            # zero constant gas opcodes - untestable
+            continue
+        cold_gas = warm_gas
+        if opcode in [
             Op.BALANCE,
             Op.EXTCODESIZE,
             Op.EXTCODECOPY,
@@ -339,33 +326,40 @@ def test_constant_gas(
             Op.CALLCODE,
             Op.DELEGATECALL,
             Op.STATICCALL,
-        ]
-        else 2600
-        if opcode == Op.SELFDESTRUCT
-        else 2000
-        if opcode == Op.SLOAD
-        else 0
-    )
+        ]:
+            cold_gas = gas_costs.G_COLD_ACCOUNT_ACCESS
+        elif opcode == Op.SELFDESTRUCT:
+            # Add the cost of accessing the send all destination account.
+            cold_gas += gas_costs.G_COLD_ACCOUNT_ACCESS
+        elif opcode == Op.SLOAD:
+            cold_gas = gas_costs.G_COLD_SLOAD
+        yield pytest.param(opcode, warm_gas, cold_gas, id=f"{opcode}")
 
-    if cap := fork.transaction_gas_limit_cap():
-        env = Environment(gas_limit=cap)
 
-    # Using `TLOAD` / `TSTORE` to work around warm/cold gas differences. We
-    # need a counter to pick a distinct salt on each `CREATE2` and avoid
-    # running into address conflicts.
-    code_increment_counter = (
-        Op.TLOAD(1234) + Op.DUP1 + Op.TSTORE(1234, Op.PUSH1(1) + Op.ADD)
-    )
+@pytest.mark.valid_from("Berlin")
+@pytest.mark.parametrize_by_fork(
+    "opcode,warm_gas,cold_gas", constant_gas_opcodes
+)
+def test_constant_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    fork: Fork,
+    warm_gas: int,
+    cold_gas: int,
+) -> None:
+    """Test that constant gas opcodes work as expected."""
+    # Using Op.GAS as salt to guarantee no address collision on CREATE2.
+    create2_salt = Op.GAS if opcode == Op.CREATE2 else Bytecode()
     setup_code = (
         Op.MLOAD(0)
         + Op.POP
         + prepare_stack_constant_gas_oog(opcode)
-        + (code_increment_counter if opcode == Op.CREATE2 else Bytecode())
+        + create2_salt
     )
     gas_test(
         fork=fork,
         state_test=state_test,
-        env=env,
         pre=pre,
         setup_code=setup_code,
         subject_code=opcode,

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -20,7 +20,6 @@ from execution_testing import (
     UndefinedOpcodes,
     gas_test,
 )
-from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 from execution_testing.forks import Byzantium
 
 from tests.unscheduled.eip7692_eof_v1.eip3540_eof_v1.opcodes import (
@@ -349,7 +348,7 @@ def test_constant_gas(
     )
 
     if cap := fork.transaction_gas_limit_cap():
-        env.gas_limit = ZeroPaddedHexNumber(cap)
+        env = Environment(gas_limit=cap)
 
     # Using `TLOAD` / `TSTORE` to work around warm/cold gas differences. We
     # need a counter to pick a distinct salt on each `CREATE2` and avoid

--- a/tests/frontier/opcodes/test_exp.py
+++ b/tests/frontier/opcodes/test_exp.py
@@ -5,7 +5,6 @@ Test EXP opcode.
 import pytest
 from execution_testing import (
     Alloc,
-    Environment,
     Fork,
     Op,
     StateTestFiller,
@@ -45,18 +44,13 @@ def test_gas(
     a: int,
     exponent: int,
     fork: Fork,
-    env: Environment,
 ) -> None:
     """Test that EXP gas works as expected."""
     gas_cost = exp_gas(fork, exponent)
 
-    if cap := fork.transaction_gas_limit_cap():
-        env = Environment(gas_limit=cap)
-
     gas_test(
         fork=fork,
         state_test=state_test,
-        env=env,
         pre=pre,
         setup_code=Op.PUSH32(exponent) + Op.PUSH32(a),
         subject_code=Op.EXP,

--- a/tests/frontier/opcodes/test_exp.py
+++ b/tests/frontier/opcodes/test_exp.py
@@ -1,0 +1,68 @@
+"""
+Test EXP opcode.
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Environment,
+    StateTestFiller,
+)
+from execution_testing.base_types.base_types import ZeroPaddedHexNumber
+from execution_testing.forks.helpers import Fork
+from execution_testing.vm import Opcodes as Op
+
+from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def exp_gas(fork: Fork, exponent: int) -> int:
+    """Calculate gas cost for EXP opcode given the exponent."""
+    byte_len = (exponent.bit_length() + 7) // 8
+    return fork.gas_costs().G_EXP + fork.gas_costs().G_EXP_BYTE * byte_len
+
+
+@pytest.mark.valid_from("Berlin")
+@pytest.mark.parametrize(
+    "a", [0, 1, pytest.param(2**256 - 1, id="a2to256minus1")]
+)
+@pytest.mark.parametrize(
+    "exponent",
+    [
+        0,
+        1,
+        2,
+        1023,
+        1024,
+        pytest.param(2**255, id="exponent2to255"),
+        pytest.param(2**256 - 1, id="exponent2to256minus1"),
+    ],
+)
+def test_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    a: int,
+    exponent: int,
+    fork: Fork,
+    env: Environment,
+) -> None:
+    """Test that EXP gas works as expected."""
+    warm_gas = exp_gas(fork, exponent)
+
+    if cap := fork.transaction_gas_limit_cap():
+        env.gas_limit = ZeroPaddedHexNumber(cap)
+
+    gas_test(
+        fork,
+        state_test,
+        env,
+        pre,
+        setup_code=Op.PUSH32(exponent) + Op.PUSH32(a),
+        subject_code=Op.EXP,
+        tear_down_code=Op.STOP,
+        cold_gas=warm_gas,
+        warm_gas=warm_gas,
+        eof=False,
+    )

--- a/tests/frontier/opcodes/test_exp.py
+++ b/tests/frontier/opcodes/test_exp.py
@@ -11,7 +11,6 @@ from execution_testing import (
     StateTestFiller,
     gas_test,
 )
-from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -19,8 +18,9 @@ REFERENCE_SPEC_VERSION = "N/A"
 
 def exp_gas(fork: Fork, exponent: int) -> int:
     """Calculate gas cost for EXP opcode given the exponent."""
+    gas_costs = fork.gas_costs()
     byte_len = (exponent.bit_length() + 7) // 8
-    return fork.gas_costs().G_EXP + fork.gas_costs().G_EXP_BYTE * byte_len
+    return gas_costs.G_EXP + gas_costs.G_EXP_BYTE * byte_len
 
 
 @pytest.mark.valid_from("Berlin")
@@ -48,10 +48,10 @@ def test_gas(
     env: Environment,
 ) -> None:
     """Test that EXP gas works as expected."""
-    warm_gas = exp_gas(fork, exponent)
+    gas_cost = exp_gas(fork, exponent)
 
     if cap := fork.transaction_gas_limit_cap():
-        env.gas_limit = ZeroPaddedHexNumber(cap)
+        env = Environment(gas_limit=cap)
 
     gas_test(
         fork=fork,
@@ -60,7 +60,6 @@ def test_gas(
         pre=pre,
         setup_code=Op.PUSH32(exponent) + Op.PUSH32(a),
         subject_code=Op.EXP,
-        tear_down_code=Op.STOP,
-        cold_gas=warm_gas,
-        warm_gas=warm_gas,
+        cold_gas=gas_cost,
+        warm_gas=gas_cost,
     )

--- a/tests/frontier/opcodes/test_exp.py
+++ b/tests/frontier/opcodes/test_exp.py
@@ -6,13 +6,12 @@ import pytest
 from execution_testing import (
     Alloc,
     Environment,
+    Fork,
+    Op,
     StateTestFiller,
+    gas_test,
 )
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
-from execution_testing.forks.helpers import Fork
-from execution_testing.vm import Opcodes as Op
-
-from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -55,14 +54,13 @@ def test_gas(
         env.gas_limit = ZeroPaddedHexNumber(cap)
 
     gas_test(
-        fork,
-        state_test,
-        env,
-        pre,
+        fork=fork,
+        state_test=state_test,
+        env=env,
+        pre=pre,
         setup_code=Op.PUSH32(exponent) + Op.PUSH32(a),
         subject_code=Op.EXP,
         tear_down_code=Op.STOP,
         cold_gas=warm_gas,
         warm_gas=warm_gas,
-        eof=False,
     )

--- a/tests/frontier/opcodes/test_log.py
+++ b/tests/frontier/opcodes/test_log.py
@@ -6,13 +6,12 @@ import pytest
 from execution_testing import (
     Alloc,
     Environment,
+    Fork,
+    Op,
     StateTestFiller,
+    gas_test,
 )
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
-from execution_testing.forks.helpers import Fork
-from execution_testing.vm import Opcodes as Op
-
-from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -62,10 +61,10 @@ def test_gas(
     print(hex(data_size))
 
     gas_test(
-        fork,
-        state_test,
-        env,
-        pre,
+        fork=fork,
+        state_test=state_test,
+        env=env,
+        pre=pre,
         setup_code=Op.MSTORE8(data_size, 0)
         + Op.PUSH1(0) * topics
         + Op.PUSH32(data_size)
@@ -74,5 +73,4 @@ def test_gas(
         tear_down_code=Op.STOP,
         cold_gas=warm_gas,
         warm_gas=warm_gas,
-        eof=False,
     )

--- a/tests/frontier/opcodes/test_log.py
+++ b/tests/frontier/opcodes/test_log.py
@@ -1,0 +1,78 @@
+"""
+Test LOGx opcodes.
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Environment,
+    StateTestFiller,
+)
+from execution_testing.base_types.base_types import ZeroPaddedHexNumber
+from execution_testing.forks.helpers import Fork
+from execution_testing.vm import Opcodes as Op
+
+from tests.unscheduled.eip7692_eof_v1.gas_test import gas_test
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def log_gas(fork: Fork, topics: int, data_size: int) -> int:
+    """
+    Calculate gas cost for LOGx opcodes given the number of topics and data
+    size.
+    """
+    return (
+        fork.gas_costs().G_LOG
+        + fork.gas_costs().G_LOG_TOPIC * topics
+        + fork.gas_costs().G_LOG_DATA * data_size
+    )
+
+
+@pytest.mark.valid_from("Berlin")
+@pytest.mark.parametrize(
+    "opcode,topics",
+    [(Op.LOG0, 0), (Op.LOG1, 1), (Op.LOG2, 2), (Op.LOG3, 3), (Op.LOG4, 4)],
+)
+@pytest.mark.parametrize(
+    "data_size",
+    [
+        0,
+        1,
+        2,
+        1023,
+        1024,
+    ],
+)
+def test_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    topics: int,
+    data_size: int,
+    fork: Fork,
+    env: Environment,
+) -> None:
+    """Test that LOGx gas works as expected."""
+    warm_gas = log_gas(fork, topics, data_size)
+
+    if cap := fork.transaction_gas_limit_cap():
+        env.gas_limit = ZeroPaddedHexNumber(cap)
+    print(hex(data_size))
+
+    gas_test(
+        fork,
+        state_test,
+        env,
+        pre,
+        setup_code=Op.MSTORE8(data_size, 0)
+        + Op.PUSH1(0) * topics
+        + Op.PUSH32(data_size)
+        + Op.PUSH1(0),
+        subject_code=opcode,
+        tear_down_code=Op.STOP,
+        cold_gas=warm_gas,
+        warm_gas=warm_gas,
+        eof=False,
+    )

--- a/tests/frontier/opcodes/test_log.py
+++ b/tests/frontier/opcodes/test_log.py
@@ -11,7 +11,6 @@ from execution_testing import (
     StateTestFiller,
     gas_test,
 )
-from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
@@ -22,10 +21,11 @@ def log_gas(fork: Fork, topics: int, data_size: int) -> int:
     Calculate gas cost for LOGx opcodes given the number of topics and data
     size.
     """
+    gas_costs = fork.gas_costs()
     return (
-        fork.gas_costs().G_LOG
-        + fork.gas_costs().G_LOG_TOPIC * topics
-        + fork.gas_costs().G_LOG_DATA * data_size
+        gas_costs.G_LOG
+        + gas_costs.G_LOG_TOPIC * topics
+        + gas_costs.G_LOG_DATA * data_size
     )
 
 
@@ -54,11 +54,10 @@ def test_gas(
     env: Environment,
 ) -> None:
     """Test that LOGx gas works as expected."""
-    warm_gas = log_gas(fork, topics, data_size)
+    gas_cost = log_gas(fork, topics, data_size)
 
     if cap := fork.transaction_gas_limit_cap():
-        env.gas_limit = ZeroPaddedHexNumber(cap)
-    print(hex(data_size))
+        env = Environment(gas_limit=cap)
 
     gas_test(
         fork=fork,
@@ -70,7 +69,6 @@ def test_gas(
         + Op.PUSH32(data_size)
         + Op.PUSH1(0),
         subject_code=opcode,
-        tear_down_code=Op.STOP,
-        cold_gas=warm_gas,
-        warm_gas=warm_gas,
+        cold_gas=gas_cost,
+        warm_gas=gas_cost,
     )

--- a/tests/frontier/opcodes/test_log.py
+++ b/tests/frontier/opcodes/test_log.py
@@ -5,7 +5,6 @@ Test LOGx opcodes.
 import pytest
 from execution_testing import (
     Alloc,
-    Environment,
     Fork,
     Op,
     StateTestFiller,
@@ -51,18 +50,13 @@ def test_gas(
     topics: int,
     data_size: int,
     fork: Fork,
-    env: Environment,
 ) -> None:
     """Test that LOGx gas works as expected."""
     gas_cost = log_gas(fork, topics, data_size)
 
-    if cap := fork.transaction_gas_limit_cap():
-        env = Environment(gas_limit=cap)
-
     gas_test(
         fork=fork,
         state_test=state_test,
-        env=env,
         pre=pre,
         setup_code=Op.MSTORE8(data_size, 0)
         + Op.PUSH1(0) * topics

--- a/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/opcodes.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/opcodes.py
@@ -212,6 +212,7 @@ V1_EOF_ONLY_OPCODES = [
     Op.EXTCALL,
     Op.EXTDELEGATECALL,
     Op.EXTSTATICCALL,
+    Op.RETURNDATALOAD,
     # EIP-7480 EOF Data Section Access
     Op.DATALOAD,
     Op.DATALOADN,
@@ -220,6 +221,8 @@ V1_EOF_ONLY_OPCODES = [
     # EIP-7620 EOF Create and Return Contract operation
     Op.EOFCREATE,
     Op.RETURNCODE,
+    # EIP-7873 TXCREATE and InitcodeTransaction
+    Op.TXCREATE,
 ]
 """
 List of valid EOF V1 opcodes that are disabled in legacy bytecode.

--- a/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_gas.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7069_extcall/test_gas.py
@@ -143,6 +143,7 @@ def test_ext_calls_gas(
     )
     cost_memory_bytes = fork.memory_expansion_gas_calculator()
     gas_test(
+        fork,
         state_test,
         state_env,
         pre,
@@ -164,6 +165,7 @@ def test_ext_calls_gas(
 def test_transfer_gas_is_cleared(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     state_env: Environment,
     opcode: Op,
     value: int,
@@ -185,6 +187,7 @@ def test_transfer_gas_is_cleared(
     push_gas = (4 if opcode == Op.EXTCALL else 3) * 3
 
     gas_test(
+        fork,
         state_test,
         state_env,
         pre,
@@ -212,6 +215,7 @@ def test_transfer_gas_is_cleared(
 def test_late_account_create(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
     state_env: Environment,
     opcode: Op,
 ) -> None:
@@ -222,6 +226,7 @@ def test_late_account_create(
     empty_address = Address(0xDECAFC0DE)
 
     gas_test(
+        fork,
         state_test,
         state_env,
         pre,

--- a/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_gas.py
+++ b/tests/unscheduled/eip7692_eof_v1/eip7620_eof_create/test_gas.py
@@ -149,6 +149,7 @@ def test_eofcreate_gas(
     )
     cost_memory_bytes = fork.memory_expansion_gas_calculator()
     gas_test(
+        fork,
         state_test,
         Environment(),
         pre,

--- a/tests/unscheduled/eip7692_eof_v1/gas_test.py
+++ b/tests/unscheduled/eip7692_eof_v1/gas_test.py
@@ -13,6 +13,8 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.forks.forks.forks import Berlin
+from execution_testing.forks.helpers import Fork
 from execution_testing.test_types.eof.v1 import Container, Section
 
 from .eip7069_extcall.spec import (
@@ -31,6 +33,7 @@ slot_sanity_call_result = next(_slot)
 
 
 def gas_test(
+    fork: Fork,
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
@@ -55,6 +58,11 @@ def gas_test(
     test, and MUST NOT have any side-effects which persist across message
     calls, and in particular, any effects on the gas usage of `subject_code`.
     """
+    if fork < Berlin:
+        raise ValueError(
+            "Gas tests before Berlin are not supported due to CALL gas changes"
+        )
+
     if cold_gas <= 0:
         raise ValueError(
             f"Target gas allocations (cold_gas) must be > 0, got {cold_gas}"

--- a/tests/unscheduled/eip7692_eof_v1/gas_test.py
+++ b/tests/unscheduled/eip7692_eof_v1/gas_test.py
@@ -46,6 +46,7 @@ def gas_test(
     out_of_gas_testing: bool = True,
     *,
     prelude_code: Bytecode | None = None,
+    eof: bool = True,
 ) -> None:
     """
     Create State Test to check the gas cost of a sequence of EOF code.
@@ -65,16 +66,22 @@ def gas_test(
 
     address_baseline = pre.deploy_contract(
         Container.Code(setup_code + tear_down_code)
+        if eof
+        else setup_code + tear_down_code
     )
     code_subject = setup_code + subject_code + tear_down_code
     address_subject = pre.deploy_contract(
-        Container.Code(code_subject)
-        if not subject_subcontainer
-        else Container(
-            sections=[
-                Section.Code(code_subject),
-                Section.Container(subject_subcontainer),
-            ]
+        code_subject
+        if not eof
+        else (
+            Container.Code(code_subject)
+            if not subject_subcontainer
+            else Container(
+                sections=[
+                    Section.Code(code_subject),
+                    Section.Container(subject_subcontainer),
+                ]
+            )
         ),
         balance=subject_balance,
         address=subject_address,


### PR DESCRIPTION
## 🗒️ Description

Adds some missing cases to cover situations where either gas is not enough to cover constant (static) cost or specific dynamic costs of EXP and LOG opcodes

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
