### PR TITLE
fix(eip7928): Track caller and target including for system contracts

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -117,11 +117,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
     """
     block_env = message.block_env
     refund_counter = U256(0)
+    track_address(message.tx_env.state_changes, message.caller)
+    track_address(message.tx_env.state_changes, message.current_target)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
             block_env.state, message.current_target
         ) or account_has_storage(block_env.state, message.current_target)
-        track_address(message.tx_env.state_changes, message.current_target)
         if is_collision:
             return MessageCallOutput(
                 Uint(0),

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_system_contracts.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_system_contracts.py
@@ -1,0 +1,119 @@
+"""Tests for EIP-7928 using the consistent data class pattern."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    BalAccountExpectation,
+    BalBalanceChange,
+    BalNonceChange,
+    BalStorageChange,
+    BalStorageSlot,
+    Block,
+    BlockAccessListExpectation,
+    BlockchainTestFiller,
+    Fork,
+    Transaction,
+    keccak256,
+)
+
+from ...cancun.eip4788_beacon_root.spec import Spec as Spec_eip4788
+from .spec import ref_spec_7928
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7928.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7928.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+def test_bal_4788_simple(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    fork: Fork,
+) -> None:
+    """
+    Ensure system contract execution related addresses and changes are
+    captured.
+    """
+    alice = pre.fund_eoa()
+    bob = pre.fund_eoa()
+    charlie = pre.fund_eoa(amount=0)
+
+    tx_alice = Transaction(
+        sender=alice,
+        to=charlie,
+        value=10,
+    )
+
+    tx_bob = Transaction(
+        sender=bob,
+        to=charlie,
+        value=10,
+    )
+
+    timestamp = 100
+    parent_beacon_block_root = keccak256(
+        int.to_bytes(timestamp, length=8, byteorder="big")
+    )
+    root_storage_slot = timestamp + Spec_eip4788.HISTORY_BUFFER_LENGTH
+
+    block = Block(
+        txs=[tx_alice, tx_bob],
+        timestamp=timestamp,
+        parent_beacon_block_root=parent_beacon_block_root,
+        expected_block_access_list=BlockAccessListExpectation(
+            account_expectations={
+                alice: BalAccountExpectation(
+                    nonce_changes=[BalNonceChange(tx_index=1, post_nonce=1)],
+                ),
+                bob: BalAccountExpectation(
+                    nonce_changes=[BalNonceChange(tx_index=2, post_nonce=1)],
+                ),
+                charlie: BalAccountExpectation(
+                    balance_changes=[
+                        BalBalanceChange(tx_index=1, post_balance=10),
+                        BalBalanceChange(tx_index=2, post_balance=20),
+                    ],
+                ),
+                Spec_eip4788.SYSTEM_ADDRESS: BalAccountExpectation(
+                    nonce_changes=[],
+                    balance_changes=[],
+                    code_changes=[],
+                    storage_changes=[],
+                    storage_reads=[],
+                ),
+                Spec_eip4788.BEACON_ROOTS_ADDRESS: BalAccountExpectation(
+                    storage_changes=[
+                        BalStorageSlot(
+                            slot=timestamp,
+                            slot_changes=[
+                                BalStorageChange(
+                                    tx_index=0,
+                                    post_value=timestamp,
+                                )
+                            ],
+                        ),
+                        BalStorageSlot(
+                            slot=root_storage_slot,
+                            slot_changes=[
+                                BalStorageChange(
+                                    tx_index=0,
+                                    post_value=parent_beacon_block_root,
+                                )
+                            ],
+                        ),
+                    ]
+                ),
+            }
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[block],
+        post={
+            alice: Account(nonce=1),
+            bob: Account(nonce=1),
+            charlie: Account(balance=20),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
The current implementation does not track `SYSTEM_ADDRESS` for system contract calls.

## 🔗 Related Issues or PRs
#1886

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

#### Cute Animal Picture

![Cute Animals - 5 of 12](https://github.com/user-attachments/assets/94eaf78c-3c93-4c02-b8d9-f26b1b3018c5)

