### PR TITLE
refactor(test-benchmark): repricing filter logic

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -115,26 +115,22 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
     if "fixed_opcode_count" in metafunc.fixturenames:
         # Only parametrize if test has repricing marker
-        has_repricing = (
-            metafunc.definition.get_closest_marker("repricing") is not None
-        )
-        if has_repricing:
-            if fixed_opcode_counts:
-                opcode_counts = [
-                    int(x.strip()) for x in fixed_opcode_counts.split(",")
-                ]
-                opcode_count_parameters = [
-                    pytest.param(
-                        opcode_count,
-                        id=f"opcount_{opcode_count}K",
-                    )
-                    for opcode_count in opcode_counts
-                ]
-                metafunc.parametrize(
-                    "fixed_opcode_count",
-                    opcode_count_parameters,
-                    scope="function",
+        if fixed_opcode_counts:
+            opcode_counts = [
+                int(x.strip()) for x in fixed_opcode_counts.split(",")
+            ]
+            opcode_count_parameters = [
+                pytest.param(
+                    opcode_count,
+                    id=f"opcount_{opcode_count}K",
                 )
+                for opcode_count in opcode_counts
+            ]
+            metafunc.parametrize(
+                "fixed_opcode_count",
+                opcode_count_parameters,
+                scope="function",
+            )
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -53,7 +53,7 @@ def pytest_collection_modifyitems(
 
     # Check if -m repricing marker filter was specified
     markexpr = config.getoption("markexpr", "")
-    if "repricing" not in markexpr:
+    if "repricing" not in markexpr or "not repricing" in markexpr:
         return
 
     filtered = []

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -44,10 +44,19 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Remove non-repricing tests when --fixed-opcode-count is specified."""
+    """
+    Filter tests based on repricing marker when both -m repricing and
+    benchmark flags are specified.
+    """
+    gas_benchmark_value = config.getoption("gas_benchmark_value")
     fixed_opcode_count = config.getoption("fixed_opcode_count")
-    if not fixed_opcode_count:
-        # If --fixed-opcode-count is not specified, don't filter anything
+
+    if not gas_benchmark_value and not fixed_opcode_count:
+        return
+
+    # Check if -m repricing marker filter was specified
+    markexpr = config.getoption("markexpr", "")
+    if "repricing" not in markexpr:
         return
 
     filtered = []

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -44,10 +44,7 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """
-    Filter tests based on repricing marker when both -m repricing and
-    benchmark flags are specified.
-    """
+    """Filter tests based on repricing marker"""
     gas_benchmark_value = config.getoption("gas_benchmark_value")
     fixed_opcode_count = config.getoption("fixed_opcode_count")
 
@@ -114,7 +111,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             )
 
     if "fixed_opcode_count" in metafunc.fixturenames:
-        # Only parametrize if test has repricing marker
         if fixed_opcode_counts:
             opcode_counts = [
                 int(x.strip()) for x in fixed_opcode_counts.split(",")

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -248,6 +248,11 @@ class BenchmarkTest(BaseTest):
 
         blocks: List[Block] = self.setup_blocks
 
+        if self.fixed_opcode_count is not None and self.code_generator is None:
+            pytest.skip(
+                "Cannot run fixed opcode count tests without a code generator"
+            )
+
         if self.code_generator is not None:
             # Inject fixed_opcode_count into the code generator if provided
             self.code_generator.fixed_opcode_count = self.fixed_opcode_count

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -49,11 +49,10 @@ def pytest_collection_modifyitems(config: Any, items: Any) -> None:
         return
 
     marker_expr = config.getoption("-m", default="")
+
     run_benchmarks = (
-        marker_expr
-        and "benchmark" in marker_expr
-        and "not benchmark" not in marker_expr
-    )
+        "benchmark" in marker_expr and "not benchmark" not in marker_expr
+    ) or ("repricing" in marker_expr and "not repricing" not in marker_expr)
     run_stateful_tests = (
         marker_expr
         and "stateful" in marker_expr


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

- Supported Command: `fill` &`execute`

- Modes:
  - `-m benchmark` (under `compute/` folder)
  - `-m stateful` (under `stateful/` folder)

- Flags
  - `--gas-benchmark-values` (specify the block gas limit)
  - `--fixed-opcode-count` (specify the opcode count)

- Options
  - `-m repricing` (run only the subset of benchmark tests for quick testing)

**Issue Description**
When running benchmark tests with the `--fixed-opcode-count` flag, the current behavior incorrectly restricts execution to only the benchmark cases marked with the repricing marker.  

However, `repricing` is meant to be an **independent option** that limits execution to a subset of the benchmark suite.  
Using `--fixed-opcode-count` should **not** imply repricing mode.

**Fix Applied in This PR**
This PR adjusts the logic so that:

- Running with `--fixed-opcode-count` executes the **full benchmark suite**: Four passes are executed (including `contract_balance` with values 0 and 1):
```bash
fill -v tests/benchmark/compute/instruction/test_account_query.py::test_selfbalance --fixed-opcode-count 10 --clean -m benchmark
```

- Running with -m repricing executes only the repricing subset: Two passes are executed (only contract_balance = 0)
```bash
fill -v tests/benchmark/compute/instruction/test_account_query.py::test_selfbalance --fixed-opcode-count 10 --clean -m repricing
```

Add a sanity check CI workflow for fixed opcode count feature.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://as1.ftcdn.net/v2/jpg/02/74/06/48/1000_F_274064877_Tuq84kGOn5nhyIJeUFTUSvXaSeedAOTT.jpg)
