### PR TITLE
feat(benchmarks): add keccak benchmark with updated memory

### DIFF
--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -70,17 +70,23 @@ def test_keccak_max_permutations(
 
 @pytest.mark.parametrize("mem_alloc", [b"", b"ff", b"ff" * 32])
 @pytest.mark.parametrize("offset", [0, 31, 1024])
+@pytest.mark.parametrize("mem_update", [True, False])
 def test_keccak(
     benchmark_test: BenchmarkTestFiller,
     offset: int,
     mem_alloc: bytes,
+    mem_update: bool
 ) -> None:
     """Benchmark KECCAK256 instruction with diff input data and offsets."""
+
+    code_hash = Op.SHA3(offset, Op.CALLDATASIZE)
+    attack_block = Op.MSTORE(Op.PUSH0, code_hash) if mem_update else Op.POP(code_hash)
+
     benchmark_test(
         target_opcode=Op.SHA3,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(offset, Op.PUSH0, Op.CALLDATASIZE),
-            attack_block=Op.POP(Op.SHA3(offset, Op.CALLDATASIZE)),
+            attack_block=attack_block,
             tx_kwargs={"data": mem_alloc},
         ),
     )

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -75,12 +75,13 @@ def test_keccak(
     benchmark_test: BenchmarkTestFiller,
     offset: int,
     mem_alloc: bytes,
-    mem_update: bool
+    mem_update: bool,
 ) -> None:
     """Benchmark KECCAK256 instruction with diff input data and offsets."""
-
     code_hash = Op.SHA3(offset, Op.CALLDATASIZE)
-    attack_block = Op.MSTORE(Op.PUSH0, code_hash) if mem_update else Op.POP(code_hash)
+    attack_block = (
+        Op.MSTORE(Op.PUSH0, code_hash) if mem_update else Op.POP(code_hash)
+    )
 
     benchmark_test(
         target_opcode=Op.SHA3,


### PR DESCRIPTION
## 🗒️ Description
This PR adds a mode to the keccak benchmark to ensure that the memory is updated each time keccak is called. This ensures that clients with a caching mechanism cannot use it (we generate a hash chain).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
- [ ] Before we merge this, I am confused by the test. The `offset` seems to place the calldata at an offset in the memory, and then if we hash it, we also start from this offset. So, we actually hash the same, regardless of what the `offset` parameter is. Is this the intent of this flag? Why is it there? The only thing it changes is that it writes to different memory (and will only do this once at startup). @LouisTsai-Csie maybe knows?
- [ ] Do not merge until we have reviewed the keccak benchmark :smile: :+1: 

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
