### PR TITLE
feat(benchmarks): fix benchmark for SELFDESTRUCT of created accounts for Osaka

### DIFF
--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -689,9 +689,10 @@ def test_selfdestruct_created(
         + memory_expansion_calc(new_bytes=32)
     )
     suffix_cost = (
-        gas_costs.G_COLD_SLOAD
+        gas_costs.G_VERY_LOW
+        + gas_costs.G_VERY_LOW * 3
+        + gas_costs.G_COLD_SLOAD
         + gas_costs.G_STORAGE_RESET
-        + (gas_costs.G_VERY_LOW * 2)
     )
 
     base_costs = prefix_cost + suffix_cost + intrinsic_gas_cost_calc()

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -753,7 +753,7 @@ def test_selfdestruct_created(
     benchmark_test(
         post=post,
         blocks=[
-            Block(txs=exec_txs),
+            Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
         expected_benchmark_gas_used=(
             max_iterations_per_tx * loop_cost + base_costs

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -681,7 +681,12 @@ def test_selfdestruct_created(
         + gas_costs.G_VERY_LOW * 6  # PUSHs, ADD, DUP, GT
         + gas_costs.G_HIGH  # JUMPI
         + gas_costs.G_JUMPDEST
-    )
+extra_costs = (
+    gas_costs.G_BASE * 2  # POP, GAS
+    + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, DUP, GT
+    + gas_costs.G_HIGH  # JUMPI
+    + gas_costs.G_JUMPDEST
+)
     loop_cost = create_costs + call_costs + extra_costs
 
     prefix_cost = (
@@ -725,11 +730,17 @@ def test_selfdestruct_created(
     )
     code = code_prefix + loop_body + code_suffix
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
-    code_addr = pre.deploy_contract(
-        code=code,
-        balance=iterations if value_bearing else 0,
-        storage={0: 1},
-    )
+max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
+num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
+
+total_expected_iterations = max_iterations_per_tx * num_exec_txs
+
+# The 0 storage slot is initialize to avoid creation costs in SSTORE above.
+code_addr = pre.deploy_contract(
+    code=code,
+    balance=total_expected_iterations if value_bearing else 0,
+    storage={0: 1},
+)
 
     max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
     num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
@@ -753,7 +764,10 @@ def test_selfdestruct_created(
         blocks=[
             Block(txs=exec_txs),
         ],
-        expected_benchmark_gas_used=iterations * loop_cost + base_costs,
+        expected_benchmark_gas_used=(
+            max_iterations_per_tx * loop_cost + base_costs
+        )
+        * num_exec_txs
     )
 
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -639,6 +639,7 @@ def test_selfdestruct_created(
     fork: Fork,
     env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """
     Benchmark SELFDESTRUCT instruction for deployed contracts within same tx.
@@ -730,15 +731,7 @@ def test_selfdestruct_created(
         storage={0: 1},
     )
 
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    effective_attack_gas_limit = (
-        min(gas_benchmark_value, gas_limit_cap)
-        if gas_limit_cap is not None
-        else gas_benchmark_value
-    )
-    max_iterations_per_tx = (
-        effective_attack_gas_limit - base_costs
-    ) // loop_cost
+    max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
     num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
 
     exec_txs = []
@@ -747,15 +740,14 @@ def test_selfdestruct_created(
             exec_txs.append(
                 Transaction(
                     to=code_addr,
-                    gas_limit=effective_attack_gas_limit,
+                    gas_limit=tx_gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )
 
     post = {
         code_addr: Account(storage={0: len(exec_txs) + 1})
-    }  # Check for successful
-    # execution.
+    }  # Check for successful execution.
     benchmark_test(
         post=post,
         blocks=[

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -643,10 +643,9 @@ def test_selfdestruct_created(
     """
     Benchmark SELFDESTRUCT instruction for deployed contracts within same tx.
     """
-    # Avoid account creation costs in the SELFDESTRUCT receipient.
+    # Avoid account creation costs in the SELFDESTRUCT recipient.
     fee_recipient = pre.fund_eoa(amount=1)
     env.fee_recipient = fee_recipient
-
 
     # SELFDESTRUCT(COINBASE) contract deployment
     initcode = (
@@ -677,18 +676,17 @@ def test_selfdestruct_created(
         + gas_costs.G_BASE  #  Parameter GAS
     )
     extra_costs = (
-        gas_costs.G_BASE * 2  # POP, GAS
-        + gas_costs.G_VERY_LOW
-        * 18  # 6 PUSHs, MSTORE, MLOAD, ADD, GT, LT, AND, 2 CALLDATALOADs
+        gas_costs.G_BASE  # POP
+        + gas_costs.G_VERY_LOW * 6  # PUSHs, ADD, DUP, GT
         + gas_costs.G_HIGH  # JUMPI
         + gas_costs.G_JUMPDEST
     )
     loop_cost = create_costs + call_costs + extra_costs
 
     prefix_cost = (
-        gas_costs.G_VERY_LOW * 7  # 2 MSTOREs, 4 PUSHs, 1 CALLDATALOAD
-        + gas_costs.G_JUMPDEST
-        + memory_expansion_calc(new_bytes=64)  # Memory for 2 MSTORE slots
+        gas_costs.G_VERY_LOW * 3
+        + gas_costs.G_BASE
+        + memory_expansion_calc(new_bytes=32)
     )
     suffix_cost = (
         gas_costs.G_COLD_SLOAD
@@ -700,11 +698,7 @@ def test_selfdestruct_created(
 
     iterations = (gas_benchmark_value - base_costs) // loop_cost
 
-    code_prefix = (
-        Op.MSTORE(0, initcode.hex())
-        + Op.MSTORE(32, Op.CALLDATALOAD(0))
-        + Op.JUMPDEST
-    )
+    code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
     code_suffix = (
         Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
         + Op.STOP
@@ -719,17 +713,9 @@ def test_selfdestruct_created(
                 )
             )
         )
-        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
-        + Op.JUMPI(
-            len(code_prefix) - 1,
-            Op.AND(
-                Op.GT(Op.GAS, suffix_cost + loop_cost),
-                Op.LT(
-                    Op.MLOAD(32),
-                    Op.ADD(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
-                ),
-            ),
-        )
+        + Op.PUSH1[1]
+        + Op.ADD
+        + Op.JUMPI(len(code_prefix) - 1, Op.GT(Op.GAS, Op.DUP1))
     )
     code = code_prefix + loop_body + code_suffix
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -677,16 +677,11 @@ def test_selfdestruct_created(
         + gas_costs.G_BASE  #  Parameter GAS
     )
     extra_costs = (
-        gas_costs.G_BASE  # POP
-        + gas_costs.G_VERY_LOW * 6  # PUSHs, ADD, DUP, GT
+        gas_costs.G_BASE * 2  # POP, GAS
+        + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, DUP, GT
         + gas_costs.G_HIGH  # JUMPI
         + gas_costs.G_JUMPDEST
-extra_costs = (
-    gas_costs.G_BASE * 2  # POP, GAS
-    + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, DUP, GT
-    + gas_costs.G_HIGH  # JUMPI
-    + gas_costs.G_JUMPDEST
-)
+    )
     loop_cost = create_costs + call_costs + extra_costs
 
     prefix_cost = (
@@ -729,21 +724,17 @@ extra_costs = (
         )
     )
     code = code_prefix + loop_body + code_suffix
-    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
-max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
-num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
-
-total_expected_iterations = max_iterations_per_tx * num_exec_txs
-
-# The 0 storage slot is initialize to avoid creation costs in SSTORE above.
-code_addr = pre.deploy_contract(
-    code=code,
-    balance=total_expected_iterations if value_bearing else 0,
-    storage={0: 1},
-)
 
     max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
     num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
+    total_expected_iterations = max_iterations_per_tx * num_exec_txs
+
+    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
+    code_addr = pre.deploy_contract(
+        code=code,
+        balance=total_expected_iterations if value_bearing else 0,
+        storage={0: 1},
+    )
 
     exec_txs = []
     with TestPhaseManager.execution():
@@ -767,7 +758,7 @@ code_addr = pre.deploy_contract(
         expected_benchmark_gas_used=(
             max_iterations_per_tx * loop_cost + base_costs
         )
-        * num_exec_txs
+        * num_exec_txs,
     )
 
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -700,7 +700,7 @@ def test_selfdestruct_created(
 
     code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
     code_suffix = (
-        Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
+        Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))  # Done for successful tx execution assertion below.
         + Op.STOP
     )
     loop_body = (
@@ -715,7 +715,7 @@ def test_selfdestruct_created(
         )
         + Op.PUSH1[1]
         + Op.ADD
-        + Op.JUMPI(len(code_prefix) - 1, Op.GT(Op.GAS, Op.DUP1))
+        + Op.JUMPI(len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost))
     )
     code = code_prefix + loop_body + code_suffix
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
@@ -750,7 +750,7 @@ def test_selfdestruct_created(
                 )
             )
 
-    post = {code_addr: Account(storage={0: 42})}  # Check for successful
+    post = {code_addr: Account(storage={0: len(exec_txs)+1})}  # Check for successful
     # execution.
     benchmark_test(
         post=post,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -633,7 +633,7 @@ def test_selfdestruct_existing(
 
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_created(
-    state_test: StateTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     value_bearing: bool,
     fork: Fork,
@@ -643,9 +643,6 @@ def test_selfdestruct_created(
     """
     Benchmark SELFDESTRUCT instruction for deployed contracts within same tx.
     """
-    fee_recipient = pre.fund_eoa(amount=1)
-    env.fee_recipient = fee_recipient
-
     # SELFDESTRUCT(COINBASE) contract deployment
     initcode = (
         Op.MSTORE8(0, Op.COINBASE.int())
@@ -675,17 +672,18 @@ def test_selfdestruct_created(
         + gas_costs.G_BASE  #  Parameter GAS
     )
     extra_costs = (
-        gas_costs.G_BASE  # POP
-        + gas_costs.G_VERY_LOW * 6  # PUSHs, ADD, DUP, GT
+        gas_costs.G_BASE * 2  # POP, GAS
+        + gas_costs.G_VERY_LOW
+        * 18  # 6 PUSHs, MSTORE, MLOAD, ADD, GT, LT, AND, 2 CALLDATALOADs
         + gas_costs.G_HIGH  # JUMPI
         + gas_costs.G_JUMPDEST
     )
     loop_cost = create_costs + call_costs + extra_costs
 
     prefix_cost = (
-        gas_costs.G_VERY_LOW * 3
-        + gas_costs.G_BASE
-        + memory_expansion_calc(new_bytes=32)
+        gas_costs.G_VERY_LOW * 7  # 2 MSTOREs, 4 PUSHs, 1 CALLDATALOAD
+        + gas_costs.G_JUMPDEST
+        + memory_expansion_calc(new_bytes=64)  # Memory for 2 MSTORE slots
     )
     suffix_cost = (
         gas_costs.G_COLD_SLOAD
@@ -697,7 +695,11 @@ def test_selfdestruct_created(
 
     iterations = (gas_benchmark_value - base_costs) // loop_cost
 
-    code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
+    code_prefix = (
+        Op.MSTORE(0, initcode.hex())
+        + Op.MSTORE(32, Op.CALLDATALOAD(0))
+        + Op.JUMPDEST
+    )
     code_suffix = (
         Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
         + Op.STOP
@@ -712,9 +714,17 @@ def test_selfdestruct_created(
                 )
             )
         )
-        + Op.PUSH1[1]
-        + Op.ADD
-        + Op.JUMPI(len(code_prefix) - 1, Op.GT(iterations, Op.DUP1))
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
+        + Op.JUMPI(
+            len(code_prefix) - 1,
+            Op.AND(
+                Op.GT(Op.GAS, suffix_cost + loop_cost),
+                Op.LT(
+                    Op.MLOAD(32),
+                    Op.ADD(Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)),
+                ),
+            ),
+        )
     )
     code = code_prefix + loop_body + code_suffix
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
@@ -723,18 +733,39 @@ def test_selfdestruct_created(
         balance=iterations if value_bearing else 0,
         storage={0: 1},
     )
-    code_tx = Transaction(
-        to=code_addr,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    effective_attack_gas_limit = (
+        min(gas_benchmark_value, gas_limit_cap)
+        if gas_limit_cap is not None
+        else gas_benchmark_value
     )
+    max_iterations_per_tx = (
+        effective_attack_gas_limit - base_costs
+    ) // loop_cost
+    num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
+
+    exec_txs = []
+    with TestPhaseManager.execution():
+        for i in range(num_exec_txs):
+            start = i * max_iterations_per_tx
+            count = min(max_iterations_per_tx, iterations - start)
+            exec_txs.append(
+                Transaction(
+                    to=code_addr,
+                    gas_limit=effective_attack_gas_limit,
+                    data=Hash(start) + Hash(count),
+                    sender=pre.fund_eoa(),
+                )
+            )
 
     post = {code_addr: Account(storage={0: 42})}  # Check for successful
     # execution.
-    state_test(
-        pre=pre,
+    benchmark_test(
         post=post,
-        tx=code_tx,
+        blocks=[
+            Block(txs=exec_txs),
+        ],
         expected_benchmark_gas_used=iterations * loop_cost + base_costs,
     )
 

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -742,9 +742,7 @@ def test_selfdestruct_created(
 
     exec_txs = []
     with TestPhaseManager.execution():
-        for i in range(num_exec_txs):
-            start = i * max_iterations_per_tx
-            count = min(max_iterations_per_tx, iterations - start)
+        for _ in range(num_exec_txs):
             exec_txs.append(
                 Transaction(
                     to=code_addr,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -643,6 +643,11 @@ def test_selfdestruct_created(
     """
     Benchmark SELFDESTRUCT instruction for deployed contracts within same tx.
     """
+    # Avoid account creation costs in the SELFDESTRUCT receipient.
+    fee_recipient = pre.fund_eoa(amount=1)
+    env.fee_recipient = fee_recipient
+
+
     # SELFDESTRUCT(COINBASE) contract deployment
     initcode = (
         Op.MSTORE8(0, Op.COINBASE.int())

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -749,7 +749,6 @@ def test_selfdestruct_created(
                 Transaction(
                     to=code_addr,
                     gas_limit=effective_attack_gas_limit,
-                    data=Hash(start) + Hash(count),
                     sender=pre.fund_eoa(),
                 )
             )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -700,7 +700,9 @@ def test_selfdestruct_created(
 
     code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
     code_suffix = (
-        Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))  # Done for successful tx execution assertion below.
+        Op.SSTORE(
+            0, Op.ADD(Op.SLOAD(0), 1)
+        )  # Done for successful tx execution assertion below.
         + Op.STOP
     )
     loop_body = (
@@ -715,7 +717,9 @@ def test_selfdestruct_created(
         )
         + Op.PUSH1[1]
         + Op.ADD
-        + Op.JUMPI(len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost))
+        + Op.JUMPI(
+            len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost)
+        )
     )
     code = code_prefix + loop_body + code_suffix
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
@@ -750,7 +754,9 @@ def test_selfdestruct_created(
                 )
             )
 
-    post = {code_addr: Account(storage={0: len(exec_txs)+1})}  # Check for successful
+    post = {
+        code_addr: Account(storage={0: len(exec_txs) + 1})
+    }  # Check for successful
     # execution.
     benchmark_test(
         post=post,


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the `test_selfdestruct_created` benchmark to work in Osaka.

Filling in this PR for Osaka and Prague for **45M** target:
- Osaka:
  - `test_system.py::test_selfdestruct_created[fork_Osaka-blockchain_test-value_bearing_False]` 36M cycles
  - `test_system.py::test_selfdestruct_created[fork_Osaka-blockchain_test-value_bearing_True]` 36M cycles
- Prague:
  - `test_system.py::test_selfdestruct_created[fork_Prague-blockchain_test-value_bearing_False]` 37M cycles
  - `test_system.py::test_selfdestruct_created[fork_Prague-blockchain_test-value_bearing_True]` 36M cycles

Although each fork is coherent with the other, felt quite low number of cycles to me. So I debugged in Geth further and got convinced all is good, since saw all the SELFDESTRUCT instructions being executed.

Then remembered two things:
- We already have a post-state check of storage slot 0 having the value 42, to check that the attack loop ended fine without unexpected EVM errors. So that is already quite good.
- Found the [original PR](https://github.com/ethereum/execution-spec-tests/pull/1678) that created this benchmark, and indeed the used gas was ~35M cycles. So that's good too. (This is why I filled with 45M above to make them comparable).

## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
![Put a link to a cute animal picture inside the parenthesis-->]()
