### PR TITLE
Fix/broken links

### DIFF
--- a/docs/writing_tests/fuzzer_bridge.md
+++ b/docs/writing_tests/fuzzer_bridge.md
@@ -258,6 +258,6 @@ builder.env_overrides = {
 
 ## Further Resources
 
-- [Blocktest Fuzzer Documentation](https://github.com/ethereum/blocktest-fuzzer)
+- [Blocktest Fuzzer Documentation](https://github.com/ethereum/execution-spec-tests)
 - [EEST Framework Documentation](../index.md)
 - [Ethereum Test Format Specifications](./reference_specification.md)

--- a/docs/writing_tests/fuzzer_bridge.md
+++ b/docs/writing_tests/fuzzer_bridge.md
@@ -258,6 +258,5 @@ builder.env_overrides = {
 
 ## Further Resources
 
-- [Blocktest Fuzzer Documentation](https://github.com/ethereum/execution-spec-tests)
 - [EEST Framework Documentation](../index.md)
 - [Ethereum Test Format Specifications](./reference_specification.md)

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -2091,8 +2091,7 @@ class Opcodes(Opcode, Enum):
     ----
     3
 
-    Source: [eips.ethereum.org/EIPS/
-    eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
+    Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
     """
 
     BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
@@ -2120,8 +2119,7 @@ class Opcodes(Opcode, Enum):
     ----
     2
 
-    Source: [eips.ethereum.org/EIPS/eip-7516](https://eips.ethereum.org/
-    EIPS/eip-7516)
+    Source: [eips.ethereum.org/EIPS/eip-7516](https://eips.ethereum.org/EIPS/eip-7516)
     """
 
     POP = Opcode(0x50, popped_stack_items=1)
@@ -2569,8 +2567,7 @@ class Opcodes(Opcode, Enum):
     ----
     100
 
-    Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/
-    eip-1153)
+    Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
     """
 
     MCOPY = Opcode(
@@ -2604,8 +2601,7 @@ class Opcodes(Opcode, Enum):
     - static_gas = 3
     - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
-    Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/
-    eip-5656)
+    Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
     """
 
     PUSH0 = Opcode(0x5F, pushed_stack_items=1)
@@ -4897,8 +4893,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/
-    eip-4200)
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     DATALOAD = Opcode(
@@ -4930,8 +4925,7 @@ class Opcodes(Opcode, Enum):
     ----
     4
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/
-    eip-7480)
+    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATALOADN = Opcode(0xD1, pushed_stack_items=1, data_portion_length=2)
@@ -4965,8 +4959,7 @@ class Opcodes(Opcode, Enum):
     ----
     3
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/
-    eip-7480)
+    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATASIZE = Opcode(0xD2, pushed_stack_items=1)
@@ -4995,8 +4988,7 @@ class Opcodes(Opcode, Enum):
     ----
     2
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/
-    eip-7480)
+    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATACOPY = Opcode(
@@ -5032,8 +5024,7 @@ class Opcodes(Opcode, Enum):
     - static_gas = 3
     - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/
-    eip-7480)
+    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
@@ -5059,8 +5050,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/
-    eip-4200)
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     RJUMPV = Opcode(
@@ -5099,8 +5089,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/
-    eip-4200)
+    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     CALLF = Opcode(0xE3, data_portion_length=2, unchecked_stack=True)
@@ -5140,8 +5129,7 @@ class Opcodes(Opcode, Enum):
     5
 
     Source:
-    [ipsilon/eof/blob/main/spec/eof.md](https://github.com/ipsilon/eof/blob/
-    main/spec/eof.md)
+    [ipsilon/eof/blob/main/spec/eof.md](https://github.com/ipsilon/eof/blob/main/spec/eof.md)
     """
 
     RETF = Opcode(0xE4, terminating=True)

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -2092,7 +2092,7 @@ class Opcodes(Opcode, Enum):
     ----
     3
 
-    Source: [eips.ethereum.org/EIPS/eip-4844](https://eips.ethereum.org/EIPS/eip-4844)
+    Source: [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
     """
 
     BLOBBASEFEE = Opcode(0x4A, popped_stack_items=0, pushed_stack_items=1)
@@ -2120,7 +2120,7 @@ class Opcodes(Opcode, Enum):
     ----
     2
 
-    Source: [eips.ethereum.org/EIPS/eip-7516](https://eips.ethereum.org/EIPS/eip-7516)
+    Source: [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516)
     """
 
     POP = Opcode(0x50, popped_stack_items=1)
@@ -2568,7 +2568,7 @@ class Opcodes(Opcode, Enum):
     ----
     100
 
-    Source: [eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+    Source: [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)
     """
 
     MCOPY = Opcode(
@@ -2602,7 +2602,7 @@ class Opcodes(Opcode, Enum):
     - static_gas = 3
     - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
-    Source: [eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
+    Source: [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656)
     """
 
     PUSH0 = Opcode(0x5F, pushed_stack_items=1)
@@ -4894,7 +4894,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
+    Source: [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     DATALOAD = Opcode(
@@ -4926,7 +4926,7 @@ class Opcodes(Opcode, Enum):
     ----
     4
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
+    Source: [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATALOADN = Opcode(0xD1, pushed_stack_items=1, data_portion_length=2)
@@ -4960,7 +4960,7 @@ class Opcodes(Opcode, Enum):
     ----
     3
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
+    Source: [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATASIZE = Opcode(0xD2, pushed_stack_items=1)
@@ -4989,7 +4989,7 @@ class Opcodes(Opcode, Enum):
     ----
     2
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
+    Source: [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     DATACOPY = Opcode(
@@ -5025,7 +5025,7 @@ class Opcodes(Opcode, Enum):
     - static_gas = 3
     - dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
 
-    Source: [eips.ethereum.org/EIPS/eip-7480](https://eips.ethereum.org/EIPS/eip-7480)
+    Source: [EIP-7480](https://eips.ethereum.org/EIPS/eip-7480)
     """
 
     RJUMPI = Opcode(0xE1, popped_stack_items=1, data_portion_length=2)
@@ -5051,7 +5051,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
+    Source: [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     RJUMPV = Opcode(
@@ -5090,7 +5090,7 @@ class Opcodes(Opcode, Enum):
     Gas
     ----
 
-    Source: [eips.ethereum.org/EIPS/eip-4200](https://eips.ethereum.org/EIPS/eip-4200)
+    Source: [EIP-4200](https://eips.ethereum.org/EIPS/eip-4200)
     """
 
     CALLF = Opcode(0xE3, data_portion_length=2, unchecked_stack=True)
@@ -5130,7 +5130,7 @@ class Opcodes(Opcode, Enum):
     5
 
     Source:
-    [ipsilon/eof/blob/main/spec/eof.md](https://github.com/ipsilon/eof/blob/main/spec/eof.md)
+    [`eof.md`](https://github.com/ipsilon/eof/blob/main/spec/eof.md)
     """
 
     RETF = Opcode(0xE4, terminating=True)

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -3,9 +3,10 @@ Ethereum Virtual Machine opcode definitions.
 
 Acknowledgments: The individual opcode documentation below is due to the work
 by [smlXL](https://github.com/smlxl) on [evm.codes](https://www.evm.codes/),
-available as open source [github.com/smlxl/
-evm.codes](https://github.com/smlxl/evm.codes) - thank you! And thanks
-to @ThreeHrSleep for integrating it in the docstrings.
+available as open source [`smlxl/evm.codes`][0]; thank you! And thanks to
+@ThreeHrSleep for integrating it in the docstrings.
+
+[0]: https://github.com/smlxl/evm.codes
 """
 
 from enum import Enum


### PR DESCRIPTION
## 🗒️ Description
**Fixes all three broken links reported in Link Checker Report #1627.**
The changes include:
1.  **Updated a deprecated repository link** in the documentation.
2.  **Fixed multiple EIP links** and the EOF repository link that were broken due to being split across two lines in the Python source code.

## 🔗 Related Issues or PRs
**Fixes #1627**

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![](
![download (1)](https://github.com/user-attachments/assets/ddd08ab0-0a0d-487b-9c13-92a8b0e14ac5)

)
