### PR TITLE
feat(test-execute): tx batching for execute remote

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `execute`
 
+- ✨ Add transaction batching to avoid RPC overload when executing tests with many transactions. Transactions are now sent in configurable batches (default: 750) with progress logging. Use `--max-tx-per-batch` to configure the batch size ([#1907](https://github.com/ethereum/execution-specs/pull/1907)).
 - ✨ `execute hive` and `execute remote` now defer funding of accounts until the minimum amount required to send the test transactions is calculated, in order to optimize the amount of Eth used to execute the tests ([#1822](https://github.com/ethereum/execution-specs/pull/1822)).
 - ✨ Dynamically fetch gas prices from the network and update all transactions to use 1.5x the current values ([#1822](https://github.com/ethereum/execution-specs/pull/1822)).
 - ✨ New `--dry-run` flag to calculate the amount of Eth that will be spent executing a test given the current network gas prices ([#1822](https://github.com/ethereum/execution-specs/pull/1822)).

--- a/docs/running_tests/execute/index.md
+++ b/docs/running_tests/execute/index.md
@@ -48,3 +48,35 @@ EOAs are funded after gas prices are determined, enabling accurate balance calcu
 ### Blob Transaction Support
 
 Blob transactions are fully supported in execute mode, including automatic gas pricing for blob gas fees and validation via `engine_getBlobsVX` endpoints when the Engine RPC is available.
+
+### Transaction Batching
+
+When executing tests with many transactions (e.g., benchmark tests), the `execute` plugin automatically batches transactions to avoid overloading the RPC service (The experiment transaction limit for RPC is 1000 requests.). This is particularly important for large-scale tests that may generate hundreds or thousands of transactions.
+
+**Default Behavior:**
+
+- Transactions are sent in batches of up to 750 transactions by default
+- Each batch is sent and confirmed before the next batch begins
+- Progress logging shows batch number and transaction ranges
+
+**CLI Configuration:**
+
+The batch size can be configured via the `--max-tx-per-batch` option:
+
+```bash
+# Use smaller batches for slower RPC endpoints
+execute --max-tx-per-batch 100 tests/
+
+# Use larger batches for high-performance RPC endpoints
+execute --max-tx-per-batch 1000 tests/
+```
+
+**Safety Threshold:**
+
+A warning is logged when `max_transactions_per_batch` exceeds 1000, as this may cause RPC service instability or failures depending on the RPC endpoint's capacity.
+
+**Use Cases:**
+
+- **Benchmark tests**: Tests that measure gas consumption often generate many transactions
+- **Stress testing**: When intentionally testing RPC endpoint limits
+- **Slow RPC endpoints**: Reduce batch size to avoid timeouts on slower endpoints

--- a/docs/running_tests/execute/remote.md
+++ b/docs/running_tests/execute/remote.md
@@ -205,6 +205,22 @@ Once the sender account is funded, the command will start executing tests one by
 
 Test transactions are not sent from the main sender account though, they are sent from a different unique account that is created for each test (accounts returned by `pre.fund_eoa`).
 
+### Transaction Batching
+
+When executing tests that generate many transactions (such as benchmark tests), transactions are automatically batched to avoid overloading the RPC endpoint. By default, transactions are sent in batches of 750.
+
+You can configure the batch size using the `--max-tx-per-batch` flag:
+
+```bash
+# Reduce batch size for slower RPC endpoints
+uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --max-tx-per-batch 100 --rpc-seed-key 0x... --chain-id 12345
+
+# Increase batch size for high-performance endpoints
+uv run execute remote --fork=Prague --rpc-endpoint=https://rpc.endpoint.io --max-tx-per-batch 1000 --rpc-seed-key 0x... --chain-id 12345
+```
+
+A warning is logged when the batch size exceeds 1000, as this may cause RPC service instability.
+
 ### Use with Parallel Execution
 
 If the `execute` is run using the `-n=N` flag (respectively `--sim-parallelism=N`), n>1, the tests will be executed in parallel, and each process will have its own separate sender account, so the amount that is swept from the seed account is divided by the number of processes, and this has to be taken into account when setting the sweep amount and also when funding the seed account.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -138,6 +138,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Don't send transactions, just print the minimum balance required per test.",
     )
+    execute_group.addoption(
+        "--max-tx-per-batch",
+        action="store",
+        dest="max_tx_per_batch",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of transactions to send in a single batch to the RPC. "
+            "Default=750. Higher values may cause RPC instability."
+        ),
+    )
 
     report_group = parser.getgroup(
         "tests", "Arguments defining html report behavior"
@@ -309,6 +320,12 @@ def default_gas_price(request: pytest.FixtureRequest) -> int | None:
 def dry_run(request: pytest.FixtureRequest) -> bool:
     """Return True if the test is a dry run."""
     return request.config.getoption("dry_run")
+
+
+@pytest.fixture(scope="session")
+def max_transactions_per_batch(request: pytest.FixtureRequest) -> int | None:
+    """Return the maximum number of transactions per batch, or None for default."""
+    return request.config.getoption("max_tx_per_batch")
 
 
 @pytest.fixture(scope="session")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -205,11 +205,13 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         get_payload_wait_time: float,
         initial_forkchoice_update_retries: int = 5,
         transaction_wait_timeout: int = 60,
+        max_transactions_per_batch: int | None = None,
     ):
         """Initialize the Ethereum RPC client for the hive simulator."""
         super().__init__(
             rpc_endpoint,
             transaction_wait_timeout=transaction_wait_timeout,
+            max_transactions_per_batch=max_transactions_per_batch,
         )
         self.fork = fork
         self.engine_rpc = engine_rpc

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -383,6 +383,7 @@ def eth_rpc(
     session_fork: Fork,
     transactions_per_block: int,
     session_temp_folder: Path,
+    max_transactions_per_batch: int | None,
 ) -> EthRPC:
     """Initialize ethereum RPC client for the execution client under test."""
     get_payload_wait_time = request.config.getoption("get_payload_wait_time")
@@ -395,4 +396,5 @@ def eth_rpc(
         session_temp_folder=session_temp_folder,
         get_payload_wait_time=get_payload_wait_time,
         transaction_wait_timeout=tx_wait_timeout,
+        max_transactions_per_batch=max_transactions_per_batch,
     )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
@@ -149,11 +149,16 @@ def eth_rpc(
     session_fork: Fork,
     transactions_per_block: int,
     session_temp_folder: Path,
+    max_transactions_per_batch: int | None,
 ) -> EthRPC:
     """Initialize ethereum RPC client for the execution client under test."""
     tx_wait_timeout = request.config.getoption("tx_wait_timeout")
     if engine_rpc is None:
-        return EthRPC(rpc_endpoint, transaction_wait_timeout=tx_wait_timeout)
+        return EthRPC(
+            rpc_endpoint,
+            transaction_wait_timeout=tx_wait_timeout,
+            max_transactions_per_batch=max_transactions_per_batch,
+        )
     get_payload_wait_time = request.config.getoption("get_payload_wait_time")
     return ChainBuilderEthRPC(
         rpc_endpoint=rpc_endpoint,
@@ -163,4 +168,5 @@ def eth_rpc(
         session_temp_folder=session_temp_folder,
         get_payload_wait_time=get_payload_wait_time,
         transaction_wait_timeout=tx_wait_timeout,
+        max_transactions_per_batch=max_transactions_per_batch,
     )

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -23,9 +23,6 @@ from .base import BaseExecute
 
 logger = get_logger(__name__)
 
-# Threshold above which RPC service may become unstable
-RPC_OVERLOAD_THRESHOLD = 1000
-
 
 class TransactionPost(BaseExecute):
     """
@@ -41,8 +38,6 @@ class TransactionPost(BaseExecute):
     skip_gas_used_validation: bool = (
         False  # Skip gas validation even if expected is set
     )
-    # Transaction batching to avoid RPC overload
-    max_transactions_per_batch: int = 750
 
     format_name: ClassVar[str] = "transaction_post_test"
     description: ClassVar[str] = (
@@ -85,21 +80,6 @@ class TransactionPost(BaseExecute):
         """Execute the format."""
         del fork
         del engine_rpc
-
-        # Check if CLI override for max_transactions_per_batch is provided
-        cli_max_tx_per_batch = request.config.getoption(
-            "max_tx_per_batch", None
-        )
-        if cli_max_tx_per_batch is not None:
-            self.max_transactions_per_batch = cli_max_tx_per_batch
-
-        # Warn if max_transactions_per_batch exceeds safe threshold
-        if self.max_transactions_per_batch > RPC_OVERLOAD_THRESHOLD:
-            logger.warning(
-                f"max_transactions_per_batch ({self.max_transactions_per_batch}) exceeds "
-                f"the safe threshold ({RPC_OVERLOAD_THRESHOLD}). "
-                "This may cause RPC service instability or failures."
-            )
 
         for block in self.blocks:
             for tx in block:
@@ -152,18 +132,9 @@ class TransactionPost(BaseExecute):
                             f"Transaction rejected as expected: {exc_info.value}"
                         )
             else:
-                # Send transactions in batches to avoid RPC overload
-                batch_size = self.max_transactions_per_batch
-                for i in range(0, len(signed_txs), batch_size):
-                    batch = signed_txs[i : i + batch_size]
-                    logger.info(
-                        f"Sending transaction batch {i // batch_size + 1} "
-                        f"({len(batch)} transactions, "
-                        f"{i + 1}-{min(i + batch_size, len(signed_txs))} "
-                        f"of {len(signed_txs)})"
-                    )
-                    eth_rpc.send_wait_transactions(batch)
-                    all_tx_hashes.extend([tx.hash for tx in batch])
+                # Send transactions (batching is handled by eth_rpc internally)
+                eth_rpc.send_wait_transactions(signed_txs)
+                all_tx_hashes.extend([tx.hash for tx in signed_txs])
 
         # Perform gas validation if required for benchmarking
         # Ensures benchmark tests consume exactly the expected gas

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -23,6 +23,9 @@ from .base import BaseExecute
 
 logger = get_logger(__name__)
 
+# Threshold above which RPC service may become unstable
+RPC_OVERLOAD_THRESHOLD = 1000
+
 
 class TransactionPost(BaseExecute):
     """
@@ -38,6 +41,8 @@ class TransactionPost(BaseExecute):
     skip_gas_used_validation: bool = (
         False  # Skip gas validation even if expected is set
     )
+    # Transaction batching to avoid RPC overload
+    max_transactions_per_batch: int = 750
 
     format_name: ClassVar[str] = "transaction_post_test"
     description: ClassVar[str] = (
@@ -80,6 +85,22 @@ class TransactionPost(BaseExecute):
         """Execute the format."""
         del fork
         del engine_rpc
+
+        # Check if CLI override for max_transactions_per_batch is provided
+        cli_max_tx_per_batch = request.config.getoption(
+            "max_tx_per_batch", None
+        )
+        if cli_max_tx_per_batch is not None:
+            self.max_transactions_per_batch = cli_max_tx_per_batch
+
+        # Warn if max_transactions_per_batch exceeds safe threshold
+        if self.max_transactions_per_batch > RPC_OVERLOAD_THRESHOLD:
+            logger.warning(
+                f"max_transactions_per_batch ({self.max_transactions_per_batch}) exceeds "
+                f"the safe threshold ({RPC_OVERLOAD_THRESHOLD}). "
+                "This may cause RPC service instability or failures."
+            )
+
         for block in self.blocks:
             for tx in block:
                 if not isinstance(tx, NetworkWrappedTransaction):
@@ -131,8 +152,18 @@ class TransactionPost(BaseExecute):
                             f"Transaction rejected as expected: {exc_info.value}"
                         )
             else:
-                eth_rpc.send_wait_transactions(signed_txs)
-                all_tx_hashes.extend([tx.hash for tx in signed_txs])
+                # Send transactions in batches to avoid RPC overload
+                batch_size = self.max_transactions_per_batch
+                for i in range(0, len(signed_txs), batch_size):
+                    batch = signed_txs[i : i + batch_size]
+                    logger.info(
+                        f"Sending transaction batch {i // batch_size + 1} "
+                        f"({len(batch)} transactions, "
+                        f"{i + 1}-{min(i + batch_size, len(signed_txs))} "
+                        f"of {len(signed_txs)})"
+                    )
+                    eth_rpc.send_wait_transactions(batch)
+                    all_tx_hashes.extend([tx.hash for tx in batch])
 
         # Perform gas validation if required for benchmarking
         # Ensures benchmark tests consume exactly the expected gas


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Benchmark PR #1885 introduces approximately 15,000 funding transactions. Currently, the execute-remote mode aggregates all transactions and submits them at once, which causes issues since the RPC endpoint cannot handle such workload. Based on current testing, a local node can now reliably handle up to around 1000 transactions.

**Solution**
- Transactions are now sent in configurable batches (default: 750 transactions per batch).
- Each batch is submitted and confirmed before the next batch is sent.
- Progress logging reports the batch number and transaction ranges.
- A warning is emitted when the batch size exceeds 1,000 transactions (the safe threshold).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="512" height="512" alt="Gemini_Generated_Image_fgwqy6fgwqy6fgwq" src="https://github.com/user-attachments/assets/8d0773ce-e54e-426d-b51c-e00bff4e6619" />
