### PR TITLE
fix(fw): Call `get_type_hints()` on class rather than instance

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -223,7 +223,7 @@ class FixtureHeader(CamelModel):
         # For each field, check if any of the annotations are of type
         # HeaderForkRequirement and if so, check if the field is required for
         # the given fork.
-        annotated_hints = get_type_hints(self, include_extras=True)
+        annotated_hints = get_type_hints(type(self), include_extras=True)
 
         for field in self.__class__.model_fields:
             if field == "fork":


### PR DESCRIPTION
## 🗒️ Description
Call `get_type_hints()` on the class rather that the instance rather than the class. Calling on the instance breaks in Python 3.14 as explained in the [Python docs](https://docs.python.org/3/whatsnew/3.14.html#related-changes):

> In previous releases, it was sometimes possible to access class annotations from an instance of an annotated class. This behavior was undocumented and accidental, and will no longer work in Python 3.14.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/my-little-fluff-just-fell-asleep-on-my-lap-like-this-she-v0-4m6r00m2c4yf1.jpg?width=1080&crop=smart&auto=webp&s=dbfac4a9913e05ac36bab5fca954e1f8c9e8df31)
