### PR TITLE
feat(test-benchmark): implement opcode count verification

### DIFF
--- a/packages/testing/src/execution_testing/base_types/composite_types.py
+++ b/packages/testing/src/execution_testing/base_types/composite_types.py
@@ -211,6 +211,12 @@ class Storage(
         """Return a new storage that is the sum of two storages."""
         return Storage({**self.root, **other.root})
 
+    def __len__(self) -> int:
+        """
+        Return the number of keys that have been explicitly set in the storage.
+        """
+        return len(self.root)
+
     def keys(self) -> set[StorageKeyValueType]:
         """Return the keys of the storage."""
         return set(self.root.keys())

--- a/packages/testing/src/execution_testing/cli/benchmark_parser.py
+++ b/packages/testing/src/execution_testing/cli/benchmark_parser.py
@@ -268,17 +268,20 @@ def categorize_patterns(
 def generate_config_json(
     config: dict[str, list[int]],
     pattern_sources: dict[str, Path],
+    default_counts: list[int],
 ) -> OpcodeCountsConfig:
     """Generate the JSON config file content."""
     categories = categorize_patterns(config, pattern_sources)
 
     scenario_configs: dict[str, list[int]] = {}
-    output = OpcodeCountsConfig(scenario_configs=scenario_configs)
     for _, patterns in categories.items():
         for pattern in patterns:
-            output.scenario_configs[pattern] = config[pattern]
+            scenario_configs[pattern] = config[pattern]
 
-    return output
+    return OpcodeCountsConfig(
+        scenario_configs=scenario_configs,
+        default_counts=default_counts,
+    )
 
 
 def main() -> int:
@@ -352,8 +355,9 @@ def main() -> int:
         if pattern in merged:
             del merged[pattern]
 
-    content = generate_config_json(merged, pattern_sources)
-    content.default_counts = existing_file.default_counts
+    content = generate_config_json(
+        merged, pattern_sources, existing_file.default_counts
+    )
     config_file.write_text(
         content.model_dump_json(exclude_defaults=True, indent=2)
     )

--- a/packages/testing/src/execution_testing/cli/benchmark_parser.py
+++ b/packages/testing/src/execution_testing/cli/benchmark_parser.py
@@ -11,9 +11,12 @@ Usage:
 
 import argparse
 import ast
-import json
 import sys
 from pathlib import Path
+
+from execution_testing.cli.pytest_commands.plugins.shared.benchmarking import (
+    OpcodeCountsConfig,
+)
 
 
 def get_repo_root() -> Path:
@@ -227,16 +230,11 @@ def scan_benchmark_tests(
     return config, pattern_sources
 
 
-def load_existing_config(config_file: Path) -> dict[str, list[int]]:
+def load_existing_config(config_file: Path) -> OpcodeCountsConfig:
     """Load existing config from .fixed_opcode_counts.json."""
     if not config_file.exists():
-        return {}
-
-    try:
-        data = json.loads(config_file.read_text())
-        return data.get("scenario_configs", {})
-    except (json.JSONDecodeError, KeyError):
-        return {}
+        return OpcodeCountsConfig()
+    return OpcodeCountsConfig.model_validate_json(config_file.read_bytes())
 
 
 def categorize_patterns(
@@ -270,18 +268,17 @@ def categorize_patterns(
 def generate_config_json(
     config: dict[str, list[int]],
     pattern_sources: dict[str, Path],
-) -> str:
+) -> OpcodeCountsConfig:
     """Generate the JSON config file content."""
     categories = categorize_patterns(config, pattern_sources)
 
     scenario_configs: dict[str, list[int]] = {}
+    output = OpcodeCountsConfig(scenario_configs=scenario_configs)
     for _, patterns in categories.items():
         for pattern in patterns:
-            scenario_configs[pattern] = config[pattern]
+            output.scenario_configs[pattern] = config[pattern]
 
-    output = {"scenario_configs": scenario_configs}
-
-    return json.dumps(output, indent=2) + "\n"
+    return output
 
 
 def main() -> int:
@@ -307,7 +304,8 @@ def main() -> int:
     detected, pattern_sources = scan_benchmark_tests(benchmark_dir)
     print(f"Detected {len(detected)} opcode patterns")
 
-    existing = load_existing_config(config_file)
+    existing_file = load_existing_config(config_file)
+    existing = existing_file.scenario_configs
     print(f"Loaded {len(existing)} existing entries")
 
     detected_keys = set(detected.keys())
@@ -355,7 +353,10 @@ def main() -> int:
             del merged[pattern]
 
     content = generate_config_json(merged, pattern_sources)
-    config_file.write_text(content)
+    content.default_counts = existing_file.default_counts
+    config_file.write_text(
+        content.model_dump_json(exclude_defaults=True, indent=2)
+    )
     print(f"\nUpdated {config_file}")
     return 0
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -432,6 +432,8 @@ class Alloc(BaseAlloc):
         fund_tx: PendingTransaction | None = None
         if delegation is not None or storage is not None:
             if storage is not None:
+                if not isinstance(storage, Storage):
+                    storage = Storage.model_validate(storage)
                 logger.debug(
                     f"Deploying storage contract for EOA {eoa} with {len(storage)} storage slots"
                 )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -432,14 +432,18 @@ class Alloc(BaseAlloc):
         fund_tx: PendingTransaction | None = None
         if delegation is not None or storage is not None:
             if storage is not None:
+                # Handle both Storage objects and plain dicts
+                storage_dict = (
+                    storage.root if isinstance(storage, Storage) else storage
+                )
                 logger.debug(
-                    f"Deploying storage contract for EOA {eoa} with {len(storage.root)} storage slots"
+                    f"Deploying storage contract for EOA {eoa} with {len(storage_dict)} storage slots"
                 )
                 sstore_address = self.deploy_contract(
                     code=(
                         sum(
                             Op.SSTORE(key, value)
-                            for key, value in storage.root.items()
+                            for key, value in storage_dict.items()
                         )
                         + Op.STOP
                     )
@@ -451,6 +455,7 @@ class Alloc(BaseAlloc):
                 set_storage_tx = PendingTransaction(
                     sender=self._sender,
                     to=eoa,
+                    value=0,
                     authorization_list=[
                         AuthorizationTuple(
                             chain_id=self._chain_id,
@@ -498,7 +503,7 @@ class Alloc(BaseAlloc):
                 fund_tx = PendingTransaction(
                     sender=self._sender,
                     to=eoa,
-                    value=amount,
+                    value=amount if amount is not None else 0,
                     authorization_list=[
                         AuthorizationTuple(
                             chain_id=self._chain_id,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -408,7 +408,7 @@ class Alloc(BaseAlloc):
         self,
         amount: NumberConvertible | None = None,
         label: str | None = None,
-        storage: Storage | None = None,
+        storage: Storage | StorageRootType | None = None,
         delegation: Address | Literal["Self"] | None = None,
         nonce: NumberConvertible | None = None,
     ) -> EOA:
@@ -432,18 +432,14 @@ class Alloc(BaseAlloc):
         fund_tx: PendingTransaction | None = None
         if delegation is not None or storage is not None:
             if storage is not None:
-                # Handle both Storage objects and plain dicts
-                storage_dict = (
-                    storage.root if isinstance(storage, Storage) else storage
-                )
                 logger.debug(
-                    f"Deploying storage contract for EOA {eoa} with {len(storage_dict)} storage slots"
+                    f"Deploying storage contract for EOA {eoa} with {len(storage)} storage slots"
                 )
                 sstore_address = self.deploy_contract(
                     code=(
                         sum(
                             Op.SSTORE(key, value)
-                            for key, value in storage_dict.items()
+                            for key, value in storage.items()
                         )
                         + Op.STOP
                     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
@@ -9,44 +9,99 @@ import pytest
 test_module_dummy = textwrap.dedent(
     """\
     import pytest
+    from execution_testing import BenchmarkTestFiller, JumpLoopGenerator, Op
 
-    from execution_testing import Environment
-
-    @pytest.mark.valid_at("Istanbul")
-    def test_dummy_benchmark_test(state_test, gas_benchmark_value) -> None:
-        state_test(
-            env=env,pre={},post={},tx=None)
+    @pytest.mark.valid_at("Prague")
+    def test_dummy_benchmark_test(benchmark_test: BenchmarkTestFiller) -> None:
+        benchmark_test(
+            target_opcode=Op.JUMPDEST,
+            code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+        )
     """
 )
 
 test_module_without_fixture = textwrap.dedent(
     """\
     import pytest
+    from execution_testing import BenchmarkTestFiller, JumpLoopGenerator, Op
 
-    from execution_testing import Environment
-
-    @pytest.mark.valid_at("Istanbul")
-    def test_dummy_no_benchmark_test(state_test) -> None:
-        state_test(env=env, pre={}, post={}, tx=None)
+    @pytest.mark.valid_at("Prague")
+    def test_dummy_no_benchmark_test(benchmark_test: BenchmarkTestFiller) -> None:
+        benchmark_test(
+            target_opcode=Op.JUMPDEST,
+            code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+        )
     """
 )
 
 test_module_with_repricing = textwrap.dedent(
     """\
     import pytest
-
-    from execution_testing import Environment
+    from execution_testing import BenchmarkTestFiller, JumpLoopGenerator, Op
 
     @pytest.mark.valid_at("Prague")
-    @pytest.mark.benchmark
     @pytest.mark.repricing
-    def test_benchmark_with_repricing(state_test, gas_benchmark_value) -> None:
-        state_test(env=env, pre={}, post={}, tx=None)
+    def test_benchmark_with_repricing(benchmark_test: BenchmarkTestFiller) -> None:
+        benchmark_test(
+            target_opcode=Op.JUMPDEST,
+            code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+        )
 
     @pytest.mark.valid_at("Prague")
-    @pytest.mark.benchmark
-    def test_benchmark_without_repricing(state_test, gas_benchmark_value) -> None:
-        state_test(env=env, pre={}, post={}, tx=None)
+    def test_benchmark_without_repricing(benchmark_test: BenchmarkTestFiller) -> None:
+        benchmark_test(
+            target_opcode=Op.JUMPDEST,
+            code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+        )
+    """
+)
+
+test_module_without_benchmark_test_fixture = textwrap.dedent(
+    """\
+    import pytest
+    from execution_testing import BenchmarkTestFiller, JumpLoopGenerator, Op
+
+    @pytest.mark.valid_at("Prague")
+    def test_with_gas_benchmark_value(state_test, gas_benchmark_value: int) -> None:
+        # This test intentionally uses state_test instead of benchmark_test
+        # to verify that --fixed-opcode-count filters it out
+        state_test(pre={}, post={}, tx=None)
+
+    @pytest.mark.valid_at("Prague")
+    def test_with_benchmark_test(benchmark_test: BenchmarkTestFiller) -> None:
+        benchmark_test(
+            target_opcode=Op.JUMPDEST,
+            code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+        )
+    """
+)
+
+test_module_with_repricing_kwargs = textwrap.dedent(
+    """\
+    import pytest
+    from execution_testing import BenchmarkTestFiller, ExtCallGenerator, Op
+
+    @pytest.mark.valid_at("Prague")
+    @pytest.mark.repricing(opcode=Op.ADD)
+    @pytest.mark.parametrize("opcode", [Op.ADD, Op.SUB, Op.MUL])
+    def test_parametrized_with_repricing_kwargs(
+        benchmark_test: BenchmarkTestFiller, opcode
+    ) -> None:
+        benchmark_test(
+            target_opcode=opcode,
+            code_generator=ExtCallGenerator(attack_block=opcode),
+        )
+
+    @pytest.mark.valid_at("Prague")
+    @pytest.mark.repricing
+    @pytest.mark.parametrize("opcode", [Op.ADD, Op.SUB])
+    def test_parametrized_with_repricing_no_kwargs(
+        benchmark_test: BenchmarkTestFiller, opcode
+    ) -> None:
+        benchmark_test(
+            target_opcode=opcode,
+            code_generator=ExtCallGenerator(attack_block=opcode),
+        )
     """
 )
 
@@ -66,9 +121,9 @@ def setup_test_directory_structure(
 
     """
     tests_dir = pytester.mkdir("tests")
-    istanbul_tests_dir = tests_dir / "istanbul"
-    istanbul_tests_dir.mkdir()
-    dummy_dir = istanbul_tests_dir / "dummy_test_module"
+    benchmark_tests_dir = tests_dir / "benchmark"
+    benchmark_tests_dir.mkdir()
+    dummy_dir = benchmark_tests_dir / "dummy_test_module"
     dummy_dir.mkdir()
     test_module = dummy_dir / test_filename
     test_module.write_text(test_content)
@@ -86,7 +141,7 @@ def test_gas_benchmark_option_added(pytester: pytest.Pytester) -> None:
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
     )
 
-    # Command: pytest -p pytest_plugins.filler.benchmarking --help
+    # Equivalent to: fill --help
     result = pytester.runpytest("-c", "pytest-fill.ini", "--help")
 
     assert result.ret == 0
@@ -101,8 +156,7 @@ def test_benchmarking_mode_configured_with_option(
     pytester: pytest.Pytester,
 ) -> None:
     """
-    Test that fill_mode is set to BENCHMARKING when --gas-benchmark-values is
-    used.
+    Test that op_mode is set to BENCHMARKING when --gas-benchmark-values used.
     """
     setup_test_directory_structure(
         pytester, test_module_dummy, "test_dummy_benchmark.py"
@@ -113,16 +167,16 @@ def test_benchmarking_mode_configured_with_option(
         "-c",
         "pytest-fill.ini",
         "--fork",
-        "Istanbul",
+        "Prague",
         "--gas-benchmark-values",
         "10,20,30",
-        "tests/istanbul/dummy_test_module/",
+        "tests/benchmark/dummy_test_module/",
         "--collect-only",
         "-q",
     )
 
     assert result.ret == 0
-    assert any("9 tests collected" in line for line in result.outlines)
+    assert any("6 tests collected" in line for line in result.outlines)
     # Check that the test names include the benchmark gas values
     assert any("benchmark-gas-value_10M" in line for line in result.outlines)
     assert any("benchmark-gas-value_20M" in line for line in result.outlines)
@@ -133,8 +187,8 @@ def test_benchmarking_mode_not_configured_without_option(
     pytester: pytest.Pytester,
 ) -> None:
     """
-    Test that fill_mode is not set to BENCHMARKING when --gas-benchmark-values
-    is not used.
+    Test that op_mode is not set to BENCHMARKING when --gas-benchmark-values
+    not used.
     """
     setup_test_directory_structure(
         pytester, test_module_dummy, "test_dummy_benchmark.py"
@@ -145,15 +199,15 @@ def test_benchmarking_mode_not_configured_without_option(
         "-c",
         "pytest-fill.ini",
         "--fork",
-        "Istanbul",
-        "tests/istanbul/dummy_test_module/",
+        "Prague",
+        "tests/benchmark/dummy_test_module/",
         "--collect-only",
         "-q",
     )
 
     assert result.ret == 0
-    # Should generate normal test variants (3) without parametrization
-    assert any("3 tests collected" in line for line in result.outlines)
+    # Should generate normal test variants (2) without parametrization
+    assert any("2 tests collected" in line for line in result.outlines)
     assert not any(
         "benchmark-gas-value_10M" in line for line in result.outlines
     )
@@ -206,7 +260,7 @@ def test_repricing_marker_filter_with_benchmark_options(
         *benchmark_args,
         "-m",
         "repricing",
-        "tests/istanbul/dummy_test_module/",
+        "tests/benchmark/dummy_test_module/",
         "--collect-only",
         "-q",
     )
@@ -218,5 +272,205 @@ def test_repricing_marker_filter_with_benchmark_options(
     )
     # The non-repricing test should NOT be collected
     assert not any(
+        "test_benchmark_without_repricing" in line for line in result.outlines
+    )
+
+
+def test_fixed_opcode_count_filters_tests_without_benchmark_test_fixture(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that --fixed-opcode-count filters out tests that don't use the
+    benchmark_test fixture.
+
+    Only tests with the benchmark_test fixture should be collected when
+    --fixed-opcode-count is provided.
+    """
+    setup_test_directory_structure(
+        pytester,
+        test_module_without_benchmark_test_fixture,
+        "test_fixture_filter.py",
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--fixed-opcode-count",
+        "1",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0
+    # Test with benchmark_test fixture should be collected
+    assert any("test_with_benchmark_test" in line for line in result.outlines)
+    # Test with only gas_benchmark_value fixture should NOT be collected
+    assert not any(
+        "test_with_gas_benchmark_value" in line for line in result.outlines
+    )
+
+
+def test_repricing_marker_with_kwargs_filters_parametrized_tests(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that repricing marker with kwargs filters parametrized tests to only
+    include matching parameter combinations.
+
+    When @pytest.mark.repricing(opcode=Op.ADD) is used, only test variants
+    where opcode=Op.ADD should be collected.
+    """
+    setup_test_directory_structure(
+        pytester,
+        test_module_with_repricing_kwargs,
+        "test_repricing_kwargs.py",
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--fixed-opcode-count",
+        "1",
+        "-m",
+        "repricing",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0
+    # For test with repricing(opcode=Op.ADD), only ADD variant should be collected
+    collected_lines = [
+        line for line in result.outlines if "test_parametrized" in line
+    ]
+
+    # test_parametrized_with_repricing_kwargs should only have ADD variants
+    # (multiple test types like blockchain_test and blockchain_test_engine)
+    kwargs_test_lines = [
+        line
+        for line in collected_lines
+        if "test_parametrized_with_repricing_kwargs" in line
+    ]
+    # All collected variants should be ADD only (no SUB or MUL)
+    assert all("ADD" in line for line in kwargs_test_lines)
+    assert not any("SUB" in line for line in kwargs_test_lines)
+    assert not any("MUL" in line for line in kwargs_test_lines)
+
+    # test_parametrized_with_repricing_no_kwargs should have all variants (ADD and SUB)
+    no_kwargs_test_lines = [
+        line
+        for line in collected_lines
+        if "test_parametrized_with_repricing_no_kwargs" in line
+    ]
+    # Should have both ADD and SUB variants
+    assert any("ADD" in line for line in no_kwargs_test_lines)
+    assert any("SUB" in line for line in no_kwargs_test_lines)
+
+
+def test_not_repricing_marker_negation(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that -m 'not repricing' does not apply the repricing filter.
+
+    When -m 'not repricing' is specified, the custom repricing filter should
+    be skipped and pytest's built-in marker filtering should be used.
+    """
+    setup_test_directory_structure(
+        pytester, test_module_with_repricing, "test_repricing_negation.py"
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--fixed-opcode-count",
+        "1",
+        "-m",
+        "not repricing",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0
+    # The repricing test should NOT be collected (negated)
+    assert not any(
+        "test_benchmark_with_repricing" in line for line in result.outlines
+    )
+    # The non-repricing test should be collected
+    assert any(
+        "test_benchmark_without_repricing" in line for line in result.outlines
+    )
+
+
+def test_mutual_exclusivity_of_benchmark_options(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that --gas-benchmark-values and --fixed-opcode-count cannot be used
+    together.
+    """
+    setup_test_directory_structure(
+        pytester, test_module_with_repricing, "test_mutual_exclusivity.py"
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--gas-benchmark-values",
+        "10",
+        "--fixed-opcode-count",
+        "1",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    # Should fail with usage error
+    assert result.ret != 0
+    assert any(
+        "mutually exclusive" in line
+        for line in result.outlines + result.errlines
+    )
+
+
+def test_without_repricing_flag_collects_all_tests(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that without -m repricing flag, both repricing and non-repricing
+    tests are collected.
+    """
+    setup_test_directory_structure(
+        pytester, test_module_with_repricing, "test_no_filter.py"
+    )
+
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Prague",
+        "--fixed-opcode-count",
+        "1",
+        "tests/benchmark/dummy_test_module/",
+        "--collect-only",
+        "-q",
+    )
+
+    assert result.ret == 0
+    # Both tests should be collected
+    assert any(
+        "test_benchmark_with_repricing" in line for line in result.outlines
+    )
+    assert any(
         "test_benchmark_without_repricing" in line for line in result.outlines
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -124,7 +124,7 @@ def pytest_collection_modifyitems(
     #
     # Here we filter out tests that do not use the benchmark_test fixture.
     # Note: At this stage we cannot filter based on whether a code generator is used.
-    if fixed_opcode_count:
+    if fixed_opcode_count or fixed_opcode_count == "":
         filtered = []
         for item in items:
             if (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -118,6 +118,22 @@ def pytest_collection_modifyitems(
     if not gas_benchmark_value and fixed_opcode_count is None:
         return
 
+    # In --fixed-opcode-count mode, we only support tests that meet all of the following:
+    #   - The test uses the benchmark_test fixture
+    #   - The benchmark test uses a code generator
+    #
+    # Here we filter out tests that do not use the benchmark_test fixture.
+    # Note: At this stage we cannot filter based on whether a code generator is used.
+    if fixed_opcode_count:
+        filtered = []
+        for item in items:
+            if (
+                hasattr(item, "fixturenames")
+                and "benchmark_test" in item.fixturenames
+            ):
+                filtered.append(item)
+        items[:] = filtered
+
     # Load config data if --fixed-opcode-count flag provided without value
     if fixed_opcode_count == "":
         config_data = load_opcode_counts_config(config)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -1,14 +1,16 @@
 """The module contains the pytest hooks for the gas benchmark values."""
 
-import json
 import re
 import warnings
+from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import ClassVar, Dict, List, Self
 
 import pytest
+from pydantic import BaseModel, Field, RootModel
 
 from execution_testing.test_types import Environment, EnvironmentDefaults
+from execution_testing.tools import ParameterSet
 
 from .execute_fill import OpMode
 
@@ -19,21 +21,21 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "benchmarking", "Arguments for benchmark test execution"
     )
     benchmark_group.addoption(
-        "--gas-benchmark-values",
+        GasBenchmarkValues.flag,
         action="store",
-        dest="gas_benchmark_value",
+        dest=GasBenchmarkValues.parameter_name,
         type=str,
         default=None,
         help=(
             "Gas limits (in millions) for benchmark tests. "
             "Example: '100,500' runs tests with 100M and 500M gas. "
-            "Cannot be used with --fixed-opcode-count."
+            f"Cannot be used with {OpcodeCountsConfig.flag}."
         ),
     )
     benchmark_group.addoption(
-        "--fixed-opcode-count",
+        OpcodeCountsConfig.flag,
         action="store",
-        dest="fixed_opcode_count",
+        dest=OpcodeCountsConfig.parameter_name,
         type=str,
         default=None,
         nargs="?",
@@ -42,7 +44,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Opcode counts (in thousands) for benchmark tests. "
             "Example: '1,10,100' runs tests with 1K, 10K, 100K opcodes. "
             "Without value, uses .fixed_opcode_counts.json config. "
-            "Cannot be used with --gas-benchmark-values."
+            f"Cannot be used with {GasBenchmarkValues.flag}."
         ),
     )
 
@@ -54,68 +56,172 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "repricing: Mark test as reference test for gas repricing analysis",
     )
-    if config.getoption("gas_benchmark_value"):
+
+    # Ensure mutual exclusivity
+    gas_benchmark_values = GasBenchmarkValues.from_config(config)
+    fixed_opcode_count = OpcodeCountsConfig.from_config(config)
+    if gas_benchmark_values is not None and fixed_opcode_count is not None:
+        raise pytest.UsageError(
+            f"{GasBenchmarkValues.flag} and --fixed-opcode-count are mutually exclusive. "
+            "Use only one at a time."
+        )
+
+    if gas_benchmark_values is not None:
         config.op_mode = OpMode.BENCHMARKING  # type: ignore[attr-defined]
 
 
-def load_opcode_counts_config(
-    config: pytest.Config,
-) -> dict[str, Any] | None:
-    """
-    Load the opcode counts configuration from `.fixed_opcode_counts.json`.
+class BenchmarkParametrizer(ABC):
+    """Object used to parametrize benchmark tests using parameters."""
 
-    Returns dictionary with scenario_configs and default_counts, or None
-    if not found.
-    """
-    config_file = Path(config.rootpath) / ".fixed_opcode_counts.json"
+    flag: ClassVar[str]
+    parameter_name: ClassVar[str]
+    config_field: ClassVar[str]
+    parameter_name: ClassVar[str]
 
-    if not config_file.exists():
-        return None
+    @classmethod
+    @abstractmethod
+    def from_parameter_value(
+        cls, config: pytest.Config, value: str
+    ) -> Self | None:
+        """Given the parameter value and config, return the expected object."""
+        pass
 
-    try:
-        data = json.loads(config_file.read_text())
-        return {
-            "scenario_configs": data.get("scenario_configs", {}),
-            "default_counts": [1],
-        }
-    except (json.JSONDecodeError, KeyError):
-        return None
+    @classmethod
+    def from_config(cls, config: pytest.Config) -> Self | None:
+        """
+        Parse the config the parametrizer configuration from the config.
+
+        Return `None` if the parameter is not specified.
+        """
+        if hasattr(config, cls.config_field):
+            return getattr(config, cls.config_field)
+
+        parameter_value = config.getoption(cls.parameter_name)
+        setattr(config, cls.config_field, None)
+
+        if parameter_value is None:
+            return None
+        else:
+            setattr(
+                config,
+                cls.config_field,
+                cls.from_parameter_value(config, parameter_value),
+            )
+        return getattr(config, cls.config_field)
+
+    @abstractmethod
+    def get_test_parameters(self, test_name: str) -> list[ParameterSet]:
+        """Get the parameters list for a given test."""
+        pass
+
+    def parametrize(self, metafunc: pytest.Metafunc) -> None:
+        """Parametrize a test."""
+        if self.parameter_name in metafunc.fixturenames:
+            test_name = metafunc.function.__name__
+            metafunc.parametrize(
+                self.parameter_name,
+                self.get_test_parameters(test_name),
+                scope="function",
+            )
 
 
-def get_opcode_counts_for_test(
-    test_name: str,
-    scenario_configs: dict[str, list[int]],
-    default_counts: list[int],
-) -> list[int]:
-    """
-    Get opcode counts for a test using regex pattern matching.
-    """
-    # Try exact match first (faster)
-    if test_name in scenario_configs:
-        return scenario_configs[test_name]
+class GasBenchmarkValues(RootModel, BenchmarkParametrizer):
+    """Gas benchmark values configuration object."""
 
-    # Try regex patterns
-    for pattern, counts in scenario_configs.items():
-        if pattern == test_name:
-            continue
-        try:
-            if re.search(pattern, test_name):
-                return counts
-        except re.error:
-            continue
+    root: List[int]
 
-    return default_counts
+    flag: ClassVar[str] = "--gas-benchmark-values"
+    config_field: ClassVar[str] = "_gas_benchmark_values_config"
+    parameter_name: ClassVar[str] = "gas_benchmark_value"
+
+    @classmethod
+    def from_parameter_value(
+        cls, config: pytest.Config, value: str
+    ) -> Self | None:
+        """Given the parameter value and config, return the expected object."""
+        return cls.model_validate(value.split(","))
+
+    def get_test_parameters(self, test_name: str) -> list[ParameterSet]:
+        """Get benchmark values. All tests have the same list."""
+        return [
+            pytest.param(
+                gas_value * 1_000_000,
+                id=f"benchmark-gas-value_{gas_value}M",
+            )
+            for gas_value in self.root
+        ]
+
+
+class OpcodeCountsConfig(BaseModel, BenchmarkParametrizer):
+    """Opcode counts configuration object."""
+
+    scenario_configs: Dict[str, List[int]] = Field(default_factory=dict)
+    default_counts: List[int] = Field(default_factory=lambda _: [1])
+
+    default_config_file_name: ClassVar[str] = ".fixed_opcode_counts.json"
+    flag: ClassVar[str] = "--fixed-opcode-count"
+    config_field: ClassVar[str] = "_opcode_counts_config"
+    parameter_name: ClassVar[str] = "fixed_opcode_count"
+
+    @classmethod
+    def from_parameter_value(
+        cls, config: pytest.Config, value: str
+    ) -> Self | None:
+        """Given the parameter value and config, return the expected object."""
+        if value == "":
+            default_file = Path(config.rootpath) / cls.default_config_file_name
+            if default_file.exists():
+                return cls.model_validate_json(default_file.read_bytes())
+            else:
+                warnings.warn(
+                    "--fixed-opcode-count was provided without a value, but "
+                    f"{cls.default_config_file_name} was not found. "
+                    "Run 'uv run benchmark_parser' to generate it, or provide "
+                    "explicit values (e.g., --fixed-opcode-count 1,10,100).",
+                    UserWarning,
+                    stacklevel=1,
+                )
+                return cls()
+        else:
+            return cls.model_validate({"default_counts": value.split(",")})
+
+    def get_test_parameters(self, test_name: str) -> list[ParameterSet]:
+        """
+        Get opcode counts for a test using regex pattern matching.
+        """
+        counts = self.default_counts
+        # Try exact match first (faster)
+        if test_name in self.scenario_configs:
+            counts = self.scenario_configs[test_name]
+        else:
+            # Try regex patterns
+            for pattern, pattern_counts in self.scenario_configs.items():
+                if pattern == test_name:
+                    continue
+                try:
+                    if re.search(pattern, test_name):
+                        counts = pattern_counts
+                        break
+                except re.error:
+                    continue
+        return [
+            pytest.param(
+                opcode_count,
+                id=f"opcount_{opcode_count}K",
+            )
+            for opcode_count in counts
+        ]
 
 
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     """Filter tests based on repricing marker."""
-    gas_benchmark_value = config.getoption("gas_benchmark_value")
-    fixed_opcode_count = config.getoption("fixed_opcode_count")
+    gas_benchmark_value = GasBenchmarkValues.from_config(config)
+    fixed_opcode_count = OpcodeCountsConfig.from_config(config)
 
     # Only filter if either benchmark option is provided
-    if not gas_benchmark_value and fixed_opcode_count is None:
+    if not gas_benchmark_value and not fixed_opcode_count:
         return
 
     # In --fixed-opcode-count mode, we only support tests that meet all of the following:
@@ -133,21 +239,6 @@ def pytest_collection_modifyitems(
             ):
                 filtered.append(item)
         items[:] = filtered
-
-    # Load config data if --fixed-opcode-count flag provided without value
-    if fixed_opcode_count == "":
-        config_data = load_opcode_counts_config(config)
-        if config_data:
-            config._opcode_counts_config = config_data  # type: ignore[attr-defined]
-        else:
-            warnings.warn(
-                "--fixed-opcode-count was provided without a value, but "
-                ".fixed_opcode_counts.json was not found. "
-                "Run 'uv run benchmark_parser' to generate it, or provide "
-                "explicit values (e.g., --fixed-opcode-count 1,10,100).",
-                UserWarning,
-                stacklevel=1,
-            )
 
     # Extract the specified flag from the command line.
     # If the `-m repricing` flag is not specified, or is negated,
@@ -186,80 +277,12 @@ def pytest_collection_modifyitems(
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Generate tests for the gas benchmark values and fixed opcode counts."""
-    gas_benchmark_values = metafunc.config.getoption("gas_benchmark_value")
-    fixed_opcode_counts_cli = metafunc.config.getoption("fixed_opcode_count")
+    parametrizer = GasBenchmarkValues.from_config(
+        metafunc.config
+    ) or OpcodeCountsConfig.from_config(metafunc.config)
 
-    # Ensure mutual exclusivity
-    if gas_benchmark_values and fixed_opcode_counts_cli:
-        raise pytest.UsageError(
-            "--gas-benchmark-values and --fixed-opcode-count are mutually exclusive. "
-            "Use only one at a time."
-        )
-
-    if "gas_benchmark_value" in metafunc.fixturenames:
-        if gas_benchmark_values:
-            gas_values = [
-                int(x.strip()) for x in gas_benchmark_values.split(",")
-            ]
-            gas_parameters = [
-                pytest.param(
-                    gas_value * 1_000_000,
-                    id=f"benchmark-gas-value_{gas_value}M",
-                )
-                for gas_value in gas_values
-            ]
-            metafunc.parametrize(
-                "gas_benchmark_value", gas_parameters, scope="function"
-            )
-
-    if "fixed_opcode_count" in metafunc.fixturenames:
-        # Parametrize for any benchmark test when --fixed-opcode-count is provided
-        if fixed_opcode_counts_cli is None:
-            return
-
-        opcode_counts_to_use = None
-
-        if fixed_opcode_counts_cli:
-            # CLI flag with value takes precedence
-            opcode_counts_to_use = [
-                int(x.strip()) for x in fixed_opcode_counts_cli.split(",")
-            ]
-        else:
-            # Flag provided without value - load from config file
-            # Check if config data was already loaded in pytest_collection_modifyitems
-            config_data = getattr(
-                metafunc.config, "_opcode_counts_config", None
-            )
-
-            # If not loaded yet (pytest_generate_tests runs first), load it now
-            if config_data is None:
-                config_data = load_opcode_counts_config(metafunc.config)
-                if config_data:
-                    metafunc.config._opcode_counts_config = config_data  # type: ignore[attr-defined]
-
-            if config_data:
-                # Look up opcode counts using regex pattern matching
-                test_name = metafunc.function.__name__
-                opcode_counts_to_use = get_opcode_counts_for_test(
-                    test_name,
-                    config_data.get("scenario_configs", {}),
-                    config_data.get("default_counts", [1]),
-                )
-
-        # Parametrize if we have counts to use
-        if opcode_counts_to_use:
-            opcode_count_parameters = [
-                pytest.param(
-                    opcode_count,
-                    id=f"opcount_{opcode_count}K",
-                )
-                for opcode_count in opcode_counts_to_use
-            ]
-            metafunc.parametrize(
-                "fixed_opcode_count",
-                opcode_count_parameters,
-                scope="function",
-            )
+    if parametrizer:
+        parametrizer.parametrize(metafunc)
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -76,7 +76,6 @@ class BenchmarkParametrizer(ABC):
     flag: ClassVar[str]
     parameter_name: ClassVar[str]
     config_field: ClassVar[str]
-    parameter_name: ClassVar[str]
 
     @classmethod
     @abstractmethod

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -1,7 +1,6 @@
 """The module contains the pytest hooks for the gas benchmark values."""
 
 import re
-import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import ClassVar, Dict, List, Self
@@ -172,17 +171,13 @@ class OpcodeCountsConfig(BaseModel, BenchmarkParametrizer):
             if default_file.exists():
                 return cls.model_validate_json(default_file.read_bytes())
             else:
-                warnings.warn(
+                pytest.UsageError(
                     "--fixed-opcode-count was provided without a value, but "
                     f"{cls.default_config_file_name} was not found. "
                     "Run 'uv run benchmark_parser' to generate it, or provide "
-                    "explicit values (e.g., --fixed-opcode-count 1,10,100).",
-                    UserWarning,
-                    stacklevel=1,
+                    "explicit values (e.g., --fixed-opcode-count 1,10,100)."
                 )
-                return cls()
-        else:
-            return cls.model_validate({"default_counts": value.split(",")})
+        return cls.model_validate({"default_counts": value.split(",")})
 
     def get_test_parameters(self, test_name: str) -> list[ParameterSet]:
         """

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -155,7 +155,7 @@ class OpcodeCountsConfig(BaseModel, BenchmarkParametrizer):
     """Opcode counts configuration object."""
 
     scenario_configs: Dict[str, List[int]] = Field(default_factory=dict)
-    default_counts: List[int] = Field(default_factory=lambda _: [1])
+    default_counts: List[int] = Field(default_factory=lambda: [1])
 
     default_config_file_name: ClassVar[str] = ".fixed_opcode_counts.json"
     flag: ClassVar[str] = "--fixed-opcode-count"
@@ -266,9 +266,6 @@ def pytest_collection_modifyitems(
                 item.callspec.params.get(key) == value
                 for key, value in repricing_marker.kwargs.items()
             ):
-                filtered.append(item)
-        else:
-            if not repricing_marker.kwargs:
                 filtered.append(item)
 
     items[:] = filtered

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -124,7 +124,7 @@ def pytest_collection_modifyitems(
     #
     # Here we filter out tests that do not use the benchmark_test fixture.
     # Note: At this stage we cannot filter based on whether a code generator is used.
-    if fixed_opcode_count or fixed_opcode_count == "":
+    if fixed_opcode_count is not None:
         filtered = []
         for item in items:
             if (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -110,7 +110,7 @@ def get_opcode_counts_for_test(
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Filter tests based on repricing marker when benchmark options are used."""
+    """Filter tests based on repricing marker."""
     gas_benchmark_value = config.getoption("gas_benchmark_value")
     fixed_opcode_count = config.getoption("fixed_opcode_count")
 
@@ -140,11 +140,9 @@ def pytest_collection_modifyitems(
 
     filtered = []
     for item in items:
-        if not item.get_closest_marker("benchmark"):
-            continue
-
         repricing_marker = item.get_closest_marker("repricing")
         if not repricing_marker:
+            filtered.append(item)
             continue
 
         if not repricing_marker.kwargs:
@@ -251,7 +249,7 @@ def gas_benchmark_value(request: pytest.FixtureRequest) -> int:
     # Only use high gas limit if --fixed-opcode-count flag was provided
     fixed_opcode_count = request.config.getoption("fixed_opcode_count")
     if fixed_opcode_count is not None:
-        return HIGH_GAS_LIMIT
+        return BENCHMARKING_MAX_GAS
 
     return EnvironmentDefaults.gas_limit
 
@@ -266,7 +264,6 @@ def fixed_opcode_count(request: pytest.FixtureRequest) -> int | None:
 
 
 BENCHMARKING_MAX_GAS = 1_000_000_000_000
-HIGH_GAS_LIMIT = 1_000_000_000
 
 
 @pytest.fixture

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -149,22 +149,28 @@ def pytest_collection_modifyitems(
                 stacklevel=1,
             )
 
-    # Check if -m repricing marker filter was specified
+    # Extract the specified flag from the command line.
+    # If the `-m repricing` flag is not specified, or is negated,
+    # we skip filtering tests by the repricing marker.
     markexpr = config.getoption("markexpr", "")
     if "repricing" not in markexpr or "not repricing" in markexpr:
         return
 
     filtered = []
     for item in items:
+        # If the test does not have the repricing marker, skip it
         repricing_marker = item.get_closest_marker("repricing")
         if not repricing_marker:
-            filtered.append(item)
             continue
 
+        # If the test has the repricing marker but no specific kwargs,
+        # include the entire parametrized test in the filtered list.
         if not repricing_marker.kwargs:
             filtered.append(item)
             continue
 
+        # If the test has the repricing marker with specific kwargs,
+        # filter the test cases according to those kwargs.
         if hasattr(item, "callspec"):
             if all(
                 item.callspec.params.get(key) == value

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -85,11 +85,34 @@ class BenchmarkCodeGenerator(ABC):
         prefix = Op.CALLDATACOPY(
             Op.PUSH0, Op.PUSH0, Op.CALLDATASIZE
         ) + Op.PUSH4(iterations)
+
+        is_state_changing_set = [
+            Op.SSTORE,
+            Op.TSTORE,
+            Op.CREATE,
+            Op.CREATE2,
+            Op.CALL,
+            Op.CALLCODE,
+            Op.SELFDESTRUCT,
+            Op.LOG0,
+            Op.LOG1,
+            Op.LOG2,
+            Op.LOG3,
+            Op.LOG4,
+        ]
+
+        # Select CALL for state-changing opcodes, STATICCALL otherwise
+        uses_state_changing_opcode = any(
+            bytes(opcode) in bytes(self.attack_block)
+            for opcode in is_state_changing_set
+        )
+        call_opcode = Op.CALL if uses_state_changing_opcode else Op.STATICCALL
+
         opcode = (
             prefix
             + Op.JUMPDEST
             + Op.POP(
-                Op.DELEGATECALL(
+                call_opcode(
                     gas=Op.GAS,
                     address=self._target_contract_address,
                     args_offset=0,

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -19,6 +19,7 @@ from pydantic import ConfigDict, Field
 
 from execution_testing.base_types import Address, HexNumber
 from execution_testing.client_clis import TransitionTool
+from execution_testing.client_clis.cli_types import OpcodeCount
 from execution_testing.exceptions import (
     BlockException,
     TransactionException,
@@ -56,6 +57,7 @@ class BenchmarkCodeGenerator(ABC):
     fixed_opcode_count: int | None = None
     code_padding_opcode: Op | None = None
     _contract_address: Address | None = None
+    _inner_iterations: int = 1000
 
     @abstractmethod
     def deploy_contracts(self, *, pre: Alloc, fork: Fork) -> Address:
@@ -72,8 +74,13 @@ class BenchmarkCodeGenerator(ABC):
         )
         self._target_contract_address = pre.deploy_contract(code=code)
 
-        iterations = self.fixed_opcode_count
-        assert iterations is not None, "fixed_opcode_count is not set"
+        assert self.fixed_opcode_count is not None, (
+            "fixed_opcode_count is not set"
+        )
+        # Adjust outer loop iterations based on inner iterations
+        # If inner is 500 instead of 1000, double the outer loop
+        outer_multiplier = 1000 // self._inner_iterations
+        iterations = self.fixed_opcode_count * outer_multiplier
 
         prefix = Op.CALLDATACOPY(
             Op.PUSH0, Op.PUSH0, Op.CALLDATASIZE
@@ -82,7 +89,7 @@ class BenchmarkCodeGenerator(ABC):
             prefix
             + Op.JUMPDEST
             + Op.POP(
-                Op.STATICCALL(
+                Op.DELEGATECALL(
                     gas=Op.GAS,
                     address=self._target_contract_address,
                     args_offset=0,
@@ -148,11 +155,32 @@ class BenchmarkCodeGenerator(ABC):
         max_iterations = available_space // len(repeated_code)
 
         # Use fixed_opcode_count if provided, otherwise fill to max
+        # Iteration Logic: The goal is to set the total operation count proportional to a
+        # 'fixed_opcode_count' multiplied by 1000, across two contracts (Loop M * Target N).
+
+        # --- 1. Determine Inner Iterations (N) ---
+        # The Target Contract's loop count is determined by block filling, capped at 1000.
+        #
+        # 1a. Calculate 'max_iterations' to fill the block.
+        # 1b. The Inner Iteration count (N) is capped at 1000.
+        # 1c. If the calculated N is less than 1000, use 500 as the fallback count.
+
+        # --- 2. Determine Outer Iterations (M) ---
+        # The Loop Contract's call count (M) is set to ensure the final total execution is consistent.
+        #
+        # 2a. If N is 1000: Set M = fixed_opcode_count. (Total ops: fixed_opcode_count * 1000)
+        # 2b. If N is 500: Set M = fixed_opcode_count * 2. (Total ops: (fixed_opcode_count * 2) * 500 = fixed_opcode_count * 1000)
         if self.fixed_opcode_count is not None:
-            max_iterations = min(max_iterations, 1000)
+            inner_iterations = 1000 if max_iterations >= 1000 else 500
+            self._inner_iterations = min(max_iterations, inner_iterations)
 
         # TODO: Unify the PUSH0 and PUSH1 usage.
-        code = setup + Op.JUMPDEST + repeated_code * max_iterations
+        iterations = (
+            self._inner_iterations
+            if self.fixed_opcode_count
+            else max_iterations
+        )
+        code = setup + Op.JUMPDEST + repeated_code * iterations
         if self.fixed_opcode_count is None:
             code += cleanup + (
                 Op.JUMP(len(setup)) if len(setup) > 0 else Op.PUSH0 + Op.JUMP
@@ -197,6 +225,7 @@ class BenchmarkTest(BaseTest):
         default_factory=lambda: int(Environment().gas_limit)
     )
     fixed_opcode_count: int | None = None
+    target_opcode: Op | None = None
     code_generator: BenchmarkCodeGenerator | None = None
 
     supported_fixture_formats: ClassVar[
@@ -392,6 +421,31 @@ class BenchmarkTest(BaseTest):
             blocks=self.blocks,
         )
 
+    def _verify_target_opcode_count(
+        self, opcode_count: OpcodeCount | None
+    ) -> None:
+        """Verify the target opcode was executed the expected number of times."""
+        # Skip validation if opcode count is not available (e.g. currently only supported for evmone filling)
+        if opcode_count is None:
+            return
+
+        assert self.target_opcode is not None, "target_opcode is not set"
+        assert self.fixed_opcode_count is not None, (
+            "fixed_opcode_count is not set"
+        )
+
+        # fixed_opcode_count is in thousands units
+        expected = self.fixed_opcode_count * 1000
+
+        actual = opcode_count.root.get(self.target_opcode, 0)
+        tolerance = expected * 0.05  # 5% tolerance
+
+        if abs(actual - expected) > tolerance:
+            raise ValueError(
+                f"Target opcode {self.target_opcode} count mismatch: "
+                f"expected ~{expected} (±5%), got {actual}"
+            )
+
     def generate(
         self,
         t8n: TransitionTool,
@@ -402,9 +456,18 @@ class BenchmarkTest(BaseTest):
             exception=self.tx.error is not None if self.tx else False
         )
         if fixture_format in BlockchainTest.supported_fixture_formats:
-            return self.generate_blockchain_test().generate(
+            blockchain_test = self.generate_blockchain_test()
+            fixture = blockchain_test.generate(
                 t8n=t8n, fixture_format=fixture_format
             )
+
+            # Verify target opcode count if specified
+            if (
+                self.target_opcode is not None
+                and self.fixed_opcode_count is not None
+            ):
+                self._verify_target_opcode_count(blockchain_test._opcode_count)
+            return fixture
         else:
             raise Exception(f"Unsupported fixture format: {fixture_format}")
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -49,6 +49,7 @@ def test_selfbalance(
 ) -> None:
     """Benchmark SELFBALANCE instruction."""
     benchmark_test(
+        target_opcode=Op.SELFBALANCE,
         code_generator=ExtCallGenerator(
             attack_block=Op.SELFBALANCE,
             contract_balance=contract_balance,
@@ -62,6 +63,7 @@ def test_codesize(
 ) -> None:
     """Benchmark CODESIZE instruction."""
     benchmark_test(
+        target_opcode=Op.CODESIZE,
         code_generator=ExtCallGenerator(attack_block=Op.CODESIZE),
     )
 
@@ -99,11 +101,12 @@ def test_codecopy(
     attack_block = Op.CODECOPY(src_dst, src_dst, Op.DUP1)  # DUP1 copies size.
 
     benchmark_test(
+        target_opcode=Op.CODECOPY,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
             code_padding_opcode=Op.STOP,
-        )
+        ),
     )
 
 
@@ -334,6 +337,7 @@ def test_extcodecopy_warm(
     )
 
     benchmark_test(
+        target_opcode=Op.EXTCODECOPY,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH10(copied_size) + Op.PUSH20(copied_contract_address),
             attack_block=Op.EXTCODECOPY(Op.DUP4, 0, 0, Op.DUP2),
@@ -411,6 +415,7 @@ def test_ext_account_query_warm(
         post[target_addr] = Account(**contract_kwargs)
 
     benchmark_test(
+        target_opcode=opcode,
         post=post,
         code_generator=JumpLoopGenerator(
             setup=Op.MSTORE(0, target_addr),
@@ -568,6 +573,7 @@ def test_ext_account_query_cold(
     blocks.append(Block(txs=execution_txs))
 
     benchmark_test(
+        target_opcode=opcode,
         post=post,
         blocks=blocks,
     )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -445,10 +445,14 @@ def test_ext_account_query_cold(
     absent_accounts: bool,
     gas_benchmark_value: int,
     tx_gas_limit: int,
+    fixed_opcode_count: int,
 ) -> None:
     """
     Benchmark stateful opcodes accessing cold accounts.
     """
+    if fixed_opcode_count:
+        pytest.skip("Fixed opcode count is not supported for this test")
+
     attack_gas_limit = gas_benchmark_value
 
     gas_costs = fork.gas_costs()

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -41,7 +41,7 @@ from tests.benchmark.compute.helpers import (
 )
 
 
-@pytest.mark.repricing(contract_balance=0)
+@pytest.mark.repricing(contract_balance=1)
 @pytest.mark.parametrize("contract_balance", [0, 1])
 def test_selfbalance(
     benchmark_test: BenchmarkTestFiller,
@@ -68,6 +68,7 @@ def test_codesize(
     )
 
 
+@pytest.mark.repricing(max_code_size_ratio=0, fixed_src_dst=True)
 @pytest.mark.parametrize(
     "max_code_size_ratio",
     [
@@ -110,6 +111,7 @@ def test_codecopy(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -318,6 +320,7 @@ def test_extcode_ops(
     )
 
 
+@pytest.mark.repricing(copied_size=512)
 @pytest.mark.parametrize(
     "copied_size",
     [
@@ -345,6 +348,11 @@ def test_extcodecopy_warm(
     )
 
 
+@pytest.mark.repricing(
+    empty_code=True,
+    initial_balance=True,
+    initial_storage=True,
+)
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -424,6 +432,7 @@ def test_ext_account_query_warm(
     )
 
 
+@pytest.mark.repricing(absent_accounts=True)
 @pytest.mark.parametrize(
     "opcode",
     [

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -159,7 +159,7 @@ def test_arithmetic(
     )
 
 
-@pytest.mark.repricing(mod_bits=255)
+@pytest.mark.repricing(mod_bits=127)
 @pytest.mark.parametrize("mod_bits", [255, 191, 127, 63])
 @pytest.mark.parametrize("opcode", [Op.MOD, Op.SMOD])
 def test_mod(
@@ -278,7 +278,7 @@ def test_mod(
     )
 
 
-@pytest.mark.repricing(mod_bits=255)
+@pytest.mark.repricing(mod_bits=191)
 @pytest.mark.parametrize("mod_bits", [255, 191, 127, 63])
 @pytest.mark.parametrize("opcode", [Op.ADDMOD, Op.MULMOD])
 def test_mod_arithmetic(

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -149,6 +149,7 @@ def test_arithmetic(
     attack_block = Op.DUP2 + opcode
     cleanup = Op.POP + Op.POP + Op.DUP2 + Op.DUP2
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
@@ -388,4 +389,6 @@ def test_mod_arithmetic(
         sender=pre.fund_eoa(),
     )
 
-    benchmark_test(tx=tx)
+    benchmark_test(
+        tx=tx,
+    )

--- a/tests/benchmark/compute/instruction/test_bitwise.py
+++ b/tests/benchmark/compute/instruction/test_bitwise.py
@@ -124,6 +124,7 @@ def test_not_op(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("opcode", [Op.SHR, Op.SAR])
 def test_shifts(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_bitwise.py
+++ b/tests/benchmark/compute/instruction/test_bitwise.py
@@ -101,6 +101,7 @@ def test_bitwise(
     attack_block = Op.DUP2 + opcode
     cleanup = Op.POP + Op.POP + Op.DUP2 + Op.DUP2
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
@@ -118,16 +119,17 @@ def test_not_op(
     Benchmark NOT instruction (takes one arg, pushes one value).
     """
     benchmark_test(
+        target_opcode=Op.NOT,
         code_generator=JumpLoopGenerator(setup=Op.PUSH0, attack_block=Op.NOT),
     )
 
 
-@pytest.mark.parametrize("shift_right", [Op.SHR, Op.SAR])
+@pytest.mark.parametrize("opcode", [Op.SHR, Op.SAR])
 def test_shifts(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
-    shift_right: Op,
+    opcode: Op,
     gas_benchmark_value: int,
 ) -> None:
     """
@@ -138,13 +140,13 @@ def test_shifts(
     """
     max_code_size = fork.max_code_size()
 
-    match shift_right:
+    match opcode:
         case Op.SHR:
             shift_right_fn = shr
         case Op.SAR:
             shift_right_fn = sar
         case _:
-            raise ValueError(f"Unexpected shift op: {shift_right}")
+            raise ValueError(f"Unexpected shift op: {opcode}")
 
     rng = random.Random(1)  # Use random with a fixed seed.
     initial_value = 2**256 - 1  # The initial value to be shifted; should be
@@ -180,7 +182,7 @@ def test_shifts(
         v, i = select_shift_amount(shl, v)
         code_body += make_dup(len(shift_amounts) - i) + Op.SHL
         v, i = select_shift_amount(shift_right_fn, v)
-        code_body += make_dup(len(shift_amounts) - i) + shift_right
+        code_body += make_dup(len(shift_amounts) - i) + opcode
 
     code = code_prefix + code_body + code_suffix
     assert len(code) == max_code_size - 2
@@ -192,7 +194,10 @@ def test_shifts(
         sender=pre.fund_eoa(),
     )
 
-    benchmark_test(tx=tx)
+    benchmark_test(
+        target_opcode=opcode,
+        tx=tx,
+    )
 
 
 @pytest.mark.repricing
@@ -201,6 +206,7 @@ def test_clz_same(benchmark_test: BenchmarkTestFiller) -> None:
     """Benchmark CLZ instruction with same input."""
     magic_value = 248  # CLZ(248) = 248
     benchmark_test(
+        target_opcode=Op.CLZ,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH1(magic_value), attack_block=Op.CLZ
         ),
@@ -238,4 +244,7 @@ def test_clz_diff(
         sender=pre.fund_eoa(),
     )
 
-    benchmark_test(tx=tx)
+    benchmark_test(
+        target_opcode=Op.CLZ,
+        tx=tx,
+    )

--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -43,6 +43,7 @@ def test_block_context_ops(
 ) -> None:
     """Benchmark zero-parameter block context instructions."""
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(attack_block=opcode),
     )
 
@@ -73,6 +74,7 @@ def test_blockhash(
     block_number = Op.AND(Op.GAS, 0xFF) if index is None else index
 
     benchmark_test(
+        target_opcode=Op.BLOCKHASH,
         setup_blocks=blocks,
         code_generator=ExtCallGenerator(
             attack_block=Op.BLOCKHASH(block_number)

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -43,6 +43,7 @@ def test_call_frame_context_ops(
 ) -> None:
     """Benchmark call zero-parameter instructions."""
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(attack_block=opcode),
     )
 
@@ -55,6 +56,7 @@ def test_calldatasize(
 ) -> None:
     """Benchmark CALLDATASIZE instruction."""
     benchmark_test(
+        target_opcode=Op.CALLDATASIZE,
         code_generator=ExtCallGenerator(
             attack_block=Op.CALLDATASIZE,
             tx_kwargs={"data": b"\x00" * calldata_length},
@@ -71,6 +73,7 @@ def test_callvalue_from_origin(
     Benchmark CALLVALUE instruction from origin.
     """
     benchmark_test(
+        target_opcode=Op.CALLVALUE,
         code_generator=JumpLoopGenerator(
             attack_block=Op.POP(Op.CALLVALUE),
             tx_kwargs={"value": int(non_zero_value)},
@@ -123,6 +126,7 @@ def test_calldataload(
 ) -> None:
     """Benchmark CALLDATALOAD instruction."""
     benchmark_test(
+        target_opcode=Op.CALLDATALOAD,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH0,
             attack_block=Op.CALLDATALOAD,
@@ -195,11 +199,12 @@ def test_calldatacopy_from_origin(
     )
 
     benchmark_test(
+        target_opcode=Op.CALLDATACOPY,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
             tx_kwargs={"data": data},
-        )
+        ),
     )
 
 
@@ -267,11 +272,12 @@ def test_calldatacopy_from_call(
     )
 
     benchmark_test(
+        target_opcode=Op.CALLDATACOPY,
         code_generator=ExtCallGenerator(
             setup=setup,
             attack_block=attack_block,
             tx_kwargs={"data": data},
-        )
+        ),
     )
 
 
@@ -316,6 +322,7 @@ def test_returndatasize_nonzero(
         )
 
     benchmark_test(
+        target_opcode=Op.RETURNDATASIZE,
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=Op.POP(Op.RETURNDATASIZE)
         ),
@@ -328,6 +335,7 @@ def test_returndatasize_zero(
 ) -> None:
     """Benchmark RETURNDATASIZE instruction with zero buffer."""
     benchmark_test(
+        target_opcode=Op.RETURNDATASIZE,
         code_generator=ExtCallGenerator(attack_block=Op.RETURNDATASIZE),
     )
 
@@ -377,6 +385,7 @@ def test_returndatacopy(
     attack_block = Op.RETURNDATACOPY(dst, Op.PUSH0, Op.RETURNDATASIZE)
 
     benchmark_test(
+        target_opcode=Op.RETURNDATACOPY,
         code_generator=JumpLoopGenerator(
             setup=returndata_gen,
             attack_block=attack_block,

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -48,7 +48,7 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(calldata_length=1_000)
+@pytest.mark.repricing(calldata_length=10_000)
 @pytest.mark.parametrize("calldata_length", [0, 1_000, 10_000])
 def test_calldatasize(
     benchmark_test: BenchmarkTestFiller,
@@ -64,6 +64,7 @@ def test_calldatasize(
     )
 
 
+@pytest.mark.repricing(non_zero_value=True)
 @pytest.mark.parametrize("non_zero_value", [True, False])
 def test_callvalue_from_origin(
     benchmark_test: BenchmarkTestFiller,
@@ -111,7 +112,7 @@ def test_callvalue_from_call(
     )
 
 
-@pytest.mark.repricing(calldata=b"")
+@pytest.mark.repricing(calldata=b"\x00")
 @pytest.mark.parametrize(
     "calldata",
     [
@@ -135,6 +136,7 @@ def test_calldataload(
     )
 
 
+@pytest.mark.repricing(size=0, fixed_src_dst=True, non_zero_data=False)
 @pytest.mark.parametrize(
     "size",
     [
@@ -282,8 +284,8 @@ def test_calldatacopy_from_call(
 
 
 @pytest.mark.repricing(
-    returned_size=1,
-    return_data_style=ReturnDataStyle.RETURN,
+    returned_size=0,
+    return_data_style=ReturnDataStyle.IDENTITY,
 )
 @pytest.mark.parametrize(
     "return_data_style",
@@ -340,7 +342,7 @@ def test_returndatasize_zero(
     )
 
 
-@pytest.mark.repricing(size=10 * 1024, fixed_dst=True)
+@pytest.mark.repricing(size=0, fixed_dst=True)
 @pytest.mark.parametrize(
     "size",
     [

--- a/tests/benchmark/compute/instruction/test_comparison.py
+++ b/tests/benchmark/compute/instruction/test_comparison.py
@@ -71,6 +71,7 @@ def test_comparison(
     attack_block = Op.DUP2 + opcode
     cleanup = Op.POP + Op.POP + Op.DUP2 + Op.DUP2
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
@@ -88,6 +89,7 @@ def test_iszero(
     Benchmark ISZERO instruction (takes one arg, pushes one value).
     """
     benchmark_test(
+        target_opcode=Op.ISZERO,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH0,
             attack_block=Op.ISZERO,

--- a/tests/benchmark/compute/instruction/test_control_flow.py
+++ b/tests/benchmark/compute/instruction/test_control_flow.py
@@ -35,6 +35,7 @@ def test_gas_op(
     )
 
 
+@pytest.mark.repricing
 def test_pc_op(
     benchmark_test: BenchmarkTestFiller,
 ) -> None:
@@ -45,6 +46,7 @@ def test_pc_op(
     )
 
 
+@pytest.mark.repricing
 def test_jumps(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,

--- a/tests/benchmark/compute/instruction/test_control_flow.py
+++ b/tests/benchmark/compute/instruction/test_control_flow.py
@@ -30,6 +30,7 @@ def test_gas_op(
 ) -> None:
     """Benchmark GAS instruction."""
     benchmark_test(
+        target_opcode=Op.GAS,
         code_generator=ExtCallGenerator(attack_block=Op.GAS),
     )
 
@@ -39,6 +40,7 @@ def test_pc_op(
 ) -> None:
     """Benchmark PC instruction."""
     benchmark_test(
+        target_opcode=Op.PC,
         code_generator=ExtCallGenerator(attack_block=Op.PC),
     )
 
@@ -53,7 +55,10 @@ def test_jumps(
         sender=pre.fund_eoa(),
     )
 
-    benchmark_test(tx=tx)
+    benchmark_test(
+        target_opcode=Op.JUMP,
+        tx=tx,
+    )
 
 
 @pytest.mark.repricing
@@ -62,6 +67,7 @@ def test_jumpi_fallthrough(
 ) -> None:
     """Benchmark JUMPI instruction with fallthrough."""
     benchmark_test(
+        target_opcode=Op.JUMPI,
         code_generator=JumpLoopGenerator(
             attack_block=Op.JUMPI(Op.PUSH0, Op.PUSH0)
         ),
@@ -80,7 +86,10 @@ def test_jumpis(
         sender=pre.fund_eoa(),
     )
 
-    benchmark_test(tx=tx)
+    benchmark_test(
+        target_opcode=Op.JUMPI,
+        tx=tx,
+    )
 
 
 @pytest.mark.repricing
@@ -88,4 +97,7 @@ def test_jumpdests(
     benchmark_test: BenchmarkTestFiller,
 ) -> None:
     """Benchmark JUMPDEST instruction."""
-    benchmark_test(code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST))
+    benchmark_test(
+        target_opcode=Op.JUMPDEST,
+        code_generator=JumpLoopGenerator(attack_block=Op.JUMPDEST),
+    )

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -63,6 +63,7 @@ def test_keccak_max_permutations(
             optimal_input_length = i
 
     benchmark_test(
+        target_opcode=Op.SHA3,
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH20[optimal_input_length],
             attack_block=Op.POP(Op.SHA3(Op.PUSH0, Op.DUP1)),
@@ -79,6 +80,7 @@ def test_keccak(
 ) -> None:
     """Benchmark KECCAK256 instruction with diff input data and offsets."""
     benchmark_test(
+        target_opcode=Op.SHA3,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(offset, Op.PUSH0, Op.CALLDATASIZE),
             attack_block=Op.POP(Op.SHA3(offset, Op.CALLDATASIZE)),

--- a/tests/benchmark/compute/instruction/test_log.py
+++ b/tests/benchmark/compute/instruction/test_log.py
@@ -19,10 +19,10 @@ from execution_testing import (
 
 
 @pytest.mark.repricing(
-    size=1024 * 1024,
+    size=0,
     non_zero_data=True,
-    zeros_topic=False,
-    fixed_offset=True,
+    zeros_topic=0,
+    fixed_offset=False,
 )
 @pytest.mark.parametrize(
     "opcode",

--- a/tests/benchmark/compute/instruction/test_log.py
+++ b/tests/benchmark/compute/instruction/test_log.py
@@ -81,6 +81,7 @@ def test_log(
     attack_block = Op.DUP1 * topic_count + size_op + offset + opcode
 
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=attack_block
         ),

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -19,7 +19,7 @@ from execution_testing import (
 )
 
 
-@pytest.mark.repricing(mem_size=1_000)
+@pytest.mark.repricing(mem_size=1)
 @pytest.mark.parametrize("mem_size", [0, 1, 1_000, 100_000, 1_000_000])
 def test_msize(
     benchmark_test: BenchmarkTestFiller,
@@ -37,7 +37,7 @@ def test_msize(
 
 
 @pytest.mark.repricing(
-    offset=31,
+    offset=0,
     offset_initialized=True,
     big_memory_expansion=True,
 )
@@ -75,7 +75,7 @@ def test_memory_access(
     )
 
 
-@pytest.mark.repricing(size=10 * 1024, fixed_src_dst=True)
+@pytest.mark.repricing(size=0, fixed_src_dst=True)
 @pytest.mark.parametrize(
     "size",
     [

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -27,6 +27,7 @@ def test_msize(
 ) -> None:
     """Benchmark MSIZE instruction."""
     benchmark_test(
+        target_opcode=Op.MSIZE,
         code_generator=ExtCallGenerator(
             setup=Op.POP(Op.MLOAD(Op.SELFBALANCE)),
             attack_block=Op.MSIZE,
@@ -67,6 +68,7 @@ def test_memory_access(
     )
 
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=attack_block
         ),
@@ -107,6 +109,7 @@ def test_mcopy(
         else Bytecode()
     )
     benchmark_test(
+        target_opcode=Op.MCOPY,
         code_generator=JumpLoopGenerator(
             attack_block=attack_block, cleanup=mem_touch
         ),

--- a/tests/benchmark/compute/instruction/test_stack.py
+++ b/tests/benchmark/compute/instruction/test_stack.py
@@ -45,6 +45,7 @@ def test_swap(
 ) -> None:
     """Benchmark SWAP instruction."""
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             attack_block=opcode, setup=Op.PUSH0 * opcode.min_stack_height
         ),
@@ -80,6 +81,7 @@ def test_dup(
     """Benchmark DUP instruction."""
     min_stack_height = opcode.min_stack_height
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(
             setup=Op.PUSH0 * min_stack_height,
             attack_block=opcode,
@@ -132,6 +134,7 @@ def test_push(
 ) -> None:
     """Benchmark PUSH instruction."""
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(
             attack_block=opcode[1] if opcode.has_data_portion() else opcode
         ),

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -54,6 +54,7 @@ def test_tload(
     tx_data = b"42" if fixed_key and not fixed_value else b""
 
     benchmark_test(
+        target_opcode=Op.TLOAD,
         code_generator=ExtCallGenerator(
             setup=setup,
             attack_block=attack_block,
@@ -83,6 +84,7 @@ def test_tstore(
     cleanup = Op.POP + Op.GAS if not fixed_key else Bytecode()
 
     benchmark_test(
+        target_opcode=Op.TSTORE,
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=attack_block, cleanup=cleanup
         ),

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -30,7 +30,7 @@ from execution_testing import (
 from tests.benchmark.compute.helpers import StorageAction, TransactionResult
 
 
-@pytest.mark.repricing(fixed_key=False, fixed_value=False)
+@pytest.mark.repricing(fixed_key=True, fixed_value=True)
 @pytest.mark.parametrize("fixed_key", [True, False])
 @pytest.mark.parametrize("fixed_value", [True, False])
 def test_tload(
@@ -89,6 +89,9 @@ def test_tstore(
     )
 
 
+@pytest.mark.repricing(
+    storage_action=StorageAction.WRITE_SAME_VALUE, absent_slots=False
+)
 @pytest.mark.parametrize(
     "storage_action,tx_result",
     [
@@ -287,6 +290,7 @@ def test_storage_access_cold(
     )
 
 
+@pytest.mark.repricing(storage_action=StorageAction.WRITE_SAME_VALUE)
 @pytest.mark.parametrize(
     "storage_action",
     [

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -40,6 +40,7 @@ from execution_testing import (
 from tests.benchmark.compute.helpers import XOR_TABLE
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -247,6 +248,7 @@ def test_xcall(
     )
 
 
+@pytest.mark.repricing(max_code_size_ratio=0)
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -358,6 +360,7 @@ def test_create(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -430,7 +433,7 @@ def test_creates_collisions(
     )
 
 
-@pytest.mark.repricing(return_size=1024, return_non_zero_data=True)
+@pytest.mark.repricing(return_size=0, return_non_zero_data=False)
 @pytest.mark.parametrize(
     "opcode",
     [Op.RETURN, Op.REVERT],
@@ -476,6 +479,7 @@ def test_return_revert(
     )
 
 
+@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_existing(
     benchmark_test: BenchmarkTestFiller,
@@ -665,6 +669,7 @@ def test_selfdestruct_existing(
     )
 
 
+@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_created(
     state_test: StateTestFiller,
@@ -773,6 +778,7 @@ def test_selfdestruct_created(
     )
 
 
+@pytest.mark.repricing(value_bearing=False)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_initcode(
     state_test: StateTestFiller,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -349,11 +349,12 @@ def test_create(
     )
 
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,
             contract_balance=1_000_000_000 if value > 0 else 0,
-        )
+        ),
     )
 
 
@@ -422,6 +423,7 @@ def test_creates_collisions(
             pre.deploy_contract(address=addr, code=Op.INVALID)
 
     benchmark_test(
+        target_opcode=opcode,
         code_generator=JumpLoopGenerator(
             setup=setup, attack_block=attack_block
         ),
@@ -465,6 +467,7 @@ def test_return_revert(
         Op.CODECOPY(size=return_size) if return_non_zero_data else Bytecode()
     )
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(
             setup=mem_preparation,
             attack_block=opcode(size=return_size),
@@ -653,6 +656,7 @@ def test_selfdestruct_existing(
 
     benchmark_test(
         post=post,
+        target_opcode=Op.SELFDESTRUCT,
         blocks=[
             Block(txs=setup_txs),
             Block(txs=exec_txs, fee_recipient=fee_recipient),

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -360,7 +360,6 @@ def test_create(
     )
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -433,7 +432,6 @@ def test_creates_collisions(
     )
 
 
-@pytest.mark.repricing(return_size=0, return_non_zero_data=False)
 @pytest.mark.parametrize(
     "opcode",
     [Op.RETURN, Op.REVERT],
@@ -479,7 +477,6 @@ def test_return_revert(
     )
 
 
-@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_existing(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_tx_context.py
+++ b/tests/benchmark/compute/instruction/test_tx_context.py
@@ -36,6 +36,7 @@ def test_call_frame_context_ops(
 ) -> None:
     """Benchmark call zero-parameter instructions."""
     benchmark_test(
+        target_opcode=opcode,
         code_generator=ExtCallGenerator(attack_block=opcode),
     )
 
@@ -67,6 +68,7 @@ def test_blobhash(
         )
 
     benchmark_test(
+        target_opcode=Op.BLOBHASH,
         code_generator=ExtCallGenerator(
             attack_block=Op.BLOBHASH(blob_index),
             tx_kwargs=tx_kwargs,

--- a/tests/benchmark/compute/instruction/test_tx_context.py
+++ b/tests/benchmark/compute/instruction/test_tx_context.py
@@ -41,7 +41,7 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(blob_index=0, blobs_present=0)
+@pytest.mark.repricing(blob_index=0, blobs_present=1)
 @pytest.mark.parametrize(
     "blob_index, blobs_present",
     [


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
There are several enhancements in this PR:
- Implement opcode-count verification for `--fixed-opcode-count` mode using the opcount field provided when generating tests with `evmone` with 5% deviation. 


- Re-label the worst-case scenarios for the repricing marker based on the Grafana [dashboard](https://grafana.observability.ethpandaops.io/d/feo4ronhsqv40d/opcodes-benchmarking?orgId=1&from=2025-12-02T11:44:15.682Z&to=2025-12-02T12:01:58.956Z&timezone=browser&var-posgreSQL=benuragv7iuwwb&var-TableName=gas_limit_benchmarks&var-ClientName=nethermind&var-ClientName=geth&var-TestTitle=$__all&viewPanel=panel-24) data and this [script](https://gist.github.com/LouisTsai-Csie/17a57d0500466261935c6919cdb2e80e) that sort the cases based on the MGas result.
  - The repricing marker under` tests/benchmark/compute/instruction/` are udpated.

Based on our discussion about the verification mechanism during sync up call, specifically whether to remove the `target_opcode` field. I would suggest not removing it for now, since this [feature](https://github.com/ethereum/execution-specs/pull/1898) depends on it, which is very helpful for me to show coverage to others, without manually update the Notion page.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue #1835 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture
<img width="1024" height="1024" alt="Gemini_Generated_Image_d360w8d360w8d360" src="https://github.com/user-attachments/assets/6826d1d1-e65a-4d0d-b574-ae0833536a94" />



