### PR TITLE
feat(benchmarks): fix benchmark for BALANCE scenario for Osaka

### DIFF
--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -448,15 +448,13 @@ def test_ext_account_query_cold(
 
     gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
     # For calculation robustness, the calculation below ignores "glue" opcodes
     # like  PUSH and POP. It should be considered a worst-case number of
     # accounts, and a few of them might not be targeted before the attacking
     # transaction runs out of gas.
     num_target_accounts = (
         attack_gas_limit - intrinsic_gas_cost_calc()
-    ) // gas_costs.G_COLD_ACCOUNT_ACCESS
-    max_target_per_tx = (
-        fork.transaction_gas_limit_cap() - intrinsic_gas_cost_calc()
     ) // gas_costs.G_COLD_ACCOUNT_ACCESS
 
     blocks = []
@@ -474,11 +472,17 @@ def test_ext_account_query_cold(
             + gas_costs.G_CALL_VALUE
             + gas_costs.G_NEW_ACCOUNT
         )
-        # To avoid brittle/tight gas calculations of glue opcodes, we take 90% of the maximum tx capacity.
-        # Even if this calculation fails in the future, it would be catched by the post-state check.
-        max_creations_per_tx = int(
-            (fork.transaction_gas_limit_cap() * 0.9) // account_creation_gas
-        )
+        # To avoid brittle/tight gas calculations of glue opcodes, we take
+        # 90% of the maximum tx capacity. Even if this calculation fails
+        # in the future, it will be caught by the post-state check.
+        # Also, this is only for the setup phase, so being optimal is
+        # not critical.
+        if tx_gas_limit_cap:
+            max_creations_per_tx = int(
+                (tx_gas_limit_cap * 0.9) // account_creation_gas
+            )
+        else:
+            max_creations_per_tx = num_target_accounts
         factory_code = (
             Op.CALLDATALOAD(0)  # addr_start
             + Op.PUSH4(max_creations_per_tx)  # counter
@@ -513,7 +517,7 @@ def test_ext_account_query_cold(
                     Transaction(
                         to=factory_address,
                         data=Hash(addr_start),
-                        gas_limit=fork.transaction_gas_limit_cap(),
+                        gas_limit=tx_gas_limit_cap or env.gas_limit,
                         sender=pre.fund_eoa(),
                     )
                 )
@@ -542,6 +546,13 @@ def test_ext_account_query_cold(
 
     execution_txs = []
     with TestPhaseManager.execution():
+        if tx_gas_limit_cap:
+            max_target_per_tx = (
+                tx_gas_limit_cap - intrinsic_gas_cost_calc()
+            ) // gas_costs.G_COLD_ACCOUNT_ACCESS
+        else:
+            max_target_per_tx = num_target_accounts
+
         num_execution_txs = math.ceil(num_target_accounts / max_target_per_tx)
         for i in range(num_execution_txs):
             address_start = i * int(max_target_per_tx)
@@ -551,7 +562,7 @@ def test_ext_account_query_cold(
                 Transaction(
                     to=op_address,
                     data=Hash(address_start) + Hash(num_to_query),
-                    gas_limit=fork.transaction_gas_limit_cap(),
+                    gas_limit=tx_gas_limit_cap or env.gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -440,6 +440,7 @@ def test_ext_account_query_cold(
     absent_accounts: bool,
     env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """
     Benchmark stateful opcodes accessing cold accounts.
@@ -448,7 +449,6 @@ def test_ext_account_query_cold(
 
     gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
     # For calculation robustness, the calculation below ignores "glue" opcodes
     # like  PUSH and POP. It should be considered a worst-case number of
     # accounts, and a few of them might not be targeted before the attacking
@@ -477,12 +477,9 @@ def test_ext_account_query_cold(
         # in the future, it will be caught by the post-state check.
         # Also, this is only for the setup phase, so being optimal is
         # not critical.
-        if tx_gas_limit_cap:
-            max_creations_per_tx = int(
-                (tx_gas_limit_cap * 0.9) // account_creation_gas
-            )
-        else:
-            max_creations_per_tx = num_target_accounts
+        max_creations_per_tx = int(
+            (tx_gas_limit * 0.9) // account_creation_gas
+        )
         factory_code = (
             Op.CALLDATALOAD(0)  # addr_start
             + Op.PUSH4(max_creations_per_tx)  # counter
@@ -517,7 +514,7 @@ def test_ext_account_query_cold(
                     Transaction(
                         to=factory_address,
                         data=Hash(addr_start),
-                        gas_limit=tx_gas_limit_cap or env.gas_limit,
+                        gas_limit=tx_gas_limit,
                         sender=pre.fund_eoa(),
                     )
                 )
@@ -546,12 +543,9 @@ def test_ext_account_query_cold(
 
     execution_txs = []
     with TestPhaseManager.execution():
-        if tx_gas_limit_cap:
-            max_target_per_tx = (
-                tx_gas_limit_cap - intrinsic_gas_cost_calc()
-            ) // gas_costs.G_COLD_ACCOUNT_ACCESS
-        else:
-            max_target_per_tx = num_target_accounts
+        max_target_per_tx = (
+            tx_gas_limit - intrinsic_gas_cost_calc()
+        ) // gas_costs.G_COLD_ACCOUNT_ACCESS
 
         num_execution_txs = math.ceil(num_target_accounts / max_target_per_tx)
         for i in range(num_execution_txs):
@@ -562,7 +556,7 @@ def test_ext_account_query_cold(
                 Transaction(
                     to=op_address,
                     data=Hash(address_start) + Hash(num_to_query),
-                    gas_limit=tx_gas_limit_cap or env.gas_limit,
+                    gas_limit=tx_gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -554,10 +554,13 @@ def test_ext_account_query_cold(
             remaining = num_target_accounts - address_start
             num_to_query = min(int(max_target_per_tx), remaining)
             gas_limit = min(tx_gas_limit, attack_gas_limit - gas_used)
+            calldata = Hash(address_start) + Hash(num_to_query)
+            if gas_limit < intrinsic_gas_cost_calc(calldata=calldata):
+                break
             execution_txs.append(
                 Transaction(
                     to=op_address,
-                    data=Hash(address_start) + Hash(num_to_query),
+                    data=calldata,
                     gas_limit=gas_limit,
                     sender=pre.fund_eoa(),
                 )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -438,7 +438,6 @@ def test_ext_account_query_cold(
     fork: Fork,
     opcode: Op,
     absent_accounts: bool,
-    env: Environment,
     gas_benchmark_value: int,
     tx_gas_limit: int,
 ) -> None:

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -548,18 +548,21 @@ def test_ext_account_query_cold(
         ) // gas_costs.G_COLD_ACCOUNT_ACCESS
 
         num_execution_txs = math.ceil(num_target_accounts / max_target_per_tx)
+        gas_used = 0
         for i in range(num_execution_txs):
             address_start = i * int(max_target_per_tx)
             remaining = num_target_accounts - address_start
             num_to_query = min(int(max_target_per_tx), remaining)
+            gas_limit = min(tx_gas_limit, attack_gas_limit - gas_used)
             execution_txs.append(
                 Transaction(
                     to=op_address,
                     data=Hash(address_start) + Hash(num_to_query),
-                    gas_limit=tx_gas_limit,
+                    gas_limit=gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )
+            gas_used += gas_limit
     blocks.append(Block(txs=execution_txs))
 
     benchmark_test(

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -455,6 +455,9 @@ def test_ext_account_query_cold(
     num_target_accounts = (
         attack_gas_limit - intrinsic_gas_cost_calc()
     ) // gas_costs.G_COLD_ACCOUNT_ACCESS
+    max_target_per_tx = (
+        fork.transaction_gas_limit_cap() - intrinsic_gas_cost_calc()
+    ) // gas_costs.G_COLD_ACCOUNT_ACCESS
 
     blocks = []
     post = {}
@@ -466,10 +469,67 @@ def test_ext_account_query_cold(
     addr_offset = int.from_bytes(pre.fund_eoa(amount=0))
 
     if not absent_accounts:
-        factory_code = Op.PUSH4(num_target_accounts) + While(
-            body=Op.POP(
-                Op.CALL(address=Op.ADD(addr_offset, Op.DUP6), value=10)
-            ),
+        account_creation_gas = (
+            gas_costs.G_COLD_ACCOUNT_ACCESS
+            + gas_costs.G_CALL_VALUE
+            + gas_costs.G_NEW_ACCOUNT
+        )
+        # To avoid brittle/tight gas calculations of glue opcodes, we take 90% of the maximum tx capacity.
+        # Even if this calculation fails in the future, it would be catched by the post-state check.
+        max_creations_per_tx = int(
+            (fork.transaction_gas_limit_cap() * 0.9) // account_creation_gas
+        )
+        factory_code = (
+            Op.CALLDATALOAD(0)  # addr_start
+            + Op.PUSH4(max_creations_per_tx)  # counter
+            # Stack: [counter, addr_start]
+            + While(
+                body=Op.POP(
+                    Op.CALL(
+                        address=Op.ADD(addr_offset, Op.ADD(Op.DUP7, Op.DUP7)),
+                        value=10,
+                    )
+                ),
+                condition=Op.PUSH1(1)
+                + Op.SWAP1
+                + Op.SUB
+                + Op.DUP1
+                + Op.ISZERO
+                + Op.ISZERO,
+            )
+        )
+        factory_address = pre.deploy_contract(
+            code=factory_code, balance=10**18
+        )
+
+        creation_txs = []
+        with TestPhaseManager.setup():
+            num_creation_txs = math.ceil(
+                num_target_accounts / max_creations_per_tx
+            )
+            for i in range(num_creation_txs):
+                addr_start = i * int(max_creations_per_tx)
+                creation_txs.append(
+                    Transaction(
+                        to=factory_address,
+                        data=Hash(addr_start),
+                        gas_limit=fork.transaction_gas_limit_cap(),
+                        sender=pre.fund_eoa(),
+                    )
+                )
+        blocks.append(Block(txs=creation_txs))
+
+        for i in range(num_target_accounts):
+            addr = Address(i + addr_offset + 1)
+            post[addr] = Account(balance=10)
+
+    # Execution
+    op_code = (
+        Op.CALLDATALOAD(0)  # address_start
+        + Op.CALLDATALOAD(32)  # num_to_query
+        # Stack: [num_to_query, address_start]
+        + While(
+            body=Op.POP(opcode(Op.ADD(addr_offset, Op.ADD(Op.DUP2, Op.DUP2)))),
             condition=Op.PUSH1(1)
             + Op.SWAP1
             + Op.SUB
@@ -477,41 +537,25 @@ def test_ext_account_query_cold(
             + Op.ISZERO
             + Op.ISZERO,
         )
-        factory_address = pre.deploy_contract(
-            code=factory_code, balance=10**18
-        )
-
-        with TestPhaseManager.setup():
-            setup_tx = Transaction(
-                to=factory_address,
-                gas_limit=env.gas_limit,
-                sender=pre.fund_eoa(),
-            )
-        blocks.append(Block(txs=[setup_tx]))
-
-        for i in range(num_target_accounts):
-            addr = Address(i + addr_offset + 1)
-            post[addr] = Account(balance=10)
-
-    # Execution
-    op_code = Op.PUSH4(num_target_accounts) + While(
-        body=Op.POP(opcode(Op.ADD(addr_offset, Op.DUP1))),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
     )
     op_address = pre.deploy_contract(code=op_code)
 
+    execution_txs = []
     with TestPhaseManager.execution():
-        op_tx = Transaction(
-            to=op_address,
-            gas_limit=attack_gas_limit,
-            sender=pre.fund_eoa(),
-        )
-    blocks.append(Block(txs=[op_tx]))
+        num_execution_txs = math.ceil(num_target_accounts / max_target_per_tx)
+        for i in range(num_execution_txs):
+            address_start = i * int(max_target_per_tx)
+            remaining = num_target_accounts - address_start
+            num_to_query = min(int(max_target_per_tx), remaining)
+            execution_txs.append(
+                Transaction(
+                    to=op_address,
+                    data=Hash(address_start) + Hash(num_to_query),
+                    gas_limit=fork.transaction_gas_limit_cap(),
+                    sender=pre.fund_eoa(),
+                )
+            )
+    blocks.append(Block(txs=execution_txs))
 
     benchmark_test(
         post=post,


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the `est_ext_account_query_cold` benchmark to work in Osaka.

To validate this still does what we want, tested with 30M attack:

- Before this PR with Prague:
    - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]` = 214M cycles
    - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_True-opcode_BALANCE]` = 98M cycles
- With this PR:
    - Filled with Osaka:
        - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]` = 213M cycles
        - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_True-opcode_BALANCE]` = 96M cycles
        - Conclusion: the difference sounds reasonable reg the gas lost in partitioning in txs.
    - Filled with Prague:
        - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_False-opcode_BALANCE]` = 214M cycles
        - `test_account_query.py::test_ext_account_query_cold[fork_Prague-blockchain_test-absent_accounts_True-opcode_BALANCE]` = 98M cycles
        - Conclusion: same as pre-PR.

## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

