### PR TITLE
fix(test-tools): fix uv sync when building fixtures for releases

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -20,7 +20,7 @@ runs:
         python-version: ${{ inputs.python_version }}
     - name: Install EEST
       shell: bash
-      run: uv sync --no-progress --extra test
+      run: uv sync --no-progress
     - name: Extract fixture release properties from config
       id: properties
       shell: bash


### PR DESCRIPTION
## 🗒️ Description

We've since moved the testing framework package to dev dependencies which are installed by default with a `uv sync`. This PR removes the old install extra call for `test` which no longer exists.

This was tested already in the latest `bal` release [here](https://github.com/ethereum/execution-specs/actions/runs/19044741165/job/54390123445). Previous fail without this change [here](https://github.com/ethereum/execution-specs/actions/runs/19044439244/job/54389105458#step:5:41).

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="589" height="552" alt="Screenshot 2025-11-03 at 11 25 45" src="https://github.com/user-attachments/assets/d40701cf-cc6b-476e-bb20-7ce5c2189e25" />
