### PR TITLE
feat: commit-message-format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,29 @@ jobs:
       - name: Run static checks
         run: tox -e static
 
+  lint-commits: 
+    runs-on: ubuntu-latest
+    needs: static  
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0  
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install gitlint
+        run: pip install gitlint>=0.20.0 
+      - name: Lint commits
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA=$(git merge-base HEAD origin/${{ github.base_ref }})
+            gitlint --commits "$BASE_SHA"..HEAD  # NEW: Lint only new commits in PR
+          else
+            gitlint --commits HEAD~10..HEAD  # NEW: Lint last 10 commits on push 
+          fi
+
   py3:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static


### PR DESCRIPTION
## 🗒️ Description

## fix(new_fork): remove docstring from new fork __init__.py via codemod

 **LibCST codemod** (`RemoveDocstringCommand`) was used to:
- **Automatically** strip the docstring
- Run **reliably** as part of `ForkBuilder`
- Enforce **clean, docstring-free templates** for all future forks

## 🔗 Related Issues or PRs
Fixes #1423

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

[![Cute Kitten](https://images.unsplash.com/photo-1518791841217-8f162f1e1131?auto=format&fit=crop&w=800&q=80)](https://unsplash.com/photos/cpLSN6LhBh4)

