### PR TITLE
fix(spec-specs): split `charge_gas` around account access

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -140,9 +140,6 @@ def access_delegation(
     if not is_valid_delegation(code):
         return False, address, code, Uint(0)
 
-    # EIP-7928: Track the authority address (delegated account being called)
-    track_address_access(state.change_tracker, address)
-
     address = Address(code[EOA_DELEGATION_MARKER_LENGTH:])
     if address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
@@ -150,9 +147,6 @@ def access_delegation(
         evm.accessed_addresses.add(address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
     code = get_account(state, address).code
-
-    # EIP-7928: Track delegation target when loaded as call target
-    track_address_access(state.change_tracker, address)
 
     return True, address, code, access_gas_cost
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -407,16 +407,28 @@ def call(evm: Evm) -> None:
     ) = access_delegation(evm, code_address)
     access_gas_cost += delegated_access_gas_cost
 
+    # Charge delegation access cost before tracking delegation target
+    if delegated_access_gas_cost > Uint(0):
+        charge_gas(evm, delegated_access_gas_cost)
+
+    # Track delegation target if delegation occurred
+    if disable_precompiles:
+        track_address_access(
+            evm.message.block_env.state.change_tracker, code_address
+        )
+
     create_gas_cost = GAS_NEW_ACCOUNT
     if value == 0 or is_account_alive(evm.message.block_env.state, to):
         create_gas_cost = Uint(0)
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+
+    # Charge remaining costs (create, transfer, subcall)
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + create_gas_cost + transfer_gas_cost,
+        Uint(0),  # Memory cost already charged
+        create_gas_cost + transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
     if evm.message.is_static and value != U256(0):
@@ -500,13 +512,25 @@ def callcode(evm: Evm) -> None:
     ) = access_delegation(evm, code_address)
     access_gas_cost += delegated_access_gas_cost
 
+    # Charge delegation access cost before tracking delegation target
+    if delegated_access_gas_cost > Uint(0):
+        charge_gas(evm, delegated_access_gas_cost)
+
+    # Track delegation target if delegation occurred
+    if disable_precompiles:
+        track_address_access(
+            evm.message.block_env.state.change_tracker, code_address
+        )
+
     transfer_gas_cost = Uint(0) if value == 0 else GAS_CALL_VALUE
+
+    # Charge remaining costs (transfer, subcall)
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost + transfer_gas_cost,
+        Uint(0),  # Memory cost already charged
+        transfer_gas_cost,
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
@@ -656,7 +680,19 @@ def delegatecall(evm: Evm) -> None:
     ) = access_delegation(evm, code_address)
     access_gas_cost += delegated_access_gas_cost
 
+    # Charge delegation access cost before tracking delegation target
+    if delegated_access_gas_cost > Uint(0):
+        charge_gas(evm, delegated_access_gas_cost)
+
+    # Track delegation target if delegation occurred
+    if disable_precompiles:
+        track_address_access(
+            evm.message.block_env.state.change_tracker, code_address
+        )
+
+    # Charge remaining costs (subcall)
     message_call_gas = calculate_message_call_gas(
+        U256(0), gas, Uint(evm.gas_left), Uint(0), Uint(0)
         U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
@@ -729,12 +765,23 @@ def staticcall(evm: Evm) -> None:
     ) = access_delegation(evm, code_address)
     access_gas_cost += delegated_access_gas_cost
 
+    # Charge delegation access cost before tracking delegation target
+    if delegated_access_gas_cost > Uint(0):
+        charge_gas(evm, delegated_access_gas_cost)
+
+    # Track delegation target if delegation occurred
+    if disable_precompiles:
+        track_address_access(
+            evm.message.block_env.state.change_tracker, code_address
+        )
+
+    # Charge remaining costs (subcall)
     message_call_gas = calculate_message_call_gas(
         U256(0),
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
-        access_gas_cost,
+        Uint(0),  # Memory cost already charged
+        Uint(0),
     )
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -392,10 +392,14 @@ def call(evm: Evm) -> None:
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    # Track address access for BAL
+    # Charge static costs (memory + access) before BAL tracking
+    charge_gas(evm, extend_memory.cost + access_gas_cost)
+
+    if to not in evm.accessed_addresses:
+        evm.accessed_addresses.add(to)
+
     track_address_access(evm.message.block_env.state.change_tracker, to)
 
     code_address = to
@@ -405,7 +409,6 @@ def call(evm: Evm) -> None:
         code,
         delegated_access_gas_cost,
     ) = access_delegation(evm, code_address)
-    access_gas_cost += delegated_access_gas_cost
 
     # Charge delegation access cost before tracking delegation target
     if delegated_access_gas_cost > Uint(0):
@@ -430,7 +433,7 @@ def call(evm: Evm) -> None:
         Uint(0),  # Memory cost already charged
         create_gas_cost + transfer_gas_cost,
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
     if evm.message.is_static and value != U256(0):
         raise WriteInStaticContext
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -496,10 +499,14 @@ def callcode(evm: Evm) -> None:
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    # Track address access for BAL
+    # Charge static costs (memory + access) before BAL tracking
+    charge_gas(evm, extend_memory.cost + access_gas_cost)
+
+    if code_address not in evm.accessed_addresses:
+        evm.accessed_addresses.add(code_address)
+
     track_address_access(
         evm.message.block_env.state.change_tracker, code_address
     )
@@ -510,7 +517,6 @@ def callcode(evm: Evm) -> None:
         code,
         delegated_access_gas_cost,
     ) = access_delegation(evm, code_address)
-    access_gas_cost += delegated_access_gas_cost
 
     # Charge delegation access cost before tracking delegation target
     if delegated_access_gas_cost > Uint(0):
@@ -532,7 +538,7 @@ def callcode(evm: Evm) -> None:
         Uint(0),  # Memory cost already charged
         transfer_gas_cost,
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -582,12 +588,17 @@ def selfdestruct(evm: Evm) -> None:
     beneficiary = to_address_masked(pop(evm.stack))
 
     # GAS
-    gas_cost = GAS_SELF_DESTRUCT
+    if beneficiary not in evm.accessed_addresses:
+        access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
+    else:
+        access_gas_cost = Uint(0)
+
+    # Charge static costs (base + access) before BAL tracking
+    charge_gas(evm, GAS_SELF_DESTRUCT + access_gas_cost)
+
     if beneficiary not in evm.accessed_addresses:
         evm.accessed_addresses.add(beneficiary)
-        gas_cost += GAS_COLD_ACCOUNT_ACCESS
 
-    # Track address access for BAL
     track_address_access(
         evm.message.block_env.state.change_tracker, beneficiary
     )
@@ -599,9 +610,7 @@ def selfdestruct(evm: Evm) -> None:
         ).balance
         != 0
     ):
-        gas_cost += GAS_SELF_DESTRUCT_NEW_ACCOUNT
-
-    charge_gas(evm, gas_cost)
+        charge_gas(evm, GAS_SELF_DESTRUCT_NEW_ACCOUNT)
 
     originator = evm.message.current_target
     originator_balance = get_account(
@@ -664,10 +673,14 @@ def delegatecall(evm: Evm) -> None:
     if code_address in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        evm.accessed_addresses.add(code_address)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    # Track address access for BAL
+    # Charge static costs (memory + access) before BAL tracking
+    charge_gas(evm, extend_memory.cost + access_gas_cost)
+
+    if code_address not in evm.accessed_addresses:
+        evm.accessed_addresses.add(code_address)
+
     track_address_access(
         evm.message.block_env.state.change_tracker, code_address
     )
@@ -678,7 +691,6 @@ def delegatecall(evm: Evm) -> None:
         code,
         delegated_access_gas_cost,
     ) = access_delegation(evm, code_address)
-    access_gas_cost += delegated_access_gas_cost
 
     # Charge delegation access cost before tracking delegation target
     if delegated_access_gas_cost > Uint(0):
@@ -693,9 +705,8 @@ def delegatecall(evm: Evm) -> None:
     # Charge remaining costs (subcall)
     message_call_gas = calculate_message_call_gas(
         U256(0), gas, Uint(evm.gas_left), Uint(0), Uint(0)
-        U256(0), gas, Uint(evm.gas_left), extend_memory.cost, access_gas_cost
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -750,10 +761,14 @@ def staticcall(evm: Evm) -> None:
     if to in evm.accessed_addresses:
         access_gas_cost = GAS_WARM_ACCESS
     else:
-        evm.accessed_addresses.add(to)
         access_gas_cost = GAS_COLD_ACCOUNT_ACCESS
 
-    # Track address access for BAL
+    # Charge static costs (memory + access) before BAL tracking
+    charge_gas(evm, extend_memory.cost + access_gas_cost)
+
+    if to not in evm.accessed_addresses:
+        evm.accessed_addresses.add(to)
+
     track_address_access(evm.message.block_env.state.change_tracker, to)
 
     code_address = to
@@ -763,7 +778,6 @@ def staticcall(evm: Evm) -> None:
         code,
         delegated_access_gas_cost,
     ) = access_delegation(evm, code_address)
-    access_gas_cost += delegated_access_gas_cost
 
     # Charge delegation access cost before tracking delegation target
     if delegated_access_gas_cost > Uint(0):
@@ -783,7 +797,7 @@ def staticcall(evm: Evm) -> None:
         Uint(0),  # Memory cost already charged
         Uint(0),
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by


### PR DESCRIPTION
## 🗒️ Description

Related to #1722, we should charge for account access costs before actually marking the account accessed. If there is not enough gas for the access, we should never expend the resources to access the account.

Test cases for all of these boundaries should be added as well.

These changes should likely be introduced at some point into all forks if we decide this is the approach that we should take.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="713" height="856" alt="Screenshot 2025-11-04 at 13 57 21" src="https://github.com/user-attachments/assets/70ab98c0-b6f5-45d0-ab28-b82c08cc2076" />
