### PR TITLE
chore(fill,execute): only collect test modules named `test_*`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -19,3 +19,5 @@ addopts =
     --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
+    --ignore tests/json_infra
+    --ignore tests/evm_tools

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -1,7 +1,7 @@
 [pytest]
 console_output_style = count
 minversion = 7.0
-python_files = *.py
+python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
 addopts = 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -20,3 +20,5 @@ addopts =
     --tb short
     --dist loadscope
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
+    --ignore tests/json_infra
+    --ignore tests/evm_tools

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -1,7 +1,7 @@
 [pytest]
 console_output_style = count
 minversion = 7.0
-python_files = *.py
+python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
 addopts = 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -1,7 +1,7 @@
 [pytest]
 console_output_style = count
 minversion = 7.0
-python_files = *.py
+python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
 addopts = 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -19,6 +19,8 @@ addopts =
     -p execution_testing.cli.pytest_commands.plugins.custom_logging.plugin_logging
     --tb short
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
+    --ignore tests/json_infra
+    --ignore tests/evm_tools
 # these customizations require the pytest-custom-report plugin
 report_passed_verbose = FILLED
 report_xpassed_verbose = XFILLED


### PR DESCRIPTION
## 🗒️ Description
Updates the `fill` and `execute` ini files to:
1. Only collect modules named with a `test_` prefix.
2. Ignore `tests/json_infra/`, `tests/evm_tools/`.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
