### PR TITLE
fix(ci): fix api rate limiting issue in consume flow

### DIFF
--- a/.github/configs/hive/master.yaml
+++ b/.github/configs/hive/master.yaml
@@ -1,0 +1,9 @@
+# Hive client configuration file with master/nightly images for CI
+# Uses ethpandaops mirror for faster pulls in CI environments
+
+# Geth (Go-Ethereum)
+- client: go-ethereum
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/geth
+    tag: master

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -45,7 +45,6 @@ jobs:
             consume_command: engine
     steps:
       - name: Checkout execution-specs
-        if: matrix.mode == 'dev'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: execution-specs
@@ -72,19 +71,6 @@ jobs:
           version: ${{ vars.UV_VERSION }}
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
-      - name: Pre-pull geth docker image
-        run: docker pull docker.ethquokkaops.io/dh/ethpandaops/geth:master
-
-      - name: Create clients.yaml
-        run: |
-          cat > hive/clients.yaml << 'EOF'
-          - client: go-ethereum
-            nametag: default
-            build_args:
-              baseimage: docker.ethquokkaops.io/dh/ethpandaops/geth
-              tag: master
-          EOF
-
       - name: Build hive
         run: |
           cd hive
@@ -97,7 +83,7 @@ jobs:
           ./hive --sim '${{ matrix.simulator }}' \
             --sim.parallelism=1 \
             --client go-ethereum \
-            --client-file clients.yaml \
+            --client-file ../execution-specs/.github/configs/hive/master.yaml \
             --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
@@ -106,7 +92,7 @@ jobs:
         if: matrix.mode == 'dev'
         run: |
           cd hive
-          ./hive --dev --client go-ethereum --client-file clients.yaml --docker.output &
+          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.output &
           echo "Waiting for Hive to be ready..."
           for i in {1..30}; do
             if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -19,6 +19,10 @@ concurrency:
   group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # Use direct URL instead of release spec (e.g., develop@v5.3.0) to avoid GitHub API rate limits
+  FIXTURES_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
+
 jobs:
   test-hive:
     name: ${{ matrix.name }}
@@ -94,7 +98,7 @@ jobs:
             --sim.parallelism=1 \
             --client go-ethereum \
             --client-file clients.yaml \
-            --sim.buildarg fixtures=develop@v5.3.0 \
+            --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
 
@@ -120,4 +124,4 @@ jobs:
           HIVE_SIMULATOR: http://127.0.0.1:3000
         run: |
           uv sync --all-extras
-          uv run consume ${{ matrix.consume_command }} --input develop@v5.3.0 -k "Osaka and test_block_at_rlp_limit_with_logs"
+          uv run consume ${{ matrix.consume_command }} --input ${{ env.FIXTURES_URL }} -k "Osaka and test_block_at_rlp_limit_with_logs"


### PR DESCRIPTION
## 🗒️ Description
This PR:
- Fixes the issue here by specifying an explicit release URL instead of using a release specifier. In the case of a release specifier `consume cache` pages all releases which can lead to rate limiting.
- Adds a `master.yaml` file, analagous to `latest.yaml`, but for client nightly builds, instead of creating the clients file on the fly.

## 🔗 Related Issues or PRs
Follow-up to:
- #1692 


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/36b2d554-3446-452a-89a3-5807f2a1ae9c" />
