### PR TITLE
fix(ci): fix hive config file path action

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -43,7 +43,7 @@ runs:
         cd hive
         ./hive --dev \
           --client besu,go-ethereum,nethermind \
-          --client-file ../.github/configs/hive/latest_client_releases.yaml \
+          --client-file ../.github/configs/hive/latest.yaml \
           --docker.output &
 
         echo "Waiting for Hive to be ready..."


### PR DESCRIPTION
## 🗒️ Description
Fixes an incorrect path to the hive client config file that got merged in #1778.
Error:
https://github.com/ethereum/execution-specs/actions/runs/19392150069/job/55487132196#step:5:2100

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
- #1778 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="1219" height="630" alt="image" src="https://github.com/user-attachments/assets/78c4a624-e57d-4cdb-8a84-2c9621f8222b" />
