### PR TITLE
fix(test): align blob params with specs for Amsterdam

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -2459,8 +2459,12 @@ class BPO5(BPO4, bpo_fork=True):
     pass
 
 
-class Amsterdam(Osaka):
+class Amsterdam(BPO2):
     """Amsterdam fork."""
+
+    # TODO: We may need to adjust which BPO Amsterdam inherits from as the
+    #  related Amsterdam specs change over time, and before Amsterdam is
+    #  live on mainnet.
 
     @classmethod
     def is_deployed(cls) -> bool:


### PR DESCRIPTION
## 🗒️ Description

Fixes issues filling for Amsterdam after the optimizations in #1924.

- We currently define `Amsterdam(Osaka)` in `forks.py` which inherits Osaka blob params (test)
- `forks/amsterdam` created `amsterdam` from `bpo5` which takes `bpo2`'s blob params (spec)
- We passed blob param values for all forks via t8n, before #1924, so it was working bc we passed Amsterdam with Osaka bpo vals and created a clone for the `ForkCache` that way.
- #1924 changes this behavior so we need to make sure that for non-bpo forks we (test framework and spec) agree on what blob parameter values the named forks use

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x]  All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="584" height="624" alt="Screenshot 2025-12-15 at 16 27 21" src="https://github.com/user-attachments/assets/41ce51d6-4157-4dcd-9e23-658510f9aad1" />

