### PR TITLE
fix(tooling): Handle AnnAssign nodes in the new fork tool

### DIFF
--- a/tests/json_infra/test_tools_new_fork.py
+++ b/tests/json_infra/test_tools_new_fork.py
@@ -62,7 +62,7 @@ def test_end_to_end(template_fork: str) -> None:
             source = f.read()
 
             assert '"""' not in source[:20]
-            assert "FORK_CRITERIA = ByTimestamp(7)" in source
+            assert "FORK_CRITERIA: ForkCriteria = ByTimestamp(7)" in source
             assert template_fork.capitalize() not in source
 
         with (fork_dir / "utils" / "hexadecimal.py").open("r") as f:


### PR DESCRIPTION
## 🗒️ Description
In a recent commit, the `FORK_CRITERIA` declarations from:
FORK_CRITERIA = ByTimestamp(...) (simple assignment → cst.Assign node)
To: FORK_CRITERIA: ForkCriteria = ByTimestamp(...) (annotated assignment → cst.AnnAssign node)

The `SetConstantCommand` codemod in constant.py only handled Assign nodes, not AnnAssign nodes, so it couldn't replace the fork criteria value.


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![3396657](https://github.com/user-attachments/assets/00500294-6539-4c01-b577-04a9f51916f1)

