### PR TITLE
feat(tests): Opcode tests: stack overflow & BLOCKHASH

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Expand cases to test *CALL opcodes causing OOG ([#1703](https://github.com/ethereum/execution-specs/pull/1703)).
 - ✨ Add tests for `modexp` and `ripemd` precompiled contracts ([#1691](https://github.com/ethereum/execution-specs/pull/1691)).
 - ✨ Add `ecrecover` precompile tests originating form `evmone` unittests ([#1685](https://github.com/ethereum/execution-specs/pull/1685)).
+- ✨ Add stack overflow tests and expand `BLOCKHASH` tests ([#1728](https://github.com/ethereum/execution-specs/pull/1728)).
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/tests/frontier/opcodes/test_blockhash.py
+++ b/tests/frontier/opcodes/test_blockhash.py
@@ -7,14 +7,28 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     Op,
-    Storage,
     Transaction,
 )
+from execution_testing.forks import Byzantium
+from execution_testing.forks.helpers import Fork
 
 
 @pytest.mark.valid_from("Frontier")
+@pytest.mark.parametrize(
+    "setup_blocks_num,setup_blocks_empty",
+    [
+        pytest.param(0, True, id="no_blocks"),
+        pytest.param(1, False, id="one_empty_block"),
+        pytest.param(1, True, id="one_block_with_tx"),
+        pytest.param(256, True, id="256_empty_blocks"),
+    ],
+)
 def test_genesis_hash_available(
-    blockchain_test: BlockchainTestFiller, pre: Alloc
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    setup_blocks_num: int,
+    setup_blocks_empty: bool,
 ) -> None:
     """
     Verify BLOCKHASH returns genesis and block 1 hashes.
@@ -29,45 +43,53 @@ def test_genesis_hash_available(
     Bug context: revm blockchaintest runner wasn't inserting block_hashes,
     causing failures in tests with BLOCKHASH-derived addresses.
     """
-    storage = Storage()
-
     # Store ISZERO(BLOCKHASH(0)) and ISZERO(BLOCKHASH(1))
     # Both should be 0 (false) if hashes exist
-    code = Op.SSTORE(
-        storage.store_next(0), Op.ISZERO(Op.BLOCKHASH(0))
-    ) + Op.SSTORE(storage.store_next(0), Op.ISZERO(Op.BLOCKHASH(1)))
+    code = Op.SSTORE(0, Op.ISZERO(Op.BLOCKHASH(0))) + Op.SSTORE(
+        1, Op.ISZERO(Op.BLOCKHASH(1))
+    )
 
     contract = pre.deploy_contract(code=code)
     sender = pre.fund_eoa()
 
-    blocks = [
-        Block(
-            txs=[
-                Transaction(
-                    sender=sender,
-                    to=contract,
-                    gas_limit=100_000,
-                    protected=False,
-                )
-            ]
-        ),
-        Block(
-            txs=[
-                Transaction(
-                    sender=sender,
-                    to=contract,
-                    gas_limit=100_000,
-                    protected=False,
-                )
-            ]
-        ),
-    ]
+    blocks = (
+        [
+            Block(
+                txs=[
+                    Transaction(
+                        sender=sender,
+                        to=contract,
+                        gas_limit=100_000,
+                        protected=fork >= Byzantium,
+                    )
+                ]
+                if not setup_blocks_empty
+                else []
+            )
+            for _ in range(setup_blocks_num)
+        ]
+    ) + (
+        [
+            Block(
+                txs=[
+                    Transaction(
+                        sender=sender,
+                        to=contract,
+                        gas_limit=100_000,
+                        protected=fork >= Byzantium,
+                    )
+                ]
+            )
+        ]
+    )
 
     post = {
         contract: Account(
             storage={
-                0: 0,  # ISZERO(BLOCKHASH(0)) = 0 (genesis hash exists)
-                1: 0,  # ISZERO(BLOCKHASH(1)) = 0 (block 1 hash exists)
+                # ISZERO(BLOCKHASH(0)) = 0 (genesis hash exists)
+                0: 1 if setup_blocks_num >= 256 else 0,
+                # ISZERO(BLOCKHASH(1)) = 0 (if block 1 hash exists)
+                1: 1 if setup_blocks_num == 0 else 0,
             }
         )
     }


### PR DESCRIPTION
## 🗒️ Description

Two additions:

1. It seems there weren't tests covering stack overflow for some opcodes
2. Other one is an addition to the existing BLOCKHASH test, which didn't cover the situation where the instruction attempts to read beyond the 256 recent blocks. Catch here is that it comes up as MC/DC coverage gap even after it is filled. But I validated manually modifying the code - removing the decision's condition does indeed cause the new tests to fail. Not sure why would the report got this wrong.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
