### PR TITLE
enhance(ci): add cache to evmone evm builds

### DIFF
--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -16,31 +16,62 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get latest evmone commit
+      id: evmone-sha
+      shell: bash
+      run: |
+        SHA=$(git ls-remote https://github.com/${{ inputs.repo }}.git refs/heads/${{ inputs.ref }} | cut -f1)
+        echo "sha=$SHA" >> $GITHUB_OUTPUT
+        echo "Latest evmone commit: $SHA"
+    - name: Prepare cache target dir
+      shell: bash
+      run: mkdir -p "$GITHUB_WORKSPACE/evmone/build"
+    - name: Restore build cache
+      id: cache-restore
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path: |
+          ${{ github.workspace }}/evmone/build
+        key: evmone-build-targets=${{ inputs.targets }}-sha=${{ steps.evmone-sha.outputs.sha }}
+        restore-keys: |
+          evmone-build-targets=${{ inputs.targets }}-
     - name: Checkout evmone
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
-        ref: ${{ inputs.ref }}
+        ref: ${{ steps.evmone-sha.outputs.sha }}
         path: evmone
         submodules: true
     - name: Setup cmake
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
       with:
         cmake-version: '3.x'
     - name: "Install GMP Linux"
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: sudo apt-get -q update && sudo apt-get -qy install libgmp-dev
     - name: Install GMP macOS
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
         brew update && brew install gmp
     - name: Build evmone binary
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin
         cd $GITHUB_WORKSPACE/evmone
         cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
         cmake --build build --parallel --target ${{ inputs.targets }}
-        echo $GITHUB_WORKSPACE/evmone/build/bin/ >> $GITHUB_PATH
+    - name: Add evmone bin to PATH
+      shell: bash
+      run: echo $GITHUB_WORKSPACE/evmone/build/bin/ >> $GITHUB_PATH
+    - name: Save build cache
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path: |
+          ${{ github.workspace }}/evmone/build
+        key: evmone-build-targets=${{ inputs.targets }}-sha=${{ steps.evmone-sha.outputs.sha }}


### PR DESCRIPTION
## 🗒️ Description

Adds basic caching to the evmone EVM build action to speed up CI workflows for benchmarking, with previous cache fall backs for when new builds may fail. The updated action flow is now as followed:
- Fetch latest commit SHA using `git ls-remote` before building (alternative to github api so no rate limiting 🙏) 
- Cache the build based on commit SHA and runner details.
- Skip build steps when cache hits, i.e when we already have the latest evmone build, it persists for 7 days from each cache hit.

The cache is shared across all workflows/PRs/branches and runners. If a new evmone commit fails to build, it'll fall back to the most recent working build with the same targets.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.8-KFB46iR1l47pN5TpunCAHaFt%3Fpid%3DApi&f=1&ipt=c03181a15cbb77d3557142f834fef1726da75e50b928ef1a7c78b1ec2a4044aa&ipo=images)
