### PR TITLE
chore(tests): fix pre alloc phase for deposit test

### DIFF
--- a/tests/prague/eip6110_deposits/test_modified_contract.py
+++ b/tests/prague/eip6110_deposits/test_modified_contract.py
@@ -107,7 +107,6 @@ DEFAULT_REQUEST_LOG = create_deposit_log_bytes(
         ),
     ],
 )
-@pytest.mark.parametrize("extra_event_type", ["transfer_log", "no_topics"])
 def test_extra_logs(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip6110_deposits/test_modified_contract.py
+++ b/tests/prague/eip6110_deposits/test_modified_contract.py
@@ -71,20 +71,38 @@ DEFAULT_REQUEST_LOG = create_deposit_log_bytes(
 
 
 @pytest.mark.parametrize(
-    "include_deposit_event",
+    "include_deposit_event,extra_event_type",
     [
         pytest.param(
             True,
+            "transfer_log",
             marks=pytest.mark.pre_alloc_group(
-                "deposit_extra_logs_with_event",
+                "deposit_extra_logs_with_event_transfer",
                 reason="Deposit contract with Transfer log AND deposit event",
             ),
         ),
         pytest.param(
-            False,
+            True,
+            "no_topics",
             marks=pytest.mark.pre_alloc_group(
-                "deposit_extra_logs_no_event",
+                "deposit_extra_logs_with_event_no_topics",
+                reason="Deposit contract with no-topics log AND deposit event",
+            ),
+        ),
+        pytest.param(
+            False,
+            "transfer_log",
+            marks=pytest.mark.pre_alloc_group(
+                "deposit_extra_logs_no_event_transfer",
                 reason="Deposit contract with Transfer log NO deposit event",
+            ),
+        ),
+        pytest.param(
+            False,
+            "no_topics",
+            marks=pytest.mark.pre_alloc_group(
+                "deposit_extra_logs_no_event_no_topics",
+                reason="Deposit contract with no-topics log NO deposit event",
             ),
         ),
     ],


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fix for: https://github.com/ethereum/execution-specs/actions/runs/19069271240/job/54467602752
Caused by: https://github.com/ethereum/execution-specs/pull/1693

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
