### PR TITLE
chore(test-client-clis): final fusaka mapper fixes

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -322,6 +322,9 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.NONCE_MISMATCH_TOO_LOW: (
             r"transaction invalid transaction nonce \d+ below sender account nonce \d+"
         ),
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: (
+            r"transaction invalid transaction nonce \d+ does not match sender account nonce \d+"
+        ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             r"transaction invalid Transaction gas limit must be at most \d+"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -23,6 +23,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: "tip higher than fee cap",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: "max fee per blob gas too low",
         TransactionException.NONCE_MISMATCH_TOO_LOW: "nonce too low",
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: "nonce too high",
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "gas limit reached",
         TransactionException.TYPE_3_TX_PRE_FORK: "blob txn is not supported by signer",
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (

--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -39,7 +39,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"reject transactions from senders with deployed code|"
             r"Sender account .* shouldn't be a contract"
         ),
-        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+|Nonce mismatch.*",
         TransactionException.NONCE_MISMATCH_TOO_HIGH: r"Nonce mismatch.*",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"

--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -39,8 +39,8 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"reject transactions from senders with deployed code|"
             r"Sender account .* shouldn't be a contract"
         ),
-        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+|"
-        r"Nonce mismatch.*",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: r"Nonce mismatch.*",
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (
             r"blob gas used \d+ exceeds maximum allowance \d+"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -391,6 +391,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "Block gas limit exceeded",
         TransactionException.NONCE_IS_MAX: "NonceTooHigh",
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
+        TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
         TransactionException.NONCE_MISMATCH_TOO_HIGH: "wrong transaction nonce",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -391,7 +391,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: "Block gas limit exceeded",
         TransactionException.NONCE_IS_MAX: "NonceTooHigh",
         TransactionException.INITCODE_SIZE_EXCEEDED: "max initcode size exceeded",
-        TransactionException.NONCE_MISMATCH_TOO_LOW: "wrong transaction nonce",
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: "wrong transaction nonce",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/reth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/reth.py
@@ -30,9 +30,6 @@ class RethExceptionMapper(ExceptionMapper):
         TransactionException.TYPE_4_TX_PRE_FORK: (
             "eip 7702 transactions present in pre-prague payload"
         ),
-        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
-            "failed to decode deposit requests from receipts"
-        ),
         BlockException.INVALID_REQUESTS: "mismatched block requests hash",
         BlockException.INVALID_RECEIPTS_ROOT: "receipt root mismatch",
         BlockException.INVALID_STATE_ROOT: "mismatched block state root",
@@ -45,6 +42,7 @@ class RethExceptionMapper(ExceptionMapper):
     }
     mapping_regex = {
         TransactionException.NONCE_MISMATCH_TOO_LOW: r"nonce \d+ too low, expected \d+",
+        TransactionException.NONCE_MISMATCH_TOO_HIGH: r"nonce \d+ too high, expected \d+",
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             r"blob gas price \(\d+\) is greater than max fee per blob gas \(\d+\)"
         ),
@@ -100,11 +98,21 @@ class RethExceptionMapper(ExceptionMapper):
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"Block's access list is invalid."
         ),
-        BlockException.INVALID_GASLIMIT: (r"child gas_limit \d+ max .* is .*"),
-        BlockException.INVALID_BLOCK_TIMESTAMP_OLDER_THAN_PARENT: (
-            r"block timestamp \d+ is in the past compared to the parent timestamp \d+"
-        ),
-        BlockException.INVALID_BLOCK_NUMBER: (
-            r"block number \d+ does not match parent block number \d+"
+        # Reth does not validate the sizes or offsets of the deposit
+        # contract logs. As a workaround we have set
+        # INVALID_DEPOSIT_EVENT_LAYOUT equal to INVALID_REQUESTS.
+        #
+        # Although this is out of spec, it is understood that this
+        # will not cause an issue so long as the mainnet/testnet
+        # deposit contracts don't change.
+        #
+        # The offsets are checked second and the sizes are checked
+        # third within the `is_valid_deposit_event_data` function:
+        # https://eips.ethereum.org/EIPS/eip-6110#block-validity
+        #
+        # EELS definition for `is_valid_deposit_event_data`:
+        # https://github.com/ethereum/execution-specs/blob/5ddb904fa7ba27daeff423e78466744c51e8cb6a/src/ethereum/forks/prague/requests.py#L51
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"failed to decode deposit requests from receipts|mismatched block requests hash"
         ),
     }

--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -30,7 +30,7 @@ def test_tx_gas_limit(
     tx = Transaction(
         gas_limit=21001,
         to=to,
-        gas_price=0x01,
+        gas_price=0x10,  # Must be >= base fee to isolate gas limit validation
         sender=sender,
         protected=False,
         error=TransactionException.GAS_ALLOWANCE_EXCEEDED,


### PR DESCRIPTION
## 🗒️ Description

### TLDR;

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Adds exception mapper fixes for the final Fusaka (Osaka) test release and fixes `test_tx_gas_limit` to isolate gas limit validation. All manually verified with consume engine.

### Exception Mapper Updates

- Besu: Added `NONCE_MISMATCH_TOO_HIGH` regex pattern ✅
- Erigon: Added `NONCE_MISMATCH_TOO_HIGH` substring mapping ✅ 
- Ethrex: Added `NONCE_MISMATCH_TOO_HIGH` regex ✅ 
- Nethermind: Fixed nonce mismatch mapping to use `NONCE_MISMATCH_TOO_HIGH` for generic "wrong
transaction nonce" error ✅ 
- Reth:
  - Added `NONCE_MISMATCH_TOO_HIGH` regex pattern ✅ 
  - Removed duplicate dict entries that were overwriting earlier patterns!
  - Combined `INVALID_DEPOSIT_EVENT_LAYOUT` patterns with explanatory comment ✅ 

### Test Tweaks
- Bumped `gas_price` in `test_tx_gas_limit` from `0x01` to `0x10` to isolate gas limit validation. The low
gas price was causing some clients (Geth/Erigon) to fail with `INSUFFICIENT_MAX_FEE_PER_GAS` before reaching the
gas limit check.
  - Geth: Passing but requires new release v5.4.1 ✅ 
  - Erigon: Passing ^^ ✅ 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
For Reth EIP-6110 failures please see: https://github.com/ethereum/execution-spec-tests/pull/2271

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%2Fid%2FOIP.y32EOIDIOE-z5wdvELdM5gHaF6%3Fcb%3Ducfimg2%26pid%3DApi%26ucfimg%3D1&f=1&ipt=f8ad1cf3fb894237f28e42408aa7afc1e13369b0cc2eae1957d022953984b2a8&ipo=images)
