### PR TITLE
chore(execute): fix execute hive mode

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -235,6 +235,12 @@ def test_suite_description() -> str:
     return "Execute EEST tests using hive endpoint."
 
 
+@pytest.fixture(scope="function")
+def test_case_description(request: pytest.FixtureRequest) -> str:
+    """The description of the current test case for hive."""
+    return f"Test: {request.node.name}"
+
+
 @pytest.fixture(autouse=True, scope="session")
 def base_hive_test(
     request: pytest.FixtureRequest,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -4,7 +4,7 @@ minversion = 7.0
 python_files = *.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
@@ -19,3 +19,6 @@ addopts =
     --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
+    # TODO: remove after https://github.com/ethereum/execution-specs/issues/1648
+    --ignore tests/json_infra
+    --ignore tests/evm_tools


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fixes execute hive mode, specifically for adding the `execute-blobs` simulator to the hive CI.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Blocker for: https://github.com/ethpandaops/fusaka-devnets/pull/115
Requires: https://github.com/ethereum/hive/pull/1365

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.RbqtjEE2CFihPQW5e377WwHaJR%3Fpid%3DApi&f=1&ipt=28dade1b903291af1a85994bc0622789a1d3f6b6488167210b7388d189082028&ipo=images)
