### PR TITLE
enhance(test-tests): more execute mainnet marked tests

### DIFF
--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -93,7 +93,9 @@ class TransactionPost(BaseExecute):
                             f"Sending transaction expecting rejection "
                             f"(expected error: {transaction.error})..."
                         )
-                        with pytest.raises(SendTransactionExceptionError) as exc_info:
+                        with pytest.raises(
+                            SendTransactionExceptionError
+                        ) as exc_info:
                             eth_rpc.send_transaction(transaction)
                         logger.info(
                             f"Transaction rejected as expected: {exc_info.value}"

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -7,6 +7,7 @@ from pytest import FixtureRequest
 
 from execution_testing.base_types import Address, Alloc, Hash
 from execution_testing.forks import Fork
+from execution_testing.logging import get_logger
 from execution_testing.rpc import (
     EngineRPC,
     EthRPC,
@@ -18,6 +19,8 @@ from execution_testing.test_types import (
 )
 
 from .base import BaseExecute
+
+logger = get_logger(__name__)
 
 
 class TransactionPost(BaseExecute):
@@ -86,8 +89,15 @@ class TransactionPost(BaseExecute):
                         eth_rpc.send_wait_transaction(transaction)
                         all_tx_hashes.append(transaction.hash)
                     else:
-                        with pytest.raises(SendTransactionExceptionError):
+                        logger.info(
+                            f"Sending transaction expecting rejection "
+                            f"(expected error: {transaction.error})..."
+                        )
+                        with pytest.raises(SendTransactionExceptionError) as exc_info:
                             eth_rpc.send_transaction(transaction)
+                        logger.info(
+                            f"Transaction rejected as expected: {exc_info.value}"
+                        )
             else:
                 eth_rpc.send_wait_transactions(signed_txs)
                 all_tx_hashes.extend([tx.hash for tx in signed_txs])

--- a/tests/byzantium/eip198_modexp_precompile/helpers.py
+++ b/tests/byzantium/eip198_modexp_precompile/helpers.py
@@ -155,10 +155,18 @@ class ModExpOutput(TestParameterGroup):
       call_success (bool): The return_code from CALL, 0 indicates
                            unsuccessful call (out-of-gas), 1 indicates call
                            succeeded.
-      returned_data(str): The output returnData is the expected
+      returned_data (Bytes): The output returnData is the expected
                           output of the call.
 
     """
 
-    call_success: bool = True
+    call_success: bool
     returned_data: Bytes
+
+    def __len__(self) -> int:
+        """Return the length of the returned data."""
+        return len(self.returned_data)
+
+    def __bytes__(self) -> bytes:
+        """Return the returned data as bytes."""
+        return bytes(self.returned_data)

--- a/tests/byzantium/eip198_modexp_precompile/helpers.py
+++ b/tests/byzantium/eip198_modexp_precompile/helpers.py
@@ -160,7 +160,7 @@ class ModExpOutput(TestParameterGroup):
 
     """
 
-    call_success: bool
+    call_success: bool = True
     returned_data: Bytes
 
     def __len__(self) -> int:

--- a/tests/osaka/eip7823_modexp_upper_bounds/conftest.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/conftest.py
@@ -168,6 +168,7 @@ def tx(
 ) -> Transaction:
     """Transaction to measure gas consumption of the ModExp precompile."""
     return Transaction(
+        ty=0x02,
         sender=pre.fund_eoa(),
         to=gas_measure_contract,
         data=bytes(modexp_input),

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
@@ -1,5 +1,5 @@
 """
-Mainnet marked tests for
+Mainnet marked execute checklist tests for
 [EIP-7823: ModExp Upper Bound](https://eips.ethereum.org/EIPS/eip-7823).
 """
 
@@ -10,7 +10,6 @@ from execution_testing import (
     Alloc,
     StateTestFiller,
     Transaction,
-    # TransactionException,
 )
 from execution_testing.base_types.base_types import Bytes
 from execution_testing.test_types.block_types import Environment
@@ -19,6 +18,7 @@ from ...byzantium.eip198_modexp_precompile.helpers import (
     ModExpInput,
     ModExpOutput,
 )
+from ..eip7883_modexp_gas_increase.spec import Spec
 from .spec import ref_spec_7823
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7823.git_path
@@ -27,78 +27,72 @@ REFERENCE_SPEC_VERSION = ref_spec_7823.version
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
 
 
-# overwrite the conftest fixture
 @pytest.fixture
 def call_succeeds(modexp_expected: ModExpOutput) -> bool:
-    """Override call_succeeds to use the parametrized ModExpOutput value."""
+    """Override `call_succeeds` to use the parametrized ModExpOutput value."""
     return modexp_expected.call_success
 
 
-# @pytest.mark.exception_test
 @pytest.mark.parametrize(
     "modexp_input,modexp_expected",
     [
         pytest.param(
             ModExpInput(
-                base="ca" * 3070,
-                exponent="ca",
-                modulus="fe",
-                declared_base_length=3070,
-                declared_exponent_length=1,
-                declared_modulus_length=1,
+                base=b"\x01" * Spec.MAX_LENGTH_BYTES,
+                exponent=b"\x00",
+                modulus=b"\x02",
             ),
             ModExpOutput(
-                call_success=False,
-                returned_data=Bytes(),
+                call_success=True,
+                returned_data=Bytes(bytes.fromhex("01")),
             ),
-            id="3070-bytes-long-base",
-        ),
-        pytest.param(
-            ModExpInput(
-                base="cd",
-                exponent="ca" * 3070,
-                modulus="dc",
-                declared_base_length=1,
-                declared_exponent_length=3070,
-                declared_modulus_length=1,
-            ),
-            ModExpOutput(
-                call_success=False,
-                returned_data=Bytes(),
-            ),
-            id="3070-bytes-long-exp",
-        ),
-        pytest.param(
-            ModExpInput(
-                base="cd",
-                exponent="cf",
-                modulus="ee" * 3070,
-                declared_base_length=1,
-                declared_exponent_length=1,
-                declared_modulus_length=3070,
-            ),
-            ModExpOutput(
-                call_success=False,
-                returned_data=Bytes(),
-            ),
-            id="3070-bytes-long-mod",
+            id="base-boundary-1024-bytes",
         ),
     ],
 )
-def test_modexp_different_base_lengths(
+def test_modexp_boundary(
     state_test: StateTestFiller,
     pre: Alloc,
     tx: Transaction,
     post: Dict,
-    modexp_input: ModExpInput,
-    modexp_expected: ModExpOutput,
-    call_succeeds: bool,
 ) -> None:
     """
-    Mainnet test for triggering gas cost increase.
-    Upper bound per length param: 1024 bytes
-    There are 3 length params: base, e, mod
-    3*1024 = 3072
-    Therefore, we can do negative tests for 3070+1+1 for each of those three.
+    Mainnet test at the 1024-byte boundary.
+
+    Tests that the ModExp precompile correctly handles input at the maximum
+    allowed length (1024 bytes) per EIP-7823.
+    """
+    state_test(env=Environment(), pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "modexp_input,modexp_expected",
+    [
+        pytest.param(
+            ModExpInput(
+                base=b"\x01" * (Spec.MAX_LENGTH_BYTES + 1),
+                exponent=b"\x00",
+                modulus=b"\x02",
+            ),
+            ModExpOutput(
+                call_success=False,
+                returned_data=Bytes(),
+            ),
+            id="base-over-boundary-1025-bytes",
+        ),
+    ],
+)
+def test_modexp_over_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    post: Dict,
+) -> None:
+    """
+    Mainnet test exceeding the 1024-byte boundary.
+
+    Tests that the ModExp precompile correctly rejects input exceeding the
+    maximum allowed length (1024 bytes) per EIP-7823. This proves the EIP
+    is correctly activated.
     """
     state_test(env=Environment(), pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
@@ -11,8 +11,6 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
-from execution_testing.base_types.base_types import Bytes
-from execution_testing.test_types.block_types import Environment
 
 from ...byzantium.eip198_modexp_precompile.helpers import (
     ModExpInput,
@@ -44,7 +42,7 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(bytes.fromhex("01")),
+                returned_data="0x01",
             ),
             id="base-boundary-1024-bytes",
         ),
@@ -62,7 +60,7 @@ def test_modexp_boundary(
     Tests that the ModExp precompile correctly handles input at the maximum
     allowed length (1024 bytes) per EIP-7823.
     """
-    state_test(env=Environment(), pre=pre, tx=tx, post=post)
+    state_test(pre=pre, tx=tx, post=post)
 
 
 @pytest.mark.parametrize(
@@ -76,7 +74,7 @@ def test_modexp_boundary(
             ),
             ModExpOutput(
                 call_success=False,
-                returned_data=Bytes(),
+                returned_data="",
             ),
             id="base-over-boundary-1025-bytes",
         ),
@@ -95,4 +93,4 @@ def test_modexp_over_boundary(
     maximum allowed length (1024 bytes) per EIP-7823. This proves the EIP
     is correctly activated.
     """
-    state_test(env=Environment(), pre=pre, tx=tx, post=post)
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
@@ -1,0 +1,86 @@
+"""
+Mainnet marked tests for
+[EIP-7823: ModExp Upper Bound](https://eips.ethereum.org/EIPS/eip-7823).
+"""
+
+from typing import Dict
+
+import pytest
+from execution_testing import (
+    Alloc,
+    StateTestFiller,
+    Transaction,
+    # TransactionException,
+)
+from execution_testing.test_types.block_types import Environment
+
+from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
+from .spec import ref_spec_7823
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7823.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7823.version
+
+pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+# @pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "modexp_input,modexp_expected",
+    [
+        pytest.param(
+            ModExpInput(
+                base="ca" * 3070,
+                exponent="ca",
+                modulus="fe",
+                declared_base_length=3070,
+                declared_exponent_length=1,
+                declared_modulus_length=1,
+            ),
+            # expected result:
+            bytes.fromhex("00"),
+            id="3070-bytes-long-base",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="cd",
+                exponent="ca" * 3070,
+                modulus="dc",
+                declared_base_length=1,
+                declared_exponent_length=3070,
+                declared_modulus_length=1,
+            ),
+            # expected result:
+            bytes.fromhex("00"),
+            id="3070-bytes-long-exp",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="cd",
+                exponent="cf",
+                modulus="ee" * 3070,
+                declared_base_length=1,
+                declared_exponent_length=1,
+                declared_modulus_length=3070,
+            ),
+            # expected result:
+            bytes.fromhex("00"),
+            id="3070-bytes-long-mod",
+        ),
+    ],
+)
+def test_modexp_different_base_lengths(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    post: Dict,
+    modexp_input: ModExpInput,
+    modexp_expected: ModExpInput,
+) -> None:
+    """
+    Mainnet test for triggering gas cost increase.
+    Upper bound per length param: 1024 bytes
+    There are 3 length params: base, e, mod
+    3*1024 = 3072
+    Therefore, we can do negative tests for 3070+1+1 for each of those three.
+    """
+    state_test(env=Environment(), pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_eip_mainnet.py
@@ -12,15 +12,26 @@ from execution_testing import (
     Transaction,
     # TransactionException,
 )
+from execution_testing.base_types.base_types import Bytes
 from execution_testing.test_types.block_types import Environment
 
-from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
+from ...byzantium.eip198_modexp_precompile.helpers import (
+    ModExpInput,
+    ModExpOutput,
+)
 from .spec import ref_spec_7823
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7823.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7823.version
 
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+# overwrite the conftest fixture
+@pytest.fixture
+def call_succeeds(modexp_expected: ModExpOutput) -> bool:
+    """Override call_succeeds to use the parametrized ModExpOutput value."""
+    return modexp_expected.call_success
 
 
 # @pytest.mark.exception_test
@@ -36,8 +47,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=1,
                 declared_modulus_length=1,
             ),
-            # expected result:
-            bytes.fromhex("00"),
+            ModExpOutput(
+                call_success=False,
+                returned_data=Bytes(),
+            ),
             id="3070-bytes-long-base",
         ),
         pytest.param(
@@ -49,8 +62,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=3070,
                 declared_modulus_length=1,
             ),
-            # expected result:
-            bytes.fromhex("00"),
+            ModExpOutput(
+                call_success=False,
+                returned_data=Bytes(),
+            ),
             id="3070-bytes-long-exp",
         ),
         pytest.param(
@@ -62,8 +77,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=1,
                 declared_modulus_length=3070,
             ),
-            # expected result:
-            bytes.fromhex("00"),
+            ModExpOutput(
+                call_success=False,
+                returned_data=Bytes(),
+            ),
             id="3070-bytes-long-mod",
         ),
     ],
@@ -74,7 +91,8 @@ def test_modexp_different_base_lengths(
     tx: Transaction,
     post: Dict,
     modexp_input: ModExpInput,
-    modexp_expected: ModExpInput,
+    modexp_expected: ModExpOutput,
+    call_succeeds: bool,
 ) -> None:
     """
     Mainnet test for triggering gas cost increase.

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
@@ -1,65 +1,67 @@
 """
-Mainnet tests for transaction gas limit cap [EIP-7825: Transaction Gas Limit
-Cap](https://eips.ethereum.org/EIPS/eip-7825).
+Mainnet marked execute checklist tests for
+[EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825).
 """
 
 import pytest
 from execution_testing import (
+    Account,
     Alloc,
     Environment,
     Op,
     StateTestFiller,
+    Storage,
     Transaction,
     TransactionException,
 )
 
-from .spec import ref_spec_7825
+from .spec import Spec, ref_spec_7825
 
-# Update reference spec constants
 REFERENCE_SPEC_GIT_PATH = ref_spec_7825.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7825.version
 
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
 
 
-@pytest.mark.exception_test
-def test_tx_gas_limit_cap_mainnet(
+def test_tx_gas_limit_cap_at_maximum(
     state_test: StateTestFiller,
     pre: Alloc,
     env: Environment,
 ) -> None:
-    """Negative test going beyond transaction gas limit cap."""
-    target_gas_wasted_min = 2 ^ 24 + 1
-
-    # repeatedly call BALANCE on different addresses until we detect
-    # that we used up target_gas_wasted_min
-    code = (
-        Op.PUSH4[target_gas_wasted_min]
-        + Op.GAS
-        + Op.PUSH1[0x0]
-        + Op.JUMPDEST
-        + Op.DUP1
-        + Op.BALANCE
-        + Op.POP
-        + Op.PUSH1[0x1]
-        + Op.ADD
-        + Op.GAS
-        + Op.DUP4
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP4
-        + Op.GT
-        + Op.PUSH1[0x8]
-        + Op.JUMPI
-        + Op.STOP
+    """Test transaction at exactly the gas limit cap (2^24)."""
+    storage = Storage()
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
     )
 
-    caller_address = pre.deploy_contract(code=code)
+    tx = Transaction(
+        to=contract_address,
+        sender=pre.fund_eoa(),
+        gas_limit=Spec.tx_gas_limit_cap,
+    )
+
+    post = {
+        contract_address: Account(storage=storage),
+    }
+
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.exception_test
+def test_tx_gas_limit_cap_exceeded(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    env: Environment,
+) -> None:
+    """Test transaction exceeding the gas limit cap (2^24 + 1)."""
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(0, 1) + Op.STOP,
+    )
 
     tx = Transaction(
-        to=caller_address,
+        to=contract_address,
         sender=pre.fund_eoa(),
-        gas_limit=17_000_000,  # more than target_gas_wasted_min
+        gas_limit=Spec.tx_gas_limit_cap + 1,
         error=TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM,
     )
 

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
@@ -5,7 +5,6 @@ Cap](https://eips.ethereum.org/EIPS/eip-7825).
 
 import pytest
 from execution_testing import (
-    Account,
     Alloc,
     Environment,
     Op,

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
@@ -7,7 +7,6 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
-    Environment,
     Op,
     StateTestFiller,
     Storage,
@@ -26,7 +25,6 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
 def test_tx_gas_limit_cap_at_maximum(
     state_test: StateTestFiller,
     pre: Alloc,
-    env: Environment,
 ) -> None:
     """Test transaction at exactly the gas limit cap (2^24)."""
     storage = Storage()
@@ -35,6 +33,7 @@ def test_tx_gas_limit_cap_at_maximum(
     )
 
     tx = Transaction(
+        ty=0x02,
         to=contract_address,
         sender=pre.fund_eoa(),
         gas_limit=Spec.tx_gas_limit_cap,
@@ -44,14 +43,13 @@ def test_tx_gas_limit_cap_at_maximum(
         contract_address: Account(storage=storage),
     }
 
-    state_test(env=env, pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.exception_test
 def test_tx_gas_limit_cap_exceeded(
     state_test: StateTestFiller,
     pre: Alloc,
-    env: Environment,
 ) -> None:
     """Test transaction exceeding the gas limit cap (2^24 + 1)."""
     contract_address = pre.deploy_contract(
@@ -59,10 +57,11 @@ def test_tx_gas_limit_cap_exceeded(
     )
 
     tx = Transaction(
+        ty=0x02,
         to=contract_address,
         sender=pre.fund_eoa(),
         gas_limit=Spec.tx_gas_limit_cap + 1,
         error=TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM,
     )
 
-    state_test(env=env, pre=pre, post={}, tx=tx)
+    state_test(pre=pre, post={}, tx=tx)

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_eip_mainnet.py
@@ -1,0 +1,67 @@
+"""
+Mainnet tests for transaction gas limit cap [EIP-7825: Transaction Gas Limit
+Cap](https://eips.ethereum.org/EIPS/eip-7825).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Environment,
+    Op,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+)
+
+from .spec import ref_spec_7825
+
+# Update reference spec constants
+REFERENCE_SPEC_GIT_PATH = ref_spec_7825.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7825.version
+
+pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+@pytest.mark.exception_test
+def test_tx_gas_limit_cap_mainnet(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    env: Environment,
+) -> None:
+    """Negative test going beyond transaction gas limit cap."""
+    target_gas_wasted_min = 2 ^ 24 + 1
+
+    # repeatedly call BALANCE on different addresses until we detect
+    # that we used up target_gas_wasted_min
+    code = (
+        Op.PUSH4[target_gas_wasted_min]
+        + Op.GAS
+        + Op.PUSH1[0x0]
+        + Op.JUMPDEST
+        + Op.DUP1
+        + Op.BALANCE
+        + Op.POP
+        + Op.PUSH1[0x1]
+        + Op.ADD
+        + Op.GAS
+        + Op.DUP4
+        + Op.SWAP1
+        + Op.SUB
+        + Op.DUP4
+        + Op.GT
+        + Op.PUSH1[0x8]
+        + Op.JUMPI
+        + Op.STOP
+    )
+
+    caller_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(
+        to=caller_address,
+        sender=pre.fund_eoa(),
+        gas_limit=17_000_000,  # more than target_gas_wasted_min
+        error=TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM,
+    )
+
+    state_test(env=env, pre=pre, post={}, tx=tx)

--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -259,6 +259,7 @@ def tx(
 ) -> Transaction:
     """Transaction to measure gas consumption of the ModExp precompile."""
     return Transaction(
+        ty=0x02,
         sender=pre.fund_eoa(),
         to=gas_measure_contract,
         data=bytes(modexp_input),

--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -15,7 +15,7 @@ from execution_testing import (
     Transaction,
     keccak256,
 )
-from execution_testing.forks import Osaka
+from execution_testing.forks import London, Osaka
 
 from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
 from .spec import Spec, Spec7883
@@ -252,6 +252,7 @@ def precompile_gas_modifier() -> int:
 
 @pytest.fixture
 def tx(
+    fork: Fork,
     pre: Alloc,
     gas_measure_contract: Address,
     modexp_input: ModExpInput,
@@ -259,7 +260,7 @@ def tx(
 ) -> Transaction:
     """Transaction to measure gas consumption of the ModExp precompile."""
     return Transaction(
-        ty=0x02,
+        ty=0x02 if fork >= London else 0x00,
         sender=pre.fund_eoa(),
         to=gas_measure_contract,
         data=bytes(modexp_input),

--- a/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
@@ -1,7 +1,5 @@
 """
-Mainnet marked tests for EIP-7883 ModExp gas cost increase.
-
-Tests for ModExp gas cost increase in
+Mainnet marked execute checklist tests for
 [EIP-7883: ModExp Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-7883).
 """
 
@@ -28,10 +26,9 @@ REFERENCE_SPEC_VERSION = ref_spec_7883.version
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
 
 
-# overwrite the conftest fixture
 @pytest.fixture
 def call_succeeds(modexp_expected: ModExpOutput) -> bool:
-    """Override call_succeeds to use the parametrized ModExpOutput value."""
+    """Override `call_succeeds` to use the parametrized ModExpOutput value."""
     return modexp_expected.call_success
 
 
@@ -128,9 +125,6 @@ def test_modexp_different_base_lengths(
     pre: Alloc,
     tx: Transaction,
     post: Dict,
-    modexp_input: ModExpInput,
-    modexp_expected: ModExpOutput,
-    call_succeeds: bool,
 ) -> None:
     """Mainnet test for triggering gas cost increase."""
     state_test(env=Environment(), pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
@@ -46,7 +46,7 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(bytes.fromhex("04")),
+                returned_data="0x04",
             ),
             id="32-bytes-long-base",
         ),
@@ -61,7 +61,7 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(bytes.fromhex("01")),
+                returned_data="0x01",
             ),
             id="33-bytes-long-base",  # higher cost than 32 bytes
         ),
@@ -76,7 +76,7 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(bytes.fromhex("02")),
+                returned_data="0x02",
             ),
             id="1024-bytes-long-exp",
         ),
@@ -91,10 +91,8 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(
-                    bytes.fromhex(
-                        "c36d804180c35d4426b57b50c5bfcca5c01856d104564cd513b461d3c8b8409128a5573e416d0ebe38f5f736766d9dc27143e4da981dfa4d67f7dc474cbee6d2"
-                    )
+                returned_data=(
+                    "0xc36d804180c35d4426b57b50c5bfcca5c01856d104564cd513b461d3c8b8409128a5573e416d0ebe38f5f736766d9dc27143e4da981dfa4d67f7dc474cbee6d2"
                 ),
             ),
             id="nagydani-1-pow0x10001",
@@ -110,10 +108,8 @@ def call_succeeds(modexp_expected: ModExpOutput) -> bool:
             ),
             ModExpOutput(
                 call_success=True,
-                returned_data=Bytes(
-                    bytes.fromhex(
-                        "0000000000000000000000000000000000000000000000000000000000000001"
-                    )
+                returned_data=(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                 ),
             ),
             id="zero-exponent-64bytes",
@@ -127,4 +123,4 @@ def test_modexp_different_base_lengths(
     post: Dict,
 ) -> None:
     """Mainnet test for triggering gas cost increase."""
-    state_test(env=Environment(), pre=pre, tx=tx, post=post)
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
@@ -13,14 +13,26 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
+from execution_testing.base_types.base_types import Bytes
+from execution_testing.test_types.block_types import Environment
 
-from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
+from ...byzantium.eip198_modexp_precompile.helpers import (
+    ModExpInput,
+    ModExpOutput,
+)
 from .spec import Spec, ref_spec_7883
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7883.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7883.version
 
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+# overwrite the conftest fixture
+@pytest.fixture
+def call_succeeds(modexp_expected: ModExpOutput) -> bool:
+    """Override call_succeeds to use the parametrized ModExpOutput value."""
+    return modexp_expected.call_success
 
 
 @pytest.mark.parametrize(
@@ -35,8 +47,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=1,
                 declared_modulus_length=1,
             ),
-            # expected result:
-            bytes.fromhex("04"),
+            ModExpOutput(
+                call_success=True,
+                returned_data=Bytes(bytes.fromhex("04")),
+            ),
             id="32-bytes-long-base",
         ),
         pytest.param(
@@ -48,8 +62,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=1,
                 declared_modulus_length=1,
             ),
-            # expected result:
-            bytes.fromhex("01"),
+            ModExpOutput(
+                call_success=True,
+                returned_data=Bytes(bytes.fromhex("01")),
+            ),
             id="33-bytes-long-base",  # higher cost than 32 bytes
         ),
         pytest.param(
@@ -61,8 +77,10 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=1024,
                 declared_modulus_length=1,
             ),
-            # expected result:
-            bytes.fromhex("02"),
+            ModExpOutput(
+                call_success=True,
+                returned_data=Bytes(bytes.fromhex("02")),
+            ),
             id="1024-bytes-long-exp",
         ),
         pytest.param(
@@ -74,9 +92,13 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=3,
                 declared_modulus_length=64,
             ),
-            # expected result:
-            bytes.fromhex(
-                "c36d804180c35d4426b57b50c5bfcca5c01856d104564cd513b461d3c8b8409128a5573e416d0ebe38f5f736766d9dc27143e4da981dfa4d67f7dc474cbee6d2"
+            ModExpOutput(
+                call_success=True,
+                returned_data=Bytes(
+                    bytes.fromhex(
+                        "c36d804180c35d4426b57b50c5bfcca5c01856d104564cd513b461d3c8b8409128a5573e416d0ebe38f5f736766d9dc27143e4da981dfa4d67f7dc474cbee6d2"
+                    )
+                ),
             ),
             id="nagydani-1-pow0x10001",
         ),
@@ -89,9 +111,13 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
                 declared_exponent_length=64,
                 declared_modulus_length=32,
             ),
-            # expected result:
-            bytes.fromhex(
-                "0000000000000000000000000000000000000000000000000000000000000001"
+            ModExpOutput(
+                call_success=True,
+                returned_data=Bytes(
+                    bytes.fromhex(
+                        "0000000000000000000000000000000000000000000000000000000000000001"
+                    )
+                ),
             ),
             id="zero-exponent-64bytes",
         ),
@@ -103,7 +129,8 @@ def test_modexp_different_base_lengths(
     tx: Transaction,
     post: Dict,
     modexp_input: ModExpInput,
-    modexp_expected: ModExpInput,
+    modexp_expected: ModExpOutput,
+    call_succeeds: bool,
 ) -> None:
     """Mainnet test for triggering gas cost increase."""
-    state_test(pre=pre, tx=tx, post=post)
+    state_test(env=Environment(), pre=pre, tx=tx, post=post)

--- a/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_eip_mainnet.py
@@ -11,8 +11,6 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
-from execution_testing.base_types.base_types import Bytes
-from execution_testing.test_types.block_types import Environment
 
 from ...byzantium.eip198_modexp_precompile.helpers import (
     ModExpInput,

--- a/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
@@ -1,0 +1,68 @@
+"""
+Mainnet testing for osaka's [EIP-7939: Count leading zeros (CLZ)](https://eips.ethereum.org/EIPS/eip-7939).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Op,
+    StateTestFiller,
+    Transaction,
+)
+from execution_testing.test_types.block_types import Environment
+
+from .spec import ref_spec_7939
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7939.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7939.version
+
+pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
+
+
+# ruff keeps making parameters unreadable by putting them in one line
+# fmt: off
+@pytest.mark.parametrize(
+    "clz_input,clz_expected",
+    [
+        pytest.param(
+            2**256 - 1,
+            0,
+            id="max-size-input-clz"
+        ),
+        pytest.param(
+            0,
+            256,
+            id="min-size-input-clz"
+        ),
+        pytest.param(
+            1231350950569847740520874169721133058840016695,
+            106,
+            id="some-other-input-clz"
+        ),
+    ],
+)
+# fmt: on
+def test_clz_mainnet(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    clz_input: int,
+    clz_expected: int,
+) -> None:
+    """
+    Test CLZ opcode on mainnet.
+    """
+    sender = pre.fund_eoa()
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.CLZ(clz_input)),
+        storage={"0x00": "0xdeadbeef"},
+    )
+    tx = Transaction(
+        to=contract_address,
+        sender=sender,
+        gas_limit=200_000,
+    )
+    post = {
+        contract_address: Account(storage={"0x00": clz_expected}),
+    }
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
@@ -1,5 +1,6 @@
 """
-Mainnet testing for osaka's [EIP-7939: Count leading zeros (CLZ)](https://eips.ethereum.org/EIPS/eip-7939).
+Mainnet marked execute checklist tests for
+[EIP-7939: Count leading zeros (CLZ)](https://eips.ethereum.org/EIPS/eip-7939).
 """
 
 import pytest
@@ -20,29 +21,17 @@ REFERENCE_SPEC_VERSION = ref_spec_7939.version
 pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
 
 
-# ruff keeps making parameters unreadable by putting them in one line
-# fmt: off
 @pytest.mark.parametrize(
     "clz_input,clz_expected",
     [
         pytest.param(
-            2**256 - 1,
-            0,
-            id="max-size-input-clz"
+            0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+            8,
+            id="clz-8-leading-zeros",
         ),
-        pytest.param(
-            0,
-            256,
-            id="min-size-input-clz"
-        ),
-        pytest.param(
-            1231350950569847740520874169721133058840016695,
-            106,
-            id="some-other-input-clz"
-        ),
+        pytest.param(0, 256, id="clz-all-zeros"),
     ],
 )
-# fmt: on
 def test_clz_mainnet(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py
@@ -11,7 +11,6 @@ from execution_testing import (
     StateTestFiller,
     Transaction,
 )
-from execution_testing.test_types.block_types import Environment
 
 from .spec import ref_spec_7939
 
@@ -47,6 +46,7 @@ def test_clz_mainnet(
         storage={"0x00": "0xdeadbeef"},
     )
     tx = Transaction(
+        ty=0x02,
         to=contract_address,
         sender=sender,
         gas_limit=200_000,
@@ -54,4 +54,4 @@ def test_clz_mainnet(
     post = {
         contract_address: Account(storage={"0x00": clz_expected}),
     }
-    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/osaka/eip7951_p256verify_precompiles/conftest.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/conftest.py
@@ -177,6 +177,7 @@ def tx(
 ) -> Transaction:
     """Transaction for the test."""
     return Transaction(
+        ty=0x02,
         gas_limit=tx_gas_limit,
         data=input_data,
         to=call_contract_address,

--- a/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
@@ -1,5 +1,6 @@
 """
-Mainnet marked tests for [EIP-7951: Precompile for secp256r1 Curve Support](https://eips.ethereum.org/EIPS/eip-7951).
+Mainnet marked execute checklist tests for
+[EIP-7951: Precompile for secp256r1 Curve Support](https://eips.ethereum.org/EIPS/eip-7951).
 """
 
 import pytest
@@ -25,7 +26,7 @@ pytestmark = [pytest.mark.valid_at("Osaka"), pytest.mark.mainnet]
     "input_data",
     [
         pytest.param(
-            H(  # 'hello world' r1 signed with privkey 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
+            H(  # 'hello world' r1 signed with private key 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
                 0xB94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9
             )
             + R(
@@ -59,7 +60,7 @@ def test_valid(
     "input_data",
     [
         pytest.param(
-            H(  # 'hello world' k1 signed (with eth prefix) with privkey 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
+            H(  # 'hello world' k1 signed (with eth prefix) with private key 0xd946578401d1980aba1fc85df2a1ddc0d2d618aadd37b213f7f7f91a553b1499  # noqa: E501
                 0xD9EBA16ED0ECAE432B71FE008C98CC872BB4CC214D3220A36F365326CF807D68
             )
             + R(

--- a/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_eip_mainnet.py
@@ -4,12 +4,7 @@ Mainnet marked execute checklist tests for
 """
 
 import pytest
-from execution_testing import (
-    Alloc,
-    Environment,
-    StateTestFiller,
-    Transaction,
-)
+from execution_testing import Alloc, StateTestFiller, Transaction
 
 from .spec import H, R, S, Spec, X, Y, ref_spec_7951
 
@@ -50,7 +45,7 @@ def test_valid(
     state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transaction
 ) -> None:
     """Positive mainnet test for the P256VERIFY precompile."""
-    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.parametrize(
@@ -89,4 +84,4 @@ def test_invalid(
     The signature actually is a valid secp256k1 signature,
     so this is an interesting test case.
     """
-    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description
Please ensure that the modexp cases correct like this, it seems to work on Sepolia.

Edit: @spencer-tb validated all updated tests on Hoodi.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).