### PR TITLE
feat(benchmarks): fix benchmark for SELFDESTRUCT of initcode contracts for Osaka

### DIFF
--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -769,8 +769,8 @@ def test_selfdestruct_initcode(
         + gas_costs.G_INITCODE_WORD
     )
     extra_costs = (
-        gas_costs.G_BASE  # POP
-        + gas_costs.G_VERY_LOW * 6  # PUSHs, ADD, DUP, GT
+        gas_costs.G_BASE * 2  # POP, GAS
+        + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, GT
         + gas_costs.G_HIGH  # JUMPI
         + gas_costs.G_JUMPDEST
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -741,7 +741,7 @@ def test_selfdestruct_created(
 
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_initcode(
-    state_test: StateTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     value_bearing: bool,
     fork: Fork,
@@ -749,6 +749,7 @@ def test_selfdestruct_initcode(
     gas_benchmark_value: int,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction executed in initcode."""
+    # Avoid account creation costs in the SELFDESTRUCT recipient.
     fee_recipient = pre.fund_eoa(amount=1)
     env.fee_recipient = fee_recipient
 
@@ -780,9 +781,10 @@ def test_selfdestruct_initcode(
         + memory_expansion_calc(new_bytes=32)
     )
     suffix_cost = (
-        gas_costs.G_COLD_SLOAD
+        gas_costs.G_VERY_LOW
+        + gas_costs.G_VERY_LOW * 3
+        + gas_costs.G_COLD_SLOAD
         + gas_costs.G_STORAGE_RESET
-        + (gas_costs.G_VERY_LOW * 2)
     )
 
     base_costs = prefix_cost + suffix_cost + intrinsic_gas_cost_calc()
@@ -792,7 +794,9 @@ def test_selfdestruct_initcode(
     initcode = Op.SELFDESTRUCT(Op.COINBASE)
     code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
     code_suffix = (
-        Op.SSTORE(0, 42)  # Done for successful tx execution assertion below.
+        Op.SSTORE(
+            0, Op.ADD(Op.SLOAD(0), 1)
+        )  # Done for successful tx execution assertion below.
         + Op.STOP
     )
 
@@ -806,24 +810,45 @@ def test_selfdestruct_initcode(
         )
         + Op.PUSH1[1]
         + Op.ADD
-        + Op.JUMPI(len(code_prefix) - 1, Op.GT(iterations, Op.DUP1))
+        + Op.JUMPI(
+            len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost)
+        )
     )
     code = code_prefix + loop_body + code_suffix
 
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
-    code_tx = Transaction(
-        to=code_addr,
-        gas_limit=gas_benchmark_value,
-        gas_price=10,
-        sender=pre.fund_eoa(),
-    )
 
-    post = {code_addr: Account(storage={0: 42})}  # Check for successful
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    effective_attack_gas_limit = (
+        min(gas_benchmark_value, gas_limit_cap)
+        if gas_limit_cap is not None
+        else gas_benchmark_value
+    )
+    max_iterations_per_tx = (
+        effective_attack_gas_limit - base_costs
+    ) // loop_cost
+    num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
+
+    exec_txs = []
+    with TestPhaseManager.execution():
+        for _ in range(num_exec_txs):
+            exec_txs.append(
+                Transaction(
+                    to=code_addr,
+                    gas_limit=effective_attack_gas_limit,
+                    sender=pre.fund_eoa(),
+                )
+            )
+
+    post = {
+        code_addr: Account(storage={0: len(exec_txs) + 1})
+    }  # Check for successful
     # execution.
-    state_test(
-        pre=pre,
+    benchmark_test(
         post=post,
-        tx=code_tx,
+        blocks=[
+            Block(txs=exec_txs),
+        ],
         expected_benchmark_gas_used=iterations * loop_cost + base_costs,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -819,8 +819,8 @@ def test_selfdestruct_initcode(
     # costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
 
-    max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
     exec_txs = []
+    expected_benchmark_gas_used = 0
     with TestPhaseManager.execution():
         used_gas = 0
         while used_gas < gas_benchmark_value:
@@ -835,18 +835,16 @@ def test_selfdestruct_initcode(
                 )
             )
             used_gas += gas_limit
+            iterations = (gas_limit - base_costs) // loop_cost
+            expected_benchmark_gas_used += iterations * loop_cost + base_costs
 
     post = {
         code_addr: Account(storage={0: len(exec_txs) + 1})
-    }  # Check for successful
-    # execution.
+    }  # Check for successful execution.
     benchmark_test(
         post=post,
         blocks=[
             Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
-        expected_benchmark_gas_used=(
-            max_iterations_per_tx * loop_cost + base_costs
-        )
-        * len(exec_txs),
+        expected_benchmark_gas_used=expected_benchmark_gas_used,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -747,6 +747,7 @@ def test_selfdestruct_initcode(
     fork: Fork,
     env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit : int,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction executed in initcode."""
     # Avoid account creation costs in the SELFDESTRUCT recipient.
@@ -820,13 +821,8 @@ def test_selfdestruct_initcode(
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
-    effective_attack_gas_limit = (
-        min(gas_benchmark_value, gas_limit_cap)
-        if gas_limit_cap is not None
-        else gas_benchmark_value
-    )
     max_iterations_per_tx = (
-        effective_attack_gas_limit - base_costs
+        tx_gas_limit - base_costs
     ) // loop_cost
     num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
 
@@ -836,7 +832,7 @@ def test_selfdestruct_initcode(
             exec_txs.append(
                 Transaction(
                     to=code_addr,
-                    gas_limit=effective_attack_gas_limit,
+                    gas_limit=tx_gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -815,7 +815,8 @@ def test_selfdestruct_initcode(
     )
     code = code_prefix + loop_body + code_suffix
 
-    # The 0 storage slot is initialized to avoid creation costs in SSTORE above.
+    # The 0 storage slot is initialized to avoid creation
+    # costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
 
     max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -843,5 +843,8 @@ def test_selfdestruct_initcode(
         blocks=[
             Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
-        expected_benchmark_gas_used=iterations * loop_cost + base_costs,
+        expected_benchmark_gas_used=(
+            max_iterations_per_tx * loop_cost + base_costs
+        )
+        * num_exec_txs,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -790,8 +790,6 @@ def test_selfdestruct_initcode(
 
     base_costs = prefix_cost + suffix_cost + intrinsic_gas_cost_calc()
 
-    iterations = (gas_benchmark_value - base_costs) // loop_cost
-
     initcode = Op.SELFDESTRUCT(Op.COINBASE)
     code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
     code_suffix = (
@@ -817,22 +815,25 @@ def test_selfdestruct_initcode(
     )
     code = code_prefix + loop_body + code_suffix
 
-    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
+    # The 0 storage slot is initialized to avoid creation costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
 
     max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
-    num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
-
     exec_txs = []
     with TestPhaseManager.execution():
-        for _ in range(num_exec_txs):
+        used_gas = 0
+        while used_gas < gas_benchmark_value:
+            gas_limit = min(tx_gas_limit, gas_benchmark_value - used_gas)
+            if gas_limit < intrinsic_gas_cost_calc():
+                break
             exec_txs.append(
                 Transaction(
                     to=code_addr,
-                    gas_limit=tx_gas_limit,
+                    gas_limit=gas_limit,
                     sender=pre.fund_eoa(),
                 )
             )
+            used_gas += gas_limit
 
     post = {
         code_addr: Account(storage={0: len(exec_txs) + 1})
@@ -846,5 +847,5 @@ def test_selfdestruct_initcode(
         expected_benchmark_gas_used=(
             max_iterations_per_tx * loop_cost + base_costs
         )
-        * num_exec_txs,
+        * len(exec_txs),
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -841,7 +841,7 @@ def test_selfdestruct_initcode(
     benchmark_test(
         post=post,
         blocks=[
-            Block(txs=exec_txs),
+            Block(txs=exec_txs, fee_recipient=fee_recipient),
         ],
         expected_benchmark_gas_used=iterations * loop_cost + base_costs,
     )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -747,7 +747,7 @@ def test_selfdestruct_initcode(
     fork: Fork,
     env: Environment,
     gas_benchmark_value: int,
-    tx_gas_limit : int,
+    tx_gas_limit: int,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction executed in initcode."""
     # Avoid account creation costs in the SELFDESTRUCT recipient.
@@ -820,10 +820,7 @@ def test_selfdestruct_initcode(
     # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
     code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
 
-    gas_limit_cap = fork.transaction_gas_limit_cap()
-    max_iterations_per_tx = (
-        tx_gas_limit - base_costs
-    ) // loop_cost
+    max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
     num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
 
     exec_txs = []


### PR DESCRIPTION
## 🗒️ Description
This PR fixes the `test_selfdestruct_initcode` benchmark to work in Osaka.

Very similar fix as I did in https://github.com/ethereum/execution-specs/pull/1906


## 🔗 Related Issues or PRs
https://github.com/ethereum/execution-specs/issues/1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [X] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
![Put a link to a cute animal picture inside the parenthesis-->]()
