### PR TITLE
feat(ci): add hive consume test workflow

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -40,26 +40,26 @@ jobs:
     steps:
       - name: Checkout execution-specs
         if: matrix.mode == 'dev'
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: execution-specs
 
       - name: Checkout Hive
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: ethereum/hive
           ref: master
           path: hive
 
       - name: Setup go env and cache
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: '>=1.24'
           cache-dependency-path: hive/go.sum
 
       - name: Setup Python
         if: matrix.mode == 'dev'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -7,9 +7,12 @@ on:
   pull_request:
     paths:
       - '.github/workflows/hive-consume.yaml'
-      - 'packages/tests/src/pytest_plugins/consume/**'
-      - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/consume.py'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini'
       - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/fixtures/consume.py'
+      - 'packages/testing/src/execution_testing/rpc/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -5,12 +5,11 @@ on:
     branches:
       - 'forks/**'
   pull_request:
-    # TODO: After initial testing, uncomment these paths to only run on relevant changes:
-    # paths:
-    #   - '.github/workflows/hive-consume.yaml'
-    #   - 'packages/tests/src/pytest_plugins/consume/**'
-    #   - 'packages/tests/src/pytest_plugins/pytest_hive/**'
-    #   - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+    paths:
+      - '.github/workflows/hive-consume.yaml'
+      - 'packages/tests/src/pytest_plugins/consume/**'
+      - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -59,17 +59,14 @@ jobs:
           go-version: '>=1.24'
           cache-dependency-path: hive/go.sum
 
-      - name: Setup Python
+      - name: Install uv and python
         if: matrix.mode == 'dev'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
         with:
-          python-version: '3.12'
-
-      - name: Install uv
-        if: matrix.mode == 'dev'
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          enable-cache: true
+          cache-dependency-glob: "execution-specs/uv.lock"
+          version: ${{ vars.UV_VERSION }}
+          python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
       - name: Pre-pull geth docker image
         run: docker pull docker.ethquokkaops.io/dh/ethpandaops/geth:master

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -94,7 +94,7 @@ jobs:
             --sim.parallelism=1 \
             --client go-ethereum \
             --client-file clients.yaml \
-            --sim.buildarg fixtures=develop@latest \
+            --sim.buildarg fixtures=develop@v5.3.0 \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
 
@@ -120,4 +120,4 @@ jobs:
           HIVE_SIMULATOR: http://127.0.0.1:3000
         run: |
           uv sync --all-extras
-          uv run consume ${{ matrix.consume_command }} --input develop@latest -k "Osaka and test_block_at_rlp_limit_with_logs"
+          uv run consume ${{ matrix.consume_command }} --input develop@v5.3.0 -k "Osaka and test_block_at_rlp_limit_with_logs"

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -1,0 +1,124 @@
+name: Hive Consume Tests
+
+on:
+  push:
+    branches:
+      - 'forks/**'
+  pull_request:
+    # TODO: After initial testing, uncomment these paths to only run on relevant changes:
+    # paths:
+    #   - '.github/workflows/hive-consume.yaml'
+    #   - 'packages/tests/src/pytest_plugins/consume/**'
+    #   - 'packages/tests/src/pytest_plugins/pytest_hive/**'
+    #   - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
+  workflow_dispatch:
+
+concurrency:
+  group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-hive:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: consume-engine
+            mode: simulator
+            simulator: ethereum/eels/consume-engine
+          - name: consume-rlp
+            mode: simulator
+            simulator: ethereum/eels/consume-rlp
+          - name: consume-sync
+            mode: simulator
+            simulator: ethereum/eels/consume-sync
+          - name: dev-mode
+            mode: dev
+            consume_command: engine
+    steps:
+      - name: Checkout execution-specs
+        if: matrix.mode == 'dev'
+        uses: actions/checkout@v5
+        with:
+          path: execution-specs
+
+      - name: Checkout Hive
+        uses: actions/checkout@v5
+        with:
+          repository: ethereum/hive
+          ref: master
+          path: hive
+
+      - name: Setup go env and cache
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.24'
+          cache-dependency-path: hive/go.sum
+
+      - name: Setup Python
+        if: matrix.mode == 'dev'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        if: matrix.mode == 'dev'
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Pre-pull geth docker image
+        run: docker pull docker.ethquokkaops.io/dh/ethpandaops/geth:master
+
+      - name: Create clients.yaml
+        run: |
+          cat > hive/clients.yaml << 'EOF'
+          - client: go-ethereum
+            nametag: default
+            build_args:
+              baseimage: docker.ethquokkaops.io/dh/ethpandaops/geth
+              tag: master
+          EOF
+
+      - name: Build hive
+        run: |
+          cd hive
+          go build .
+
+      - name: Run simulator tests
+        if: matrix.mode == 'simulator'
+        run: |
+          cd hive
+          ./hive --sim '${{ matrix.simulator }}' \
+            --sim.parallelism=1 \
+            --client go-ethereum \
+            --client-file clients.yaml \
+            --sim.buildarg fixtures=develop@latest \
+            --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
+            --docker.output
+
+      - name: Start Hive in dev mode
+        if: matrix.mode == 'dev'
+        run: |
+          cd hive
+          ./hive --dev --client go-ethereum --client-file clients.yaml --docker.output &
+          echo "Waiting for Hive to be ready..."
+          for i in {1..30}; do
+            if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then
+              echo "Hive is ready!"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run consume in dev mode
+        if: matrix.mode == 'dev'
+        working-directory: execution-specs
+        env:
+          HIVE_SIMULATOR: http://127.0.0.1:3000
+        run: |
+          uv sync --all-extras
+          uv run consume ${{ matrix.consume_command }} --input develop@latest -k "Osaka and test_block_at_rlp_limit_with_logs"


### PR DESCRIPTION
## Description
Adds a CI workflow to validate hive integration with consume commands. Previously, we lacked CI for consume, which has led to breaking changes going undetected until they impacted downstream EL clients.

This workflow provides early detection of consume-related regressions, preventing disruption to client teams who depend on our test fixtures.

## What's Tested

The workflow runs four parallel test jobs:
- `ethereum/eels/consume-engine`
- `ethereum/eels/consume-rlp`
- `ethereum/eels/consume-sync`
- `ethereum/eels/consume-engine` Dev mode validation

All tests use `go-ethereum` as the reference client and filter to a subset of Osaka fork tests to keep CI runtime reasonable while still providing meaningful coverage. We pull the latest `go-ethereum` image from `ethpandaops`.

We run a single test just to check for no fails. It assumes `go-ethereum` will pass this test always. It takes no longer that 5 minutes to run the workflow.

We may consider expanding the filter for when we run this workflow, to include any changes to `packages/testing`.
