### PR TITLE
docs: Update package names from ethereum_test_* to execution_testing.*

### DIFF
--- a/docs/getting_started/repository_overview.md
+++ b/docs/getting_started/repository_overview.md
@@ -4,42 +4,43 @@
 The most relevant folders and files in the repo are:
 
 ```text
-📁 execution-test-specs/
-├─╴📁 tests/                     # test cases
-│   ├── 📁 eips/
-│   ├── 📁 vm/
+📁 execution-specs/
+├─╴📁 tests/                     # test cases organized by fork
+│   ├── 📁 amsterdam/
+│   ├── 📁 osaka/
+│   ├── 📁 prague/
 │   └── 📁 ...
 ├─╴📁 fixtures/                  # default fixture output dir
 │   ├── 📁 blockchain_tests/
 │   ├── 📁 blockchain_tests_engine/
 │   ├── 📁 state_tests/
 │   └── 📁 ...
-├─╴📁 src/                       # library & framework packages
-│   ├── 📁 execution_testing/
+├─╴📁 packages/                  # library & framework packages
+│   └── 📁 testing/
+│       └── 📁 src/
+│           └── 📁 execution_testing/
+├─╴📁 src/                       # execution spec packages
+│   ├── 📁 ethereum/
 │   └── 📁 ...
 ├─╴📁 docs/                      # markdown documentation
-│   ├── 📁 getting_started
-│   ├── 📁 dev
+│   ├── 📁 getting_started/
+│   ├── 📁 dev/
 │   └── 📁 ...
-├─╴📁 .vscode/                   # visual studio code config
-│   ├── 📄 settings.recommended.json # copy to settings.json
-│   ├── 📄 launch.recommended.json
-│   └── 📄 extensions.json
 └── 📄 whitelist.txt             # spellcheck dictionary
 ```
 
 #### `tests/`
 
-Contains the implementation of the Ethereum consensus tests available in this repository.
+Contains the implementation of the Ethereum consensus tests available in this repository, organized by fork.
+
+#### `packages/`
+
+Contains the `execution_testing` package which provides tools to define test cases and to interface with the `evm t8n` command. Additionally, it contains packages that enable test case execution by customizing pytest which acts as the test framework.
 
 #### `src/`
 
-Contains various packages that help to define test cases and to interface with the `evm t8n` command. Additionally, it contains some packages that enable test case execution by customizing pytest which acts as the test framework.
+Contains the Ethereum execution spec packages.
 
 #### `docs/`
 
 Contains documentation configuration and source files.
-
-#### `.vscode/`
-
-See [VS Code Setup](./setup_vs_code.md).

--- a/docs/getting_started/repository_overview.md
+++ b/docs/getting_started/repository_overview.md
@@ -15,8 +15,7 @@ The most relevant folders and files in the repo are:
 │   ├── 📁 state_tests/
 │   └── 📁 ...
 ├─╴📁 src/                       # library & framework packages
-│   ├── 📁 ethereum_test_fork/
-│   ├── 📁 ethereum_test_tools/
+│   ├── 📁 execution_testing/
 │   └── 📁 ...
 ├─╴📁 docs/                      # markdown documentation
 │   ├── 📁 getting_started

--- a/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
+++ b/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md
@@ -1040,10 +1040,10 @@ Verify, given multiple initial values, that a block is accepted or rejected depe
 ### Framework Changes
 
 - Add the new header field to the relevant objects:
-    - `ethereum_test_fixtures.FixtureHeader`.
-    - `ethereum_test_fixtures.FixtureExecutionPayload`.
-    - `ethereum_test_specs.Header`.
-- Add the appropriate `header_*_required` fork method to `BaseFork` in `ethereum_test_forks`.
+    - `execution_testing.fixtures.FixtureHeader`.
+    - `execution_testing.fixtures.FixtureExecutionPayload`.
+    - `execution_testing.specs.Header`.
+- Add the appropriate `header_*_required` fork method to `BaseFork` in `execution_testing.forks`.
 
 ## New Block Body Field
 
@@ -1068,10 +1068,10 @@ Verify, given multiple initial values, that a block is accepted or rejected depe
 ### Framework Changes
 
 - Add the new body field to the relevant objects.
-    - `ethereum_test_fixtures.FixtureBlockBase`.
-    - `ethereum_test_fixtures.FixtureEngineNewPayload`.
-    - `ethereum_test_specs.Block`.
-- Modify `ethereum_test_specs.BlockchainTest` filling behavior to account for the new block field.
+    - `execution_testing.fixtures.FixtureBlockBase`.
+    - `execution_testing.fixtures.FixtureEngineNewPayload`.
+    - `execution_testing.specs.Block`.
+- Modify `execution_testing.specs.BlockchainTest` filling behavior to account for the new block field.
 
 ## Gas Cost Changes
 


### PR DESCRIPTION
## 🗒️ Description

Update documentation to reflect package renaming from `ethereum_test_*` to `execution_testing.*` namespace (follow-up to PR #1654).

Changes:
- Update module references in `eip_testing_checklist_template.md`
- Update directory structure in `repository_overview.md`

All module references now use the unified `execution_testing.*` namespace.

## 🔗 Related Issues or PRs

Fixes #1672

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails
    - Note: Changes are documentation-only (markdown files) and have been manually verified.

- [x] All: PR title adheres to the repo standard - starts with `type(scope):`
    - Commit message: `docs: update package names from ethereum_test_* to execution_testing.*`

- [ ] All: Considered adding an entry to CHANGELOG.md
    - Not needed: This is a documentation-only change following up on PR #1654

- [x] All: Considered updating the online docs
    - Updated: `docs/getting_started/repository_overview.md` and `docs/writing_tests/checklist_templates/eip_testing_checklist_template.md`

- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

- [ ] Tests: Not applicable - No new tests added

#### Cute Animal Picture

![Cute Animal](https://pin.it/56m1VJUGm)