### PR TITLE
enhance(ci): Add EIP Tracker Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -43,9 +43,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## EIP ${{ form.eip_number }}: ${{ form.eip_title }}
-
-        **Link:** https://eips.ethereum.org/EIPS/eip-${{ form.eip_number }}
+        ## [EIP-${{ form.eip_number }}](https://eips.ethereum.org/EIPS/eip-${{ form.eip_number }})
 
         ## Target Fork
 

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -1,0 +1,77 @@
+name: "EIP Implementation Tracker"
+description: "Track specification and testing progress for an EIP"
+title: "EIP ${{ form.eip_number }} Progress Tracker"
+labels:
+  - A-spec-specs
+  - A-spec-tests
+  - C-eip
+  - C-test
+
+body:
+  - type: input
+    id: eip_number
+    attributes:
+      label: "EIP Number"
+      description: "Enter the EIP number (digits only)."
+      placeholder: "e.g., 8024"
+    validations:
+      required: true
+
+  - type: input
+    id: eip_title
+    attributes:
+      label: "EIP Title"
+      description: "Copy the title from the EIP."
+      placeholder: "e.g., Backwards compatible SWAPN, DUPN, EXCHANGE"
+    validations:
+      required: true
+  
+  - type: dropdown
+    id: fork
+    attributes:
+      label: "Fork"
+      description: |
+        Specify the target fork **only if the EIP has reached the CFI stage**.
+        More info: https://eips.ethereum.org/EIPS/eip-7723#considered-for-inclusion
+      options:
+        - TBD
+        - amsterdam
+        - bogota
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## EIP ${{ form.eip_number }}: ${{ form.eip_title }}
+
+        **Link:** https://eips.ethereum.org/EIPS/eip-${{ form.eip_number }}
+
+        ## Target Fork
+
+        Fork **${{ form.fork }}**
+
+        - [ ] Add issue to fork milestone (if applicable).
+
+        ## Ownership
+        
+        Owner(s): **TBD**
+
+        ## Specification + Testing Status
+
+        - [ ] Testing complexity assessed and documented.
+        - [ ] Specification implementation merged to `eips/${{ form.fork }}/eip-${{ form.eip_number }}`.
+        - [ ] Specification updates merged to the corresponding `forks/${{ form.fork }}` branch.
+        - [ ] Required testing framework modifications implemented.
+        - [ ] Test suite implemented.
+        - [ ] Full code coverage for all changes.
+        - [ ] Testing checklist complete  
+              (https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md).
+        - [ ] No regressions or failures in tests from prior forks (including static tests).
+        - [ ] Hardening session completed.
+        - [ ] Benchmarking performed and results documented.
+
+        ## Process Status
+        
+        - [ ] Client implementation prototypes done.
+        - [ ] EIP included in a devnet.

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -56,7 +56,7 @@ body:
         > [!IMPORTANT]
         > A specifications specialist and a testing specialist should ideally share ownership of the EIP.
 
-        - [ ] Add the issue to the target fork milestone if applicable (i.e., the EIP is at least in the (CFI stage)[https://eips.ethereum.org/EIPS/eip-7723#considered-for-inclusion]).
+        - [ ] Add the issue to the target fork milestone if applicable (i.e., the EIP is at least in the [CFI stage](https://eips.ethereum.org/EIPS/eip-7723#considered-for-inclusion)).
 
         ### Specification + Testing Status
 

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -71,6 +71,8 @@ body:
         - [ ] No regressions or failures in tests from prior forks (including static tests).
         - [ ] Hardening session completed.
         - [ ] Benchmarking performed and results documented.
+        - [ ] Ran tests using `execute` to ensure compatibility, and marked specific tests to be skipped when they cannot be executed on live networks.
+        - [ ] Added Mainnet-marked tests ([example test](https://github.com/ethereum/execution-specs/blob/2a6f9ee98ba7c0d04c7d523a0ea0ee8a98a5c418/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py)).
 
         ### Process Status
         

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -57,6 +57,8 @@ body:
         
         Owner(s): **TBD**
 
+        **Important note:** A specifications specialist and a testing specialist should ideally share ownership of the EIP.
+
         ## Specification + Testing Status
 
         - [ ] Testing complexity assessed and documented.
@@ -73,5 +75,5 @@ body:
 
         ## Process Status
         
-        - [ ] Client implementation prototypes done.
+        - [ ] Hive tests passing on all implementations.
         - [ ] EIP included in a devnet.

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -78,3 +78,4 @@ body:
         
         - [ ] Hive tests passing on all implementations.
         - [ ] EIP included in a devnet.
+        

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -58,6 +58,20 @@ body:
 
         - [ ] Add the issue to the target fork milestone if applicable (i.e., the EIP is at least in the [CFI stage](https://eips.ethereum.org/EIPS/eip-7723#considered-for-inclusion)).
 
+        #### Guidance for Marking Items Complete
+
+        An item should only be checked off once the EIP is considered *stable*. In this context, stable means:
+
+        - No major issues or ambiguities are still being uncovered in the specification or tests.
+        - There are no open discussion points awaiting resolution.
+        - Client implementations have been consistently passing the tests for at least a week.
+
+        It is ultimately up to the owners' discretion to decide when an item should be marked as complete, using this guidance as the basis for that decision.
+
+        In exceptional cases, an EIP may require changes after some items have been marked complete or even after the entire issue has been completed and closed. This can happen, for example, when significant design optimizations are identified and agreed upon in ACD, or when critical security issues surface and require updates to the specification or tests.
+        
+        When this occurs, owners should either unmark the relevant checkboxes if the issue is still open, or create a new tracking issue for the modifications if the original issue had already been closed.
+
         ### Specification + Testing Status
 
         - [ ] Testing complexity assessed and documented.
@@ -67,10 +81,10 @@ body:
         - [ ] Required testing framework modifications implemented.
         - [ ] Test suite implemented.
         - [ ] Full code coverage for all changes.
-        - [ ] [Testing checklist](https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md) complete.
         - [ ] No regressions or failures in tests from prior forks (including static tests).
+        - [ ] [Testing checklist](https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md) complete.
         - [ ] Hardening session completed.
-        - [ ] Benchmarking performed and results documented.
+        - [ ] Benchmarking tests written and results documented.
         - [ ] Ran tests using `execute` to ensure compatibility, and marked specific tests to be skipped when they cannot be executed on live networks.
         - [ ] Added Mainnet-marked tests ([example test](https://github.com/ethereum/execution-specs/blob/2a6f9ee98ba7c0d04c7d523a0ea0ee8a98a5c418/tests/osaka/eip7939_count_leading_zeros/test_eip_mainnet.py)).
 
@@ -78,4 +92,3 @@ body:
         
         - [ ] Hive tests passing on all implementations.
         - [ ] EIP included in a devnet.
-        

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -68,8 +68,8 @@ body:
         - [ ] Required testing framework modifications implemented.
         - [ ] Test suite implemented.
         - [ ] Full code coverage for all changes.
-        - [ ] Testing checklist complete  
-              (https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md).
+        - [ ] [Testing checklist](https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md) complete  
+              .
         - [ ] No regressions or failures in tests from prior forks (including static tests).
         - [ ] Hardening session completed.
         - [ ] Benchmarking performed and results documented.

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -90,5 +90,5 @@ body:
 
         ### Process Status
         
-        - [ ] Hive tests passing on all implementations.
+        - [ ] Hive tests passing on at least two implementations.
         - [ ] EIP included in a devnet.

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -45,34 +45,34 @@ body:
       value: |
         ## [EIP-${{ form.eip_number }}](https://eips.ethereum.org/EIPS/eip-${{ form.eip_number }})
 
-        ## Target Fork
+        ### Target Fork
 
         Fork **${{ form.fork }}**
 
-        - [ ] Add issue to fork milestone (if applicable).
-
-        ## Ownership
+        ### Instructions
         
-        Owner(s): **TBD**
+        - [ ] Assign issue to EIP specification and testing owner(s).
 
-        [!IMPORTANT]
-        A specifications specialist and a testing specialist should ideally share ownership of the EIP.
+        > [!IMPORTANT]
+        > A specifications specialist and a testing specialist should ideally share ownership of the EIP.
 
-        ## Specification + Testing Status
+        - [ ] Add the issue to the target fork milestone if applicable (i.e., the EIP is at least in the (CFI stage)[https://eips.ethereum.org/EIPS/eip-7723#considered-for-inclusion]).
+
+        ### Specification + Testing Status
 
         - [ ] Testing complexity assessed and documented.
-        - [ ] Specification implementation merged to `eips/${{ form.fork }}/eip-${{ form.eip_number }}`.
+        - [ ] Specification implementation merged to `eips/${{ form.fork }}/eip-${{ form.eip_number }}` *(skip if the fork branch merge below is already complete)*.
         - [ ] Specification updates merged to the corresponding `forks/${{ form.fork }}` branch.
+        - [ ] EIP updates proposed in case of architectural choices surfaced during implementation.
         - [ ] Required testing framework modifications implemented.
         - [ ] Test suite implemented.
         - [ ] Full code coverage for all changes.
-        - [ ] [Testing checklist](https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md) complete  
-              .
+        - [ ] [Testing checklist](https://github.com/ethereum/execution-specs/blob/HEAD/docs/writing_tests/checklist_templates/eip_testing_checklist_template.md) complete.
         - [ ] No regressions or failures in tests from prior forks (including static tests).
         - [ ] Hardening session completed.
         - [ ] Benchmarking performed and results documented.
 
-        ## Process Status
+        ### Process Status
         
         - [ ] Hive tests passing on all implementations.
         - [ ] EIP included in a devnet.

--- a/.github/ISSUE_TEMPLATE/eip-tracker.yaml
+++ b/.github/ISSUE_TEMPLATE/eip-tracker.yaml
@@ -57,7 +57,8 @@ body:
         
         Owner(s): **TBD**
 
-        **Important note:** A specifications specialist and a testing specialist should ideally share ownership of the EIP.
+        [!IMPORTANT]
+        A specifications specialist and a testing specialist should ideally share ownership of the EIP.
 
         ## Specification + Testing Status
 


### PR DESCRIPTION
## 🗒️ Description

Adds a tracker issue template for EIPs to help better monitor the specification and testing progress.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1413061082/photo/portrait-of-little-calf-on-grass-field.jpg?s=612x612&w=0&k=20&c=OSGam8VlAl2qrKSbTKuEQI33ZUMI4kEhnuRDlJ7IFiY=)
