### PR TITLE
chore(ci): generate genesis files for benchmark releases

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -1,0 +1,82 @@
+name: Build Benchmark Genesis Asset
+description: Generate benchmark_genesis.tar.gz from benchmark fixtures using Hive
+inputs:
+  fixtures_path:
+    description: "Path to the benchmark fixtures tarball"
+    required: true
+outputs:
+  genesis_tarball:
+    description: "Path to the generated benchmark_genesis.tar.gz"
+    value: ${{ steps.create-tarball.outputs.path }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Hive
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        repository: ethereum/hive
+        ref: master
+        path: hive
+
+    - name: Setup Go for Hive
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version: ">=1.24"
+        cache-dependency-path: hive/go.sum
+
+    - name: Build Hive
+      shell: bash
+      run: |
+        cd hive
+        go build .
+
+    - name: Extract benchmark fixtures
+      shell: bash
+      run: |
+        echo "Extracting fixtures from ${{ inputs.fixtures_path }}"
+        tar -xzf "${{ inputs.fixtures_path }}"
+        echo "Fixtures extracted successfully"
+
+    - name: Start Hive in dev mode
+      shell: bash
+      run: |
+        cd hive
+        ./hive --dev \
+          --client besu,go-ethereum,nethermind \
+          --client-file ../.github/configs/hive/latest_client_releases.yaml \
+          --docker.output &
+
+        echo "Waiting for Hive to be ready..."
+        for i in {1..30}; do
+          if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then
+            echo "Hive is ready!"
+            exit 0
+          fi
+          echo "Waiting... ($i/30)"
+          sleep 2
+        done
+        echo "Hive failed to start within timeout"
+        exit 1
+
+    - name: Extract genesis configs from clients
+      shell: bash
+      env:
+        HIVE_SIMULATOR: http://127.0.0.1:3000
+      run: |
+        echo "Running extract_config for benchmark fixtures..."
+        uv run extract_config \
+          --fixture fixtures/blockchain_tests_engine_x/pre_alloc/ \
+          --output genesis/ \
+          --hive-url http://127.0.0.1:3000
+
+        echo "Genesis configs extracted successfully"
+        ls -la genesis/
+
+    - name: Create benchmark_genesis.tar.gz
+      id: create-tarball
+      shell: bash
+      run: |
+        tar czf benchmark_genesis.tar.gz genesis/
+        echo "Created benchmark_genesis.tar.gz"
+        ls -lh benchmark_genesis.tar.gz
+        echo "path=benchmark_genesis.tar.gz" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -38,7 +38,18 @@ runs:
           uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
         else
           uv run fill -n ${{ steps.evm-builder.outputs.x-dist }} --evm-bin=${{ steps.evm-builder.outputs.evm-bin }} ${{ steps.properties.outputs.fill-params }} --output=fixtures_${{ inputs.release_name }}.tar.gz --build-name ${{ inputs.release_name }}
-        fi 
+        fi
+    - name: Generate Benchmark Genesis Files
+      if: contains(inputs.release_name, 'benchmark')
+      uses: ./.github/actions/build-benchmark-genesis
+      with:
+        fixtures_path: fixtures_${{ inputs.release_name }}.tar.gz
+    - name: Upload Benchmark Genesis Artifact
+      if: contains(inputs.release_name, 'benchmark')
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      with:
+        name: benchmark_genesis_${{ inputs.release_name }}
+        path: benchmark_genesis.tar.gz
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: fixtures_${{ inputs.release_name }}

--- a/.github/configs/hive/latest.yaml
+++ b/.github/configs/hive/latest.yaml
@@ -1,0 +1,49 @@
+# Hive client configuration file with latest release images
+
+# Geth (Go-Ethereum)
+# Docker Hub: https://hub.docker.com/r/ethereum/client-go
+- client: go-ethereum
+  nametag: ""
+  build_args:
+    baseimage: docker.io/ethereum/client-go
+    tag: latest
+
+# Nethermind
+# Docker Hub: https://hub.docker.com/r/nethermind/nethermind
+- client: nethermind
+  nametag: ""
+  build_args:
+    baseimage: docker.io/nethermind/nethermind
+    tag: latest
+
+# Besu (Hyperledger Besu)
+# Docker Hub: https://hub.docker.com/r/hyperledger/besu
+- client: besu
+  nametag: ""
+  build_args:
+    baseimage: docker.io/hyperledger/besu
+    tag: latest
+
+# Reth (Paradigm)
+# GHCR: https://ghcr.io/paradigmxyz/reth
+- client: reth
+  nametag: ""
+  build_args:
+    baseimage: ghcr.io/paradigmxyz/reth
+    tag: latest
+
+# Erigon
+# Docker Hub: https://hub.docker.com/r/erigontech/erigon
+- client: erigon
+  nametag: ""
+  build_args:
+    baseimage: docker.io/erigontech/erigon
+    tag: latest
+
+# Nimbus Execution Layer (nimbus-eth1)
+# Docker Hub: https://hub.docker.com/r/statusim/nimbus-eth1
+- client: nimbus-el
+  nametag: "" # latest-release
+  build_args:
+    baseimage: docker.io/statusim/nimbus-eth1
+    tag: linux-amd64-latest


### PR DESCRIPTION
## 🗒️ Description

Automates generation and attachment of `benchmark_genesis.tar.gz` asset to benchmark feature releases. This asset contains genesis configuration files extracted from Ethereum clients (besu, go-ethereum, nethermind) for all benchmark fixtures.

###  Changes

####  New Files

- `.github/actions/build-benchmark-genesis/action.yaml`: Composite action that:
  - Clones and builds Hive
  - Starts Hive in dev mode with 3 clients (besu, go-ethereum, nethermind)
  - Extracts genesis configs from `fixtures/blockchain_tests_engine_x/pre_alloc/` using extract_config CLI
  - Creates `benchmark_genesis.tar.gz` tarball
  - Cleans up Hive process

####  Modified Files

- `.github/actions/build-fixtures/action.yaml`: Added conditional steps (lines 42-54) to:
  - Call `build-benchmark-genesis` action when release name contains "benchmark"
  - Upload `benchmark_genesis.tar.gz` as workflow artifact

####  Behavior

The benchmark_genesis.tar.gz asset is automatically generated and attached to:
- ✅ benchmark feature releases (e.g., benchmark@v1.0.0)
- ✅ benchmark_develop feature releases (e.g., benchmark_develop@v1.0.0)
- ✅ Full releases that include the benchmark feature (e.g., v5.0.0)

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="387" height="599" alt="image" src="https://github.com/user-attachments/assets/edf4586d-1a40-4115-968b-8d7cc580bf98" />

