### PR TITLE
fix(testing): format `eest make test` output with project Ruff config

### DIFF
--- a/packages/testing/src/execution_testing/cli/eest/make/commands/test.py
+++ b/packages/testing/src/execution_testing/cli/eest/make/commands/test.py
@@ -7,14 +7,16 @@ generated test file is saved in the appropriate directory with a rendered
 template using Jinja2.
 """
 
-import os
 import sys
 from pathlib import Path
+import subprocess
+import shutil
 
 import click
 import jinja2
 
 from execution_testing.config.docs import DocsConfig
+from execution_testing.config import AppConfig
 from execution_testing.forks import get_development_forks, get_forks
 
 from ....input import input_select, input_text
@@ -26,6 +28,26 @@ template_env = jinja2.Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+
+
+def _ruff_cmd() -> list[str]:
+    r = shutil.which("ruff")
+    return [r] if r else [sys.executable, "-m", "ruff"]
+
+
+def _project_pyproject() -> Path:
+    # ROOT_DIR -> packages/testing/src/execution_testing
+    # pyproject  -> packages/testing/pyproject.toml
+    return (AppConfig().ROOT_DIR.parent.parent / "pyproject.toml").resolve()
+
+
+def _ruff_format_file(target: Path) -> None:
+    cfg = _project_pyproject()
+    cmd = _ruff_cmd() + ["format"]
+    if cfg.exists():
+        cmd += ["--config", str(cfg)]
+    cmd += [str(target)]
+    subprocess.run(cmd, check=True)
 
 
 def exit_now() -> None:
@@ -146,7 +168,7 @@ def test() -> None:
         )
         sys.exit(1)
 
-    os.makedirs(directory_path, exist_ok=True)
+    directory_path.mkdir(parents=True, exist_ok=True)
 
     template = template_env.get_template(f"{test_type.lower()}_test.py.j2")
     rendered_template = template.render(
@@ -158,6 +180,9 @@ def test() -> None:
 
     with open(module_path, "w") as file:
         file.write(rendered_template)
+
+    _ruff_format_file(module_path)
+    _ruff_format_file(module_path)
 
     click.echo(
         click.style(

--- a/packages/testing/src/execution_testing/cli/eest/make/tests/test_make_test_formatting.py
+++ b/packages/testing/src/execution_testing/cli/eest/make/tests/test_make_test_formatting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import importlib
+import sys
+
+# Import the module object explicitly to avoid grabbing the Click command
+make_test = importlib.import_module(
+    "execution_testing.cli.eest.make.commands.test"
+)
+
+
+def test_ruff_called_with_project_config(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    called: dict[str, list[str]] = {}
+
+    # Force a predictable Ruff invocation
+    monkeypatch.setattr(
+        make_test, "_ruff_cmd", lambda: [sys.executable, "-m", "ruff"]
+    )
+
+    # Capture the subprocess invocation
+    def fake_run(cmd: list[str], check: bool = True) -> int:
+        called["cmd"] = cmd
+        return 0
+
+    monkeypatch.setattr(make_test.subprocess, "run", fake_run)
+
+    # Point to a dummy pyproject.toml
+    dummy_cfg = tmp_path / "pyproject.toml"
+    dummy_cfg.write_text("")
+
+    monkeypatch.setattr(make_test, "_project_pyproject", lambda: dummy_cfg)
+
+    target = tmp_path / "sample.py"
+    target.write_text("x='1'\n")
+
+    make_test._ruff_format_file(target)
+
+    cmd = called["cmd"]
+    assert cmd[:3] == [sys.executable, "-m", "ruff"]
+    assert "format" in cmd
+    idx = cmd.index("--config")
+    assert cmd[idx + 1] == str(dummy_cfg)
+    assert cmd[-1] == str(target)


### PR DESCRIPTION
## Description
`eest make test` now formats the generated file with Ruff using the **project** config:

--config (AppConfig().ROOT_DIR.parent.parent / "pyproject.toml")

After #1654, `ROOT_DIR` points to `packages/testing/src/execution_testing`, while the project `pyproject.toml` lives at `packages/testing/`. Passing `--config` ensures the generated file matches repo style. The formatter runs right after the file is written.

## Changes
- Add `_ruff_cmd()`, `_project_pyproject()`, `_ruff_format_file(path)`.
- Call `_ruff_format_file(module_path)` after writing the file.
- Guard: only pass `--config` if the file exists (installed envs won’t error).
- Test: `test_make_test_formatting.py` asserts the Ruff CLI args.

## Checks
- [x] `uvx tox -e static` (ruff, ruff format --check, mypy, ethereum-spec-lint)
- [x] Unit test passes

Closes #1675.
