### PR TITLE
doc(benchmark): update doc string for supported ops

### DIFF
--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -1,6 +1,15 @@
 """
 Benchmark operations that require querying the account state, either on the
 current executing account or on a target account.
+
+Supported Opcodes:
+- SELFBALANCE
+- CODESIZE
+- CODECOPY
+- EXTCODESIZE
+- EXTCODEHASH
+- EXTCODECOPY
+- BALANCE
 """
 
 import math

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -1,4 +1,20 @@
-"""Benchmark arithmetic instructions."""
+"""
+Benchmark arithmetic instructions.
+
+Supported Opcodes:
+- ADD
+- ADDMOD
+- MUL
+- MULMOD
+- SUB
+- SUBMOD
+- DIV
+- SDIV
+- MOD
+- SMOD
+- EXP
+- SIGNEXTEND
+"""
 
 import operator
 import random
@@ -15,15 +31,6 @@ from execution_testing import (
 )
 
 from tests.benchmark.compute.helpers import DEFAULT_BINOP_ARGS, make_dup, neg
-
-# Arithmetic instructions:
-# ADD, ADDMOD
-# SUB, SUBMOD
-# MUL, MULMOD
-# DIV, SDIV
-# MOD, SMOD
-# EXP
-# SIGNEXTEND
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_bitwise.py
+++ b/tests/benchmark/compute/instruction/test_bitwise.py
@@ -1,4 +1,17 @@
-"""Benchmark bitwise instructions."""
+"""
+Benchmark bitwise instructions.
+
+Supported Opcodes:
+- AND
+- OR
+- XOR
+- NOT
+- BYTE
+- SHL
+- SHR
+- SAR
+- CLZ
+"""
 
 import random
 from typing import Callable
@@ -21,9 +34,6 @@ from tests.benchmark.compute.helpers import (
     shl,
     shr,
 )
-
-# Bitwise instructions:
-# AND, OR, XOR, NOT, BYTE, SHL, SHR, SAR, CLZ
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -1,4 +1,17 @@
-"""Benchmark block context instructions."""
+"""
+Benchmark block context instructions.
+
+Supported Opcodes:
+- BLOCKHASH
+- COINBASE
+- TIMESTAMP
+- NUMBER
+- PREVRANDAO
+- GASLIMIT
+- CHAINID
+- BASEFEE
+- BLOBBASEFEE
+"""
 
 import pytest
 from execution_testing import (
@@ -7,10 +20,6 @@ from execution_testing import (
     ExtCallGenerator,
     Op,
 )
-
-# Block context instructions:
-# BLOCKHASH, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT, CHAINID,
-# BASEFEE, BLOBBASEFEE
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -1,4 +1,16 @@
-"""Benchmark call frame context instructions."""
+"""
+Benchmark call frame context instructions.
+
+Supported Opcodes:
+- ADDRESS
+- CALLER
+- CALLVALUE
+- CALLDATASIZE
+- CALLDATACOPY
+- CALLDATALOAD
+- RETURNDATASIZE
+- RETURNDATACOPY
+"""
 
 import pytest
 from execution_testing import (

--- a/tests/benchmark/compute/instruction/test_comparison.py
+++ b/tests/benchmark/compute/instruction/test_comparison.py
@@ -1,4 +1,14 @@
-"""Benchmark comparison instructions."""
+"""
+Benchmark comparison instructions.
+
+Supported Opcodes:
+- LT
+- SLT
+- GT
+- SGT
+- EQ
+- ISZERO
+"""
 
 import pytest
 from execution_testing import (
@@ -6,9 +16,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
 )
-
-# Comparison instructions:
-# LT, SLT, GT, SGT, EQ, ISZERO
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_control_flow.py
+++ b/tests/benchmark/compute/instruction/test_control_flow.py
@@ -1,4 +1,14 @@
-"""Benchmark control flow instructions."""
+"""
+Benchmark control flow instructions.
+
+Supported Opcodes:
+- STOP
+- JUMP
+- JUMPI
+- PC
+- GAS
+- JUMPDEST
+"""
 
 from execution_testing import (
     Alloc,

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -1,4 +1,9 @@
-"""Benchmark keccak instructions."""
+"""
+Benchmark keccak instructions.
+
+Supported Opcodes:
+- KECCAK256
+"""
 
 import math
 
@@ -8,9 +13,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
 )
-
-# Keccak instructions:
-# KECCAK256
 
 KECCAK_RATE = 136
 

--- a/tests/benchmark/compute/instruction/test_log.py
+++ b/tests/benchmark/compute/instruction/test_log.py
@@ -1,4 +1,13 @@
-"""Benchmark log instructions."""
+"""
+Benchmark log instructions.
+
+Supported Opcodes:
+- LOG0
+- LOG1
+- LOG2
+- LOG3
+- LOG4
+"""
 
 import pytest
 from execution_testing import (
@@ -7,9 +16,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
 )
-
-# Log instructions:
-# LOG0, LOG1, LOG2, LOG3, LOG4
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -1,4 +1,13 @@
-"""Benchmark memory instructions."""
+"""
+Benchmark memory instructions.
+
+Supported Opcodes:
+- MSTORE
+- MSTORE8
+- MLOAD
+- MSIZE
+- MCOPY
+"""
 
 import pytest
 from execution_testing import (
@@ -8,9 +17,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
 )
-
-# Memory instructions:
-# MSTORE, MSTORE8, MLOAD, MSIZE, MCOPY
 
 
 @pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000, 1_000_000])

--- a/tests/benchmark/compute/instruction/test_stack.py
+++ b/tests/benchmark/compute/instruction/test_stack.py
@@ -1,4 +1,12 @@
-"""Benchmark stack instructions."""
+"""
+Benchmark stack instructions.
+
+Supported Opcodes:
+- POP
+- PUSHx
+- DUPx
+- SWAPx
+"""
 
 import pytest
 from execution_testing import (
@@ -9,9 +17,6 @@ from execution_testing import (
     JumpLoopGenerator,
     Op,
 )
-
-# Stack instructions:
-# POP, PUSHx, DUPx, SWAPx
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -1,4 +1,12 @@
-"""Benchmark storage instructions."""
+"""
+Benchmark storage instructions.
+
+Supported Opcodes:
+- SLOAD
+- SSTORE
+- TLOAD
+- TSTORE
+"""
 
 import pytest
 from execution_testing import (
@@ -17,9 +25,6 @@ from execution_testing import (
 )
 
 from tests.benchmark.compute.helpers import StorageAction, TransactionResult
-
-# Storage instructions:
-# SLOAD, SSTORE, TLOAD, TSTORE
 
 
 # `key_mut` indicates the key isn't fixed.

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -1,4 +1,17 @@
-"""Benchmark system instructions."""
+"""
+Benchmark system instructions.
+
+Supported Opcodes:
+- CREATE
+- CREATE2
+- RETURN
+- REVERT
+- CALL
+- CALLCODE
+- DELEGATECALL
+- STATICCALL
+- SELFDESTRUCT
+"""
 
 import math
 
@@ -23,11 +36,6 @@ from execution_testing import (
 )
 
 from tests.benchmark.compute.helpers import XOR_TABLE
-
-# System instructions:
-# CREATE, CREATE2
-# RETURN, REVERT
-# CALL, CALLCODE, SELFDESTRUCT, DELEGATECALL, STATICCALL
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_tx_context.py
+++ b/tests/benchmark/compute/instruction/test_tx_context.py
@@ -1,4 +1,11 @@
-"""Benchmark transaction context instructions."""
+"""
+Benchmark transaction context instructions.
+
+Supported Opcodes:
+- ORIGIN
+- GASPRICE
+- BLOBHASH
+"""
 
 from typing import Any, Dict
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

update docstrings in each benchmark test folder to indicate supported operations, improving collaboration with external contributors while documentation rendering is still pending.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
