### PR TITLE
feat(benchmarks): fix bytecode attack for CALL-like opcodes to work in Osaka

### DIFF
--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -55,7 +55,6 @@ def test_xcall(
     pre: Alloc,
     fork: Fork,
     opcode: Op,
-    env: Environment,
     gas_benchmark_value: int,
     tx_gas_limit: int,
 ) -> None:
@@ -99,6 +98,8 @@ def test_xcall(
         num_contracts_per_tx = int(tx_gas_limit * 0.9) // (
             gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
         )
+        if num_contracts_per_tx == 0:
+            pytest.skip("tx_gas_limit too low to deploy max-size contract")
         setup_txs = math.ceil(num_contracts / num_contracts_per_tx)
 
         contracts_deployment_txs = []

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -109,16 +109,33 @@ def test_xcall(
             "during the setup phase of this test."
         )
 
-    initcode, factory_address, factory_caller_address = deploy_max_contract_factory(pre, fork)
+    initcode, factory_address, factory_caller_address = (
+        deploy_max_contract_factory(pre, fork)
+    )
 
     with TestPhaseManager.setup():
-        contracts_deployment_tx = Transaction(
-            to=factory_caller_address,
-            gas_limit=env.gas_limit,
-            gas_price=10**6,
-            data=Hash(num_contracts),
-            sender=pre.fund_eoa(),
+        # We require deploying num_contracts by calling the factory contract. Each call can only
+        # use up to the transaction gas limit cap, thus we need to split the deployment into
+        # multiple transactions. The factory contract uses a storage slot to keep track of the last
+        # seed used to generate bytecodes, so it is safe to call it multiple times in different txs.
+        num_contracts_per_tx = (
+            3  # TODO: Try generalizing for any tx gas limit cap. For 17M is 3.
         )
+        num_contract_creation_txs = math.ceil(
+            num_contracts / num_contracts_per_tx
+        )
+
+        contracts_deployment_txs = []
+        for _ in range(num_contract_creation_txs):
+            contracts_deployment_txs.append(
+                Transaction(
+                    to=factory_caller_address,
+                    gas_limit=fork.transaction_gas_limit_cap(),
+                    gas_price=10**6,
+                    data=Hash(num_contracts_per_tx),
+                    sender=pre.fund_eoa(),
+                )
+            )
 
     post = {}
     deployed_contract_addresses = []
@@ -174,16 +191,17 @@ def test_xcall(
         pre=pre,
         post=post,
         blocks=[
-            Block(txs=[contracts_deployment_tx]),
-            Block(txs=[opcode_tx]),
+            Block(txs=contracts_deployment_txs),
+            # Block(txs=[opcode_tx]),
         ],
         exclude_full_post_state_in_output=True,
     )
 
+
 def deploy_max_contract_factory(
     pre: Alloc,
     fork: Fork,
-) -> tuple[Bytecode, Address, Address]: 
+) -> tuple[Bytecode, Address, Address]:
     max_contract_size = fork.max_code_size()
 
     # The initcode will take its address as a starting point to the input to

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -59,19 +59,16 @@ def test_xcall(
     gas_benchmark_value: int,
 ) -> None:
     """Benchmark a system execution where a single opcode execution."""
-    # The attack gas limit is the gas limit which the target tx will use The
-    # test will scale the block gas limit to setup the contracts accordingly to
-    # be able to pay for the contract deposit. This has to take into account
-    # the 200 gas per byte, but also the quadratic memory expansion costs which
-    # have to be paid each time the memory is being setup
+    # The attack gas limit represents the transaction gas limit cap or
+    # the block gas limit. If eip-7825 is applied, the test will create
+    # multiple transactions for contract deployment. It should account
+    # for the 200 gas per byte cost and the quadratic memory-expansion
+    # costs, which must be paid each time memory is initialized.
     attack_gas_limit = gas_benchmark_value
     max_contract_size = fork.max_code_size()
 
     gas_costs = fork.gas_costs()
     tx_gas_limit_cap = fork.transaction_gas_limit_cap()
-    assert tx_gas_limit_cap is not None, (
-        "This benchmark requires a tx gas limit cap"
-    )
 
     # Calculate the absolute minimum gas costs to deploy the contract This does
     # not take into account setting up the actual memory (using KECCAK256 and
@@ -126,17 +123,24 @@ def test_xcall(
         # If this estimation is incorrect in the future (i.e. tx gas limit cap)
         # is increased or cost per byte, the post-state check will detect it
         # and can be adjusted with a more complex formula.
-        num_contracts_per_tx = tx_gas_limit_cap // (
-            gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
+        num_contracts_per_tx = (
+            tx_gas_limit_cap
+            // (gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size)
+            if tx_gas_limit_cap
+            else num_contracts
         )
-        attack_txs = math.ceil(num_contracts / num_contracts_per_tx)
+        attack_txs = (
+            math.ceil(num_contracts / num_contracts_per_tx)
+            if num_contracts_per_tx
+            else 1
+        )
 
         contracts_deployment_txs = []
         for _ in range(attack_txs):
             contracts_deployment_txs.append(
                 Transaction(
                     to=factory_caller_address,
-                    gas_limit=tx_gas_limit_cap,
+                    gas_limit=tx_gas_limit_cap or env.gas_limit,
                     data=Hash(num_contracts_per_tx),
                     sender=pre.fund_eoa(),
                 )
@@ -176,13 +180,17 @@ def test_xcall(
     attack_address = pre.deploy_contract(code=attack_code)
 
     with TestPhaseManager.execution():
-        full_txs = attack_gas_limit // tx_gas_limit_cap
-        remainder = attack_gas_limit % tx_gas_limit_cap
+        full_txs = (
+            attack_gas_limit // tx_gas_limit_cap if tx_gas_limit_cap else 1
+        )
+        remainder = (
+            attack_gas_limit % tx_gas_limit_cap if tx_gas_limit_cap else 0
+        )
 
         num_targeted_contracts_per_full_tx = (
             # Base available gas:
             # TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
-            tx_gas_limit_cap
+            (tx_gas_limit_cap or attack_gas_limit)
             - intrinsic_gas_cost_calc()
             - gas_costs.G_VERY_LOW * 4
         ) // loop_cost
@@ -192,7 +200,7 @@ def test_xcall(
             opcode_txs.append(
                 Transaction(
                     to=attack_address,
-                    gas_limit=tx_gas_limit_cap,
+                    gas_limit=tx_gas_limit_cap or attack_gas_limit,
                     data=Hash(contract_start_index),
                     sender=pre.fund_eoa(),
                 )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -98,7 +98,7 @@ def test_xcall(
         # complexity and potential brittleness.
         num_contracts_per_tx = int(tx_gas_limit * 0.9) // (
             gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
-        ) 
+        )
         setup_txs = math.ceil(num_contracts / num_contracts_per_tx)
 
         contracts_deployment_txs = []

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -91,7 +91,7 @@ def test_xcall(
         + gas_costs.G_COLD_ACCOUNT_ACCESS  # Opcode cost
         + 30  # ~Gluing opcodes
     )
-    # Calculate the number of contracts to be targeted
+    # Calculate an upper bound of the number of contracts to be targeted
     num_contracts = (
         # Base available gas = GAS_LIMIT - intrinsic - (out of loop MSTOREs)
         attack_gas_limit - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
@@ -121,12 +121,10 @@ def test_xcall(
         num_contracts_per_tx = (
             3  # TODO: Try generalizing for any tx gas limit cap. For 17M is 3.
         )
-        num_contract_creation_txs = math.ceil(
-            num_contracts / num_contracts_per_tx
-        )
+        attack_txs = math.ceil(num_contracts / num_contracts_per_tx)
 
         contracts_deployment_txs = []
-        for _ in range(num_contract_creation_txs):
+        for _ in range(attack_txs):
             contracts_deployment_txs.append(
                 Transaction(
                     to=factory_caller_address,
@@ -138,7 +136,6 @@ def test_xcall(
             )
 
     post = {}
-    deployed_contract_addresses = []
     for i in range(num_contracts):
         deployed_contract_address = compute_create2_address(
             address=factory_address,
@@ -146,7 +143,6 @@ def test_xcall(
             initcode=initcode,
         )
         post[deployed_contract_address] = Account(nonce=1)
-        deployed_contract_addresses.append(deployed_contract_address)
 
     attack_call = Bytecode()
     if opcode == Op.EXTCODECOPY:
@@ -162,7 +158,7 @@ def test_xcall(
         # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
         Op.MSTORE(0, factory_address)
         + Op.MSTORE8(32 - 20 - 1, 0xFF)
-        + Op.MSTORE(32, 0)
+        + Op.MSTORE(32, Op.CALLDATALOAD(0))
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
@@ -177,22 +173,47 @@ def test_xcall(
             f"Code size {len(attack_code)} exceeds maximum "
             f"code size {max_contract_size}"
         )
-    opcode_address = pre.deploy_contract(code=attack_code)
+    attack_address = pre.deploy_contract(code=attack_code)
 
     with TestPhaseManager.execution():
-        opcode_tx = Transaction(
-            to=opcode_address,
-            gas_limit=attack_gas_limit,
-            gas_price=10**9,
-            sender=pre.fund_eoa(),
-        )
+        tx_gas_cap = fork.transaction_gas_limit_cap()
+        full_txs = attack_gas_limit // tx_gas_cap
+        remainder = attack_gas_limit % tx_gas_cap
+
+        num_targeted_contracts_per_full_tx = (
+            # Base available gas = TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
+            tx_gas_cap - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
+        ) // loop_cost
+        contract_start_index = 0
+        opcode_txs = []
+        for _ in range(full_txs):
+            opcode_txs.append(
+                Transaction(
+                    to=attack_address,
+                    gas_limit=tx_gas_cap,
+                    gas_price=10**9,
+                    data=Hash(contract_start_index),
+                    sender=pre.fund_eoa(),
+                )
+            )
+            contract_start_index += num_targeted_contracts_per_full_tx
+        if remainder > 0:
+            opcode_txs.append(
+                Transaction(
+                    to=attack_address,
+                    gas_limit=remainder,
+                    gas_price=10**9,
+                    data=Hash(contract_start_index),
+                    sender=pre.fund_eoa(),
+                )
+            )
 
     blockchain_test(
         pre=pre,
         post=post,
         blocks=[
             Block(txs=contracts_deployment_txs),
-            # Block(txs=[opcode_tx]),
+            Block(txs=opcode_txs),
         ],
         exclude_full_post_state_in_output=True,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -68,7 +68,10 @@ def test_xcall(
     max_contract_size = fork.max_code_size()
 
     gas_costs = fork.gas_costs()
-    tx_gas_limit_cap = fork.transaction_gas_limit_cap() or attack_gas_limit
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert tx_gas_limit_cap is not None, (
+        "This benchmark requires a tx gas limit cap"
+    )
 
     # Calculate the absolute minimum gas costs to deploy the contract This does
     # not take into account setting up the actual memory (using KECCAK256 and

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -137,7 +137,6 @@ def test_xcall(
                 Transaction(
                     to=factory_caller_address,
                     gas_limit=tx_gas_limit_cap,
-                    gas_price=10**6,
                     data=Hash(num_contracts_per_tx),
                     sender=pre.fund_eoa(),
                 )
@@ -174,13 +173,6 @@ def test_xcall(
         )
     )
 
-    if len(attack_code) > max_contract_size:
-        # TODO: A workaround could be to split the opcode code into multiple
-        # contracts and call them in sequence.
-        raise ValueError(
-            f"Code size {len(attack_code)} exceeds maximum "
-            f"code size {max_contract_size}"
-        )
     attack_address = pre.deploy_contract(code=attack_code)
 
     with TestPhaseManager.execution():
@@ -201,7 +193,6 @@ def test_xcall(
                 Transaction(
                     to=attack_address,
                     gas_limit=tx_gas_limit_cap,
-                    gas_price=10**9,
                     data=Hash(contract_start_index),
                     sender=pre.fund_eoa(),
                 )
@@ -212,7 +203,6 @@ def test_xcall(
                 Transaction(
                     to=attack_address,
                     gas_limit=remainder,
-                    gas_price=10**9,
                     data=Hash(contract_start_index),
                     sender=pre.fund_eoa(),
                 )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -18,6 +18,7 @@ import math
 import pytest
 from execution_testing import (
     Account,
+    Address,
     Alloc,
     BenchmarkTestFiller,
     Block,
@@ -108,74 +109,7 @@ def test_xcall(
             "during the setup phase of this test."
         )
 
-    # The initcode will take its address as a starting point to the input to
-    # the keccak hash function. It will reuse the output of the hash function
-    # in a loop to create a large amount of seemingly random code, until it
-    # reaches the maximum contract size.
-    initcode = (
-        Op.MSTORE(0, Op.ADDRESS)
-        + While(
-            body=(
-                Op.SHA3(Op.SUB(Op.MSIZE, 32), 32)
-                # Use a xor table to avoid having to call the "expensive" sha3
-                # opcode as much
-                + sum(
-                    (
-                        Op.PUSH32[xor_value]
-                        + Op.XOR
-                        + Op.DUP1
-                        + Op.MSIZE
-                        + Op.MSTORE
-                    )
-                    for xor_value in XOR_TABLE
-                )
-                + Op.POP
-            ),
-            condition=Op.LT(Op.MSIZE, max_contract_size),
-        )
-        # Despite the whole contract has random bytecode, we make the first
-        # opcode be a STOP so CALL-like attacks return as soon as possible,
-        # while EXTCODE(HASH|SIZE) work as intended.
-        + Op.MSTORE8(0, 0x00)
-        + Op.RETURN(0, max_contract_size)
-    )
-    initcode_address = pre.deploy_contract(code=initcode)
-
-    # The factory contract will simply use the initcode that is already
-    # deployed, and create a new contract and return its address if successful.
-    factory_code = (
-        Op.EXTCODECOPY(
-            address=initcode_address,
-            dest_offset=0,
-            offset=0,
-            size=Op.EXTCODESIZE(initcode_address),
-        )
-        + Op.MSTORE(
-            0,
-            Op.CREATE2(
-                value=0,
-                offset=0,
-                size=Op.EXTCODESIZE(initcode_address),
-                salt=Op.SLOAD(0),
-            ),
-        )
-        + Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
-        + Op.RETURN(0, 32)
-    )
-    factory_address = pre.deploy_contract(code=factory_code)
-
-    # The factory caller will call the factory contract N times, creating N new
-    # contracts. Calldata should contain the N value.
-    factory_caller_code = Op.CALLDATALOAD(0) + While(
-        body=Op.POP(Op.CALL(address=factory_address)),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
-    )
-    factory_caller_address = pre.deploy_contract(code=factory_caller_code)
+    initcode, factory_address, factory_caller_address = deploy_max_contract_factory(pre, fork)
 
     with TestPhaseManager.setup():
         contracts_deployment_tx = Transaction(
@@ -245,6 +179,83 @@ def test_xcall(
         ],
         exclude_full_post_state_in_output=True,
     )
+
+def deploy_max_contract_factory(
+    pre: Alloc,
+    fork: Fork,
+) -> tuple[Bytecode, Address, Address]: 
+    max_contract_size = fork.max_code_size()
+
+    # The initcode will take its address as a starting point to the input to
+    # the keccak hash function. It will reuse the output of the hash function
+    # in a loop to create a large amount of seemingly random code, until it
+    # reaches the maximum contract size.
+    initcode = (
+        Op.MSTORE(0, Op.ADDRESS)
+        + While(
+            body=(
+                Op.SHA3(Op.SUB(Op.MSIZE, 32), 32)
+                # Use a xor table to avoid having to call the "expensive" sha3
+                # opcode as much
+                + sum(
+                    (
+                        Op.PUSH32[xor_value]
+                        + Op.XOR
+                        + Op.DUP1
+                        + Op.MSIZE
+                        + Op.MSTORE
+                    )
+                    for xor_value in XOR_TABLE
+                )
+                + Op.POP
+            ),
+            condition=Op.LT(Op.MSIZE, max_contract_size),
+        )
+        # Despite the whole contract has random bytecode, we make the first
+        # opcode be a STOP so CALL-like attacks return as soon as possible,
+        # while EXTCODE(HASH|SIZE) work as intended.
+        + Op.MSTORE8(0, 0x00)
+        + Op.RETURN(0, max_contract_size)
+    )
+    initcode_address = pre.deploy_contract(code=initcode)
+
+    # The factory contract will simply use the initcode that is already
+    # deployed, and create a new contract and return its address if successful.
+    factory_code = (
+        Op.EXTCODECOPY(
+            address=initcode_address,
+            dest_offset=0,
+            offset=0,
+            size=Op.EXTCODESIZE(initcode_address),
+        )
+        + Op.MSTORE(
+            0,
+            Op.CREATE2(
+                value=0,
+                offset=0,
+                size=Op.EXTCODESIZE(initcode_address),
+                salt=Op.SLOAD(0),
+            ),
+        )
+        + Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
+        + Op.RETURN(0, 32)
+    )
+    factory_address = pre.deploy_contract(code=factory_code)
+
+    # The factory caller will call the factory contract N times, creating N new
+    # contracts. Calldata should contain the N value.
+    factory_caller_code = Op.CALLDATALOAD(0) + While(
+        body=Op.POP(Op.CALL(address=factory_address)),
+        condition=Op.PUSH1(1)
+        + Op.SWAP1
+        + Op.SUB
+        + Op.DUP1
+        + Op.ISZERO
+        + Op.ISZERO,
+    )
+    factory_caller_address = pre.deploy_contract(code=factory_caller_code)
+
+    return initcode, factory_address, factory_caller_address
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -68,6 +68,7 @@ def test_xcall(
     max_contract_size = fork.max_code_size()
 
     gas_costs = fork.gas_costs()
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap() or attack_gas_limit
 
     # Calculate the absolute minimum gas costs to deploy the contract This does
     # not take into account setting up the actual memory (using KECCAK256 and
@@ -122,7 +123,7 @@ def test_xcall(
         # If this estimation is incorrect in the future (i.e. tx gas limit cap)
         # is increased or cost per byte, the post-state check will detect it
         # and can be adjusted with a more complex formula.
-        num_contracts_per_tx = fork.transaction_gas_limit_cap() // (
+        num_contracts_per_tx = tx_gas_limit_cap // (
             gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
         )
         attack_txs = math.ceil(num_contracts / num_contracts_per_tx)
@@ -132,7 +133,7 @@ def test_xcall(
             contracts_deployment_txs.append(
                 Transaction(
                     to=factory_caller_address,
-                    gas_limit=fork.transaction_gas_limit_cap(),
+                    gas_limit=tx_gas_limit_cap,
                     gas_price=10**6,
                     data=Hash(num_contracts_per_tx),
                     sender=pre.fund_eoa(),
@@ -180,14 +181,15 @@ def test_xcall(
     attack_address = pre.deploy_contract(code=attack_code)
 
     with TestPhaseManager.execution():
-        tx_gas_cap = fork.transaction_gas_limit_cap()
-        full_txs = attack_gas_limit // tx_gas_cap
-        remainder = attack_gas_limit % tx_gas_cap
+        full_txs = attack_gas_limit // tx_gas_limit_cap
+        remainder = attack_gas_limit % tx_gas_limit_cap
 
         num_targeted_contracts_per_full_tx = (
             # Base available gas:
             # TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
-            tx_gas_cap - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
+            tx_gas_limit_cap
+            - intrinsic_gas_cost_calc()
+            - gas_costs.G_VERY_LOW * 4
         ) // loop_cost
         contract_start_index = 0
         opcode_txs = []
@@ -195,7 +197,7 @@ def test_xcall(
             opcode_txs.append(
                 Transaction(
                     to=attack_address,
-                    gas_limit=tx_gas_cap,
+                    gas_limit=tx_gas_limit_cap,
                     gas_price=10**9,
                     data=Hash(contract_start_index),
                     sender=pre.fund_eoa(),

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -57,6 +57,7 @@ def test_xcall(
     opcode: Op,
     env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """Benchmark a system execution where a single opcode execution."""
     # The attack gas limit represents the transaction gas limit cap or
@@ -68,19 +69,6 @@ def test_xcall(
     max_contract_size = fork.max_code_size()
 
     gas_costs = fork.gas_costs()
-    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
-
-    # Calculate the absolute minimum gas costs to deploy the contract This does
-    # not take into account setting up the actual memory (using KECCAK256 and
-    # XOR) so the actual costs of deploying the contract is higher
-    memory_expansion_gas_calculator = fork.memory_expansion_gas_calculator()
-    memory_gas_minimum = memory_expansion_gas_calculator(
-        new_bytes=len(bytes(max_contract_size))
-    )
-    code_deposit_gas_minimum = (
-        fork.gas_costs().G_CODE_DEPOSIT_BYTE * max_contract_size
-        + memory_gas_minimum
-    )
 
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
     # Calculate the loop cost of the attacker to query one address
@@ -98,18 +86,6 @@ def test_xcall(
         attack_gas_limit - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
     ) // loop_cost
 
-    # Set the block gas limit to a relative high value to ensure the code
-    # deposit tx fits in the block (there is enough gas available in the block
-    # to execute this)
-    minimum_gas_limit = code_deposit_gas_minimum * 2 * num_contracts
-    if env.gas_limit < minimum_gas_limit:
-        raise Exception(
-            f"`BENCHMARKING_MAX_GAS` ({env.gas_limit}) is no longer enough to"
-            f" support this test, which requires {minimum_gas_limit} gas for "
-            "its setup. Update the value or consider optimizing gas usage "
-            "during the setup phase of this test."
-        )
-
     initcode, factory_address, factory_caller_address = (
         _deploy_max_contract_factory(pre, fork)
     )
@@ -117,30 +93,20 @@ def test_xcall(
     # Deploy num_contracts via multiple txs (each capped by tx gas limit).
     with TestPhaseManager.setup():
         # Rough estimate (rounded down) of contracts per tx based on dominant
-        # cost factor only. E.g., 17M gas limit + 24KiB contracts = ~3 per tx.
+        # cost factor only, and up to 90% of the block gas limit.
         # The goal is to involve the minimum amount of gas pricing to avoid
         # complexity and potential brittleness.
-        # If this estimation is incorrect in the future (i.e. tx gas limit cap)
-        # is increased or cost per byte, the post-state check will detect it
-        # and can be adjusted with a more complex formula.
-        num_contracts_per_tx = (
-            tx_gas_limit_cap
-            // (gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size)
-            if tx_gas_limit_cap
-            else num_contracts
-        )
-        attack_txs = (
-            math.ceil(num_contracts / num_contracts_per_tx)
-            if num_contracts_per_tx
-            else 1
-        )
+        num_contracts_per_tx = int(tx_gas_limit * 0.9) // (
+            gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
+        ) 
+        setup_txs = math.ceil(num_contracts / num_contracts_per_tx)
 
         contracts_deployment_txs = []
-        for _ in range(attack_txs):
+        for _ in range(setup_txs):
             contracts_deployment_txs.append(
                 Transaction(
                     to=factory_caller_address,
-                    gas_limit=tx_gas_limit_cap or env.gas_limit,
+                    gas_limit=tx_gas_limit,
                     data=Hash(num_contracts_per_tx),
                     sender=pre.fund_eoa(),
                 )
@@ -180,19 +146,13 @@ def test_xcall(
     attack_address = pre.deploy_contract(code=attack_code)
 
     with TestPhaseManager.execution():
-        full_txs = (
-            attack_gas_limit // tx_gas_limit_cap if tx_gas_limit_cap else 1
-        )
-        remainder = (
-            attack_gas_limit % tx_gas_limit_cap if tx_gas_limit_cap else 0
-        )
+        full_txs = attack_gas_limit // tx_gas_limit
+        remainder = attack_gas_limit % tx_gas_limit
 
         num_targeted_contracts_per_full_tx = (
             # Base available gas:
             # TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
-            (tx_gas_limit_cap or attack_gas_limit)
-            - intrinsic_gas_cost_calc()
-            - gas_costs.G_VERY_LOW * 4
+            tx_gas_limit - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
         ) // loop_cost
         contract_start_index = 0
         opcode_txs = []
@@ -200,7 +160,7 @@ def test_xcall(
             opcode_txs.append(
                 Transaction(
                     to=attack_address,
-                    gas_limit=tx_gas_limit_cap or attack_gas_limit,
+                    gas_limit=tx_gas_limit,
                     data=Hash(contract_start_index),
                     sender=pre.fund_eoa(),
                 )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -110,16 +110,20 @@ def test_xcall(
         )
 
     initcode, factory_address, factory_caller_address = (
-        deploy_max_contract_factory(pre, fork)
+        _deploy_max_contract_factory(pre, fork)
     )
 
+    # Deploy num_contracts via multiple txs (each capped by tx gas limit).
     with TestPhaseManager.setup():
-        # We require deploying num_contracts by calling the factory contract. Each call can only
-        # use up to the transaction gas limit cap, thus we need to split the deployment into
-        # multiple transactions. The factory contract uses a storage slot to keep track of the last
-        # seed used to generate bytecodes, so it is safe to call it multiple times in different txs.
-        num_contracts_per_tx = (
-            3  # TODO: Try generalizing for any tx gas limit cap. For 17M is 3.
+        # Rough estimate (rounded down) of contracts per tx based on dominant
+        # cost factor only. E.g., 17M gas limit + 24KiB contracts = ~3 per tx.
+        # The goal is to involve the minimum amount of gas pricing to avoid
+        # complexity and potential brittleness.
+        # If this estimation is incorrect in the future (i.e. tx gas limit cap)
+        # is increased or cost per byte, the post-state check will detect it
+        # and can be adjusted with a more complex formula.
+        num_contracts_per_tx = fork.transaction_gas_limit_cap() // (
+            gas_costs.G_CODE_DEPOSIT_BYTE * max_contract_size
         )
         attack_txs = math.ceil(num_contracts / num_contracts_per_tx)
 
@@ -181,7 +185,8 @@ def test_xcall(
         remainder = attack_gas_limit % tx_gas_cap
 
         num_targeted_contracts_per_full_tx = (
-            # Base available gas = TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
+            # Base available gas:
+            # TX_GAS_LIMIT - intrinsic - (out of loop MSTOREs)
             tx_gas_cap - intrinsic_gas_cost_calc() - gas_costs.G_VERY_LOW * 4
         ) // loop_cost
         contract_start_index = 0
@@ -219,7 +224,7 @@ def test_xcall(
     )
 
 
-def deploy_max_contract_factory(
+def _deploy_max_contract_factory(
     pre: Alloc,
     fork: Fork,
 ) -> tuple[Bytecode, Address, Address]:

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -135,7 +135,7 @@ def test_xcall(
         # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
         Op.MSTORE(0, factory_address)
         + Op.MSTORE8(32 - 20 - 1, 0xFF)
-        + Op.MSTORE(32, Op.CALLDATALOAD(0))
+        + Op.MSTORE(32, Op.CALLDATALOAD(0)) # Calldata is the starting value of the CREATE2 salt
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
@@ -166,7 +166,7 @@ def test_xcall(
                 )
             )
             contract_start_index += num_targeted_contracts_per_full_tx
-        if remainder > 0:
+        if remainder > intrinsic_gas_cost_calc(calldata=32):
             opcode_txs.append(
                 Transaction(
                     to=attack_address,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -135,7 +135,9 @@ def test_xcall(
         # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
         Op.MSTORE(0, factory_address)
         + Op.MSTORE8(32 - 20 - 1, 0xFF)
-        + Op.MSTORE(32, Op.CALLDATALOAD(0)) # Calldata is the starting value of the CREATE2 salt
+        + Op.MSTORE(
+            32, Op.CALLDATALOAD(0)
+        )  # Calldata is the starting value of the CREATE2 salt
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
@@ -166,7 +168,7 @@ def test_xcall(
                 )
             )
             contract_start_index += num_targeted_contracts_per_full_tx
-        if remainder > intrinsic_gas_cost_calc(calldata=32):
+        if remainder > intrinsic_gas_cost_calc(calldata=bytes(32)):
             opcode_txs.append(
                 Transaction(
                     to=attack_address,


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the `test_xcall` benchmarks to work with Osaka. `test_xcall` has a CALL-like variant of the bytecode attack exploiting unchunkified code, highly relevant for zkVM worst-cases.

I think the solution should feel quite natural — I’ll add some review comments.

I checked this is doing what we want with two independent checks:

1. Hack a bit the Geth codebase to inspect how many distinct bytecodes were accessed during the block execution.
2. Actually running the worst-case block for zkVM execution and inspecting that indeed the witness to be sent to the guest program indeed is blowed up — since bytecode must be part of the input to the guest program.

For 1. and `--block-gas-limit 30M`, my Geth reports accessing ~260MiB of bytecodes were the upper limit is ~280MiB (30M/2600 — but this isn’t accounting for glue opcodes, intrinsic costs of splitting in txs, etc). So this looks fine.

For 2. and `--block-gas-limit 30M`, I also confirmed it really blows up the guest program witness, which is prob the best ultimate confirmation this is doing what we wanted. i.e: the json-encoded files have ~524MiB size which makes sense since bytes are hex encoded (with other things).

## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


