### PR TITLE
bug(test-benchmark): skip benchmark `test_blockhash`

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -48,22 +48,25 @@ def test_block_context_ops(
 
 @pytest.mark.repricing
 @pytest.mark.parametrize(
-    "index",
+    "index,chain_length",
     [
-        0,
-        1,
-        256,
-        257,
-        pytest.param(None, id="random"),
+        pytest.param(0, 256, id="genesis"),
+        pytest.param(1, 256, id="block_1"),
+        pytest.param(256, 256, id="block_256"),
+        pytest.param(257, 256, id="current_block"),
+        pytest.param(None, 256, id="random"),
     ],
 )
+@pytest.mark.slow("Generates long chain")
+@pytest.mark.skip("Blocks release generation")
 def test_blockhash(
     benchmark_test: BenchmarkTestFiller,
     index: int | None,
+    chain_length: int,
 ) -> None:
     """Benchmark BLOCKHASH instruction accessing oldest allowed block."""
-    # Create 256 dummy blocks to fill the blockhash window.
-    blocks = [Block()] * 256
+    # Create `chain_length` dummy blocks to fill the blockhash window.
+    blocks = [Block()] * chain_length
 
     block_number = Op.AND(Op.GAS, 0xFF) if index is None else index
 


### PR DESCRIPTION
## 🗒️ Description
Skip `tests/benchmark/compute/instruction/test_block_context.py::test_blockhash` to unblock benchmark releases.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
