### PR TITLE
feat(test-client-clis): Optimize fill for non-bpo forks

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -97,7 +97,11 @@ class ExecutionSpecsTransitionTool(TransitionTool):
             t8n_args.append("--state-test")
 
         if transition_tool_data.blob_params:
-            t8n_args.append("--input.blobParams=stdin")
+            fork = transition_tool_data.fork
+            if fork.bpo_fork() and fork != fork.non_bpo_ancestor():
+                # Only send this information for BPO forks.
+                # TODO: This should be optimized by the t8n tool instead.
+                t8n_args.append("--input.blobParams=stdin")
 
         if self.trace:
             t8n_args.extend(


### PR DESCRIPTION
## 🗒️ Description
Fixes fill slowdown for non-bpo forks by skipping sending the `--input.blobParams` unless required.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://nypost.com/wp-content/uploads/sites/2/2019/10/squirrel-nut-ki-415099-flower.jpg?quality=75&strip=all&w=744)
