### PR TITLE
feat: add mainnet tests for osaka

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -116,7 +116,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--eoa-fund-amount-default",
         action="store",
         dest="eoa_fund_amount_default",
-        default=10**18,
+        default=10**17,
         type=int,
         help="The default amount of wei to fund each EOA in each test with.",
     )

--- a/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
@@ -1,0 +1,109 @@
+"""
+Mainnet marked tests for EIP-7883 ModExp gas cost increase.
+
+Tests for ModExp gas cost increase in
+[EIP-7883: ModExp Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-7883).
+"""
+
+from typing import Dict
+
+import pytest
+from execution_testing import (
+    Alloc,
+    StateTestFiller,
+    Transaction,
+)
+
+from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
+from .spec import Spec, ref_spec_7883
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7883.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7883.version
+
+pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+@pytest.mark.parametrize(
+    "modexp_input,modexp_expected",
+    [
+        pytest.param(
+            ModExpInput(
+                base="ff" * 31 + "fc",
+                exponent="02",
+                modulus="05",
+                declared_base_length=32,
+                declared_exponent_length=1,
+                declared_modulus_length=1,
+            ),
+            # expected result:
+            bytes.fromhex("04"),
+            id="32-bytes-long-base",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="ff" * 32 + "fb",
+                exponent="02",
+                modulus="05",
+                declared_base_length=33,
+                declared_exponent_length=1,
+                declared_modulus_length=1,
+            ),
+            # expected result:
+            bytes.fromhex("01"),
+            id="33-bytes-long-base",  # higher cost than 32 bytes
+        ),
+        pytest.param(
+            ModExpInput(
+                base="ee" * 32,
+                exponent="ff" * Spec.MAX_LENGTH_BYTES,  # 1024 is upper limit
+                modulus="03",
+                declared_base_length=32,
+                declared_exponent_length=1024,
+                declared_modulus_length=1,
+            ),
+            # expected result:
+            bytes.fromhex("02"),
+            id="1024-bytes-long-exp",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="e09ad9675465c53a109fac66a445c91b292d2bb2c5268addb30cd82f80fcb0033ff97c80a5fc6f39193ae969c6ede6710a6b7ac27078a06d90ef1c72e5c85fb5",
+                exponent="010001",
+                modulus="fc9e1f6beb81516545975218075ec2af118cd8798df6e08a147c60fd6095ac2bb02c2908cf4dd7c81f11c289e4bce98f3553768f392a80ce22bf5c4f4a248c6b",
+                declared_base_length=64,
+                declared_exponent_length=3,
+                declared_modulus_length=64,
+            ),
+            # expected result:
+            bytes.fromhex(
+                "c36d804180c35d4426b57b50c5bfcca5c01856d104564cd513b461d3c8b8409128a5573e416d0ebe38f5f736766d9dc27143e4da981dfa4d67f7dc474cbee6d2"
+            ),
+            id="nagydani-1-pow0x10001",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="8d74b1229cc36912165d7ed62334d5ce0683ad12dbade86cdbd705f46693d6c0",
+                exponent="00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                modulus="8f70e8f94c5ad28ed971e258ea3854ebf57131ae4c842e5cafe1c70db8272caf",
+                declared_base_length=32,
+                declared_exponent_length=64,
+                declared_modulus_length=32,
+            ),
+            # expected result:
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            ),
+            id="zero-exponent-64bytes",
+        ),
+    ],
+)
+def test_modexp_different_base_lengths(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    post: Dict,
+    modexp_input: ModExpInput,
+    modexp_expected: ModExpInput,
+) -> None:
+    """Mainnet test for triggering gas cost increase."""
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
@@ -1,0 +1,91 @@
+"""
+Mainnet marked tests for [EIP-7951: Precompile for secp256r1 Curve Support](https://eips.ethereum.org/EIPS/eip-7951).
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Environment,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import H, R, S, Spec, X, Y, ref_spec_7951
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7951.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7951.version
+
+pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+@pytest.mark.parametrize(
+    "expected_output", [Spec.SUCCESS_RETURN_VALUE], ids=[""]
+)
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        pytest.param(
+            H(  # 'hello world' r1 signed with privkey 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
+                0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9
+            )
+            + R(
+                0x434287FA699FF2BE2A4475CCD9C063D1A22A424B6AB357D9BB0B31F7A71307B9
+            )
+            + S(
+                0xBE6AF716032D408183C53F6F76945363144555FAD2A5FF7854159166E52FC1D0
+            )
+            + X(
+                0xDA3C553A4215893E6D95D5818DF2519E13233A1E0E56E0EA7B4817A92A6973F9
+            )
+            + Y(
+                0xD8C8877A49383E20C3FDC21D4E8E280EF1FEEB72C333036770369A4387168D33
+            ),
+            id="valid_r1_sig",
+        ),
+    ],
+)
+@pytest.mark.parametrize("precompile_address", [Spec.P256VERIFY], ids=[""])
+def test_valid(
+    state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transaction
+) -> None:
+    """Positive mainnet test for the P256VERIFY precompile."""
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "expected_output", [Spec.INVALID_RETURN_VALUE], ids=[""]
+)
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        pytest.param(
+            H(  # 'hello world' k1 signed (with eth prefix) with privkey 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
+                0xD9EBA16ED0ECAE432B71FE008C98CC872BB4CC214D3220A36F365326CF807D68
+            )
+            + R(
+                0x69CCCD84CA870C08D49D596342F464017F2A05B0BE539682EAA7529E4BE2DE36
+            )
+            + S(
+                0x2CDB85FE13CB7DE39C1C7385BE9F38E8BDE9963CCBECD96281C4DF3ACA38F537
+            )
+            + X(
+                0x82AE98A95AE76E389354F0EC660CF071309EA2D2CB14ADB6543106B790BE27FD
+            )
+            + Y(
+                0x77B2CDC82C3AA8F2CF21E6257C197D75F84DCD0BC2FF8875C3E245C0E0874751
+            ),
+            id="invalid_r1_sig_but_valid_k1_sig",
+        ),
+    ],
+)
+@pytest.mark.parametrize("precompile_address", [Spec.P256VERIFY], ids=[""])
+def test_invalid(
+    state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transaction
+) -> None:
+    """
+    Negative mainnet test for the P256VERIFY precompile.
+
+    The signature actually is a valid secp256k1 signature,
+    so this is an interesting test case.
+    """
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
Adds tests for modexp cost increase and introduction of secp256r1 precompile.
Blob tests still missing, standalone script still has to be integrated into framework for that.

Partially solves #1714 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img src="https://i.pinimg.com/736x/88/d7/f5/88d7f5505d1ed229afa61027cab567ee.jpg" width="30%">
