### PR TITLE
chore(testing/cli): add ethrex exception mappers

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -95,6 +95,12 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob count exceeded.*"
         ),
+        TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW: (
+            r"Invalid transaction: Gas limit price product overflow.*"
+        ),
+        TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
+            r"Invalid transaction: Transaction gas limit exceeds maximum.*"
+        ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"System call failed.*"),
         BlockException.SYSTEM_CONTRACT_EMPTY: (
             r"System contract:.* has no code after deployment"
@@ -110,5 +116,8 @@ class EthrexExceptionMapper(ExceptionMapper):
         ),
         BlockException.INVALID_BLOCK_HASH: (
             r"Invalid block hash. Expected \w+, got \w+"
+        ),
+        BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
+            r"Maximum block size exceeded.*"
         ),
     }


### PR DESCRIPTION
## Description
Adds three new exception mappers to the Ethrex CLI to handle gas limit and RLP block size validation errors:
- `BlockException.GASLIMIT_PRICE_PRODUCT_OVERFLOW` - handles "Invalid transaction: Gas limit price product overflow" errors
- `BlockException.RLP_BLOCK_LIMIT_EXCEEDED` - handles "Maximum block size exceeded" errors  
- `BlockException.GAS_LIMIT_EXCEEDS_MAXIMUM` - handles "Invalid transaction: Transaction gas limit exceeds maximum" errors

Fixes the hive failures for consume engine where ethrex error messages were not being properly matched to their corresponding exception types: https://hive.ethpandaops.io/#/test/fusaka/1761412944-237887dd8db2b19dbb8a9463444420b3?testnumber=6019