### PR TITLE
feat(test-benchmarks): add dynamic `EXP` byte tests

### DIFF
--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -419,15 +419,6 @@ def test_mod_arithmetic(
     )
 
 
-params = [
-    (base, exp)
-    for base in [3, 5, 7, 11, 13, 136279841]
-    # Mersenne prime exponent used as base and exp
-    for exp in [3, 5, 7, 11, 13, 136279841]
-]
-
-
-# Mersenne prime exponent used as base and exp
 @pytest.mark.parametrize("base", [3, 5, 7, 11, 13, 136279841])
 @pytest.mark.parametrize("exp", [3, 5, 7, 11, 13, 136279841])
 def test_exp_bench_arithmetic(

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -421,7 +421,8 @@ def test_mod_arithmetic(
 params = [
     (base, exp)
     for base in [3, 5, 7, 11, 13, 136279841]
-    for exp in [3, 5, 7, 11, 13, 136279841] # Mersenne prime exponent used as base and exp
+    # Mersenne prime exponent used as base and exp
+    for exp in [3, 5, 7, 11, 13, 136279841]
 ]
 @pytest.mark.parametrize("base, exp", params)
 def test_exp_bench_arithmetic(

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -431,11 +431,7 @@ params = [
 def test_exp_bench_arithmetic(
     benchmark_test: BenchmarkTestFiller, base: int, exp: int
 ) -> None:
-    """
-    Benchmark binary instructions (takes two args, pushes one value).
-    The execution starts with two initial values on the stack
-    The stack is balanced by the DUP2 instruction.
-    """
+    """Benchmark EXP instruction."""
     tx_data = b"".join(
         arg.to_bytes(32, byteorder="big") for arg in (base, exp)
     )

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -427,7 +427,9 @@ params = [
 ]
 
 
-@pytest.mark.parametrize("base, exp", params)
+# Mersenne prime exponent used as base and exp
+@pytest.mark.parametrize("base", [3, 5, 7, 11, 13, 136279841])
+@pytest.mark.parametrize("exp", [3, 5, 7, 11, 13, 136279841])
 def test_exp_bench_arithmetic(
     benchmark_test: BenchmarkTestFiller, base: int, exp: int
 ) -> None:

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -418,17 +418,18 @@ def test_mod_arithmetic(
         tx=tx,
     )
 
+
 params = [
     (base, exp)
     for base in [3, 5, 7, 11, 13, 136279841]
     # Mersenne prime exponent used as base and exp
     for exp in [3, 5, 7, 11, 13, 136279841]
 ]
+
+
 @pytest.mark.parametrize("base, exp", params)
 def test_exp_bench_arithmetic(
-    benchmark_test: BenchmarkTestFiller,
-    base: int,
-    exp: int
+    benchmark_test: BenchmarkTestFiller, base: int, exp: int
 ) -> None:
     """
     Benchmark binary instructions (takes two args, pushes one value).

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -417,3 +417,35 @@ def test_mod_arithmetic(
     benchmark_test(
         tx=tx,
     )
+
+params = [
+    (base, exp)
+    for base in [3, 5, 7, 11, 13, 136279841]
+    for exp in [3, 5, 7, 11, 13, 136279841] # Mersenne prime exponent used as base and exp
+]
+@pytest.mark.parametrize("base, exp", params)
+def test_exp_bench_arithmetic(
+    benchmark_test: BenchmarkTestFiller,
+    base: int,
+    exp: int
+) -> None:
+    """
+    Benchmark binary instructions (takes two args, pushes one value).
+    The execution starts with two initial values on the stack
+    The stack is balanced by the DUP2 instruction.
+    """
+    tx_data = b"".join(
+        arg.to_bytes(32, byteorder="big") for arg in (base, exp)
+    )
+
+    setup = Op.CALLDATALOAD(0) + Op.CALLDATALOAD(32) + Op.DUP2 + Op.DUP2
+    attack_block = Op.DUP2 + Op.EXP
+    cleanup = Op.POP + Op.POP + Op.DUP2 + Op.DUP2
+    benchmark_test(
+        code_generator=JumpLoopGenerator(
+            setup=setup,
+            attack_block=attack_block,
+            cleanup=cleanup,
+            tx_kwargs={"data": tx_data},
+        ),
+    )


### PR DESCRIPTION
## 🗒️ Description
Adds benchmark cases for the EXP opcode. Currently, only EXP for max base/exp are tested: 

https://github.com/ethereum/execution-specs/blob/d1e7e6b38f11e874f89d988d2fdca5609e710ae2/tests/benchmark/compute/instruction/test_arithmetic.py#L112-L121

This PR adds values where the exponent result changes the base of the next exponent operation, so it cannot be cached.

NOTE: the gas price is calculated dependent on the byte length of the exponent.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
- [ ] VERIFY CORRECTNESS
- [ ] Drop the case where the [0] base is executed on all exponents

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
