### PR TITLE
feat(tests): expand *CALL gas testing test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 - 🐞 Fix BALs opcode OOG test vectors by updating the Amsterdam commit hash in specs and validating appropriately on the testing side ([#2293](https://github.com/ethereum/execution-spec-tests/pull/2293)).
 - ✨ Fix test vector for BALs SSTORE with OOG by pointing to updated specs; add new boundary conditions cases for SSTORE w/ OOG ([#2297](https://github.com/ethereum/execution-spec-tests/pull/2297)).
+- ✨ Expand cases to test *CALL opcodes causing OOG ([#1703](https://github.com/ethereum/execution-specs/pull/1703)).
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -1,16 +1,18 @@
 """
-Tests nested CALL/CALLCODE gas usage with positive value transfer.
+Tests nested CALL/CALLCODE/DELEGATECALL/STATICCALL gas usage with positive
+value transfer (where applicable).
 
 This test investigates an issue identified in EthereumJS, as reported in:
 https://github.com/ethereumjs/ethereumjs-monorepo/issues/3194.
 
-The issue pertains to the incorrect gas calculation for CALL/CALLCODE
-operations with a positive value transfer, due to the pre-addition of the
-gas stipend (2300) to the currently available gas instead of adding it to
-the new call frame. This bug was specific to the case where insufficient
-gas was provided for the CALL/CALLCODE operation. Due to the pre-addition
-of the stipend to the currently available gas, the case for insufficient
-gas was not properly failing with an out-of-gas error.
+The issue pertains to the incorrect gas calculation for
+CALL/CALLCODE/DELEGATECALL/STATICCALL operations with a positive value
+transfer, due to the pre-addition of the gas stipend (2300) to the currently
+available gas instead of adding it to the new call frame. This bug was specific
+to the case where insufficient gas was provided for the CALL/CALLCODE
+operation. Due to the pre-addition of the stipend to the currently available
+gas, the case for insufficient gas was not properly failing with an out-of-gas
+error.
 
 Test setup:
 
@@ -44,45 +46,86 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
-
-"""
-PUSH opcode cost is 3, GAS opcode cost is 2.
-We need 6 PUSH's and one GAS to fill the stack for both CALL & CALLCODE,
-in the callee contract.
-"""
-CALLEE_INIT_STACK_GAS = 6 * 3 + 2
-
-"""
-CALL gas breakdowns: (https://www.evm.codes/#f1)
-memory_exp_cost + code_exec_cost + address_access_cost +
-positive_value_cost + empty_account_cost
-= 0 + 0 + 2600 + 9000 + 25000 = 36600
-"""
-CALL_GAS = 36600
-CALL_SUFFICIENT_GAS = CALL_GAS + CALLEE_INIT_STACK_GAS
-
-"""
-CALLCODE gas breakdowns: (https://www.evm.codes/#f2)
-memory_exp_cost + code_exec_cost + address_access_cost +
-positive_value_cost = 0 + 0 + 2600 + 9000 = 11600
-"""
-CALLCODE_GAS = 11600
-CALLCODE_SUFFICIENT_GAS = CALLCODE_GAS + CALLEE_INIT_STACK_GAS
+from execution_testing.forks.forks.forks import Berlin, Byzantium, Homestead
+from execution_testing.forks.helpers import Fork
 
 
 @pytest.fixture
-def callee_code(pre: Alloc, callee_opcode: Op) -> Bytecode:
+def callee_init_stack_gas(callee_opcode: Op, fork: Fork) -> int:
+    """
+    Calculate the initial stack gas for the callee opcode.
+    """
+    if fork < Byzantium:
+        # all *CALL arguments handled with PUSHes
+        return len(callee_opcode.kwargs) * 3
+    else:
+        # gas argument handled with GAS which is cheaper
+        return (len(callee_opcode.kwargs) - 1) * 3 + 2
+
+
+@pytest.fixture
+def sufficient_gas(
+    callee_opcode: Op, callee_init_stack_gas: int, fork: Fork
+) -> int:
+    """
+    Calculate the sufficient gas for the nested call opcode with positive
+    value transfer.
+    """
+    # memory_exp_cost is zero for our case.
+    cost = 0
+
+    if fork >= Berlin:
+        cost += 2600  # call and address_access_cost
+    elif Byzantium <= fork < Berlin:
+        cost += 700  # call
+    elif fork == Homestead:
+        cost += 40  # call
+        cost += 1  # mandatory callee gas allowance
+    else:
+        raise Exception("Only forks Homestead and >=Byzantium supported")
+
+    is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
+    if is_value_call:
+        cost += 9000  # positive_value_cost
+
+    if callee_opcode == Op.CALL:
+        cost += 25000  # empty_account_cost
+
+    cost += callee_init_stack_gas
+
+    return cost
+
+
+@pytest.fixture
+def callee_code(pre: Alloc, callee_opcode: Op, fork: Fork) -> Bytecode:
     """
     Code called by the caller contract:
       PUSH1 0x00 * 4
-      PUSH1 0x01 <- for positive value transfer
+      PUSH1 0x01 <- for positive value transfer, if applies
       PUSH2 Contract.nonexistent
-      GAS <- value doesn't matter
-      CALL/CALLCODE.
+      PUSH1 0x00 or GAS <- value doesn't matter:
+        - PUSH1 0x01: pre Byzantium tests, as they require `gas_left` to be at
+          least `gas`. In these cases we want non-zero `gas`, so that that
+          condition check can also be triggered - see `gas_shortage` parameter
+          values.
+        - GAS: other forks, to not alter previous test behavior
+      CALL/CALLCODE/DELEGATECALL/STATICCALL.
     """
     # The address needs to be empty and different for each execution of the
     # fixture, otherwise the calculations (empty_account_cost) are incorrect.
-    return callee_opcode(Op.GAS(), pre.empty_account(), 1, 0, 0, 0, 0)
+    is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
+    extra_args = {"value": 1} if is_value_call else {}
+
+    return callee_opcode(
+        unchecked=False,
+        gas=1 if fork < Byzantium else Op.GAS,
+        address=pre.empty_account(),
+        args_offset=0,
+        args_size=0,
+        ret_offset=0,
+        ret_size=0,
+        **extra_args,
+    )
 
 
 @pytest.fixture
@@ -98,7 +141,9 @@ def callee_address(pre: Alloc, callee_code: Bytecode) -> Address:
 
 
 @pytest.fixture
-def caller_code(caller_gas_limit: int, callee_address: Address) -> Bytecode:
+def caller_code(
+    sufficient_gas: int, gas_shortage: int, callee_address: Address
+) -> Bytecode:
     """
     Code to CALL the callee contract:
       PUSH1 0x00 * 5
@@ -108,6 +153,8 @@ def caller_code(caller_gas_limit: int, callee_address: Address) -> Bytecode:
       PUSH1 0x00
       SSTORE.
     """
+    caller_gas_limit = sufficient_gas - gas_shortage
+
     return Op.SSTORE(
         0, Op.CALL(caller_gas_limit, callee_address, 0, 0, 0, 0, 0)
     )
@@ -128,36 +175,32 @@ def caller_address(pre: Alloc, caller_code: Bytecode) -> Address:
 
 
 @pytest.fixture
-def caller_tx(sender: EOA, caller_address: Address) -> Transaction:
+def caller_tx(sender: EOA, caller_address: Address, fork: Fork) -> Transaction:
     """Transaction that performs the call to the caller contract."""
     return Transaction(
         to=caller_address,
         value=1,
         gas_limit=500_000,
         sender=sender,
+        protected=fork >= Byzantium,
     )
 
 
 @pytest.fixture
 def post(  # noqa: D103
-    caller_address: Address, is_sufficient_gas: bool
+    caller_address: Address, gas_shortage: int
 ) -> Dict[Address, Account]:
     return {
         caller_address: Account(
-            storage={0x00: 0x01 if is_sufficient_gas else 0x00}
+            storage={0x00: 0x01 if gas_shortage == 0 else 0x00}
         ),
     }
 
 
 @pytest.mark.parametrize(
-    "callee_opcode, caller_gas_limit, is_sufficient_gas",
-    [
-        (Op.CALL, CALL_SUFFICIENT_GAS, True),
-        (Op.CALL, CALL_SUFFICIENT_GAS - 1, False),
-        (Op.CALLCODE, CALLCODE_SUFFICIENT_GAS, True),
-        (Op.CALLCODE, CALLCODE_SUFFICIENT_GAS - 1, False),
-    ],
+    "callee_opcode", [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]
 )
+@pytest.mark.parametrize("gas_shortage", [0, 1])
 @pytest.mark.valid_from("London")
 def test_value_transfer_gas_calculation(
     state_test: StateTestFiller,
@@ -166,7 +209,48 @@ def test_value_transfer_gas_calculation(
     post: Dict[str, Account],
 ) -> None:
     """
-    Tests the nested CALL/CALLCODE opcode gas consumption with a positive value
-    transfer.
+    Tests the nested CALL/CALLCODE/DELEGATECALL/STATICCALL opcode gas
+    consumption with a positive value transfer.
+    """
+    state_test(env=Environment(), pre=pre, post=post, tx=caller_tx)
+
+
+@pytest.mark.parametrize(
+    "callee_opcode", [Op.CALL, Op.CALLCODE, Op.DELEGATECALL, Op.STATICCALL]
+)
+@pytest.mark.parametrize("gas_shortage", [0, 1])
+@pytest.mark.valid_from("Byzantium")
+@pytest.mark.valid_until("Berlin")
+def test_value_transfer_gas_calculation_byzantium(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    caller_tx: Transaction,
+    post: Dict[str, Account],
+) -> None:
+    """
+    Tests the nested CALL/CALLCODE/DELEGATECALL/STATICCALL opcode gas
+    consumption with a positive value transfer.
+    """
+    state_test(env=Environment(), pre=pre, post=post, tx=caller_tx)
+
+
+@pytest.mark.parametrize(
+    "callee_opcode", [Op.CALL, Op.CALLCODE, Op.DELEGATECALL]
+)
+# pre-Byzantium rules have one more condition to fail on:
+# the check for `gas_left` to be at least `gas` allowance specified
+# in the CALL. We will be setting that allowance to `1` and either
+# making the call miss that amount or fail on the earlier gas check.
+@pytest.mark.parametrize("gas_shortage", [0, 1, 2])
+@pytest.mark.valid_at("Homestead")
+def test_value_transfer_gas_calculation_homestead(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    caller_tx: Transaction,
+    post: Dict[str, Account],
+) -> None:
+    """
+    Tests the nested CALL/CALLCODE/DELEGATECALL opcode gas
+    consumption with a positive value transfer.
     """
     state_test(env=Environment(), pre=pre, post=post, tx=caller_tx)


### PR DESCRIPTION
## 🗒️ Description

Various lines in the call implementation in `evmone` were reporting as missing coverage - revolving around conditions which trigger OOG on the stages of processing the call.

Here, an almost complete test case existed in EEST, so I took the liberty to extend it, rather than pulling in the `gas_test` machinery as yet another approach. The existing test got a bit more complicated, but I think still makes sense. I think I've managed to retain the existing test cases intact.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
