### PR TITLE
chore: fix `ruff` devex and `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,10 @@ This saves you having to apply code review feedback repeatedly for each fork.
 
 Running the tests necessary to merge into the repository requires:
 
-- Python 3.11.x, and
+- [`uv`](https://docs.astral.sh/uv/) package manager,
+- Python 3.11.x,
 - [PyPy](https://www.pypy.org/) [7.3.19](https://downloads.python.org/pypy/) or later.
-- `geth` installed and present in `$PATH`
+- `geth` installed and present in `$PATH`.
 
 `execution-specs` depends on a submodule that contains common tests that are run across all clients, so we need to clone the repo with the --recursive flag. Example:
 
@@ -67,10 +68,10 @@ tox
 The development tools can also be run outside of `tox`, and can automatically reformat the code:
 
 ```bash
-uv run --extra lint ruff check                # Detects code issues and produces a report to STDOUT
-uv run --extra lint ruff check --fix          # Fixes minor code issues (like unsorted imports).
-uv run --extra lint ruff format               # Formats code.
-uv run --extra lint mypy src packages tests   # Verifies type annotations.
+uv run ruff check        # Detects code issues and produces a report to STDOUT.
+uv run ruff check --fix  # Fixes minor code issues (like unsorted imports).
+uv run ruff format       # Formats code.
+uv run mypy              # Verifies type annotations.
 ```
 
 It is recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) to keep your system Python installation clean.
@@ -80,9 +81,9 @@ Note: Make sure to run the EVM trace on a small number of tests at a time. The l
 Below is an example.
 
 ```bash
-uv run --extra test \
-    pytest 'tests/json_infra/test_state_tests.py::test_state_tests_frontier[stAttackTest - ContractCreationSpam - 0]' \
-        --evm_trace
+uv run pytest \
+    'tests/json_infra/test_state_tests.py::test_state_tests_frontier[stAttackTest - ContractCreationSpam - 0]' \
+    --evm_trace
 ```
 
 ## CLI Utilities `ethereum_spec_tools`

--- a/docs/dev/deps_and_packaging.md
+++ b/docs/dev/deps_and_packaging.md
@@ -6,7 +6,7 @@ A minimum version of `uv>=0.7.0` is required to ensure `uv` writes `uv.lock` fil
 
 ## Managing Dependencies
 
-We aim to provide specific [version specifiers](https://peps.python.org/pep-0440/#version-specifiers) for each of our direct and extra dependencies.
+We aim to provide specific [version specifiers](https://peps.python.org/pep-0440/#version-specifiers) for all of our dependencies.
 
 !!! note "Packages should be managed via `uv`"
 
@@ -57,28 +57,58 @@ ethereum-spec-evm-resolver = { git = "https://github.com/petertdavies/ethereum-s
     uv add "ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver@623ac4565025e72b65f45b926da2a3552041b469"
     ```
 
+### Adding/modifying development dependencies
+
+Development dependencies are managed in dependency groups: `lint`, `doc`, `test`, and `mkdocs` defined in the `pyproject.toml`:
+
+```toml
+[dependency-groups]
+test = [
+    "pytest>=8,<9",
+    "pytest-cov>=4.1.0,<5",
+    ...
+]
+lint = [
+    "ruff==0.13.2",
+    "mypy==1.17.0",
+    "types-requests>=2.31,<2.33",
+    ...
+]
+```
+
+These can be modified via `uv`on the command-line or edited by hand. If editing manually, you must run `uv lock` afterwards to update the lockfile.
+
+!!! example "Example: Updating a development dependency"
+
+    Using uv:
+    ```console
+    uv add --group lint "types-requests>=2.31,<2.33"
+    ```
+
+    Or edit `pyproject.toml` manually and then run:
+    ```console
+    uv lock
+    ```
+
 ### Adding/modifying optional dependencies
 
-The package versions in the optional "extra" groups should also be managed via uv on the command-line These are the: `lint`, `docs`, `test` optional groups defined in the `pyproject.toml`:
+The `optimized` optional extra provides performance enhancements and is the only remaining optional dependency group:
 
 ```toml
 [project.optional-dependencies]
-test = ["pytest-cov>=4.1.0,<5"]
-lint = [
-    "ruff==0.9.4",
-    "mypy>=1.15.0,<1.16",
-    "types-requests>=2.31,<2.33",
-]
-docs = [
-    ...
+optimized = [
+    "rust-pyspec-glue>=0.0.9,<0.1.0",
+    "ethash>=1.1.0,<2",
 ]
 ```
 
 !!! example "Example: Updating an optional dependency"
 
+    ```console
+    uv add --optional optimized "ethash>=1.1.0,<2"
     ```
-    uv add --optional lint "types-requests>=2.31,<2.33"
-    ```
+
+    Or edit `pyproject.toml` by hand and run `uv lock`.
 
 ## Upgrading Pinned Dependencies in `uv.lock`
 

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -5,7 +5,7 @@ The `execution-spec-tests` documentation is generated via [`mkdocs`](https://www
 ## Prerequisites
 
 ```console
-uv sync --all-extras
+uv sync
 ```
 
 ## Build and Verify the Documentation

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -33,7 +33,7 @@ Clone [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) a
     cd execution-spec-tests
     uv python install 3.12
     uv python pin 3.12
-    uv sync --all-extras
+    uv sync
     ```
 
 Static tests/maintainers only: To learn how to build the `solc` binary from source (optional) follow [this guide](./installation_troubleshooting.md#problem-exception-failed-to-compile-yul-source).

--- a/docs/getting_started/installation_troubleshooting.md
+++ b/docs/getting_started/installation_troubleshooting.md
@@ -5,7 +5,7 @@ This page provides guidance on how to troubleshoot common issues that may arise 
 ## Problem: `Failed building wheel for coincurve`
 
 !!! danger "Problem: `Failed building wheel for coincurve`"
-    Installing EEST and its dependencies via `uv sync --all-extras` fails with:
+    Installing EEST and its dependencies via `uv sync` fails with:
 
     ```bash
     Stored in directory: /tmp/...
@@ -126,10 +126,10 @@ This page provides guidance on how to troubleshoot common issues that may arise 
 
 !!! success "Solution: Install all required dependencies and select the correct interpreter"
 
-    1.  Ensure all dependencies are installed, including the `lint` extras.
+    1.  Ensure all developer dependencies are installed:
 
         ```bash
-        uv sync --all-extras
+        uv sync
         ```
 
     2.  In VS Code, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and select `Python: Select Interpreter`.

--- a/packages/testing/src/execution_testing/cli/tox_helpers.py
+++ b/packages/testing/src/execution_testing/cli/tox_helpers.py
@@ -203,7 +203,7 @@ def codespell() -> None:
             error_message="Codespell found spelling errors in the code.",
             fix_commands=[
                 "# Ensure codespell is installed (part of docs extras)",
-                "uv sync --all-extras",
+                "uv sync",
                 "",
                 "# Check for spelling errors",
                 f"uv run codespell {paths_str}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,11 @@ ignore = [
     "N815"          # The traces must use camel case in JSON property names
 ]
 "tests/*" = ["ARG001"]
+"vulture_whitelist.py" = [
+    "B018",  # Useless expression (intentional for Vulture whitelisting)
+    "F403",  # Star imports needed for whitelisting
+    "F405",  # Undefined names from star imports
+]
 
 [tool.codespell]
 builtin = "clear,code,usage"    # Built-in dictionaries to use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,7 @@ ignore_names = ["pytest_*"]
 line-length = 79
 
 [tool.ruff.lint]
+exclude = ["tests/fixtures"]
 select = [
     "E", # pycodestyle errors
     "F", # Pyflakes

--- a/scripts/download_geth_linux.py
+++ b/scripts/download_geth_linux.py
@@ -21,7 +21,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def download_geth_linux(dir: str) -> None:
+def download_geth_linux(target_dir: str) -> None:
     """Download geth from windows.net."""
     geth_release_name = "geth-linux-amd64-1.10.8-26675454"
     url = (
@@ -30,15 +30,15 @@ def download_geth_linux(dir: str) -> None:
     )
     r = requests.get(url)
 
-    with open(f"{dir}/geth.tar.gz", "wb") as f:
+    with open(f"{target_dir}/geth.tar.gz", "wb") as f:
         f.write(r.content)
 
-    geth_tar = tarfile.open(f"{dir}/geth.tar.gz")
-    geth_tar.extractall(dir)
+    geth_tar = tarfile.open(f"{target_dir}/geth.tar.gz")
+    geth_tar.extractall(target_dir)
 
-    shutil.move(f"{dir}/{geth_release_name}/geth", dir)
-    shutil.rmtree(f"{dir}/{geth_release_name}", ignore_errors=True)
-    os.remove(f"{dir}/geth.tar.gz")
+    shutil.move(f"{target_dir}/{geth_release_name}/geth", target_dir)
+    shutil.rmtree(f"{target_dir}/{geth_release_name}", ignore_errors=True)
+    os.remove(f"{target_dir}/geth.tar.gz")
 
 
 if __name__ == "__main__":

--- a/scripts/download_geth_linux.py
+++ b/scripts/download_geth_linux.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""
+Helper script to download geth for Linux.
+"""
+
 import argparse
 import os
 import shutil
@@ -8,6 +12,7 @@ import requests
 
 
 def parse_args():
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dir", help="Directory to which geth binary will be downloaded to"
@@ -17,6 +22,7 @@ def parse_args():
 
 
 def download_geth_linux(dir: str) -> None:
+    """Download geth from windows.net."""
     geth_release_name = "geth-linux-amd64-1.10.8-26675454"
     url = (
         f"https://gethstore.blob.core.windows.net/builds/"

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ wheel_build_env = .pkg
 description = Run spelling, lint, typechecking and dependency checks
 commands =
     codespell docs src packages tests
-    ruff check docs/scripts/ src packages tests --exclude tests/fixtures
-    ruff format docs/scripts src packages tests --check
+    ruff check 
+    ruff format --check
     mypy
     ethereum-spec-lint
     uv lock --check

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,6 +1,17 @@
+"""
+Whitelist for Vulture dead code detection.
+
+This file references symbols that Vulture might incorrectly flag as unused.
+The symbols are used indirectly through reflection, public APIs, or dynamic
+imports. Each bare expression tells Vulture to ignore that specific symbol.
+"""
+
 from ethereum.cancun.blocks import Withdrawal
+from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
+
 from ethereum.ethash import *
 from ethereum.fork_criteria import Unscheduled
+from ethereum.trace import EvmTracer
 from ethereum.utils.hexadecimal import hex_to_bytes256
 from ethereum_optimized.state_db import State
 from ethereum_spec_tools.docc import *
@@ -11,18 +22,16 @@ from ethereum_spec_tools.evm_tools.loaders.transaction_loader import (
 )
 from ethereum_spec_tools.evm_tools.t8n.env import Ommer
 from ethereum_spec_tools.evm_tools.t8n.evm_trace.eip3155 import (
-    Trace,
     FinalTrace,
+    Trace,
 )
-from ethereum_spec_tools.evm_tools.t8n.transition_tool import EELST8N
 from ethereum_spec_tools.lint.lints.glacier_forks_hygiene import (
     GlacierForksHygiene,
 )
 from ethereum_spec_tools.lint.lints.import_hygiene import ImportHygiene
+from ethereum_spec_tools.new_fork.codemod.comment import CommentReplaceCommand
 from ethereum_spec_tools.new_fork.codemod.constant import SetConstantCommand
 from ethereum_spec_tools.new_fork.codemod.string import StringReplaceCommand
-from ethereum_spec_tools.new_fork.codemod.comment import CommentReplaceCommand
-from ethereum.trace import EvmTracer
 
 # src/ethereum/utils/hexadecimal.py
 hex_to_bytes256


### PR DESCRIPTION
## 🗒️ Description
- Fix invalid `ruff`/`mypy`/`pytest` commands in `CONTRIBUTING.md`; we no longer manage developer deps via `optional-dependencies`/extras; they are listed in `dependency-groups`, cf #1713. This means dev deps get installed automatically via `uv run` (`--extra` is not required; now it gives an error).
- Avoid having to specify paths to `ruff` by fixing remaining lint issues and `ruff` config in `pyproject.toml`.
- Update markdown docs according to #1713.
 
## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #1713
- #1713

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.

#### Cute Animal Picture

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d75a8edb-a4c5-4d0a-9f7d-fbc0438b0c0f" />
