### PR TITLE
chore(ci): add sanity check for filling benchmark tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - mainnet
-      - 'forks/**'
+      - "forks/**"
   workflow_dispatch:
   pull_request:
 
@@ -97,6 +97,22 @@ jobs:
         env:
           PYPY_GC_MAX: "2G"
           PYPY_GC_MIN: "1G"
+
+  benchmark:
+    runs-on: [self-hosted-ghr, size-xl-x64]
+    needs: static
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          submodules: recursive
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build-evmone
+      - name: Fill benchmark tests
+        run: tox -e benchmark
 
   json_infra:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/tox.ini
+++ b/tox.ini
@@ -110,6 +110,21 @@ commands =
         --until Osaka \
         tests
 
+[testenv:benchmark]
+description = Fill the benchmark tests using EELS (with Python)
+commands =
+    fill \
+        --generate-all-formats \
+        --gas-benchmark-values 5 \
+        --evm-bin=evmone-t8n \
+        -m "benchmark and not state_test" \
+        -n auto --maxprocesses 10 --dist=loadgroup \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        --fork Prague \
+        tests/benchmark
+
 [testenv:optimized]
 description = Run unit tests for optimized state and ethash
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -111,11 +111,11 @@ commands =
         tests
 
 [testenv:benchmark]
-description = Fill the benchmark tests using EELS (with Python)
+description = Fill the benchmark tests using evmone-t8n (with Python)
 commands =
     fill \
         --generate-all-formats \
-        --gas-benchmark-values 5 \
+        --gas-benchmark-values 1 \
         --evm-bin=evmone-t8n \
         -m "benchmark and not state_test" \
         -n auto --maxprocesses 10 --dist=loadgroup \


### PR DESCRIPTION
## 🗒️ Description
Adds a test env to `tox` and a corresponding CI job to sanity check filling benchmark tests with `evmone`. 

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img width="949" height="623" alt="image" src="https://github.com/user-attachments/assets/b9fffb90-2f30-4906-80d5-b348d7038ad9" />


