### PR TITLE
fix(testing/specs): Fix benchmark pre-alloc grouping

### DIFF
--- a/packages/testing/src/execution_testing/cli/eofwrap.py
+++ b/packages/testing/src/execution_testing/cli/eofwrap.py
@@ -323,6 +323,7 @@ class EofWrapper:
 
         test = BlockchainTest(
             genesis_environment=env,
+            fork=EOFv1,
             pre=pre.root,
             post=fixture.post_state.root if fixture.post_state else {},
             blocks=[],
@@ -373,7 +374,6 @@ class EofWrapper:
 
         result = test.generate(
             t8n=t8n,
-            fork=EOFv1,
             fixture_format=BlockchainFixture,
         )
         assert isinstance(result, BlockchainFixture)

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/blocktest_builder.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/blocktest_builder.py
@@ -68,7 +68,6 @@ class BlocktestBuilder:
         # Generate fixture
         fixture = test.generate(
             t8n=self.t8n,
-            fork=fork,
             fixture_format=BlockchainFixture,
         )
 

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/converter.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/converter.py
@@ -251,6 +251,7 @@ def blockchain_test_from_fuzzer(
 
     return BlockchainTest(
         pre=pre,
+        fork=fork,
         blocks=blocks,
         post={},  # Post-state verification can be added later
         genesis_environment=genesis_env,

--- a/packages/testing/src/execution_testing/cli/fuzzer_bridge/production_test.py
+++ b/packages/testing/src/execution_testing/cli/fuzzer_bridge/production_test.py
@@ -201,6 +201,7 @@ class FuzzerBridge:
         # Create test
         test = BlockchainTest(
             genesis_environment=test_params["genesis_environment"],
+            fork=fork,
             pre=test_params["pre"],
             post=test_params["post"],
             blocks=test_params["blocks"],
@@ -210,7 +211,6 @@ class FuzzerBridge:
         # Generate fixture
         fixture = test.generate(
             t8n=self.t8n,
-            fork=fork,
             fixture_format=BlockchainFixture,
         )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -437,9 +437,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     [str(eoa) for eoa in pre._funded_eoa]
                 )
 
-                execute = self.execute(
-                    fork=fork, execute_format=execute_format
-                )
+                execute = self.execute(execute_format=execute_format)
                 execute.execute(
                     fork=fork,
                     eth_rpc=eth_rpc,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -407,6 +407,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     kwargs["expected_benchmark_gas_used"] = (
                         request.getfixturevalue("gas_benchmark_value")
                     )
+                kwargs["fork"] = fork
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -28,11 +28,11 @@ from execution_testing.base_types import (
     Alloc,
     ReferenceSpec,
 )
-from execution_testing.client_clis import TransitionTool
-from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.cli.gen_index import (
     generate_fixtures_index,
 )
+from execution_testing.client_clis import TransitionTool
+from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.fixtures import (
     BaseFixture,
     FixtureCollector,
@@ -1350,6 +1350,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     kwargs["pre"] = pre
                 if "expected_benchmark_gas_used" not in kwargs:
                     kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
+                kwargs["fork"] = fork
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1381,7 +1381,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     # Use the original update_pre_alloc_groups method which
                     # returns the groups
                     self.update_pre_alloc_groups(
-                        session.pre_alloc_groups, fork, request.node.nodeid
+                        session.pre_alloc_groups, request.node.nodeid
                     )
                     return  # Skip fixture generation in phase 1
 
@@ -1392,15 +1392,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     FixtureFillingPhase.PRE_ALLOC_GENERATION
                     in fixture_format.format_phases
                 ):
-                    pre_alloc_hash = self.compute_pre_alloc_group_hash(
-                        fork=fork
-                    )
+                    pre_alloc_hash = self.compute_pre_alloc_group_hash()
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 try:
                     fixture = self.generate(
                         t8n=t8n,
-                        fork=fork,
                         fixture_format=fixture_format,
                     )
                 finally:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
@@ -24,12 +24,14 @@ class MockTest(BaseTest):
     def __init__(
         self,
         pre: Alloc,
+        fork: Fork,
         genesis_environment: Environment,
         request: Mock | None = None,
     ) -> None:
         """Initialize mock test."""
         super().__init__(  # type: ignore
             pre=pre,
+            fork=fork,
             genesis_environment=genesis_environment,
         )
         self._request = request
@@ -38,9 +40,9 @@ class MockTest(BaseTest):
         """Mock generate method."""
         raise NotImplementedError("This is a mock test class")
 
-    def get_genesis_environment(self, fork: Fork) -> Environment:
+    def get_genesis_environment(self) -> Environment:
         """Return the genesis environment."""
-        return self.genesis_environment.set_fork_requirements(fork)
+        return self.genesis_environment.set_fork_requirements(self.fork)
 
 
 def test_pre_alloc_group_separate() -> None:
@@ -51,8 +53,8 @@ def test_pre_alloc_group_separate() -> None:
     fork = Prague
 
     # Create test without marker
-    test1 = MockTest(pre=pre, genesis_environment=env)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test with "separate" marker
     mock_request = Mock()
@@ -62,15 +64,17 @@ def test_pre_alloc_group_separate() -> None:
     mock_marker.args = ("separate",)
     mock_request.node.get_closest_marker = Mock(return_value=mock_marker)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be different due to "separate" marker
     assert hash1 != hash2
 
     # Create another test without marker - should match first test
-    test3 = MockTest(pre=pre, genesis_environment=env)
-    hash3 = test3.compute_pre_alloc_group_hash(fork)
+    test3 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash3 = test3.compute_pre_alloc_group_hash()
 
     assert hash1 == hash3
 
@@ -89,8 +93,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker1.args = ("eip1234",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create another test with same custom group "eip1234"
     mock_request2 = Mock()
@@ -102,8 +108,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker2.args = ("eip1234",)  # Same group
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - both in "eip1234" group
     assert hash1 == hash2
@@ -116,8 +124,10 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker3.args = ("eip5678",)  # Different group
     mock_request3.node.get_closest_marker = Mock(return_value=mock_marker3)
 
-    test3 = MockTest(pre=pre, genesis_environment=env, request=mock_request3)
-    hash3 = test3.compute_pre_alloc_group_hash(fork)
+    test3 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request3, fork=fork
+    )
+    hash3 = test3.compute_pre_alloc_group_hash()
 
     # Hash should be different - different custom group
     assert hash1 != hash3
@@ -138,8 +148,10 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker1.args = ("separate",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test with "separate" and nodeid2
     mock_request2 = Mock()
@@ -149,8 +161,10 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker2.args = ("separate",)
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be different due to different nodeids
     assert hash1 != hash2
@@ -168,12 +182,14 @@ def test_no_pre_alloc_group_marker() -> None:
     mock_request.node.nodeid = "test_module.py::test_function"
     mock_request.node.get_closest_marker = Mock(return_value=None)  # No marker
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create test without any request
-    test2 = MockTest(pre=pre, genesis_environment=env)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - both have no marker
     assert hash1 == hash2
@@ -196,8 +212,10 @@ def test_pre_alloc_group_with_reason() -> None:
     }
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(pre=pre, genesis_environment=env, request=mock_request1)
-    hash1 = test1.compute_pre_alloc_group_hash(fork)
+    test1 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
+    )
+    hash1 = test1.compute_pre_alloc_group_hash()
 
     # Create another test with same group but different reason
     mock_request2 = Mock()
@@ -208,8 +226,10 @@ def test_pre_alloc_group_with_reason() -> None:
     mock_marker2.kwargs = {"reason": "Different reason but same group"}
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(pre=pre, genesis_environment=env, request=mock_request2)
-    hash2 = test2.compute_pre_alloc_group_hash(fork)
+    test2 = MockTest(
+        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
+    )
+    hash2 = test2.compute_pre_alloc_group_hash()
 
     # Hashes should be the same - reason doesn't affect grouping
     assert hash1 == hash2

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tools_support.py
@@ -265,12 +265,12 @@ def test_t8n_support(fork: Fork, installed_t8n: TransitionTool) -> None:
 
     test = BlockchainTest(
         genesis_environment=env,
+        fork=fork,
         pre=pre,
         post=block_1.expected_post_state,
         blocks=[block_1, block_2],
     )
     test.generate(
         t8n=installed_t8n,
-        fork=fork,
         fixture_format=BlockchainFixture,
     )

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -194,7 +194,6 @@ class BaseTest(BaseModel):
         self,
         *,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
@@ -203,11 +202,9 @@ class BaseTest(BaseModel):
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
-        del fork
         raise Exception(f"Unsupported execute format: {execute_format}")
 
     @classmethod
@@ -290,7 +287,7 @@ class BaseTest(BaseModel):
                     "from the test."
                 )
 
-    def get_genesis_environment(self, fork: Fork) -> Environment:
+    def get_genesis_environment(self) -> Environment:
         """
         Get the genesis environment for pre-allocation groups.
 
@@ -303,7 +300,7 @@ class BaseTest(BaseModel):
         )
 
     def update_pre_alloc_groups(
-        self, pre_alloc_groups: PreAllocGroups, fork: Fork, test_id: str
+        self, pre_alloc_groups: PreAllocGroups, test_id: str
     ) -> PreAllocGroups:
         """
         Create or update the pre-allocation group with the pre from the current
@@ -314,7 +311,7 @@ class BaseTest(BaseModel):
                 f"{self.__class__.__name__} does not have a 'pre' field. Pre-allocation groups "
                 "are only supported for test types that define pre-allocation."
             )
-        pre_alloc_hash = self.compute_pre_alloc_group_hash(fork=fork)
+        pre_alloc_hash = self.compute_pre_alloc_group_hash()
 
         if pre_alloc_hash in pre_alloc_groups:
             # Update existing group - just merge pre-allocations
@@ -324,36 +321,36 @@ class BaseTest(BaseModel):
                 self.pre,
                 key_collision_mode=Alloc.KeyCollisionMode.ALLOW_IDENTICAL_ACCOUNTS,
             )
-            group.fork = fork
+            group.fork = self.fork
             group.test_ids.append(str(test_id))
             pre_alloc_groups[pre_alloc_hash] = group
         else:
             # Create new group - use Environment instead of expensive genesis
             # generation
-            genesis_env = self.get_genesis_environment(fork)
+            genesis_env = self.get_genesis_environment()
             pre_alloc = Alloc.merge(
-                Alloc.model_validate(fork.pre_allocation_blockchain()),
+                Alloc.model_validate(self.fork.pre_allocation_blockchain()),
                 self.pre,
             )
             group = PreAllocGroup(
                 test_ids=[str(test_id)],
-                fork=fork,
+                fork=self.fork,
                 environment=genesis_env,
                 pre=pre_alloc,
             )
             pre_alloc_groups[pre_alloc_hash] = group
         return pre_alloc_groups
 
-    def compute_pre_alloc_group_hash(self, fork: Fork) -> str:
+    def compute_pre_alloc_group_hash(self) -> str:
         """Hash (fork, env) in order to group tests by genesis config."""
         if not hasattr(self, "pre"):
             raise AttributeError(
                 f"{self.__class__.__name__} does not have a 'pre' field. Pre-allocation group "
                 "usage is only supported for test types that define pre-allocs."
             )
-        fork_digest = hashlib.sha256(fork.name().encode("utf-8")).digest()
+        fork_digest = hashlib.sha256(self.fork.name().encode("utf-8")).digest()
         fork_hash = int.from_bytes(fork_digest[:8], byteorder="big")
-        genesis_env = self.get_genesis_environment(fork)
+        genesis_env = self.get_genesis_environment()
         combined_hash = fork_hash ^ hash(genesis_env)
 
         # Check if test has pre_alloc_group marker

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -39,6 +39,7 @@ from execution_testing.fixtures import (
     PreAllocGroups,
 )
 from execution_testing.forks import Fork
+from execution_testing.forks.base_fork import BaseFork
 from execution_testing.test_types import Alloc, Environment, Withdrawal
 
 
@@ -91,6 +92,11 @@ class BaseTest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tag: str = ""
+    fork: Fork = (
+        BaseFork  # type: ignore[type-abstract]
+        # default to BaseFork to allow the filler to set it,
+        # instead of each test having to set it
+    )
 
     _request: pytest.FixtureRequest | None = PrivateAttr(None)
     _operation_mode: OpMode | None = PrivateAttr(None)
@@ -113,6 +119,16 @@ class BaseTest(BaseModel):
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = []
 
     supported_markers: ClassVar[Dict[str, str]] = {}
+
+    def model_post_init(self, __context: Any, /) -> None:
+        """
+        Model post-init to assert that the custom pre-allocation was
+        provided and the default was not used.
+        """
+        super().model_post_init(__context)
+        assert self.fork != BaseFork, (
+            "Fork was not provided by the filler/executor."
+        )
 
     @classmethod
     def discard_fixture_format_by_marks(
@@ -148,6 +164,7 @@ class BaseTest(BaseModel):
         """Create a test in a different format from a base test."""
         new_instance = cls(
             tag=base_test.tag,
+            fork=base_test.fork,
             t8n_dump_dir=base_test.t8n_dump_dir,
             expected_benchmark_gas_used=base_test.expected_benchmark_gas_used,
             skip_gas_used_validation=base_test.skip_gas_used_validation,

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -171,6 +171,47 @@ class BenchmarkTest(BaseTest):
             "pre allocation was not provided"
         )
 
+        set_props = [
+            name
+            for name, val in [
+                ("code_generator", self.code_generator),
+                ("blocks", self.blocks),
+                ("tx", self.tx),
+            ]
+            if val is not None
+        ]
+
+        if len(set_props) != 1:
+            raise ValueError(
+                f"Exactly one must be set, but got {len(set_props)}: {', '.join(set_props)}"
+            )
+
+        blocks: List[Block] = self.setup_blocks
+
+        if self.code_generator is not None:
+            generated_blocks = self.generate_blocks_from_code_generator()
+            blocks += generated_blocks
+
+        elif self.blocks is not None:
+            blocks += self.blocks
+
+        elif self.tx is not None:
+            gas_limit = (
+                self.fork.transaction_gas_limit_cap()
+                or self.gas_benchmark_value
+            )
+
+            transactions = self.split_transaction(self.tx, gas_limit)
+
+            blocks.append(Block(txs=transactions))
+
+        else:
+            raise ValueError(
+                "Cannot create BlockchainTest without a code generator, transactions, or blocks"
+            )
+
+        self.blocks = blocks
+
     @classmethod
     def pytest_parameter_name(cls) -> str:
         """
@@ -200,9 +241,9 @@ class BenchmarkTest(BaseTest):
 
     def get_genesis_environment(self, fork: Fork) -> Environment:
         """Get the genesis environment for this benchmark test."""
-        return self.generate_blockchain_test(
+        return self.generate_blockchain_test().get_genesis_environment(
             fork=fork
-        ).get_genesis_environment(fork=fork)
+        )
 
     def split_transaction(
         self, tx: Transaction, gas_limit_cap: int | None
@@ -234,14 +275,13 @@ class BenchmarkTest(BaseTest):
 
         return split_transactions
 
-    def generate_blocks_from_code_generator(self, fork: Fork) -> List[Block]:
+    def generate_blocks_from_code_generator(self) -> List[Block]:
         """Generate blocks using the code generator."""
         if self.code_generator is None:
             raise Exception("Code generator is not set")
-
-        self.code_generator.deploy_contracts(pre=self.pre, fork=fork)
+        self.code_generator.deploy_contracts(pre=self.pre, fork=self.fork)
         gas_limit = (
-            fork.transaction_gas_limit_cap() or self.gas_benchmark_value
+            self.fork.transaction_gas_limit_cap() or self.gas_benchmark_value
         )
         benchmark_tx = self.code_generator.generate_transaction(
             pre=self.pre, gas_benchmark_value=gas_limit
@@ -252,52 +292,14 @@ class BenchmarkTest(BaseTest):
 
         return [execution_block]
 
-    def generate_blockchain_test(self, fork: Fork) -> BlockchainTest:
+    def generate_blockchain_test(self) -> BlockchainTest:
         """Create a BlockchainTest from this BenchmarkTest."""
-        set_props = [
-            name
-            for name, val in [
-                ("code_generator", self.code_generator),
-                ("blocks", self.blocks),
-                ("tx", self.tx),
-            ]
-            if val is not None
-        ]
-
-        if len(set_props) != 1:
-            raise ValueError(
-                f"Exactly one must be set, but got {len(set_props)}: {', '.join(set_props)}"
-            )
-
-        blocks: List[Block] = self.setup_blocks
-
-        if self.code_generator is not None:
-            generated_blocks = self.generate_blocks_from_code_generator(fork)
-            blocks += generated_blocks
-
-        elif self.blocks is not None:
-            blocks += self.blocks
-
-        elif self.tx is not None:
-            gas_limit = (
-                fork.transaction_gas_limit_cap() or self.gas_benchmark_value
-            )
-
-            transactions = self.split_transaction(self.tx, gas_limit)
-
-            blocks.append(Block(txs=transactions))
-
-        else:
-            raise ValueError(
-                "Cannot create BlockchainTest without a code generator, transactions, or blocks"
-            )
-
         return BlockchainTest.from_test(
             base_test=self,
             genesis_environment=self.env,
             pre=self.pre,
             post=self.post,
-            blocks=blocks,
+            blocks=self.blocks,
         )
 
     def generate(
@@ -311,7 +313,7 @@ class BenchmarkTest(BaseTest):
             exception=self.tx.error is not None if self.tx else False
         )
         if fixture_format in BlockchainTest.supported_fixture_formats:
-            return self.generate_blockchain_test(fork=fork).generate(
+            return self.generate_blockchain_test().generate(
                 t8n=t8n, fork=fork, fixture_format=fixture_format
             )
         else:

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -239,11 +239,9 @@ class BenchmarkTest(BaseTest):
             return fixture_format != BlockchainEngineFixture
         return False
 
-    def get_genesis_environment(self, fork: Fork) -> Environment:
+    def get_genesis_environment(self) -> Environment:
         """Get the genesis environment for this benchmark test."""
-        return self.generate_blockchain_test().get_genesis_environment(
-            fork=fork
-        )
+        return self.generate_blockchain_test().get_genesis_environment()
 
     def split_transaction(
         self, tx: Transaction, gas_limit_cap: int | None
@@ -305,7 +303,6 @@ class BenchmarkTest(BaseTest):
     def generate(
         self,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the blockchain test fixture."""
@@ -314,7 +311,7 @@ class BenchmarkTest(BaseTest):
         )
         if fixture_format in BlockchainTest.supported_fixture_formats:
             return self.generate_blockchain_test().generate(
-                t8n=t8n, fork=fork, fixture_format=fixture_format
+                t8n=t8n, fixture_format=fixture_format
             )
         else:
             raise Exception(f"Unsupported fixture format: {fixture_format}")
@@ -322,12 +319,9 @@ class BenchmarkTest(BaseTest):
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the benchmark test by sending it to the live network."""
-        del fork
-
         if execute_format == TransactionPost:
             return TransactionPost(
                 blocks=[[self.tx]],

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -200,8 +200,9 @@ class BenchmarkTest(BaseTest):
 
     def get_genesis_environment(self, fork: Fork) -> Environment:
         """Get the genesis environment for this benchmark test."""
-        del fork
-        return self.env
+        return self.generate_blockchain_test(
+            fork=fork
+        ).get_genesis_environment(fork=fork)
 
     def split_transaction(
         self, tx: Transaction, gas_limit_cap: int | None

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -10,7 +10,6 @@ from execution_testing.fixtures import (
     BaseFixture,
     FixtureFormat,
 )
-from execution_testing.forks import Fork
 from execution_testing.test_types import (
     NetworkWrappedTransaction,
     Transaction,
@@ -38,22 +37,18 @@ class BlobsTest(BaseTest):
         self,
         *,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the list of test fixtures."""
-        del t8n, fork
+        del t8n
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Generate the list of test fixtures."""
-        del fork
-
         if execute_format == BlobTransaction:
             return BlobTransaction(
                 txs=self.txs,

--- a/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_benchmark.py
@@ -6,6 +6,7 @@ transaction splitting functionality.
 import pytest
 
 from execution_testing.base_types import HexNumber
+from execution_testing.forks import Osaka
 from execution_testing.specs.benchmark import BenchmarkTest
 from execution_testing.test_types import Alloc, Environment, Transaction
 
@@ -34,6 +35,7 @@ def test_split_transaction(
 
     # Create a minimal BenchmarkTest instance
     benchmark_test = BenchmarkTest(
+        fork=Osaka,
         pre=Alloc(),
         post=Alloc(),
         tx=Transaction(sender=HexNumber(0), to=HexNumber(0), nonce=0),
@@ -96,7 +98,9 @@ def test_split_transaction_edge_cases(
     gas_benchmark_value: int, gas_limit_cap: int | None
 ) -> None:
     """Test edge cases for transaction splitting."""
+    fork = Osaka
     benchmark_test = BenchmarkTest(
+        fork=fork,
         pre=Alloc(),
         post=Alloc(),
         tx=Transaction(

--- a/packages/testing/src/execution_testing/specs/tests/test_expect.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_expect.py
@@ -70,13 +70,17 @@ def fork() -> Fork:  # noqa: D103
 
 @pytest.fixture
 def state_test(  # noqa: D103
-    pre: Mapping[Any, Any], post: Mapping[Any, Any], tx: Transaction
+    pre: Mapping[Any, Any],
+    post: Mapping[Any, Any],
+    tx: Transaction,
+    fork: Fork,
 ) -> StateTest:
     return StateTest(
         env=Environment(),
         pre=pre,
         post=post,
         tx=tx,
+        fork=fork,
     )
 
 
@@ -173,9 +177,7 @@ def test_post_storage_value_mismatch(
     generation.
     """
     with pytest.raises(Storage.KeyValueMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == expected_exception
 
 
@@ -216,14 +218,10 @@ def test_post_nonce_value_mismatch(
     pre_nonce = pre_account.nonce
     post_nonce = post_account.nonce
     if "nonce" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.NonceMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.NonceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_nonce, got=pre_nonce
     )
@@ -266,14 +264,10 @@ def test_post_code_value_mismatch(
     pre_code = pre_account.code
     post_code = post_account.code
     if "code" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.CodeMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.CodeMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_code, got=pre_code
     )
@@ -316,14 +310,10 @@ def test_post_balance_value_mismatch(
     pre_balance = pre_account.balance
     post_balance = post_account.balance
     if "balance" not in post_account.model_fields_set:  # no exception
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(Account.BalanceMismatchError) as e_info:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
     assert e_info.value == Account.BalanceMismatchError(
         address=ADDRESS_UNDER_TEST, want=post_balance, got=pre_balance
     )
@@ -370,14 +360,10 @@ def test_post_account_mismatch(
     fixture generation.
     """
     if exception_type is None:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
         return
     with pytest.raises(exception_type) as _:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=StateFixture
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=StateFixture)
 
 
 # Transaction result mismatch tests
@@ -466,14 +452,10 @@ def test_transaction_expectation(
             f"({default_t8n.__class__.__name__})."
         )
     if exception_type is None:
-        state_test.generate(
-            t8n=default_t8n, fork=fork, fixture_format=fixture_format
-        )
+        state_test.generate(t8n=default_t8n, fixture_format=fixture_format)
     else:
         with pytest.raises(exception_type) as _:
-            state_test.generate(
-                t8n=default_t8n, fork=fork, fixture_format=fixture_format
-            )
+            state_test.generate(t8n=default_t8n, fixture_format=fixture_format)
 
 
 @pytest.mark.parametrize(
@@ -552,18 +534,18 @@ def test_block_intermediate_state(
     if expected_exception:
         with pytest.raises(expected_exception) as _:
             BlockchainTest(
+                fork=fork,
                 genesis_environment=env,
                 pre=pre,
                 post=block_3.expected_post_state,
                 blocks=[block_1, block_2, block_3],
-            ).generate(
-                t8n=default_t8n, fork=fork, fixture_format=fixture_format
-            )
+            ).generate(t8n=default_t8n, fixture_format=fixture_format)
         return
     else:
         BlockchainTest(
+            fork=fork,
             genesis_environment=env,
             pre=pre,
             post=block_3.expected_post_state,
             blocks=[block_1, block_2, block_3],
-        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+        ).generate(t8n=default_t8n, fixture_format=fixture_format)

--- a/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
@@ -109,12 +109,13 @@ def test_make_genesis(
     )
 
     fixture = BlockchainTest(
+        fork=fork,
         genesis_environment=env,
         pre=pre,
         post={},
         blocks=[],
         tag="some_state_test",
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=BlockchainFixture)
+    ).generate(t8n=default_t8n, fixture_format=BlockchainFixture)
     assert isinstance(fixture, BlockchainFixture)
     assert fixture.genesis is not None
 
@@ -193,12 +194,13 @@ def test_fill_state_test(
     }
 
     generated_fixture = StateTest(
+        fork=fork,
         env=env,
         pre=pre,
         post=post,
         tx=tx,
         tag="my_chain_id_test",
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+    ).generate(t8n=default_t8n, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     fixture = {
         f"000/my_chain_id_test/{fork}/tx_type_{tx_type}": generated_fixture.json_dict_with_info(
@@ -521,12 +523,13 @@ class TestFillBlockchainValidTxs:
         default_t8n: TransitionTool,
     ) -> BaseFixture:
         return BlockchainTest(
+            fork=fork,
             pre=pre,
             post=post,
             blocks=blocks,
             genesis_environment=genesis_environment,
             tag="my_blockchain_test_valid_txs",
-        ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+        ).generate(t8n=default_t8n, fixture_format=fixture_format)
 
     @pytest.mark.parametrize("fork", [London, Shanghai], indirect=True)
     def test_fill_blockchain_valid_txs(  # noqa: D102
@@ -914,11 +917,12 @@ def test_fill_blockchain_invalid_txs(
         BlockchainEngineFixture if check_hive else BlockchainFixture
     )
     generated_fixture = BlockchainTest(
+        fork=fork,
         pre=pre,
         post=post,
         blocks=blocks,
         genesis_environment=genesis_environment,
-    ).generate(t8n=default_t8n, fork=fork, fixture_format=fixture_format)
+    ).generate(t8n=default_t8n, fixture_format=fixture_format)
     assert generated_fixture.__class__ == fixture_format
     # BlockchainEngineFixture inherits from BlockchainEngineFixtureCommon
     # (not BlockchainFixtureCommon)

--- a/packages/testing/src/execution_testing/specs/tests/test_transaction.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_transaction.py
@@ -28,10 +28,10 @@ def test_transaction_test_filling(
 ) -> None:
     """Test the transaction test filling."""
     generated_fixture = TransactionTest(
-        tx=tx.with_signature_and_sender()
+        tx=tx.with_signature_and_sender(),
+        fork=fork,
     ).generate(
         t8n=None,  # type: ignore
-        fork=fork,
         fixture_format=TransactionFixture,
     )
     assert generated_fixture.__class__ == TransactionFixture

--- a/packages/testing/src/execution_testing/specs/transaction.py
+++ b/packages/testing/src/execution_testing/specs/transaction.py
@@ -16,7 +16,6 @@ from execution_testing.fixtures import (
     TransactionFixture,
 )
 from execution_testing.fixtures.transaction import FixtureResult
-from execution_testing.forks import Fork
 from execution_testing.test_types import Alloc, Transaction
 
 from .base import BaseTest
@@ -45,7 +44,6 @@ class TransactionTest(BaseTest):
 
     def make_transaction_test_fixture(
         self,
-        fork: Fork,
     ) -> TransactionFixture:
         """Create a fixture from the transaction test definition."""
         if self.tx.error is not None:
@@ -57,7 +55,7 @@ class TransactionTest(BaseTest):
             )
         else:
             intrinsic_gas_cost_calculator = (
-                fork.transaction_intrinsic_cost_calculator()
+                self.fork.transaction_intrinsic_cost_calculator()
             )
             intrinsic_gas = intrinsic_gas_cost_calculator(
                 calldata=self.tx.data,
@@ -74,7 +72,7 @@ class TransactionTest(BaseTest):
 
         return TransactionFixture(
             result={
-                fork: result,
+                self.fork: result,
             },
             transaction=self.tx.with_signature_and_sender().rlp(),
         )
@@ -82,7 +80,6 @@ class TransactionTest(BaseTest):
     def generate(
         self,
         t8n: TransitionTool,
-        fork: Fork,
         fixture_format: FixtureFormat,
     ) -> BaseFixture:
         """Generate the TransactionTest fixture."""
@@ -90,19 +87,16 @@ class TransactionTest(BaseTest):
 
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format == TransactionFixture:
-            return self.make_transaction_test_fixture(fork)
+            return self.make_transaction_test_fixture()
 
         raise Exception(f"Unknown fixture format: {fixture_format}")
 
     def execute(
         self,
         *,
-        fork: Fork,
         execute_format: ExecuteFormat,
     ) -> BaseExecute:
         """Execute the transaction test by sending it to the live network."""
-        del fork
-
         if execute_format == TransactionPost:
             return TransactionPost(
                 blocks=[[self.tx]],

--- a/packages/testing/src/execution_testing/tools/tests/test_code.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_code.py
@@ -690,13 +690,13 @@ def test_switch(
     }
     state_test = StateTest(
         env=Environment(),
+        fork=Cancun,
         pre=pre,
         tx=tx,
         post=post,
     )
     state_test.generate(
         t8n=default_t8n,
-        fork=Cancun,
         fixture_format=BlockchainFixture,
     )
 


### PR DESCRIPTION
## 🗒️ Description

This PR addresses issues when generating pre-allocation groups with the `BenchmarkTest` spec type.

There were two main issues that had to be addressed for this:

### `BenchmarkTest.get_genesis_environment` not using `BlockchainTest.get_genesis_environment`

`BenchmarkTest.get_genesis_environment` was directly generating the genesis from `env` without adding the extra required argument that `BlockchainTest.get_genesis_environment` uses.

One potential proper (follow-up) fix could be that `BenchmarkTest` inherits `BlockchainTest`.

### `BenchmarkTest.generate` modifying `pre`

`BenchmarkTest` modified an invariant that the pre-alloc grouping relied on: `pre` is not touched after the test function completes.

This resulted in, correctly, test filling failing on the test running step because the base `Alloc` does not implement `deploy_contract` because there should not be any more deployments.

But the problem was that `BenchmarkTest` required the `fork` instance in order to determine how many blocks to use (because of the transaction gas limit cap), and this value was only passed when the `generate` or the `execution` functions are called.

Solution was to include `fork` in the `BaseTest` class and make it mandatory for the filler, execute, or any other code that instantiated a test spec, to pass the fork during the initialization:
https://github.com/marioevz/execution-specs/blob/fc2bd475b8e7caf506b39ec6453e9d049e8f418e/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py#L1353
Example in an unit test:
https://github.com/marioevz/execution-specs/blob/fc2bd475b8e7caf506b39ec6453e9d049e8f418e/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py#L56

This resulted in `fork` being removed from `generate`, `execute` and other instance methods within `BaseTest`, which is a nice bonus.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
