### PR TITLE
feat(logging): add filepath+linenumber to logs

### DIFF
--- a/packages/testing/src/execution_testing/logging/logger.py
+++ b/packages/testing/src/execution_testing/logging/logger.py
@@ -86,8 +86,7 @@ logger = get_logger(__name__)
 
 class UTCFormatter(logging.Formatter):
     """
-    Log formatter that formats UTC timestamps with milliseconds and +00:00
-    suffix.
+    Log formatter that formats UTC timestamps without milliseconds.
     """
 
     def formatTime(self, record: LogRecord, datefmt: str | None = None) -> str:  # noqa: D102,N802
@@ -95,7 +94,17 @@ class UTCFormatter(logging.Formatter):
         del datefmt
 
         dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
-        return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "+00:00"
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    def format(self, record: LogRecord) -> str:
+        """Format with relative pathname from current working directory."""
+        # Make pathname relative to cwd
+        try:
+            record.pathname = "./" + str(Path(record.pathname).relative_to(Path.cwd()))
+        except ValueError:
+            # If path is not relative to cwd, keep as is
+            pass
+        return super().format(record)
 
 
 class ColorFormatter(UTCFormatter):
@@ -163,7 +172,9 @@ def configure_logging(
     log_level: int | str = "INFO",
     log_file: Optional[str | Path] = None,
     log_to_stdout: bool = True,
-    log_format: str = "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    log_format: str = (
+        "%(asctime)s [%(levelname)s] %(pathname)s:%(lineno)d: %(message)s"
+    ),
     use_color: Optional[bool] = None,
 ) -> Optional[logging.FileHandler]:
     """

--- a/packages/testing/src/execution_testing/logging/logger.py
+++ b/packages/testing/src/execution_testing/logging/logger.py
@@ -100,7 +100,9 @@ class UTCFormatter(logging.Formatter):
         """Format with relative pathname from current working directory."""
         # Make pathname relative to cwd
         try:
-            record.pathname = "./" + str(Path(record.pathname).relative_to(Path.cwd()))
+            record.pathname = "./" + str(
+                Path(record.pathname).relative_to(Path.cwd())
+            )  # noqa: E501
         except ValueError:
             # If path is not relative to cwd, keep as is
             pass
@@ -159,7 +161,7 @@ class LogLevel:
 
         valid = ", ".join(logging._nameToLevel.keys())
         raise ValueError(
-            f"Invalid log level '{value}'. Expected one of: {valid} or a number."
+            f"Invalid log level '{value}'. Expected: {valid} or a number."
         )
 
 

--- a/packages/testing/src/execution_testing/logging/tests/test_logging.py
+++ b/packages/testing/src/execution_testing/logging/tests/test_logging.py
@@ -7,7 +7,6 @@ including both the standalone configuration and the pytest integration.
 
 import io
 import logging
-import re
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -103,9 +102,14 @@ class TestFormatters:
         )
 
         formatted = formatter.format(record)
-        assert re.match(
-            r"2021-01-01 00:00:00\.\d{3}\+00:00: Test message", formatted
-        )
+
+        # logs contain
+        #       timestamp
+        assert "2021-01-01 00:00:00" in formatted
+        #       message
+        assert "Test message" in formatted
+        #       filepath
+        assert "/tests/test_logging.py" in formatted
 
     def test_color_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that ColorFormatter adds color codes to the log level."""

--- a/packages/testing/src/execution_testing/logging/tests/test_logging.py
+++ b/packages/testing/src/execution_testing/logging/tests/test_logging.py
@@ -108,8 +108,6 @@ class TestFormatters:
         assert "2021-01-01 00:00:00" in formatted
         #       message
         assert "Test message" in formatted
-        #       filepath
-        assert "/tests/test_logging.py" in formatted
 
     def test_color_formatter(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that ColorFormatter adds color codes to the log level."""


### PR DESCRIPTION
## 🗒️ Description
With this PR a logged line from our custom logging plugin appears as e.g.:
`2025-11-20 13:53:22 [INFO] ./tests/frontier/opcodes/test_dup.py:60: hello`
Before it would vaguely describe the name of the pytest plugin (still visible now when errors occur in what pytest prints) and you still would not know in which file and which line things happened. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
