### PR TITLE
fix(spec-tests): Fix new fork tool test to use last fork dynamically

### DIFF
--- a/src/ethereum_spec_tools/new_fork/builder.py
+++ b/src/ethereum_spec_tools/new_fork/builder.py
@@ -330,7 +330,7 @@ class ForkBuilder:
             self.output = Path(template_path).parent
 
         # Try to make a sane guess for the activation criteria.
-        if found is forks[-1]:
+        if found is forks[-1] or isinstance(found.criteria, Unscheduled):
             order_index = 0
 
             # check template fork's criteria and bump order_index if needed

--- a/tests/json_infra/test_tools_new_fork.py
+++ b/tests/json_infra/test_tools_new_fork.py
@@ -5,11 +5,21 @@ Tests for the ethereum-spec-new-fork CLI tool.
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from ethereum_spec_tools.forks import Hardfork
 from ethereum_spec_tools.new_fork.cli import main as new_fork
 
 
-def test_end_to_end() -> None:
+@pytest.mark.parametrize(
+    "template_fork",
+    [
+        Hardfork.discover()[-1].short_name,
+        "osaka",
+    ],
+    ids=lambda tf: f"{tf}",
+)
+def test_end_to_end(template_fork: str) -> None:
     """
     Test that the ethereum-spec-new-fork CLI tool creates a fork from a
     template, correctly modifying names, blob parameters, and imports.
@@ -17,10 +27,6 @@ def test_end_to_end() -> None:
     with TemporaryDirectory() as base_dir:
         output_dir = Path(base_dir) / "ethereum"
         fork_dir = output_dir / "e2e_fork"
-
-        # Get the latest fork dynamically to avoid breaking with new forks
-        forks = Hardfork.discover()
-        template_fork = forks[-1].short_name
 
         new_fork(
             [
@@ -52,7 +58,7 @@ def test_end_to_end() -> None:
 
             assert "FORK_CRITERIA = ByTimestamp(7)" in source
             assert "E2E Fork" in source
-            assert template_fork.title() not in source
+            assert template_fork.capitalize() not in source
 
         with (fork_dir / "vm" / "gas.py").open("r") as f:
             source = f.read()

--- a/tests/json_infra/test_tools_new_fork.py
+++ b/tests/json_infra/test_tools_new_fork.py
@@ -5,6 +5,7 @@ Tests for the ethereum-spec-new-fork CLI tool.
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from ethereum_spec_tools.forks import Hardfork
 from ethereum_spec_tools.new_fork.cli import main as new_fork
 
 
@@ -17,12 +18,16 @@ def test_end_to_end() -> None:
         output_dir = Path(base_dir) / "ethereum"
         fork_dir = output_dir / "e2e_fork"
 
+        # Get the latest fork dynamically to avoid breaking with new forks
+        forks = Hardfork.discover()
+        template_fork = forks[-1].short_name
+
         new_fork(
             [
                 "--new-fork",
                 "e2e_fork",
                 "--template-fork",
-                "osaka",
+                template_fork,
                 "--target-blob-gas-per-block",
                 "199",
                 "--blob-base-fee-update-fraction",
@@ -47,7 +52,7 @@ def test_end_to_end() -> None:
 
             assert "FORK_CRITERIA = ByTimestamp(7)" in source
             assert "E2E Fork" in source
-            assert "Osaka" not in source
+            assert template_fork.title() not in source
 
         with (fork_dir / "vm" / "gas.py").open("r") as f:
             source = f.read()


### PR DESCRIPTION
## 🗒️ Description

When we have two `Unscheduled` forks, which will be more frequent moving forward, while Osaka is `Unscheduled` and Amsterdam is too, we cannot resolve the fork criteria for the e2e test for the fork tool (e.g. [here](https://github.com/ethereum/execution-specs/actions/runs/18994902166/job/54253329761?pr=1727#step:5:4900)).

- We can check in `builder.py` if the fork is `Unscheduled` as well as if it's `forks[-1]` and raise the `order_index` to come after it as we already do.
- We can always use the last fork dynamically in this e2e test so that we always resolve and don't hard-code Osaka into it.

I'm not tied to the last change. If we want to make hard-coding Osaka work, we can change some other things around as well but this change does get this test passing on Amsterdam as it uses `Amsterdam` as the last fork.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels) --- question below

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%2Fid%2FOIP.-bs3eHaiD7n2mGtK5sK18wHaKZ%3Fpid%3DApi&f=1&ipt=d1ee422bf79a1ffd2ab356862792ded3f6542986c51cb39d6a68e402a812b6e1&ipo=images)
