### PR TITLE
Fix 1753 fork criteria

### DIFF
--- a/src/ethereum/forks/arrow_glacier/__init__.py
+++ b/src/ethereum/forks/arrow_glacier/__init__.py
@@ -28,6 +28,6 @@ in this fork.
 [nm]: https://github.com/NethermindEth/nethermind/releases/tag/1.11.7
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(13773000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(13773000)

--- a/src/ethereum/forks/berlin/__init__.py
+++ b/src/ethereum/forks/berlin/__init__.py
@@ -38,6 +38,6 @@ with the first new transaction type—optional access lists.
 [oe]: https://github.com/openethereum/openethereum/releases/tag/v3.2.0
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(12244000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(12244000)

--- a/src/ethereum/forks/byzantium/__init__.py
+++ b/src/ethereum/forks/byzantium/__init__.py
@@ -45,6 +45,6 @@ contracts, and adds cryptographic primitives for layer 2 scaling.
 [p]: https://github.com/paritytech/parity/releases/tag/v1.7.6
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(4370000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(4370000)

--- a/src/ethereum/forks/cancun/__init__.py
+++ b/src/ethereum/forks/cancun/__init__.py
@@ -44,6 +44,6 @@ same transaction, and adds an instruction to read the blob base fee.
 [r]: https://github.com/paradigmxyz/reth/releases/tag/v0.1.0-alpha.19
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByTimestamp
+from ethereum.fork_criteria import ByTimestamp, ForkCriteria
 
-FORK_CRITERIA = ByTimestamp(1710338135)
+FORK_CRITERIA: ForkCriteria = ByTimestamp(1710338135)

--- a/src/ethereum/forks/constantinople/__init__.py
+++ b/src/ethereum/forks/constantinople/__init__.py
@@ -46,6 +46,6 @@ awkward situation and presents only a single fork without EIP-1283.
 [t]: https://github.com/ethereum/trinity/releases/tag/v0.1.0-alpha.23
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(7280000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(7280000)

--- a/src/ethereum/forks/dao_fork/__init__.py
+++ b/src/ethereum/forks/dao_fork/__init__.py
@@ -24,6 +24,6 @@ recovers the stolen funds into a new contract.
 [Geth 1.4.10]: https://github.com/ethereum/go-ethereum/releases/tag/v1.4.10
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(1920000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(1920000)

--- a/src/ethereum/forks/dao_fork/fork.py
+++ b/src/ethereum/forks/dao_fork/fork.py
@@ -29,6 +29,7 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
+from ethereum.fork_criteria import ByBlockNumber
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt
@@ -270,6 +271,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
     block_parent_hash = keccak256(rlp.encode(parent_header))
     if header.parent_hash != block_parent_hash:
         raise InvalidBlock
+
+    assert isinstance(FORK_CRITERIA, ByBlockNumber)
 
     if (
         header.number >= FORK_CRITERIA.block_number

--- a/src/ethereum/forks/frontier/__init__.py
+++ b/src/ethereum/forks/frontier/__init__.py
@@ -2,6 +2,6 @@
 Frontier is the first production-ready iteration of the Ethereum protocol.
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(0)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(0)

--- a/src/ethereum/forks/gray_glacier/__init__.py
+++ b/src/ethereum/forks/gray_glacier/__init__.py
@@ -29,6 +29,6 @@ in this fork.
 [n]: https://github.com/NethermindEth/nethermind/releases/tag/1.13.3
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(15050000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(15050000)

--- a/src/ethereum/forks/homestead/__init__.py
+++ b/src/ethereum/forks/homestead/__init__.py
@@ -29,6 +29,6 @@ difficulty bomb, and adds an improved delegate call EVM instruction.
 [Geth 1.3.5]: https://github.com/ethereum/go-ethereum/releases/tag/v1.3.5
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(1150000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(1150000)

--- a/src/ethereum/forks/istanbul/__init__.py
+++ b/src/ethereum/forks/istanbul/__init__.py
@@ -48,6 +48,6 @@ instruction to fetch the current chain identifier.
 [t]: https://github.com/ethereum/trinity/releases/tag/v0.1.0-alpha.31
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(9069000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(9069000)

--- a/src/ethereum/forks/london/__init__.py
+++ b/src/ethereum/forks/london/__init__.py
@@ -43,6 +43,6 @@ reserves a contract prefix for future use, and delays the difficulty bomb.
 [oe]: https://github.com/openethereum/openethereum/releases/tag/v3.3.0-rc.4
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(12965000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(12965000)

--- a/src/ethereum/forks/london/fork.py
+++ b/src/ethereum/forks/london/fork.py
@@ -28,6 +28,7 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
+from ethereum.fork_criteria import ByBlockNumber
 
 from . import FORK_CRITERIA, vm
 from .blocks import Block, Header, Log, Receipt, encode_receipt
@@ -318,6 +319,8 @@ def validate_header(chain: BlockChain, header: Header) -> None:
 
     if header.gas_used > header.gas_limit:
         raise InvalidBlock
+
+    assert isinstance(FORK_CRITERIA, ByBlockNumber)
 
     expected_base_fee_per_gas = INITIAL_BASE_FEE
     if header.number != FORK_CRITERIA.block_number:

--- a/src/ethereum/forks/muir_glacier/__init__.py
+++ b/src/ethereum/forks/muir_glacier/__init__.py
@@ -33,6 +33,6 @@ in this fork.
 [t]: https://github.com/ethereum/trinity/releases/tag/v0.1.0-alpha.34
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(9200000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(9200000)

--- a/src/ethereum/forks/osaka/__init__.py
+++ b/src/ethereum/forks/osaka/__init__.py
@@ -50,6 +50,6 @@ secp256r1 curve.
 [EIP-7910]: https://eips.ethereum.org/EIPS/eip-7910
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByTimestamp
+from ethereum.fork_criteria import ByTimestamp, ForkCriteria
 
-FORK_CRITERIA = ByTimestamp(1764798551)
+FORK_CRITERIA: ForkCriteria = ByTimestamp(1764798551)

--- a/src/ethereum/forks/paris/__init__.py
+++ b/src/ethereum/forks/paris/__init__.py
@@ -34,10 +34,10 @@ marks the integration of the [consensus layer] with the execution layer
 [nm]: https://github.com/NethermindEth/nethermind/releases/tag/1.14.1
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
 # The actual trigger for the Paris hardfork was The Merge occurring when
 # total difficulty (the sum of the all block difficulties) reached the
 # Terminal Total Difficulty value (58750000000000000000000 on Mainnet). The
 # Merge is now a historical event.
-FORK_CRITERIA = ByBlockNumber(15537394)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(15537394)

--- a/src/ethereum/forks/prague/__init__.py
+++ b/src/ethereum/forks/prague/__init__.py
@@ -49,6 +49,6 @@ contract][b].
 [EIP-7549]: https://eips.ethereum.org/EIPS/eip-7549
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByTimestamp
+from ethereum.fork_criteria import ByTimestamp, ForkCriteria
 
-FORK_CRITERIA = ByTimestamp(1746612311)
+FORK_CRITERIA: ForkCriteria = ByTimestamp(1746612311)

--- a/src/ethereum/forks/shanghai/__init__.py
+++ b/src/ethereum/forks/shanghai/__init__.py
@@ -42,6 +42,6 @@ bytecode, and deprecates the self-destruct EVM instruction.
 [js]: https://github.com/ethereumjs/ethereumjs-monorepo/releases/tag/%40ethereumjs%2Fvm%406.4.0
 """  # noqa: E501
 
-from ethereum.fork_criteria import ByTimestamp
+from ethereum.fork_criteria import ByTimestamp, ForkCriteria
 
-FORK_CRITERIA = ByTimestamp(1681338455)
+FORK_CRITERIA: ForkCriteria = ByTimestamp(1681338455)

--- a/src/ethereum/forks/spurious_dragon/__init__.py
+++ b/src/ethereum/forks/spurious_dragon/__init__.py
@@ -33,6 +33,6 @@ empty accounts.
 [rb]: https://github.com/cryptape/ruby-ethereum/releases/tag/v0.11.0
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(2675000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(2675000)

--- a/src/ethereum/forks/tangerine_whistle/__init__.py
+++ b/src/ethereum/forks/tangerine_whistle/__init__.py
@@ -27,6 +27,6 @@ empty accounts.
 [p]: https://github.com/openethereum/parity-ethereum/releases/tag/v1.3.8
 """
 
-from ethereum.fork_criteria import ByBlockNumber
+from ethereum.fork_criteria import ByBlockNumber, ForkCriteria
 
-FORK_CRITERIA = ByBlockNumber(2463000)
+FORK_CRITERIA: ForkCriteria = ByBlockNumber(2463000)


### PR DESCRIPTION
## 🗒️ Description
This PR explicitly annotates the FORK_CRITERIA variable with the ForkCriteria supertype across all fork definition files (src/ethereum/forks/*/__init__.py). This addresses a type-checking issue where the narrower type (e.g., ByBlockNumber) was being inferred, which could lead to API breakage when transitioning to a broader type (e.g., ByTimestamp).

## 🔗 Related Issues or PRs
Fixes #1753

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![download (4)](https://github.com/user-attachments/assets/bfcff650-ef64-49bb-b95f-f5db6d9fe718)


