### PR TITLE
bug(test-cli-execute): multiple fixes to repair `execute recover`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/execute.py
@@ -92,8 +92,6 @@ recover = _create_execute_subcommand(
         "--destination=0x0000000000000000000000000000000000000000",
     ],
     command_logic_test_paths=[
-        Path(
-            "cli/pytest_commands/plugins/execute/execute_recover.py"
-        )
+        Path("cli/pytest_commands/plugins/execute/execute_recover.py")
     ],
 )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/execute.py
@@ -76,7 +76,7 @@ eth_config = _create_execute_subcommand(
     ],
     command_logic_test_paths=[
         Path(
-            "execution_testing/cli/pytest_commands/plugins/execute/eth_config/execute_eth_config.py"
+            "cli/pytest_commands/plugins/execute/eth_config/execute_eth_config.py"
         )
     ],
 )
@@ -87,13 +87,13 @@ recover = _create_execute_subcommand(
     "Recover funds from test executions using a remote RPC endpoint.",
     required_args=[
         "--rpc-endpoint=http://localhost:8545",
-        "--rpc-chain-id=1",
+        "--chain-id=1",
         "--start-eoa-index=1",
         "--destination=0x0000000000000000000000000000000000000000",
     ],
     command_logic_test_paths=[
         Path(
-            "execution_testing/cli/pytest_commands/plugins/execute/execute_recover.py"
+            "cli/pytest_commands/plugins/execute/execute_recover.py"
         )
     ],
 )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -174,7 +174,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # Configure the chain ID for the tests.
     rpc_chain_id = config.getoption("rpc_chain_id", None)
-    chain_id = config.getoption("chain_id")
+    chain_id = config.getoption("chain_id", None)
     if rpc_chain_id is not None or chain_id is not None:
         if rpc_chain_id is not None and chain_id is not None:
             if chain_id != rpc_chain_id:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_recover.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_recover.py
@@ -28,7 +28,8 @@ def test_recover_funds(
     tx_cost = refund_gas_limit * gas_price
     if remaining_balance < tx_cost:
         pytest.skip(
-            f"Balance {remaining_balance} is less than the transaction cost {tx_cost}"
+            f"Balance {remaining_balance} is less than the "
+            f"transaction cost {tx_cost}"
         )
 
     # Get the current nonce for this address from the RPC

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_recover.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_recover.py
@@ -31,12 +31,16 @@ def test_recover_funds(
             f"Balance {remaining_balance} is less than the transaction cost {tx_cost}"
         )
 
+    # Get the current nonce for this address from the RPC
+    current_nonce = eth_rpc.get_transaction_count(eoa)
+
     refund_tx = Transaction(
         sender=eoa,
         to=destination,
         gas_limit=refund_gas_limit,
         gas_price=gas_price,
         value=remaining_balance - tx_cost,
+        nonce=current_nonce,
     ).with_signature_and_sender()
 
     eth_rpc.send_wait_transaction(refund_tx)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/recover.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/recover.py
@@ -1,8 +1,14 @@
 """Pytest plugin to recover funds from a failed remote execution."""
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Generator, Literal
+
 import pytest
 
 from execution_testing.base_types import Address, HexNumber
+from execution_testing.forks import Paris
+from execution_testing.forks.helpers import Fork
 from execution_testing.test_types import EOA
 
 
@@ -51,7 +57,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     start_eoa_index = metafunc.config.option.start_eoa_index
 
     print(
-        f"Generating {max_index} test cases starting from index {start_eoa_index}"
+        f"Generating {max_index} test cases starting from index {start_eoa_index}"  # noqa: E501
     )
 
     indexes_keys = [
@@ -63,3 +69,22 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         indexes_keys,
         ids=[f"{index}-{eoa}" for index, eoa in indexes_keys],
     )
+
+
+@pytest.fixture(scope="session")
+def session_fork() -> Fork:
+    """Return a default fork for the recover command."""
+    return Paris
+
+
+@pytest.fixture(scope="session")
+def transactions_per_block() -> Literal[1]:
+    """Return the number of transactions per block for the recover command."""
+    return 1
+
+
+@pytest.fixture(scope="session")
+def session_temp_folder() -> Generator[Path, Any, None]:
+    """Return a temporary folder for the session."""
+    with TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
@@ -27,6 +27,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="RPC endpoint to an execution client",
     )
     remote_rpc_group.addoption(
+        "--chain-id",
+        action="store",
+        dest="chain_id",
+        required=False,
+        type=int,
+        default=None,
+        help="ID of the chain where the tests will be executed.",
+    )
+    remote_rpc_group.addoption(
         "--rpc-chain-id",
         action="store",
         dest="rpc_chain_id",
@@ -91,13 +100,28 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 def pytest_configure(config: pytest.Config) -> None:
     """Check if a chain ID configuration is provided."""
-    if (
-        config.getoption("rpc_chain_id") is None
-        and config.getoption("chain_id") is None
-    ):
+    rpc_chain_id = config.getoption("rpc_chain_id", None)
+    chain_id = config.getoption("chain_id", None)
+
+    if rpc_chain_id is None and chain_id is None:
         pytest.exit("No chain ID configuration found. Please use --chain-id.")
-    # Verify the chain ID configuration is consistent with the remote RPC
-    # endpoint
+
+    # Handle both --chain-id and deprecated --rpc-chain-id
+    if rpc_chain_id is not None and chain_id is not None:
+        if chain_id != rpc_chain_id:
+            pytest.exit(
+                "Conflicting chain ID configuration. "
+                "The --rpc-chain-id flag is deprecated and will be removed in a future "
+                "release. Use --chain-id instead."
+            )
+
+    # Set the chain ID
+    if chain_id is not None:
+        ChainConfigDefaults.chain_id = chain_id
+    elif rpc_chain_id is not None:
+        ChainConfigDefaults.chain_id = rpc_chain_id
+
+    # Verify the chain ID configuration is consistent with the remote RPC endpoint
     rpc_endpoint = config.getoption("rpc_endpoint")
     eth_rpc = EthRPC(rpc_endpoint)
     remote_chain_id = eth_rpc.chain_id()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-recover.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-recover.ini
@@ -2,7 +2,7 @@
 console_output_style = count
 minversion = 7.0
 python_files = *.py
-addopts = 
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.remote
     -p execution_testing.cli.pytest_commands.plugins.execute.recover
     -p execution_testing.cli.pytest_commands.plugins.help.help


### PR DESCRIPTION
## 🗒️ Description

## What was broken?
* The --chain-id option was defined in execute.execute plugin, which couldn't be loaded for recover because it filtered out tests without a fork parameter. So it refused to work without chain-id, but when you passed chain-id it didn't know what it is and failed
* Test path resolution had duplicate execution_testing/ prefix causing file not found errors
* The recovery test wasn't fetching the current nonce of the sender via RPC, so the resulting tx was invalid

## How to reproduce?
e.g. on sepolia:
`uv run execute recover --rpc-endpoint=https://SECRET1@rpc.srv1.snapshotter.sepolia.ethpandaops.io --tx-wait-timeout=180 --destination=ADDRESS_TO_REFUND_TO --start-eoa-index=SECRET2 --chain-id=11155111 --max-index=1`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://myheartteddy.com/wp-content/uploads/2025/01/capybara-plush-hamburger-duo-350x350.webp)
