### PR TITLE
feat(specs): EIP-7928 move bal from payload

### DIFF
--- a/src/ethereum/forks/amsterdam/blocks.py
+++ b/src/ethereum/forks/amsterdam/blocks.py
@@ -19,7 +19,6 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 
-from .block_access_lists.rlp_types import BlockAccessList
 from .fork_types import Address, Bloom, Root
 from .transactions import (
     AccessListTransaction,
@@ -304,13 +303,6 @@ class Block:
     withdrawals: Tuple[Withdrawal, ...]
     """
     A tuple of withdrawals processed in this block.
-    """
-
-    block_access_list: BlockAccessList
-    """
-    Block Access List containing all accounts and storage locations accessed
-    during block execution. Introduced in [EIP-7928].
-    [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
     """
 
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -30,6 +30,7 @@ from ethereum.exceptions import (
 
 from . import vm
 from .block_access_lists.builder import build_block_access_list
+from .block_access_lists.rlp_types import BlockAccessList
 from .block_access_lists.rlp_utils import compute_block_access_list_hash
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
@@ -206,7 +207,9 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
     return recent_block_hashes
 
 
-def state_transition(chain: BlockChain, block: Block) -> None:
+def state_transition(
+    chain: BlockChain, block: Block, block_access_list: BlockAccessList
+) -> None:
     """
     Attempts to apply a block to an existing block chain.
 
@@ -227,6 +230,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         History and current state.
     block :
         Block to apply to `chain`.
+    block_access_list :
+        The block access list containing all state accesses during block execution.
 
     """
     if len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE:
@@ -256,6 +261,11 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         transactions=block.transactions,
         withdrawals=block.withdrawals,
     )
+    
+    # Verify the provided block access list matches what was computed
+    if block_output.block_access_list != block_access_list:
+        raise InvalidBlock("Block access list mismatch")
+    
     block_state_root = state_root(block_env.state)
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
@@ -263,7 +273,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     withdrawals_root = root(block_output.withdrawals_trie)
     requests_hash = compute_requests_hash(block_output.requests)
     computed_block_access_list_hash = compute_block_access_list_hash(
-        block_output.block_access_list
+        block_access_list
     )
 
     if block_output.block_gas_used != block.header.gas_used:

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -256,7 +256,6 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         transactions=block.transactions,
         withdrawals=block.withdrawals,
     )
-    
     block_state_root = state_root(block_env.state)
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -30,7 +30,6 @@ from ethereum.exceptions import (
 
 from . import vm
 from .block_access_lists.builder import build_block_access_list
-from .block_access_lists.rlp_types import BlockAccessList
 from .block_access_lists.rlp_utils import compute_block_access_list_hash
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
@@ -207,9 +206,7 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
     return recent_block_hashes
 
 
-def state_transition(
-    chain: BlockChain, block: Block, block_access_list: BlockAccessList
-) -> None:
+def state_transition(chain: BlockChain, block: Block) -> None:
     """
     Attempts to apply a block to an existing block chain.
 
@@ -230,8 +227,6 @@ def state_transition(
         History and current state.
     block :
         Block to apply to `chain`.
-    block_access_list :
-        The block access list containing all state accesses during block execution.
 
     """
     if len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE:
@@ -262,10 +257,6 @@ def state_transition(
         withdrawals=block.withdrawals,
     )
     
-    # Verify the provided block access list matches what was computed
-    if block_output.block_access_list != block_access_list:
-        raise InvalidBlock("Block access list mismatch")
-    
     block_state_root = state_root(block_env.state)
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
@@ -273,7 +264,7 @@ def state_transition(
     withdrawals_root = root(block_output.withdrawals_trie)
     requests_hash = compute_requests_hash(block_output.requests)
     computed_block_access_list_hash = compute_block_access_list_hash(
-        block_access_list
+        block_output.block_access_list
     )
 
     if block_output.block_gas_used != block.header.gas_used:


### PR DESCRIPTION
🗒️ Description

This PR completes the EIP-7928 block access list (BAL) refactoring by moving BAL validation outside of the state transition function. 

The changes across the last two commits:
  - Previous commit: Moved BAL from the block body to be passed separately to state_transition
  - The second commit: Removed BAL parameter entirely from state_transition, keeping only hash validation

The state transition now:
  - Generates the BAL during block execution via apply_body()
  - Computes the hash of the generated BAL
  - Validates only that this hash matches block.header.block_access_list_hash

This simplifies the state transition by removing the need to pass and validate the full BAL, since the actual BAL validation (checking p2p received BAL matches the hash) is handled at the engine API layer.

  🔗 Related Issues or PRs

  N/A.

<img src="https://github.com/user-attachments/assets/a6bb23c7-b7ac-4a23-9438-f45a8ccaae8a" alt="Alt text" width="400" >

