### PR TITLE
fix(test_blockhash): Excluded engine x format for test_blockhash to avoid extreme slowdown

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -220,6 +220,7 @@ class BenchmarkTest(BaseTest):
     supported_markers: ClassVar[Dict[str, str]] = {
         "blockchain_test_engine_only": "Only generate a blockchain test engine fixture",
         "blockchain_test_only": "Only generate a blockchain test fixture",
+        "blockchain_test_no_engine_x": "Exclude blockchain test engine x fixture (for tests that are slow with pre-allocation groups)",
         "repricing": "Mark test as reference test for gas repricing analysis",
     }
 
@@ -306,10 +307,13 @@ class BenchmarkTest(BaseTest):
         """
         del fork
 
-        if "blockchain_test_only" in [m.name for m in markers]:
+        marker_names = [m.name for m in markers]
+        if "blockchain_test_only" in marker_names:
             return fixture_format != BlockchainFixture
-        if "blockchain_test_engine_only" in [m.name for m in markers]:
+        if "blockchain_test_engine_only" in marker_names:
             return fixture_format != BlockchainEngineFixture
+        if "blockchain_test_no_engine_x" in marker_names:
+            return fixture_format == BlockchainEngineXFixture
         return False
 
     def get_genesis_environment(self) -> Environment:

--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -47,6 +47,7 @@ def test_block_context_ops(
 
 
 @pytest.mark.repricing
+@pytest.mark.blockchain_test_no_engine_x
 @pytest.mark.parametrize(
     "index,chain_length",
     [
@@ -64,6 +65,17 @@ def test_blockhash(
     index: int | None,
     chain_length: int,
 ) -> None:
+    """
+    Benchmark BLOCKHASH instruction accessing oldest allowed block.
+
+    Note: This test is excluded from engine x format generation because it
+    creates 256 empty blocks which are particularly slow to process in
+    pre-allocation grouping mode. The test still generates blockchain_test and
+    blockchain_test_engine formats which are sufficient for benchmarking
+    purposes.
+    """
+    # Create 256 dummy blocks to fill the blockhash window.
+    blocks = [Block()] * 256
     """Benchmark BLOCKHASH instruction accessing oldest allowed block."""
     # Create `chain_length` dummy blocks to fill the blockhash window.
     blocks = [Block()] * chain_length


### PR DESCRIPTION
fix(test_blockhash): Exclude engine x format for test_blockhash to avoid extreme slowdown

Fixed issue #1792 by excluding the engine x format for `test_blockhash`, which is extremely slow in the pre-allocation grouping mode.

## 🛠️ Changes

### Added marker to disable Engine X for slow tests
- Introduced new marker `blockchain_test_no_engine_x` in **BenchmarkTest**.
- Added the marker to `supported_markers` with proper documentation.
- Updated `discard_fixture_format_by_marks()` so that when this marker is present, the `BlockchainEngineXFixture` format is excluded.

### Applied marker to `test_blockhash`
- Added the new marker to `test_blockhash`.
- Included a docstring explaining why Engine X is excluded for this test.
- Test still generates:
  - `blockchain_test`
  - `blockchain_test_engine`
  formats as usual; only Engine X is skipped.

## 🔗 Related Issues or PRs
- #1792

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also Code Standards:
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the repo standard — must start with `type(scope):`
- [ ] All: Considered adding an entry to `CHANGELOG.md`
- [ ] All: Considered updating the online docs in `./docs/`
- [x] All: Set appropriate labels for the changes (maintainers only)
- [] Tests: Ran `mkdocs serve` locally and verified auto-generated docs for new tests in the Test Case Reference
- [ ] Tests: For PRs implementing a missed test case, updated the post-mortem document
- [ ] Ported Tests: Assigned `@ported_from` marker if applicable

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
