### PR TITLE
feat(tests): add more sload/sstore combos

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -518,6 +518,8 @@ APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
 @pytest.mark.parametrize(
     "sload_percent,sstore_percent",
     [
+        pytest.param(10, 90, id="10-90"),
+        pytest.param(30, 70, id="30-70"),
         pytest.param(50, 50, id="50-50"),
         pytest.param(70, 30, id="70-30"),
         pytest.param(90, 10, id="90-10"),


### PR DESCRIPTION
## 🗒️ Description
This tests adds the 10-90 and 30-70 scenarios to the SLOAD-SSTORE multi-opcode tests to help triaging the worst case.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
