### PR TITLE
chore(client-clis): Add system contract and deposit `BlockExceptions` for `evmone`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `fill`
 
+- 🐞 Allow `evmone` to fill Prague and Osaka blockchain tests (mainly modified deposit contract tests) ([#1689](https://github.com/ethereum/execution-specs/pull/1689))
+
 #### `consume`
 
 - 🐞 Fix a bug with `consume sync` tests where some clients don't have JSON-RPC immediately available after syncing and can't yet serve the synced block ([#1670](https://github.com/ethereum/execution-specs/pull/1670)).

--- a/packages/testing/src/execution_testing/client_clis/clis/evmone.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/evmone.py
@@ -11,6 +11,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional
 
+from execution_testing.exceptions.exceptions.block import BlockException
 import pytest
 
 from execution_testing.client_clis.file_utils import (
@@ -358,6 +359,11 @@ class EvmoneExceptionMapper(ExceptionMapper):
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
         TransactionException.NONCE_MISMATCH_TOO_HIGH: "nonce too high",
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: "max gas limit exceeded",
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "invalid deposit event layout",
+        # TODO EVMONE needs to differentiate when the system contract is
+        # missing or failing
+        BlockException.SYSTEM_CONTRACT_EMPTY: "system contract empty or failed",
+        BlockException.SYSTEM_CONTRACT_CALL_FAILED: "system contract empty or failed",
         # TODO EVMONE needs to differentiate when the section is missing in the
         # header or body
         EOFException.MISSING_STOP_OPCODE: "err: no_terminating_instruction",


### PR DESCRIPTION
## 🗒️ Description

Allow evmone to fill all new Prague blockchain tests, once combined with the (merged) https://github.com/ipsilon/evmone/pull/1339

## 🔗 Related Issues or PRs

https://github.com/ipsilon/evmone/issues/1337

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
