### PR TITLE
fix(testing): restore default gas after `fill` pytester test

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for filler tests."""
+
+from typing import Generator
+
+import pytest
+
+
+@pytest.fixture
+def restore_environment_defaults() -> Generator[None, None, None]:
+    """Restore EnvironmentDefaults.gas_limit after test runs to prevent side effects."""
+    from execution_testing.test_types.block_types import EnvironmentDefaults
+
+    original_gas_limit = EnvironmentDefaults.gas_limit
+    yield
+    EnvironmentDefaults.gas_limit = original_gas_limit

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -603,6 +603,7 @@ test_module_environment_variables = textwrap.dedent(
         ),
     ],
 )
+@pytest.mark.usefixtures("restore_environment_defaults")
 def test_fill_variables(
     testdir: pytest.Testdir,
     args: list[str],


### PR DESCRIPTION
## 🗒️ Description
A suggestion how to fix the race condition observed in `packages/testing` unit tests, cf #1711.

The error described in #1711 can be reproduced on master by running the two tests in this order:
```bash
cd packages/testing
uv run pytest \
  src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py::test_fill_variables[higher-gas-limit] \
  src/execution_testing/test_types/tests/test_types.py::test_model_copy[Environment]
```

## 🔗 Related Issues or PRs
#1711 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img width="406" height="522" alt="image" src="https://github.com/user-attachments/assets/e1a14bcb-fd99-499e-9250-fe03b5cca446" />
