### PR TITLE
fix(test-types): format `Transaction` values as readable hex-strings instead of raw bytes (#1803)

### DIFF
--- a/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
+++ b/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
@@ -89,7 +89,6 @@ def format_code(code: str) -> str:
                 str(formatter_path),
                 "format",
                 str(input_file_path),
-                "--quiet",
                 "--no-cache",
                 "--config",
                 str(config_path),
@@ -100,7 +99,8 @@ def format_code(code: str) -> str:
         if result.returncode != 0:
             raise Exception(
                 f"Error formatting code using formatter '{formatter_path}': "
-                f"{result.stderr}"
+                f"returncode={result.returncode}, stdout={result.stdout!r}, "
+                f"stderr={result.stderr!r}"
             )
 
         # Return the formatted source code

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -848,8 +848,8 @@ class Transaction(
         """
         Format a field value for string representation.
 
-        Uses hex encoding for any value that supports it
-        (Address, Bytes, Hash, HexNumber, etc).
+        Uses decimal for numeric values (int, HexNumber, etc.) and
+        hex encoding for Address, Bytes, Hash, etc.
         """
         if value is None:
             return "None"

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -1,7 +1,6 @@
 """Transaction-related types for Ethereum tests."""
 
 from dataclasses import dataclass
-import decimal
 from enum import IntEnum
 from functools import cached_property
 import numbers

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -856,11 +856,6 @@ class Transaction(
 
         # fields like 'value' should be shown as decimal number
         if isinstance(value, numbers.Number):
-            if isinstance(value, decimal.Decimal):
-                # Convert to string to avoid scientific notation (1E-9)
-                # while removing unnecessary trailing zeros (100.000000 -> 100)
-                return "{:f}".format(value).rstrip("0").rstrip(".")
-
             # Force decimal representation for int subclasses like HexNumber
             if isinstance(value, int):
                 return str(int(value))

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -852,7 +852,7 @@ class Transaction(
         if value is None:
             return "None"
         elif hasattr(value, "hex"):
-            return value.hex()
+            return f'"{value.hex()}"'
         else:
             return repr(value)
 

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -861,6 +861,10 @@ class Transaction(
                 # while removing unnecessary trailing zeros (100.000000 -> 100)
                 return "{:f}".format(value).rstrip("0").rstrip(".")
 
+            # Force decimal representation for int subclasses like HexNumber
+            if isinstance(value, int):
+                return str(int(value))
+
             return str(value)
 
         # fields like 'to' should be shown as hex string

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -842,6 +842,37 @@ class Transaction(
         else:
             return gas_price * gas_limit + self.value
 
+    def _format_field_value(self, value: Any) -> str:
+        """
+        Format a field value for string representation.
+
+        Uses hex encoding for any value that supports it
+        (Address, Bytes, Hash, HexNumber, etc).
+        """
+        if value is None:
+            return "None"
+        elif hasattr(value, "hex"):
+            return value.hex()
+        else:
+            return repr(value)
+
+    def __repr__(self) -> str:
+        """
+        Return string representation with hex-encoded values for
+        applicable fields.
+        """
+        field_strs = []
+        for field_name in self.__class__.model_fields:
+            value = getattr(self, field_name)
+            formatted_value = self._format_field_value(value)
+            field_strs.append(f"{field_name}={formatted_value}")
+
+        return f"{self.__class__.__name__}({', '.join(field_strs)})"
+
+    def __str__(self) -> str:
+        """Return the repr string representation."""
+        return self.__repr__()
+
 
 class NetworkWrappedTransaction(CamelModel, RLPSerializable):
     """

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -1,8 +1,10 @@
 """Transaction-related types for Ethereum tests."""
 
 from dataclasses import dataclass
+import decimal
 from enum import IntEnum
 from functools import cached_property
+import numbers
 from typing import Any, ClassVar, Dict, Generic, List, Literal, Self, Sequence
 
 import ethereum_rlp as eth_rlp
@@ -851,10 +853,21 @@ class Transaction(
         """
         if value is None:
             return "None"
-        elif hasattr(value, "hex"):
+
+        # fields like 'value' should be shown as decimal number
+        if isinstance(value, numbers.Number):
+            if isinstance(value, decimal.Decimal):
+                # Convert to string to avoid scientific notation (1E-9)
+                # while removing unnecessary trailing zeros (100.000000 -> 100)
+                return "{:f}".format(value).rstrip("0").rstrip(".")
+
+            return str(value)
+
+        # fields like 'to' should be shown as hex string
+        if hasattr(value, "hex") and callable(value.hex):
             return f'"{value.hex()}"'
-        else:
-            return repr(value)
+
+        return repr(value)
 
     def __repr__(self) -> str:
         """


### PR DESCRIPTION
## 🗒️ Description
```
a = Transaction()
print(f"{a}")
```
Before this PR the resulting log is unreadable, you don't even see who is sending to who. With this PR you get readable addresses 0x...

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture
<img src="https://cdn.discordapp.com/attachments/1337018504141864963/1460628488066171106/IMG_0019.jpg?ex=69679bc8&is=69664a48&hm=2dd5f39fece13bf15a305553e507efb8a18b7075c1e36d95705a5a3190cc207d&" width="50%" alt="Description">
