### PR TITLE
refactor(test-benchmark): optimize benchmark test cases

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -151,8 +151,6 @@ class BenchmarkCodeGenerator(ABC):
         if self.fixed_opcode_count is not None:
             max_iterations = min(max_iterations, 1000)
 
-        print(f"max_iterations: {max_iterations}")
-
         # TODO: Unify the PUSH0 and PUSH1 usage.
         code = setup + Op.JUMPDEST + repeated_code * max_iterations
         if self.fixed_opcode_count is None:

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -327,31 +327,20 @@ def test_extcodecopy_warm(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     copied_size: int,
-    gas_benchmark_value: int,
 ) -> None:
     """Benchmark EXTCODECOPY instruction."""
     copied_contract_address = pre.deploy_contract(
         code=Op.JUMPDEST * copied_size,
     )
 
-    execution_code = (
-        Op.PUSH10(copied_size)
-        + Op.PUSH20(copied_contract_address)
-        + While(
-            body=Op.EXTCODECOPY(Op.DUP4, 0, 0, Op.DUP2),
-        )
-    )
-    execution_code_address = pre.deploy_contract(code=execution_code)
-    tx = Transaction(
-        to=execution_code_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
+    benchmark_test(
+        code_generator=JumpLoopGenerator(
+            setup=Op.PUSH10(copied_size) + Op.PUSH20(copied_contract_address),
+            attack_block=Op.EXTCODECOPY(Op.DUP4, 0, 0, Op.DUP2),
+        ),
     )
 
-    benchmark_test(tx=tx)
 
-
-@pytest.mark.repricing(absent_target=False)
 @pytest.mark.parametrize(
     "opcode",
     [


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Optimize some benchmark test cases to enable code generator in benchmark test wrapper.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
