### PR TITLE
chore(ci): use self-hosted runners and harden hive dev mode

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -39,43 +39,18 @@ runs:
 
     - name: Start Hive in dev mode
       id: start-hive
+      uses: ./.github/actions/start-hive-dev
+      with:
+        clients: besu,go-ethereum,nethermind
+        client-file: .github/configs/hive/latest.yaml
+        hive-path: hive
+
+    - name: Extract genesis configs
       shell: bash
       env:
-        HIVE_SIMULATOR: http://127.0.0.1:3000
+        HIVE_SIMULATOR: ${{ steps.start-hive.outputs.hive-url }}
       run: |
-        cd hive
-        ./hive --dev \
-          --client besu,go-ethereum,nethermind \
-          --client-file ../.github/configs/hive/latest.yaml \
-          --docker.output &
-        export HIVE_PID=$!
-
-        echo "Waiting for Hive to be ready, pid=$HIVE_PID"
-        deadline=$((SECONDS + 600))
-        
-        while :; do
-          # condition 1: time is up
-          if (( SECONDS >= deadline )); then
-            echo "Hive failed to start within timeout"
-            exit 1
-          fi
-
-          # condition 2: process exited
-          if ! kill -0 "$HIVE_PID" 2>/dev/null; then
-            echo "Hive process died"
-            exit 1
-          fi
-
-          # condition 3: curl succeeded
-          if curl -s $HIVE_SIMULATOR > /dev/null; then
-            echo "Hive is ready!"
-            break
-          fi
-          sleep 1
-        done
-
         echo "Running extract_config for benchmark fixtures..."
-        cd ..
         uv run extract_config \
           --fixture fixtures/blockchain_tests_engine_x/pre_alloc/ \
           --output genesis/ \

--- a/.github/actions/start-hive-dev/action.yaml
+++ b/.github/actions/start-hive-dev/action.yaml
@@ -1,0 +1,63 @@
+name: Start Hive in Dev Mode
+description: Start Hive simulator API in dev mode with robust waiting
+
+inputs:
+  clients:
+    description: "Comma-separated list of clients to use"
+    required: true
+  client-file:
+    description: "Path to YAML file with client configurations"
+    required: true
+  timeout:
+    description: "Timeout in seconds waiting for Hive to be ready"
+    required: false
+    default: "600"
+  hive-path:
+    description: "Path to hive directory (must be checked out and built)"
+    required: false
+    default: "hive"
+
+outputs:
+  hive-url:
+    description: "URL of the Hive simulator API"
+    value: ${{ steps.start.outputs.hive-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Start Hive dev mode
+      id: start
+      shell: bash
+      run: |
+        cd "${{ inputs.hive-path }}"
+
+        ./hive --dev \
+          --client "${{ inputs.clients }}" \
+          --client-file "../${{ inputs.client-file }}" \
+          --docker.output &
+        HIVE_PID=$!
+
+        HIVE_URL="http://127.0.0.1:3000"
+        echo "hive-url=$HIVE_URL" >> "$GITHUB_OUTPUT"
+
+        echo "Waiting for Hive to be ready (pid=$HIVE_PID, timeout=${{ inputs.timeout }}s)..."
+        deadline=$((SECONDS + ${{ inputs.timeout }}))
+
+        while :; do
+          if (( SECONDS >= deadline )); then
+            echo "::error::Hive failed to start within ${{ inputs.timeout }}s timeout"
+            exit 1
+          fi
+
+          if ! kill -0 "$HIVE_PID" 2>/dev/null; then
+            echo "::error::Hive process died unexpectedly"
+            exit 1
+          fi
+
+          if curl -s "$HIVE_URL" > /dev/null; then
+            echo "Hive is ready at $HIVE_URL"
+            exit 0
+          fi
+
+          sleep 1
+        done

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -83,7 +83,7 @@ jobs:
           ./hive --sim '${{ matrix.simulator }}' \
             --sim.parallelism=1 \
             --client go-ethereum \
-            --client-file ../execution-specs/.github/configs/hive/master.yaml \
+            --client-file ../execution-specs/.github/configs/hive/latest.yaml \
             --sim.buildarg fixtures=${{ env.FIXTURES_URL }} \
             --sim.limit=".*test_block_at_rlp_limit_with_logs.*Osaka.*" \
             --docker.output
@@ -94,7 +94,7 @@ jobs:
         uses: ./execution-specs/.github/actions/start-hive-dev
         with:
           clients: go-ethereum
-          client-file: execution-specs/.github/configs/hive/master.yaml
+          client-file: execution-specs/.github/configs/hive/latest.yaml
           hive-path: hive
           timeout: "120"
 

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -3,16 +3,16 @@ name: Hive Consume Tests
 on:
   push:
     branches:
-      - 'forks/**'
+      - "forks/**"
   pull_request:
     paths:
-      - '.github/workflows/hive-consume.yaml'
-      - 'packages/testing/src/execution_testing/cli/pytest_commands/consume.py'
-      - 'packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini'
-      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**'
-      - 'packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**'
-      - 'packages/testing/src/execution_testing/fixtures/consume.py'
-      - 'packages/testing/src/execution_testing/rpc/**'
+      - ".github/workflows/hive-consume.yaml"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/consume.py"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**"
+      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**"
+      - "packages/testing/src/execution_testing/fixtures/consume.py"
+      - "packages/testing/src/execution_testing/rpc/**"
   workflow_dispatch:
 
 concurrency:
@@ -59,7 +59,7 @@ jobs:
       - name: Setup go env and cache
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '>=1.24'
+          go-version: ">=1.24"
           cache-dependency-path: hive/go.sum
 
       - name: Install uv and python
@@ -90,24 +90,19 @@ jobs:
 
       - name: Start Hive in dev mode
         if: matrix.mode == 'dev'
-        run: |
-          cd hive
-          ./hive --dev --client go-ethereum --client-file ../execution-specs/.github/configs/hive/master.yaml --docker.output &
-          echo "Waiting for Hive to be ready..."
-          for i in {1..30}; do
-            if curl -s http://127.0.0.1:3000 > /dev/null 2>&1; then
-              echo "Hive is ready!"
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 2
-          done
+        id: start-hive
+        uses: ./execution-specs/.github/actions/start-hive-dev
+        with:
+          clients: go-ethereum
+          client-file: execution-specs/.github/configs/hive/master.yaml
+          hive-path: hive
+          timeout: "120"
 
       - name: Run consume in dev mode
         if: matrix.mode == 'dev'
         working-directory: execution-specs
         env:
-          HIVE_SIMULATOR: http://127.0.0.1:3000
+          HIVE_SIMULATOR: ${{ steps.start-hive.outputs.hive-url }}
         run: |
           uv sync --all-extras
           uv run consume ${{ matrix.consume_command }} --input ${{ env.FIXTURES_URL }} -k "Osaka and test_block_at_rlp_limit_with_logs"

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   test-hive:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr, size-l-x64]
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## 🗒️ Description

- Moves the consume ci checks to use self-hosted runners to solve "no space left on device" issues with Github runners (cf #1855).
- Create reusable `start-hive-dev` action with the robust startup waiting logic that was originally added in #1800.
- Refactor `build-benchmark-genesis` and `hive-consume` workflows to use the new action.

#### Problem

The `dev-mode` job in `hive-consume.yaml` can fail due to a race condition. The wait loop only polled for 60 seconds (30 iterations × 2s), but Hive takes longer to build Docker images (`hiveproxy`, client images). The loop silently fell through without failing, causing the next step to start while Hive was still building - resulting in "Error connecting to hive simulator" failures. Example flow:

- https://github.com/ethereum/execution-specs/actions/runs/19991793699/job/57333576450?pr=1855

This behavior is also seen in this screenshot:
<img width="1136" height="521" alt="image" src="https://github.com/user-attachments/assets/b676beff-5f76-4062-99e9-ec57b64205a7" />

#### Solution

Extract the robust waiting logic from `build-benchmark-genesis` (which already had proper timeout handling) into a reusable action that:

- Uses deadline-based timeout instead of iteration count.
- Monitors process health to detect if Hive crashes (`kill -0`).
- Fails explicitly on timeout with clear error messages.
- Outputs `hive-url` for use in subsequent steps.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
#### Cute Animal Picture

<img width="405" height="720" alt="image" src="https://github.com/user-attachments/assets/267609aa-1f0d-4ac3-80a9-f9bd8e7ba718" />

