### PR TITLE
Bug: Update Codecov integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,6 +101,9 @@ jobs:
   json_infra:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
@@ -112,12 +115,30 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Run json infra tests
         run: tox -e json_infra
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+      - name: Summarize coverage in GitHub summary
+        shell: bash
+        run: |
+          python - <<'PY' > coverage_pct.txt
+          import xml.etree.ElementTree as ET
+          try:
+              tree = ET.parse('.tox/coverage.xml')
+              root = tree.getroot()
+              cov = float(root.get('line-rate', '0'))
+              pct = round(cov * 100, 2)
+              print(f"Coverage: {pct}%")
+          except Exception as e:
+              print(f"Coverage: unavailable ({e})")
+          PY
+          echo "## Coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo "$(cat coverage_pct.txt)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage to Codecov (required)
+        uses: codecov/codecov-action@v4
         with:
           files: .tox/coverage.xml
           flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
   optimized:
     runs-on: [self-hosted-ghr, size-xl-x64]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Codecov updated its GitHub integration and now requires OIDC + Codecov App. See: https://about.codecov.io/blog/codecov-is-updating-its-github-integration/

**Maintainer action:** Please install the [Codecov GitHub App](https://github.com/apps/codecov) on this repository or the `ethereum` organization to enable OIDC-based uploads.

This PR updates the GitHub Actions workflow to be compatible with the new Codecov integration and ensures that coverage reports are correctly uploaded and annotated on PRs.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

Fixes #1458 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
