### PR TITLE
feat(tests): add 7702 auth chain id 0x00 test (invalid)

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -43,6 +43,15 @@ class OversizedInt(FixedSizeBytes[2]):  # type: ignore
 
     pass
 
+class OversizedZeroInt(FixedSizeBytes[1]):  # type: ignore
+    """
+    Oversized 1-byte zero.
+
+    Encodes "zero" as 0x00 (byte length 1) instead of 0x (byte length 0).
+    """
+
+    pass
+
 
 class OversizedAddress(FixedSizeBytes[21]):  # type: ignore
     """Oversized Address Type."""
@@ -188,8 +197,12 @@ def test_invalid_tx_invalid_auth_chain_id(
 
 
 @pytest.mark.parametrize(
-    "auth_chain_id",
-    [pytest.param(0), pytest.param(1)],
+    "auth_chain_id, oversized_type",
+    [
+        pytest.param(0, OversizedZeroInt, id="zero_oversized_zero"),
+        pytest.param(0, OversizedInt, id="zero_oversized_int"),
+        pytest.param(1, OversizedInt, id="one_oversized_int"),
+    ],
 )
 @pytest.mark.parametrize(
     "delegate_address",
@@ -205,6 +218,7 @@ def test_invalid_tx_invalid_auth_chain_id_encoding(
     pre: Alloc,
     delegate_address: Address,
     auth_chain_id: int,
+    oversized_type: type,
 ) -> None:
     """
     Test sending a transaction where the chain id field of an authorization has
@@ -212,7 +226,7 @@ def test_invalid_tx_invalid_auth_chain_id_encoding(
     """
 
     class ModifiedAuthorizationTuple(AuthorizationTuple):
-        chain_id: OversizedInt  # type: ignore
+        chain_id: oversized_type  # type: ignore
 
     authorization = ModifiedAuthorizationTuple(
         address=delegate_address,

--- a/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
+++ b/tests/prague/eip7702_set_code_tx/test_invalid_tx.py
@@ -43,6 +43,7 @@ class OversizedInt(FixedSizeBytes[2]):  # type: ignore
 
     pass
 
+
 class OversizedZeroInt(FixedSizeBytes[1]):  # type: ignore
     """
     Oversized 1-byte zero.


### PR DESCRIPTION
## 🗒️ Description
This adds a test for 7702 tests where we test invalid auth chain id encoded as 0x00 (1-byte length). Previously encoded is 0x0000 (2 bytes). Should also test the 0x00 case. Raised by: https://github.com/ethereumjs/ethereumjs-monorepo/pull/4204

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
