### PR TITLE
feat(tests): add benchmark test & layout for MLOAD & MSTORE

### DIFF
--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -104,3 +104,71 @@ def test_mcopy(
             attack_block=attack_block, cleanup=mem_touch
         ),
     )
+
+@pytest.mark.parametrize("opcode", [Op.MLOAD, Op.MSTORE, Op.MSTORE8])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [
+        pytest.param("sequential", id="sequential"),
+        pytest.param("sparse", id="sparse"),
+        pytest.param("overlapping", id="overlapping"),
+    ],
+)
+@pytest.mark.parametrize("overwrite_existing", [True, False])
+def test_memory_layout_access(
+    benchmark_test: BenchmarkTestFiller,
+    opcode: Op,
+    memory_layout: str,
+    overwrite_existing: bool,
+) -> None:
+    """
+    Benchmark memory access with custom layouts and overwriting scenarios.
+    
+    Variants:
+    - memory_layout: Memory initialization pattern
+      (sequential=stride 32, sparse=stride 1000, overlapping=stride 16)
+    - overwrite_existing: Pre-write to the access offset before operations
+    - opcode: Memory operation (MLOAD, MSTORE, MSTORE8)
+    """
+    setup = Bytecode()
+    
+    # Initialize memory with pattern
+    if memory_layout == "sequential":
+        # Write sequential 32-byte words: 0, 32, 64, 96, 128...
+        for i in range(10):
+            setup += Op.MSTORE(i * 32, i)
+        access_offset = 64  # Access middle of initialized memory
+    elif memory_layout == "sparse":
+        # Write to sparse locations: 0, 1000, 2000, 3000...
+        for i in range(10):
+            setup += Op.MSTORE(i * 1000, i)
+        access_offset = 2000  # Access sparse location
+    elif memory_layout == "overlapping":
+        # Overlapping 32-byte words (16-byte stride)
+        for i in range(20):
+            setup += Op.MSTORE(i * 16, i)
+        access_offset = 48  # Access overlapping region
+    
+    # Overwrite pattern: pre-write to the access offset
+    if overwrite_existing:
+        if opcode == Op.MSTORE8:
+            setup += Op.MSTORE8(access_offset, 0xEF)
+        else:
+            setup += Op.MSTORE(access_offset, 0xDEADBEEF)
+    
+    # Prepare stack for operation
+    setup += Op.PUSH1(42) + Op.PUSH2(access_offset)
+    
+    # Attack block performs the memory operation
+    attack_block = (
+        Op.POP(Op.MLOAD(Op.DUP1))
+        if opcode == Op.MLOAD
+        else opcode(Op.DUP2, Op.DUP2)
+    )
+    
+    benchmark_test(
+        code_generator=JumpLoopGenerator(
+            setup=setup,
+            attack_block=attack_block,
+        ),
+    )

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -112,6 +112,7 @@ def test_mcopy(
         ),
     )
 
+
 @pytest.mark.parametrize("opcode", [Op.MLOAD, Op.MSTORE, Op.MSTORE8])
 @pytest.mark.parametrize(
     "memory_layout",
@@ -130,7 +131,7 @@ def test_memory_layout_access(
 ) -> None:
     """
     Benchmark memory access with custom layouts and overwriting scenarios.
-    
+
     Variants:
     - memory_layout: Memory initialization pattern
       (sequential=stride 32, sparse=stride 1000, overlapping=stride 16)
@@ -138,7 +139,7 @@ def test_memory_layout_access(
     - opcode: Memory operation (MLOAD, MSTORE, MSTORE8)
     """
     setup = Bytecode()
-    
+
     # Initialize memory with pattern
     if memory_layout == "sequential":
         # Write sequential 32-byte words: 0, 32, 64, 96, 128...
@@ -155,24 +156,24 @@ def test_memory_layout_access(
         for i in range(20):
             setup += Op.MSTORE(i * 16, i)
         access_offset = 48  # Access overlapping region
-    
+
     # Overwrite pattern: pre-write to the access offset
     if overwrite_existing:
         if opcode == Op.MSTORE8:
             setup += Op.MSTORE8(access_offset, 0xEF)
         else:
             setup += Op.MSTORE(access_offset, 0xDEADBEEF)
-    
+
     # Prepare stack for operation
     setup += Op.PUSH1(42) + Op.PUSH2(access_offset)
-    
+
     # Attack block performs the memory operation
     attack_block = (
         Op.POP(Op.MLOAD(Op.DUP1))
         if opcode == Op.MLOAD
         else opcode(Op.DUP2, Op.DUP2)
     )
-    
+
     benchmark_test(
         code_generator=JumpLoopGenerator(
             setup=setup,


### PR DESCRIPTION
## 🗒️ Description
close #1783 

I created `test_memory_layout_access` to keep `test_memory_access` simple. Please let me know if extending  `test_memory_access` would be better.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.
