### PR TITLE
fix(benchmark): fix failing benchmark cases

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -107,7 +107,9 @@ class BenchmarkCodeGenerator(ABC):
         code += Op.JUMP(len(setup)) if len(setup) > 0 else Op.PUSH0 + Op.JUMP
         # Pad the code to the maximum code size.
         if self.code_padding_opcode is not None:
-            code += self.code_padding_opcode * (max_code_size - len(code))
+            padding_size = max_code_size - len(code)
+            if padding_size > 0:
+                code += self.code_padding_opcode * padding_size
         self._validate_code_size(code, fork)
 
         return code

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -393,22 +393,26 @@ def test_ext_account_query_warm(
     # Setup
     post = {}
 
+    # Case 1: Completely empty account (no balance, no storage, no code)
     if not initial_balance and not initial_storage and empty_code:
         target_addr = pre.empty_account()
-    else:
-        kwargs: dict[str, Any] = {}
+    # Case 2: EOA with optional balance and storage
+    elif empty_code:
+        eoa_kwargs: dict[str, Any] = {}
         if initial_balance:
-            kwargs["balance"] = 100
+            eoa_kwargs["amount"] = 100
         if initial_storage:
-            kwargs["storage"] = {0: 0x1337}
-
-        if empty_code:
-            target_addr = pre.fund_eoa(**kwargs)
-        else:
-            code = Op.STOP + Op.JUMPDEST * 100
-            kwargs["code"] = code
-            target_addr = pre.deploy_contract(**kwargs)
-            post[target_addr] = Account(**kwargs)
+            eoa_kwargs["storage"] = {0: 0x1337}
+        target_addr = pre.fund_eoa(**eoa_kwargs)
+    # Case 3: Contract with optional balance and storage
+    else:
+        contract_kwargs: dict[str, Any] = {"code": Op.STOP + Op.JUMPDEST * 100}
+        if initial_balance:
+            contract_kwargs["balance"] = 100
+        if initial_storage:
+            contract_kwargs["storage"] = {0: 0x1337}
+        target_addr = pre.deploy_contract(**contract_kwargs)
+        post[target_addr] = Account(**contract_kwargs)
 
     benchmark_test(
         post=post,

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -48,7 +48,7 @@ def test_tload(
     if fixed_key and fixed_value:
         attack_block = Op.TLOAD(Op.CALLDATASIZE)
 
-    tx_data = b"42" if fixed_key and not fixed_value else 0
+    tx_data = b"42" if fixed_key and not fixed_value else b""
 
     benchmark_test(
         code_generator=ExtCallGenerator(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Fix the failing test cases:

- test_tload
- test_return_revert
- test_ext_account_query_warm

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Small follow-up to:
- https://github.com/ethereum/execution-specs/pull/1768

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
