### PR TITLE
chore(ci): switch commit lint to PR title validation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,9 +43,9 @@ jobs:
       - name: Check PR Title against Conventional Commits
         # This action validates the PR title against the Conventional Commits spec
         uses: amannn/action-semantic-pull-request@v6 
-        env:
-          # This token grants the action permission to read PR metadata
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:  # <--- Change 'env' to 'with'
+          # The GITHUB_TOKEN is passed as an input parameter to the action
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   py3:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,6 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check PR Title against Conventional Commits
-        # This action validates the PR title against the Conventional Commits spec
         uses: amannn/action-semantic-pull-request@v6 
         with:  # <--- Change 'env' to 'with'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,6 @@ jobs:
         # This action validates the PR title against the Conventional Commits spec
         uses: amannn/action-semantic-pull-request@v6 
         with:  # <--- Change 'env' to 'with'
-          # The GITHUB_TOKEN is passed as an input parameter to the action
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   py3:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,38 +32,20 @@ jobs:
       - name: Run static checks
         run: tox -e static
 
-  lint-commits:
+  # Replacing the old 'lint-commits' job with a 'lint-pr-title' job
+  # since the policy is to squash, making the PR title the source of truth.
+  lint-pr-title:
+    name: Validate Pull Request Title
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'push' || github.ref_name != github.event.repository.default_branch }}
+    # Ensure it only runs on Pull Request events
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Dump GitHub context # Debugging why this job is running on forks/osaka.
+      - name: Check PR Title against Conventional Commits
+        # This action validates the PR title against the Conventional Commits spec
+        uses: amannn/action-semantic-pull-request@v6 
         env:
-          EVENT_NAME: ${{ toJson(github.event_name) }}
-          REF_NAME: ${{ toJson(github.ref_name) }}
-          GH_REPO: ${{ toJson(github.event.repository) }}
-        run: |
-          printenv EVENT_NAME
-          printenv REF_NAME
-          printenv GH_REPO
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: "3.11"
-      - name: Install gitlint
-        run: pip install gitlint>=0.20.0
-      - name: Lint commits
-        run: |
-          BASE_REF="${{ github.base_ref || github.repository.default_branch }}"
-          BASE_SHA=$(git merge-base HEAD "origin/$BASE_REF")
-          echo "Linting commits from $BASE_SHA to HEAD (base ref: $BASE_REF)"
-          echo "Commits in range:"
-          git log --oneline "$BASE_SHA"..HEAD || echo "No new commits"
-          gitlint --contrib CT1 --commits "$BASE_SHA"..HEAD --ignore body-is-missing
-          echo "Conventional Commits linting PASSED!"
+          # This token grants the action permission to read PR metadata
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   py3:
     runs-on: [self-hosted-ghr, size-xl-x64]


### PR DESCRIPTION
## 🗒️ Description
This PR addresses the inefficiency of linting individual commit messages when the repository policy uses **squash and merge**, which makes the Pull Request Title the source of the final commit message.
This change modifies the CI workflow to ensure that only the PR title is validated against the Conventional Commit standards.
Specifically, it makes the following change in `.github/workflows/test.yaml`:

1.  **Removes** the outdated `lint-commits` job (which used Python/`gitlint` to check commit history).
2.  **Replaces** it with a new, more efficient `lint-pr-title` job that uses the dedicated GitHub Action `amannn/action-semantic-pull-request@v6` to validate the PR title.

## 🔗 Related Issues or PRs
**Fixes #1757**

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Top 15 Cutest Animals Of The Week To Start The Day With An &#39;Aww&#39; (July 9, 2023)](https://github.com/user-attachments/assets/0394db2c-32af-4390-99b4-37a698487c9a)





