### PR TITLE
chore(test-config): update mainnet block numbers for `eth_config`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/networks.yml
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/networks.yml
@@ -18,6 +18,9 @@ Mainnet:
     Shanghai:           1681338455
     Cancun:             1710338135
     Prague:             1746612311
+    Osaka:              1764798551
+    BPO1:               1765290071
+    BPO2:               1767747671
   blobSchedule:
     Cancun:
       target: 3


### PR DESCRIPTION
## 🗒️ Description
Updates the `eth_config` network file to use the block numbers for mainnet, BPO1 & BPO2 from:
https://blog.ethereum.org/2025/11/06/fusaka-mainnet-announcement

All ELs are passing with the following command:
```bash
uv run execute eth-config --network Mainnet --rpc-endpoint=<mainnet_rpc_endpoint> --chain-id=1
```

ELs were tested against the following latest mainnet releases as defined in the blog:
- Reth: "reth/v1.9.3-27a8c0f/x86_64-unknown-linux-gnu"
- Erigon: "erigon/3.3.0/linux-amd64/go1.25.4"
- Besu: "besu/v25.11.0/linux-x86_64/openjdk-java-21"
- Nethermind: "Nethermind/v1.35.3+d9febbce/linux-x64/dotnet9.0.10"
- Geth: "Geth/v1.16.7-stable-b9f3a3d9/linux-amd64/go1.24.9"

This essentially means that these clients are configured for:
  | Field   | Activation Time | Fork   | Blob Schedule     |
  |---------|-----------------|--------|-------------------|
  | current | 1746612311      | Prague | target=6, max=9   |
  | next    | 1764798551      | Osaka  | target=6, max=9   |
  | last    | 1767747671      | BPO2   | target=14, max=21 |
  
After the fork we will run `eth_config` again and expect the following from each EL client:
 | Field   | Activation Time | Fork  | Blob Schedule     |
  |---------|-----------------|-------|-------------------|
  | current | 1764798551      | Osaka | target=6, max=9   |
  | next    | 1765290071      | BPO1  | target=10, max=15 |
  | last    | 1767747671      | BPO2  | target=14, max=21 |

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.tvQWKnaxk3lg2NqKYPSqZwHaMC%3Fpid%3DApi&f=1&ipt=5af8c16ad0d882ecf548d260418c52eb9fa944f9881984f7ad763e3c2e2833e2&ipo=images)
