### PR TITLE
fix(github): Fix benchmark genesis generation

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -38,6 +38,7 @@ runs:
         echo "Fixtures extracted successfully"
 
     - name: Start Hive in dev mode
+      id: start-hive
       shell: bash
       run: |
         cd hive
@@ -45,18 +46,35 @@ runs:
           --client besu,go-ethereum,nethermind \
           --client-file ../.github/configs/hive/latest_client_releases.yaml \
           --docker.output &
+        
+        export HIVE_PID=$!
+        export HIVE_SIMULATOR=http://127.0.0.1:3000
 
-        echo "Waiting for Hive to be ready..."
-        for i in {1..30}; do
-          if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then
-            echo "Hive is ready!"
-            exit 0
+        echo "Waiting for Hive to be ready, pid=$HIVE_PID"
+        deadline=$((SECONDS + 600))
+        
+        while :; do
+          # condition 1: time is up
+          if (( SECONDS >= deadline )); then
+            echo "Hive failed to start within timeout"
+            exit 1
           fi
-          echo "Waiting... ($i/30)"
-          sleep 2
+
+          # condition 2: process exited
+          if ! kill -0 "$HIVE_PID" 2>/dev/null; then
+            echo "Hive process died"
+            exit 1
+          fi
+
+          # condition 3: curl succeeded
+          if curl -s $HIVE_SIMULATOR > /dev/null; then
+            echo "Hive is ready!"
+            break
+          fi
+          sleep 1
         done
-        echo "Hive failed to start within timeout"
-        exit 1
+
+        echo "hive_pid=$HIVE_PID" >> "$GITHUB_OUTPUT"
 
     - name: Extract genesis configs from clients
       shell: bash
@@ -67,10 +85,16 @@ runs:
         uv run extract_config \
           --fixture fixtures/blockchain_tests_engine_x/pre_alloc/ \
           --output genesis/ \
-          --hive-url http://127.0.0.1:3000
+          --hive-url $HIVE_SIMULATOR
 
         echo "Genesis configs extracted successfully"
         ls -la genesis/
+
+    - name: Stop Hive
+      shell: bash
+      run: |
+
+        kill -SIGINT ${{ steps.start-hive.outputs.path }}
 
     - name: Create benchmark_genesis.tar.gz
       id: create-tarball

--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -40,15 +40,15 @@ runs:
     - name: Start Hive in dev mode
       id: start-hive
       shell: bash
+      env:
+        HIVE_SIMULATOR: http://127.0.0.1:3000
       run: |
         cd hive
         ./hive --dev \
           --client besu,go-ethereum,nethermind \
           --client-file ../.github/configs/hive/latest.yaml \
           --docker.output &
-        
         export HIVE_PID=$!
-        export HIVE_SIMULATOR=http://127.0.0.1:3000
 
         echo "Waiting for Hive to be ready, pid=$HIVE_PID"
         deadline=$((SECONDS + 600))

--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -44,7 +44,7 @@ runs:
         cd hive
         ./hive --dev \
           --client besu,go-ethereum,nethermind \
-          --client-file ../.github/configs/hive/latest_client_releases.yaml \
+          --client-file ../.github/configs/hive/latest.yaml \
           --docker.output &
         
         export HIVE_PID=$!

--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -74,14 +74,8 @@ runs:
           sleep 1
         done
 
-        echo "hive_pid=$HIVE_PID" >> "$GITHUB_OUTPUT"
-
-    - name: Extract genesis configs from clients
-      shell: bash
-      env:
-        HIVE_SIMULATOR: http://127.0.0.1:3000
-      run: |
         echo "Running extract_config for benchmark fixtures..."
+        cd ..
         uv run extract_config \
           --fixture fixtures/blockchain_tests_engine_x/pre_alloc/ \
           --output genesis/ \
@@ -89,12 +83,6 @@ runs:
 
         echo "Genesis configs extracted successfully"
         ls -la genesis/
-
-    - name: Stop Hive
-      shell: bash
-      run: |
-
-        kill -SIGINT ${{ steps.start-hive.outputs.path }}
 
     - name: Create benchmark_genesis.tar.gz
       id: create-tarball


### PR DESCRIPTION
## 🗒️ Description
Fix benchmark genesis generation.

To reproduce, build the benchmark release using [`act`](https://github.com/nektos/act) locally:

```bash
act push -e ./benchmark-tag.json -W ./.github/workflows/fixture_feature_release.yaml -P self-hosted-ghr=ghcr.io/catthehacker/ubuntu:act-latest -P size-gigachungus-x64=ghcr.io/catthehacker/ubuntu:act-latest -s GITHUB_TOKEN=YOUR_GITHUB_TOKEN
```
Where `benchmark-tag.json` contains:
```json
{
    "ref": "refs/tags/tests-benchmark@v0.0.9",
    "ref_type": "tag"
}
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t4.ftcdn.net/jpg/07/16/31/15/360_F_716311575_XgBANglhJiIGGlyQ69AFxjtHq0gCwWex.jpg)
