### PR TITLE
chore(ci): add path filters to render workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -17,6 +17,10 @@ on:
       - 'static/**'
       - '.github/workflows/gh-pages.yaml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build Documentation"

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,8 +6,16 @@ on:
       - master
       - mainnet
       - 'forks/**'
+    paths:
+      - 'src/ethereum/**'
+      - 'static/**'
+      - '.github/workflows/gh-pages.yaml'
   workflow_dispatch:
   pull_request:
+    paths:
+      - 'src/ethereum/**'
+      - 'static/**'
+      - '.github/workflows/gh-pages.yaml'
 
 jobs:
   build:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,16 +6,16 @@ on:
       - master
       - mainnet
       - 'forks/**'
-    paths:
+    paths: &render_paths
       - 'src/ethereum/**'
       - 'static/**'
       - '.github/workflows/gh-pages.yaml'
+      - 'uv.lock'
+      - 'src/ethereum_spec_tools/docc.py'
+      - 'src/ethereum_spec_tools/forks.py'
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'src/ethereum/**'
-      - 'static/**'
-      - '.github/workflows/gh-pages.yaml'
+    paths: *render_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Optimize the render workflow to only run when changes affect the EELS documentation build:
- `src/ethereum/**` (EELS specification code)
- `static/**` (CSS and static assets used by docc)
- `.github/workflows/gh-pages.yaml` (workflow itself)

This prevents unnecessary builds when changes are made to areas that don't affect it. Adds concurrency control so spamming commits on the same branch don't run the workflow multiple times.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://duckduckgo.com/i/db069b7477d9232f.png)
