### PR TITLE
fix(ci): run coverage from py3 instead of json_infra

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,12 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Run py3 tests
         run: tox -e py3
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+        with:
+          files: .tox/coverage.xml
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   pypy3:
     runs-on: [self-hosted-ghr, size-xl-x64]
@@ -117,12 +123,6 @@ jobs:
           cat $FILE_LIST
       - name: Run json infra tests
         run: tox -e json_infra -- --file-list="${{ steps.get-changed-files.outputs.file_list }}"
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
-        with:
-          files: .tox/coverage.xml
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   optimized:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/tox.ini
+++ b/tox.ini
@@ -65,12 +65,6 @@ commands =
     pytest \
         -m "not slow" \
         -n auto --maxprocesses 6 --dist=loadfile \
-        --cov-config=pyproject.toml \
-        --cov=ethereum \
-        --cov-report=term \
-        --cov-report "xml:{toxworkdir}/coverage.xml" \
-        --no-cov-on-fail \
-        --cov-branch \
         --basetemp="{temp_dir}/pytest" \
         {posargs} \
         tests/json_infra
@@ -81,6 +75,12 @@ commands =
     fill \
         -m "not slow and not zkevm and not benchmark" \
         -n auto --maxprocesses 10 --dist=loadgroup \
+        --cov-config=pyproject.toml \
+        --cov=ethereum \
+        --cov-report=term \
+        --cov-report "xml:{toxworkdir}/coverage.xml" \
+        --no-cov-on-fail \
+        --cov-branch \
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \


### PR DESCRIPTION
## 🗒️ Description
Run coverage report in the `py3` environment instead of `json_infra`. Post #1666 we run `json_infra` tests selectively based on which part of the codebase a particular PR touches. This could lead to wildly fluctuating coverage reports.

## 🔗 Related Issues or PRs
#1666 

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


![Cute Animals - 6 of 12](https://github.com/user-attachments/assets/5623d14b-971c-47ba-b885-d8ede950bc26)
