### PR TITLE
feat(benchmarks): fix benchmark for SELFDESTRUCT of existing accounts for Osaka

### DIFF
--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -630,7 +630,7 @@ def test_selfdestruct_existing(
                 Transaction(
                     to=code_addr,
                     gas_limit=tx_gas_limit,
-                    data=Hash(start) + Hash(count),
+                    data=Hash(start),
                     sender=pre.fund_eoa(),
                 )
             )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -515,10 +515,10 @@ def test_selfdestruct_existing(
         + 63  # ~Gluing opcodes
     )
     final_storage_gas = (
-        gas_costs.G_VERY_LOW # ADD
-        + gas_costs.G_VERY_LOW * 3 # PUSHs
-        + gas_costs.G_COLD_SLOAD # SSTORE cold
-        + gas_costs.G_STORAGE_RESET # SSTORE new value
+        gas_costs.G_VERY_LOW  # ADD
+        + gas_costs.G_VERY_LOW * 3  # PUSHs
+        + gas_costs.G_COLD_SLOAD  # SSTORE cold
+        + gas_costs.G_STORAGE_RESET  # SSTORE new value
     )
     memory_expansion_cost = fork().memory_expansion_gas_calculator()(
         new_bytes=96

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -479,15 +479,14 @@ def test_selfdestruct_existing(
     fork: Fork,
     pre: Alloc,
     value_bearing: bool,
-    env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """
     Benchmark SELFDESTRUCT instruction for existing contracts.
     contracts.
     """
     attack_gas_limit = gas_benchmark_value
-    effective_tx_gas_limit = fork.transaction_gas_limit_cap() or env.gas_limit
     fee_recipient = pre.fund_eoa(amount=1)
 
     # Template code that will be used to deploy a large number of contracts.
@@ -576,9 +575,7 @@ def test_selfdestruct_existing(
     # The deployed code length is two-bytes. The dominant factor
     # is the static cost, plus a few glue opcodes/memory-expansion costs.
     estimated_gas_per_creation = gas_costs.G_CREATE + 3_000
-    max_creations_per_tx = int(
-        effective_tx_gas_limit // estimated_gas_per_creation
-    )
+    max_creations_per_tx = int(tx_gas_limit // estimated_gas_per_creation)
     num_setup_txs = math.ceil(num_contracts / max_creations_per_tx)
 
     setup_txs = []
@@ -590,7 +587,7 @@ def test_selfdestruct_existing(
             setup_txs.append(
                 Transaction(
                     to=factory_caller_address,
-                    gas_limit=effective_tx_gas_limit,
+                    gas_limit=tx_gas_limit,
                     data=Hash(count),
                     sender=pre.fund_eoa(),
                 )
@@ -624,13 +621,7 @@ def test_selfdestruct_existing(
     code_addr = pre.deploy_contract(code=code, storage={0: 1})
 
     # Calculate max targets per execution TX based on effective gas limit
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    effective_attack_gas_limit = (
-        min(attack_gas_limit, gas_limit_cap)
-        if gas_limit_cap is not None
-        else attack_gas_limit
-    )
-    max_targets_per_tx = (effective_attack_gas_limit - base_costs) // loop_cost
+    max_targets_per_tx = (tx_gas_limit - base_costs) // loop_cost
     num_exec_txs = math.ceil(num_contracts / max_targets_per_tx)
 
     exec_txs = []
@@ -641,7 +632,7 @@ def test_selfdestruct_existing(
             exec_txs.append(
                 Transaction(
                     to=code_addr,
-                    gas_limit=effective_attack_gas_limit,
+                    gas_limit=tx_gas_limit,
                     data=Hash(start) + Hash(count),
                     sender=pre.fund_eoa(),
                 )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -487,6 +487,7 @@ def test_selfdestruct_existing(
     contracts.
     """
     attack_gas_limit = gas_benchmark_value
+    effective_tx_gas_limit = fork.transaction_gas_limit_cap() or env.gas_limit
     fee_recipient = pre.fund_eoa(amount=1)
 
     # Template code that will be used to deploy a large number of contracts.
@@ -531,7 +532,7 @@ def test_selfdestruct_existing(
     num_contracts = (attack_gas_limit - base_costs) // loop_cost
     expected_benchmark_gas_used = num_contracts * loop_cost + base_costs
 
-    # Create a factory that deployes a new SELFDESTRUCT contract instance pre-
+    # Create a factory that deploys a new SELFDESTRUCT contract instance pre-
     # funded depending on the value_bearing parameter. We use CREATE2 so the
     # caller contract can easily reproduce the addresses in a loop for CALLs.
     factory_code = (
@@ -554,8 +555,9 @@ def test_selfdestruct_existing(
         + Op.RETURN(0, 32)
     )
 
-    required_balance = num_contracts if value_bearing else 0  # 1 wei per
-    # contract
+    required_balance = (
+        num_contracts if value_bearing else 0
+    )  # 1 wei per contract
     factory_address = pre.deploy_contract(
         code=factory_code, balance=required_balance
     )
@@ -571,28 +573,48 @@ def test_selfdestruct_existing(
     )
     factory_caller_address = pre.deploy_contract(code=factory_caller_code)
 
+    # The deployed code length is two-bytes. The dominant factor
+    # is the static cost, plus a few glue opcodes/memory-expansion costs.
+    estimated_gas_per_creation = gas_costs.G_CREATE + 3_000
+    max_creations_per_tx = int(
+        effective_tx_gas_limit // estimated_gas_per_creation
+    )
+    num_setup_txs = math.ceil(num_contracts / max_creations_per_tx)
+
+    setup_txs = []
     with TestPhaseManager.setup():
-        contracts_deployment_tx = Transaction(
-            to=factory_caller_address,
-            gas_limit=env.gas_limit,
-            data=Hash(num_contracts),
-            sender=pre.fund_eoa(),
-        )
+        for i in range(num_setup_txs):
+            count = min(
+                max_creations_per_tx, num_contracts - i * max_creations_per_tx
+            )
+            setup_txs.append(
+                Transaction(
+                    to=factory_caller_address,
+                    gas_limit=effective_tx_gas_limit,
+                    data=Hash(count),
+                    sender=pre.fund_eoa(),
+                )
+            )
 
     code = (
         # Setup memory for later CREATE2 address generation loop.
         # 0xFF+[Address(20bytes)]+[seed(32bytes)]+[initcode keccak(32bytes)]
         Op.MSTORE(0, factory_address)
         + Op.MSTORE8(32 - 20 - 1, 0xFF)
-        + Op.MSTORE(32, 0)
+        + Op.MSTORE(32, Op.CALLDATALOAD(0))  # Starting address from calldata
         + Op.MSTORE(64, initcode.keccak256())
         # Main loop
         + While(
             body=Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
             + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
-            # Only loop if we have enough gas to cover another iteration plus
-            # the final storage gas.
-            condition=Op.GT(Op.GAS, final_storage_gas + loop_cost),
+            # Loop while we have enough gas AND within target count
+            condition=Op.AND(
+                Op.GT(Op.GAS, final_storage_gas + loop_cost),
+                Op.LT(
+                    Op.MLOAD(32),
+                    Op.ADD(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+                ),
+            ),
         )
         + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
     )
@@ -600,12 +622,30 @@ def test_selfdestruct_existing(
 
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, storage={0: 1})
+
+    # Calculate max targets per execution TX based on effective gas limit
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    effective_attack_gas_limit = (
+        min(attack_gas_limit, gas_limit_cap)
+        if gas_limit_cap is not None
+        else attack_gas_limit
+    )
+    max_targets_per_tx = (effective_attack_gas_limit - base_costs) // loop_cost
+    num_exec_txs = math.ceil(num_contracts / max_targets_per_tx)
+
+    exec_txs = []
     with TestPhaseManager.execution():
-        opcode_tx = Transaction(
-            to=code_addr,
-            gas_limit=attack_gas_limit,
-            sender=pre.fund_eoa(),
-        )
+        for i in range(num_exec_txs):
+            start = i * max_targets_per_tx
+            count = min(max_targets_per_tx, num_contracts - start)
+            exec_txs.append(
+                Transaction(
+                    to=code_addr,
+                    gas_limit=effective_attack_gas_limit,
+                    data=Hash(start) + Hash(count),
+                    sender=pre.fund_eoa(),
+                )
+            )
 
     post = {
         factory_address: Account(storage={0: num_contracts}),
@@ -624,8 +664,8 @@ def test_selfdestruct_existing(
     benchmark_test(
         post=post,
         blocks=[
-            Block(txs=[contracts_deployment_tx]),
-            Block(txs=[opcode_tx], fee_recipient=fee_recipient),
+            Block(txs=setup_txs),
+            Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
         expected_benchmark_gas_used=expected_benchmark_gas_used,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -531,7 +531,6 @@ def test_selfdestruct_existing(
         + memory_expansion_cost
     )
     num_contracts = (attack_gas_limit - base_costs) // loop_cost
-    expected_benchmark_gas_used = num_contracts * loop_cost + base_costs
 
     # Create a factory that deploys a new SELFDESTRUCT contract instance pre-
     # funded depending on the value_bearing parameter. We use CREATE2 so the
@@ -658,7 +657,7 @@ def test_selfdestruct_existing(
             Block(txs=setup_txs),
             Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
-        expected_benchmark_gas_used=expected_benchmark_gas_used,
+        skip_gas_used_validation=True,
     )
 
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -515,9 +515,10 @@ def test_selfdestruct_existing(
         + 63  # ~Gluing opcodes
     )
     final_storage_gas = (
-        gas_costs.G_STORAGE_RESET
-        + gas_costs.G_COLD_SLOAD
-        + (gas_costs.G_VERY_LOW * 2)
+        gas_costs.G_VERY_LOW # ADD
+        + gas_costs.G_VERY_LOW * 3 # PUSHs
+        + gas_costs.G_COLD_SLOAD # SSTORE cold
+        + gas_costs.G_STORAGE_RESET # SSTORE new value
     )
     memory_expansion_cost = fork().memory_expansion_gas_calculator()(
         new_bytes=96
@@ -605,15 +606,11 @@ def test_selfdestruct_existing(
             body=Op.POP(Op.CALL(address=Op.SHA3(32 - 20 - 1, 85)))
             + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
             # Loop while we have enough gas AND within target count
-            condition=Op.AND(
-                Op.GT(Op.GAS, final_storage_gas + loop_cost),
-                Op.LT(
-                    Op.MLOAD(32),
-                    Op.ADD(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
-                ),
-            ),
+            condition=Op.GT(Op.GAS, final_storage_gas + loop_cost),
         )
-        + Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
+        + Op.SSTORE(
+            0, Op.ADD(Op.SLOAD(0), 1)
+        )  # Done for successful tx execution assertion below.
     )
     assert len(code) <= fork.max_code_size()
 
@@ -640,7 +637,9 @@ def test_selfdestruct_existing(
 
     post = {
         factory_address: Account(storage={0: num_contracts}),
-        code_addr: Account(storage={0: 42}),  # Check for successful execution.
+        code_addr: Account(
+            storage={0: len(exec_txs) + 1}
+        ),  # Check for successful execution.
     }
     deployed_contract_addresses = []
     for i in range(num_contracts):

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -511,8 +511,9 @@ def test_selfdestruct_existing(
         # cost for CREATE2
         + gas_costs.G_VERY_LOW * 3  # ~MSTOREs+ADDs
         + gas_costs.G_COLD_ACCOUNT_ACCESS  # CALL to self-destructing contract
+        + gas_costs.G_BASE
         + gas_costs.G_SELF_DESTRUCT
-        + 63  # ~Gluing opcodes
+        + 88  # ~Gluing opcodes
     )
     final_storage_gas = (
         gas_costs.G_VERY_LOW  # ADD


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the `test_selfdestruct_existing` benchmark to work in Osaka.

To validate this still does coherent work, I compare in this PR filling for Osaka vs Prague, tested with 30M target:

- Osaka:
    - `test_system.py::test_selfdestruct_existing[fork_Osaka-blockchain_test-value_bearing_False]` 154M cycles
    - `test_system.py::test_selfdestruct_existing[fork_Osaka-blockchain_test-value_bearing_True]` 188M cycles
- Prague
    - `test_system.py::test_selfdestruct_existing[fork_Prague-blockchain_test-value_bearing_False]` 154 cycles
    - `test_system.py::test_selfdestruct_existing[fork_Prague-blockchain_test-value_bearing_True]` 189 cycles

So looks like it is working fine reg the amount of work in Prague vs Osaka in this PR. (Prague slightly doing more effort, but makes sense due to partitioning gas overheads)

## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
