### PR TITLE
chore(test-cli-fill): suppress pytest warnings for plugin imports and register `fully_tagged` marker

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
@@ -5,7 +5,7 @@ python_files = *.py
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py or
 # src/execution_testing/cli/pytest_commands/plugins/spec_version_checker/spec_version_checker.py
 testpaths = tests/
-addopts =  
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.spec_version_checker.spec_version_checker
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.filler.pre_alloc
@@ -16,3 +16,5 @@ addopts =
     -p execution_testing.cli.pytest_commands.plugins.help.help
     -m eip_version_check
     --tb short
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -4,7 +4,7 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
@@ -21,3 +21,5 @@ addopts =
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_infra
     --ignore tests/evm_tools
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -4,7 +4,7 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.execute.execute_flags.execute_flags
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
@@ -23,3 +23,5 @@ addopts =
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_infra
     --ignore tests/evm_tools
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -4,7 +4,7 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.filler.pre_alloc
     -p execution_testing.cli.pytest_commands.plugins.filler.filler
@@ -21,6 +21,8 @@ addopts =
     --ignore tests/cancun/eip4844_blobs/point_evaluation_vectors/
     --ignore tests/json_infra
     --ignore tests/evm_tools
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning
 # these customizations require the pytest-custom-report plugin
 report_passed_verbose = FILLED
 report_xpassed_verbose = XFILLED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,10 @@ markers = [
     "json_blockchain_tests: marks tests as json_blockchain_tests (deselect with '-m \"not json_blockchain_tests\"')",
     "json_state_tests: marks tests as json_state_tests (deselect with '-m \"not json_state_tests\"')",
     "vm_test: marks tests as vm_test (deselect with '-m \"not vm_test\"')",
+    "fully_tagged: marks tests as fully tagged with all metadata",
+]
+filterwarnings = [
+    "ignore::pytest.PytestAssertRewriteWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This PR removes the existing pytest warnings from `fill`: 
```
 =============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812: 49 warnings
  /opt/actions-runner/_work/execution-specs/execution-specs/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812: 
PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.shared.execute_fill
    self.import_plugin(arg, consider_entry_points=True)

.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812: 49 warnings
  /opt/actions-runner/_work/execution-specs/execution-specs/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812: 
PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.forks.forks
    self.import_plugin(arg, consider_entry_points=True)

packages/testing/src/execution_testing/specs/static_state/state_static.py:221: 48 warnings
  /opt/actions-runner/_work/execution-specs/execution-specs/packages/testing/src/execution_testing/specs/static_state/state_static.py:221: 
PytestUnknownMarkWarning: Unknown pytest.mark.fully_tagged - is this a typo?  You can register custom marks to avoid this warning - for 
details, see https://docs.pytest.org/en/stable/how-to/mark.html
    test_state_vectors = pytest.mark.fully_tagged(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- Log file: /opt/actions-runner/_work/execution-specs/execution-specs/logs/fill-20251206-204804-main.log -
- Generated html report: file:///opt/actions-runner/_work/execution-specs/execution-specs/fixtures_develop/.meta/report_fill.html -
=  No tests executed - the test fixtures in "fixtures_develop/" may now be executed against a client  =
======= 260767 passed, 1270 skipped, 146 warnings in 9235.35s (2:33:55) ========
```

It will additionally remove the following warnings, fixed by reordering the plugins within the ini files.
```
.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:812
  /Users/spencer-tb/Ethereum/execution-specs/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:812: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.shared.execute_fill
    self.import_plugin(arg, consider_entry_points=True)

.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:812
  /Users/spencer-tb/Ethereum/execution-specs/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:812: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.forks.forks
    self.import_plugin(arg, consider_entry_points=True)
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
