### PR TITLE
feat(benchmark): separate pre-alloc group for `blockhash`

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -58,7 +58,7 @@ def test_block_context_ops(
     ],
 )
 @pytest.mark.slow("Generates long chain")
-@pytest.mark.skip("Blocks release generation")
+@pytest.mark.pre_alloc_group("separate", reason="Generates long chain")
 def test_blockhash(
     benchmark_test: BenchmarkTestFiller,
     index: int | None,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Separate the `blockhash` preallocation group from the rest of the benchmark pre-allocation.

After doing so, the `blockhash` benchmark with the `release` parameter takes ~90 minutes to run. And the rest of the benchmark tests takes roughly 6 hours ([reference](https://github.com/ethereum/execution-specs/actions/runs/19451519257)).
<img width="999" height="75" alt="Screenshot 2025-11-18 at 7 05 55 AM" src="https://github.com/user-attachments/assets/8c7c6cfc-d72b-41f5-b54b-3595d1fbcefa" />


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue #1792 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
