### PR TITLE
bug(test-cli-consume): fix path where consume puts its metadata

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/consume.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/consume.py
@@ -533,7 +533,10 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: D103
         and config.getoption("htmlpath") is None
     ):
         # generate an html report by default, unless explicitly disabled
-        config.option.htmlpath = Path(default_html_report_file_path())
+        config.option.htmlpath = (
+            config.fixtures_source.path  # type: ignore[attr-defined]
+            / default_html_report_file_path()
+        )
 
 
 def pytest_html_report_title(report: Any) -> None:


### PR DESCRIPTION
## 🗒️ Description

Fix path where `consume` puts its metadata to mirror what filler does [here](https://github.com/fselmo/execution-specs/blob/b5576c8428e6a6f9fc1d581114dbf129937291da/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py#L707-L710). Otherwise, it was putting it in the current working dir and isn't in `.gitignore` so it gets added to your list of changes and is quite a nuisance.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="281" height="258" alt="Screenshot 2025-12-05 at 11 23 48" src="https://github.com/user-attachments/assets/de3e8ce9-2343-4d42-abb0-df6b1fafe1a7" />

