### PR TITLE
feat(tests): add benchmark for transfers to non-existent receivers

### DIFF
--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -37,6 +37,59 @@ from execution_testing import (
 )
 
 
+def test_contract_calling_many_addresses(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Benchmark a contract that calls many addresses.
+
+    Creates a contract that generates addresses dynamically using KECCAK256
+    and calls each one with 1 wei.
+    Stop when the gas is less than the loop cost.
+    """
+    gas_costs = fork.gas_costs()
+    loop_cost = (
+        gas_costs.G_JUMPDEST  # 1
+        + gas_costs.G_VERY_LOW * 4  # 4× PUSH1 for CALL zero args = 12
+        + gas_costs.G_BASE * 2  # 2× GAS = 4
+        + gas_costs.G_VERY_LOW * 5  # PUSH1 value, DUP6, SWAP1, SUB, GT = 15
+        + gas_costs.G_VERY_LOW * 2  # PUSH1 dest, PUSH2 loop_cost = 6
+        + gas_costs.G_HIGH  # JUMPI = 10
+        + gas_costs.G_COLD_ACCOUNT_ACCESS  # 2600
+        + gas_costs.G_CALL_VALUE  # 9000
+        + gas_costs.G_NEW_ACCOUNT  # 25000
+        - gas_costs.G_CALL_STIPEND  # -2300 (refunded when callee has no code)
+    )
+    # Build contract code that generates addresses and calls them
+    # Pattern:
+    # 1. Pushes the current blockhash on the stack
+    # 2. JUMPDEST (loop start)
+    # 3. Call into the address at the top of the stack with 1 wei
+    # 4. Subtract 1 from the blockhash
+    # 5. Jump to the start of the loop if the gas is greater than the loop cost
+    # 6. otherwise, return 0
+
+    setup = Op.BLOCKHASH(0)
+    code = (
+        setup
+        + Op.JUMPDEST  # [BLOCKHASH]
+        + Op.CALL(address=Op.DUP6, value=1)  # [1, BLOCKHASH]
+        + Op.SWAP1  # [BLOCKHASH, 1] // Assume every CALL is successful
+        + Op.SUB  # [BLOCKHASH-1]
+        + Op.JUMPI(Op.GT(Op.GAS, loop_cost), len(setup))
+        + Op.RETURN(0, 0)
+    )
+
+    benchmark_test(
+        tx=Transaction(
+            to=pre.deploy_contract(code=code),
+            sender=pre.fund_eoa(),
+        )
+    )
+
+
 @pytest.mark.repricing(max_code_size_ratio=0)
 @pytest.mark.parametrize(
     "opcode",

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -17,7 +17,9 @@ import math
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
+    Address,
     Alloc,
     BenchmarkTestFiller,
     Block,
@@ -37,55 +39,59 @@ from execution_testing import (
 )
 
 
+@pytest.mark.parametrize("transfer_amount", [0, 1])
+@pytest.mark.parametrize("opcode", [Op.CALL, Op.CALLCODE])
+@pytest.mark.parametrize("access_warm", [True, False])
 def test_contract_calling_many_addresses(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
+    transfer_amount: int,
+    opcode: Op,
+    access_warm: bool,
+    tx_gas_limit: int,
 ) -> None:
-    """
-    Benchmark a contract that calls many addresses.
+    """Benchmark a contract that calls many addresses."""
+    warm_start_addr = 2**80 - 1
+    setup = Op.PUSH20(warm_start_addr) if access_warm else Op.GAS
 
-    Creates a contract that generates addresses dynamically using KECCAK256
-    and calls each one with 1 wei.
-    Stop when the gas is less than the loop cost.
-    """
-    gas_costs = fork.gas_costs()
-    loop_cost = (
-        gas_costs.G_JUMPDEST  # 1
-        + gas_costs.G_VERY_LOW * 4  # 4× PUSH1 for CALL zero args = 12
-        + gas_costs.G_BASE * 2  # 2× GAS = 4
-        + gas_costs.G_VERY_LOW * 5  # PUSH1 value, DUP6, SWAP1, SUB, GT = 15
-        + gas_costs.G_VERY_LOW * 2  # PUSH1 dest, PUSH2 loop_cost = 6
-        + gas_costs.G_HIGH  # JUMPI = 10
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # 2600
-        + gas_costs.G_CALL_VALUE  # 9000
-        + gas_costs.G_NEW_ACCOUNT  # 25000
-        - gas_costs.G_CALL_STIPEND  # -2300 (refunded when callee has no code)
-    )
-    # Build contract code that generates addresses and calls them
-    # Pattern:
-    # 1. Pushes the current blockhash on the stack
-    # 2. JUMPDEST (loop start)
-    # 3. Call into the address at the top of the stack with 1 wei
-    # 4. Subtract 1 from the blockhash
-    # 5. Jump to the start of the loop if the gas is greater than the loop cost
-    # 6. otherwise, return 0
+    def loop(threshold: int) -> Bytecode:
+        return (
+            Op.JUMPDEST
+            + opcode(address=Op.DUP6, value=transfer_amount)
+            + Op.SWAP1
+            + Op.SUB
+            + Op.JUMPI(Op.GT(Op.GAS, threshold), len(setup))
+        )
 
-    setup = Op.BLOCKHASH(0)
-    code = (
-        setup
-        + Op.JUMPDEST  # [BLOCKHASH]
-        + Op.CALL(address=Op.DUP6, value=1)  # [1, BLOCKHASH]
-        + Op.SWAP1  # [BLOCKHASH, 1] // Assume every CALL is successful
-        + Op.SUB  # [BLOCKHASH-1]
-        + Op.JUMPI(Op.GT(Op.GAS, loop_cost), len(setup))
-        + Op.RETURN(0, 0)
-    )
+    cost = loop(0xFFFF).gas_cost(fork)
+    code = setup + loop(cost)
+
+    access_list = None
+    if access_warm:
+        gas_costs = fork.gas_costs()
+        intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
+
+        iterations = (tx_gas_limit - intrinsic_cost_calc()) // (
+            gas_costs.G_ACCESS_LIST_ADDRESS + cost
+        )
+
+        access_list = [
+            AccessList(
+                address=Address(warm_start_addr - i),
+                storage_keys=[],
+            )
+            for i in range(iterations)
+        ]
 
     benchmark_test(
         tx=Transaction(
-            to=pre.deploy_contract(code=code),
+            to=pre.deploy_contract(
+                code=code,
+                balance=10**18 if transfer_amount > 0 else 0,
+            ),
             sender=pre.fund_eoa(),
+            access_list=access_list,
         )
     )
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -49,6 +49,7 @@ def test_contract_calling_many_addresses(
     transfer_amount: int,
     opcode: Op,
     access_warm: bool,
+    gas_benchmark_value: int,
     tx_gas_limit: int,
 ) -> None:
     """Benchmark a contract that calls many addresses."""
@@ -67,33 +68,46 @@ def test_contract_calling_many_addresses(
     cost = loop(0xFFFF).gas_cost(fork)
     code = setup + loop(cost)
 
-    access_list = None
-    if access_warm:
-        gas_costs = fork.gas_costs()
-        intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-
-        iterations = (tx_gas_limit - intrinsic_cost_calc()) // (
-            gas_costs.G_ACCESS_LIST_ADDRESS + cost
-        )
-
-        access_list = [
-            AccessList(
-                address=Address(warm_start_addr - i),
-                storage_keys=[],
-            )
-            for i in range(iterations)
-        ]
-
-    benchmark_test(
-        tx=Transaction(
-            to=pre.deploy_contract(
-                code=code,
-                balance=10**18 if transfer_amount > 0 else 0,
-            ),
-            sender=pre.fund_eoa(),
-            access_list=access_list,
-        )
+    contract_addr = pre.deploy_contract(
+        code=code,
+        balance=10**18 if transfer_amount > 0 else 0,
     )
+
+    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_cost = intrinsic_cost_calc()
+    access_list_addr_cost = fork.gas_costs().G_ACCESS_LIST_ADDRESS
+
+    txs = []
+    remaining_gas = gas_benchmark_value
+    while remaining_gas > intrinsic_cost:
+        per_tx_gas = min(tx_gas_limit, remaining_gas)
+        remaining_gas -= per_tx_gas
+
+        access_list = None
+        if access_warm:
+            iterations = (per_tx_gas - intrinsic_cost) // (
+                access_list_addr_cost + cost
+            )
+            if iterations <= 0:
+                break
+            access_list = [
+                AccessList(
+                    address=Address(warm_start_addr - i),
+                    storage_keys=[],
+                )
+                for i in range(iterations)
+            ]
+
+        txs.append(
+            Transaction(
+                to=contract_addr,
+                sender=pre.fund_eoa(),
+                gas_limit=per_tx_gas,
+                access_list=access_list,
+            )
+        )
+
+    benchmark_test(blocks=[Block(txs=txs)])
 
 
 @pytest.mark.repricing(max_code_size_ratio=0)


### PR DESCRIPTION
## 🗒️ Description
Adds a benchmark that touches many non-existent accounts

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
