### PR TITLE
fix(testing-fill): don't split slow tests into separate pre-alloc groups

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1547,33 +1547,6 @@ def pytest_collection_modifyitems(
 
         markers = list(item.iter_markers())
 
-        # Automatically apply pre_alloc_group marker to slow tests that are not
-        # benchmark tests
-        has_slow_marker = any(marker.name == "slow" for marker in markers)
-        has_benchmark_marker = any(
-            marker.name == "benchmark" for marker in markers
-        )
-        has_pre_alloc_group_marker = any(
-            marker.name == "pre_alloc_group" for marker in markers
-        )
-
-        if (
-            has_slow_marker
-            and not has_benchmark_marker
-            and not has_pre_alloc_group_marker
-        ):
-            # Add pre_alloc_group marker to isolate slow non-benchmark tests
-            pre_alloc_marker = pytest.mark.pre_alloc_group(
-                "separate",
-                reason=(
-                    "Non-benchmark tests marked as slow should be generated "
-                    "with their own pre-alloc-group"
-                ),
-            )
-            item.add_marker(pre_alloc_marker)
-            # Re-collect markers after adding the new one
-            markers = list(item.iter_markers())
-
         # Both the fixture format itself and the spec filling it have a chance
         # to veto the filling of a specific format.
         if fixture_format.discard_fixture_format_by_marks(fork, markers):


### PR DESCRIPTION
## 🗒️ Description

This PR removes the automatic application of `@pytest.mark.pre_alloc_group` if a test case  is marked as `slow`.

This removes > 1000 unnecessary pre-alloc groups, which speeds up `consume enginex`.

⚠️ @spencer-tb perhaps you should tag a release before this gets merged, just in case this causes release generation to time out - after #1804 this shouldn't be a problem. 

## 🔗 Related Issues or PRs
Spotted while testing the `enginex` simulator:
- https://github.com/danceratopz/execution-specs/pull/1

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/10ad9dee-b927-49e2-a17f-192b6e67dd6e" />

