### PR TITLE
chore(test-config): align gas limit to mainnet configuration for benchmark tests

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,7 +11,7 @@ develop:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Prague --gas-benchmark-values 1,10,30,45,60,100,150 -m "benchmark and not state_test" ./tests/benchmark
+  fill-params: --fork=Prague --gas-benchmark-values 1,10,30,60,100,150 -m "benchmark and not state_test" ./tests/benchmark
 
 benchmark_develop:
   evm-type: benchmark

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🛠️ Framework
 
+#### General
+
+- 🔀 Updated default block gas limit from 45M to 60M to align with [EIP-7935](https://eips.ethereum.org/EIPS/eip-7935) for the Osaka fork.
+
 #### `fill`
 
 - 🐞 Allow `evmone` to fill Prague and Osaka blockchain tests (mainly modified deposit contract tests) ([#1689](https://github.com/ethereum/execution-specs/pull/1689)).

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -23,7 +23,7 @@ from execution_testing.base_types import (
 from execution_testing.forks import Fork
 
 DEFAULT_BASE_FEE = 7
-CURRENT_MAINNET_BLOCK_GAS_LIMIT = 45_000_000
+CURRENT_MAINNET_BLOCK_GAS_LIMIT = 60_000_000
 DEFAULT_BLOCK_GAS_LIMIT = CURRENT_MAINNET_BLOCK_GAS_LIMIT * 2
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Current gas limit is 60M ([Link](https://gaslimit.pics/)), update the gas limit from 45M to 60M and remove outdated gas benchmark configurations.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
