### PR TITLE
chore(ci): bump hive consume runner to self hosted

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -83,7 +83,7 @@ jobs:
           ./hive --sim '${{ matrix.simulator }}' \
             --sim.parallelism=1 \
             --client go-ethereum \
-            --client-file ../execution-specs/.github/configs/hive/latest.yaml \
+            --client-file ../execution-specs/.github/configs/hive/master.yaml \
             --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
@@ -92,7 +92,7 @@ jobs:
         if: matrix.mode == 'dev'
         run: |
           cd hive
-          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/latest.yaml --docker.output &
+          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.output &
           echo "Waiting for Hive to be ready..."
           for i in {1..30}; do
             if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -83,7 +83,7 @@ jobs:
           ./hive --sim '${{ matrix.simulator }}' \
             --sim.parallelism=1 \
             --client go-ethereum \
-            --client-file ../execution-specs/.github/configs/hive/master.yaml \
+            --client-file ../execution-specs/.github/configs/hive/latest.yaml \
             --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
@@ -92,7 +92,7 @@ jobs:
         if: matrix.mode == 'dev'
         run: |
           cd hive
-          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.output &
+          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/latest.yaml --docker.output &
           echo "Waiting for Hive to be ready..."
           for i in {1..30}; do
             if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   test-hive:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr, size-l-x64]
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Should fix the existing hive consume CI failures.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
