### PR TITLE
enhance(test-benchmark): add setup and execution transaction label

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -19,6 +19,7 @@ from execution_testing import (
     Block,
     ExtCallGenerator,
     Op,
+    TestPhaseManager,
 )
 
 
@@ -66,7 +67,8 @@ def test_blockhash(
 ) -> None:
     """Benchmark BLOCKHASH instruction accessing oldest allowed block."""
     # Create `chain_length` dummy blocks to fill the blockhash window.
-    blocks = [Block()] * chain_length
+    with TestPhaseManager.setup():
+        blocks = [Block()] * chain_length
 
     block_number = Op.AND(Op.GAS, 0xFF) if index is None else index
 

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -255,22 +255,24 @@ def test_storage_access_cold(
         + Op.RETURN(0, Op.MSIZE)
     )
     sender_addr = pre.fund_eoa()
-    setup_tx = Transaction(
-        to=None,
-        gas_limit=env.gas_limit,
-        data=creation_code,
-        sender=sender_addr,
-    )
+    with TestPhaseManager.setup():
+        setup_tx = Transaction(
+            to=None,
+            gas_limit=env.gas_limit,
+            data=creation_code,
+            sender=sender_addr,
+        )
 
     blocks = [Block(txs=[setup_tx])]
 
     contract_address = compute_create_address(address=sender_addr, nonce=0)
 
-    op_tx = Transaction(
-        to=contract_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    with TestPhaseManager.execution():
+        op_tx = Transaction(
+            to=contract_address,
+            gas_limit=gas_benchmark_value,
+            sender=pre.fund_eoa(),
+        )
     blocks.append(Block(txs=[op_tx]))
 
     benchmark_test(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
We introduce the test phase manager in previous PR, now this PR will label the benchmark tests with proper phases.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
This is required for issue #1586 to progress

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
