### PR TITLE
refactor(test-cli-consume,rpc): use tenacity for retry logic

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/exceptions.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/exceptions.py
@@ -23,6 +23,18 @@ from execution_testing.client_clis.clis.nimbus import (
 from execution_testing.client_clis.clis.reth import RethExceptionMapper
 from execution_testing.exceptions import ExceptionMapper
 from execution_testing.fixtures.blockchain import FixtureHeader
+from execution_testing.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class LoggedError(Exception):
+    """Exception that uses the logger to log the failure."""
+
+    def __init__(self, *args: object) -> None:
+        """Initialize the exception and log the failure."""
+        super().__init__(*args)
+        logger.fail(str(self))
 
 
 class GenesisBlockMismatchExceptionError(Exception):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -19,22 +19,16 @@ from execution_testing.rpc.rpc_types import (
 )
 
 from execution_testing.logging import get_logger
-from ..helpers.exceptions import GenesisBlockMismatchExceptionError
+from ..helpers.exceptions import (
+    GenesisBlockMismatchExceptionError,
+    LoggedError,
+)
 from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)
 
 MAX_RETRIES = 30
 DELAY_BETWEEN_RETRIES_IN_SEC = 1
-
-
-class LoggedError(Exception):
-    """Exception that uses the logger to log the failure."""
-
-    def __init__(self, *args: object) -> None:
-        """Initialize the exception and log the failure."""
-        super().__init__(*args)
-        logger.fail(str(self))
 
 
 def test_blockchain_via_engine(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -14,7 +14,6 @@ from execution_testing.rpc import (
     EngineRPC,
     EthRPC,
     ForkchoiceUpdateTimeoutError,
-    forkchoice_updated_with_retry,
 )
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
@@ -50,8 +49,7 @@ def test_blockchain_via_engine(
     with timing_data.time("Initial forkchoice update"):
         logger.info("Sending initial forkchoice update to genesis block...")
         try:
-            response = forkchoice_updated_with_retry(
-                engine_rpc=engine_rpc,
+            response = engine_rpc.forkchoice_updated_with_retry(
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -7,18 +7,21 @@ Each `engine_newPayloadVX` is verified against the appropriate VALID/INVALID
 responses.
 """
 
-import time
-
 from execution_testing.exceptions import UndefinedException
 from execution_testing.fixtures import BlockchainEngineFixture
-from execution_testing.rpc import EngineRPC, EthRPC
+from execution_testing.logging import get_logger
+from execution_testing.rpc import (
+    EngineRPC,
+    EthRPC,
+    ForkchoiceUpdateTimeoutError,
+    forkchoice_updated_with_retry,
+)
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     JSONRPCError,
     PayloadStatusEnum,
 )
 
-from execution_testing.logging import get_logger
 from ..helpers.exceptions import (
     GenesisBlockMismatchExceptionError,
     LoggedError,
@@ -26,9 +29,6 @@ from ..helpers.exceptions import (
 from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)
-
-MAX_RETRIES = 30
-DELAY_BETWEEN_RETRIES_IN_SEC = 1
 
 
 def test_blockchain_via_engine(
@@ -46,38 +46,30 @@ def test_blockchain_via_engine(
     3. For valid payloads a forkchoice update is performed to finalize the
        chain.
     """
-    # Send a initial forkchoice update
+    # Send initial forkchoice update
     with timing_data.time("Initial forkchoice update"):
         logger.info("Sending initial forkchoice update to genesis block...")
-        for attempt in range(1, MAX_RETRIES + 1):
-            forkchoice_response = engine_rpc.forkchoice_updated(
+        try:
+            response = forkchoice_updated_with_retry(
+                engine_rpc=engine_rpc,
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),
-                payload_attributes=None,
-                version=fixture.payloads[0].forkchoice_updated_version,
+                forkchoice_version=fixture.payloads[
+                    0
+                ].forkchoice_updated_version,
+                max_attempts=30,
+                wait_fixed=1.0,
             )
-            status = forkchoice_response.payload_status.status
-            logger.info(
-                f"Initial forkchoice update response attempt {attempt}: {status}"
-            )
-            if status != PayloadStatusEnum.SYNCING:
-                break
-
-            if attempt < MAX_RETRIES:
-                time.sleep(DELAY_BETWEEN_RETRIES_IN_SEC)
-
-        if (
-            forkchoice_response.payload_status.status
-            != PayloadStatusEnum.VALID
-        ):
-            logger.error(
-                f"Client failed to initialize properly after {MAX_RETRIES} attempts, "
-                f"final status: {forkchoice_response.payload_status.status}"
-            )
+            if response.payload_status.status != PayloadStatusEnum.VALID:
+                raise LoggedError(
+                    f"Unexpected status on forkchoice updated to genesis: "
+                    f"{response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
             raise LoggedError(
-                f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
-            )
+                f"Timed out waiting for forkchoice update to genesis: {e}"
+            ) from None
 
     with timing_data.time("Get genesis block"):
         logger.info("Calling getBlockByNumber to get genesis block...")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -12,8 +12,6 @@ This simulator:
 4. Verifies that the sync was successful
 """
 
-import time
-
 import pytest
 
 from execution_testing.exceptions import UndefinedException
@@ -26,6 +24,7 @@ from execution_testing.rpc import (
     EthRPC,
     ForkchoiceUpdateTimeoutError,
     NetRPC,
+    PeerConnectionTimeoutError,
     forkchoice_updated_with_retry,
 )
 from execution_testing.rpc.rpc_types import (
@@ -319,20 +318,18 @@ def test_blockchain_via_sync(
     except Exception as e:
         raise LoggedError(f"admin_addPeer failed: {e}") from e
 
-    # quick sleep to allow for connection - TODO: is this necessary?
-    time.sleep(1)
-
+    # Wait for peer connection to establish
     try:
-        sync_peer_count = sync_net_rpc.peer_count()
-        client_peer_count = net_rpc.peer_count()
-        logger.info(
-            f"Peer count: sync_client={sync_peer_count}, client_under_test={client_peer_count}"
-        )
-
-        if sync_peer_count == 0 and client_peer_count == 0:
-            raise LoggedError("No P2P connection established between clients")
-    except Exception as e:
-        logger.warning(f"Could not verify peer connection: {e}")
+        sync_net_rpc.wait_for_peer_connection()
+        logger.info("Peer connection established on sync client")
+    except PeerConnectionTimeoutError:
+        try:
+            net_rpc.wait_for_peer_connection()
+            logger.info("Peer connection established on client under test")
+        except PeerConnectionTimeoutError as e:
+            raise LoggedError(
+                f"No P2P connection established between clients: {e}"
+            ) from e
 
     # Trigger sync by sending the target block via newPayload followed by
     # forkchoice update
@@ -404,23 +401,24 @@ def test_blockchain_via_sync(
                     "Sync client accepted the block, may start syncing ancestors"
                 )
 
-            # Give a moment for P2P connections to establish after sync starts
-            time.sleep(1)
-
-            # Check peer count after triggering sync Note: Reth does not
-            # actually raise the peer count but doesn't seem to need this to
-            # sync.
+            # Wait for P2P connections after sync starts
+            # Note: Reth does not report peer count but still syncs successfully
             try:
                 assert sync_net_rpc is not None, "sync_net_rpc is required"
-                client_peer_count = net_rpc.peer_count()
-                sync_peer_count = sync_net_rpc.peer_count()
-                if sync_peer_count > 0 or client_peer_count > 0:
+                sync_net_rpc.wait_for_peer_connection()
+                logger.debug(
+                    "Peer connection verified on sync client after sync trigger"
+                )
+            except PeerConnectionTimeoutError:
+                try:
+                    net_rpc.wait_for_peer_connection()
                     logger.debug(
-                        f"Peers connected: client_under_test={client_peer_count}, "
-                        f"sync_client={sync_peer_count}"
+                        "Peer connection verified on client under test"
                     )
-            except Exception as e:
-                logger.debug(f"Could not check peer count: {e}")
+                except PeerConnectionTimeoutError as e:
+                    logger.debug(
+                        f"Peer connection not verified (may still sync): {e}"
+                    )
 
         except Exception as e:
             logger.warning(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -18,14 +18,21 @@ import pytest
 
 from execution_testing.exceptions import UndefinedException
 from execution_testing.fixtures import BlockchainEngineSyncFixture
-from execution_testing.rpc import AdminRPC, EngineRPC, EthRPC, NetRPC
+from execution_testing.logging import get_logger
+from execution_testing.rpc import (
+    AdminRPC,
+    EngineRPC,
+    EthRPC,
+    ForkchoiceUpdateTimeoutError,
+    NetRPC,
+    forkchoice_updated_with_retry,
+)
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     JSONRPCError,
     PayloadStatusEnum,
 )
 
-from execution_testing.logging import get_logger
 from ..helpers.exceptions import (
     GenesisBlockMismatchExceptionError,
     LoggedError,
@@ -61,38 +68,27 @@ def test_blockchain_via_sync(
     # Initialize client under test
     with timing_data.time("Initialize client under test"):
         logger.info("Initializing client under test with genesis block...")
-
-        # Send initial forkchoice update to client under test
-        delay = 0.5
-        for attempt in range(3):
-            forkchoice_response = engine_rpc.forkchoice_updated(
+        try:
+            response = forkchoice_updated_with_retry(
+                engine_rpc=engine_rpc,
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),
-                payload_attributes=None,
-                version=fixture.payloads[0].forkchoice_updated_version,
+                forkchoice_version=fixture.payloads[
+                    0
+                ].forkchoice_updated_version,
+                max_attempts=4,
+                wait_fixed=0.5,
             )
-            status = forkchoice_response.payload_status.status
-            logger.info(
-                f"Initial forkchoice update response attempt {attempt + 1}: {status}"
-            )
-            if status != PayloadStatusEnum.SYNCING:
-                break
-            if attempt < 2:
-                time.sleep(delay)
-                delay *= 2
-
-        if (
-            forkchoice_response.payload_status.status
-            != PayloadStatusEnum.VALID
-        ):
-            logger.error(
-                f"Client under test failed to initialize properly after 3 attempts, "
-                f"final status: {forkchoice_response.payload_status.status}"
-            )
+            if response.payload_status.status != PayloadStatusEnum.VALID:
+                raise LoggedError(
+                    f"Unexpected status on forkchoice updated to genesis: "
+                    f"{response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
             raise LoggedError(
-                f"unexpected status on forkchoice updated to genesis: {forkchoice_response}"
-            )
+                f"Timed out waiting for forkchoice update to genesis: {e}"
+            ) from None
 
     # Verify genesis block on client under test
     with timing_data.time("Verify genesis on client under test"):
@@ -290,39 +286,27 @@ def test_blockchain_via_sync(
     # Initialize sync client
     with timing_data.time("Initialize sync client"):
         logger.info("Initializing sync client with genesis block...")
-
-        # Send initial forkchoice update to sync client
-        delay = 0.5
-        for attempt in range(3):
-            forkchoice_response = sync_engine_rpc.forkchoice_updated(
+        try:
+            response = forkchoice_updated_with_retry(
+                engine_rpc=sync_engine_rpc,
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),
-                payload_attributes=None,
-                version=fixture.payloads[0].forkchoice_updated_version,
+                forkchoice_version=fixture.payloads[
+                    0
+                ].forkchoice_updated_version,
+                max_attempts=4,
+                wait_fixed=0.5,
             )
-            status = forkchoice_response.payload_status.status
-            logger.info(
-                f"Sync client forkchoice update response attempt {attempt + 1}: {status}"
-            )
-            if status != PayloadStatusEnum.SYNCING:
-                break
-            if attempt < 2:
-                time.sleep(delay)
-                delay *= 2
-
-        if (
-            forkchoice_response.payload_status.status
-            != PayloadStatusEnum.VALID
-        ):
-            logger.error(
-                f"Sync client failed to initialize properly after 3 attempts, "
-                f"final status: {forkchoice_response.payload_status.status}"
-            )
+            if response.payload_status.status != PayloadStatusEnum.VALID:
+                raise LoggedError(
+                    f"Unexpected status on sync client forkchoice updated to genesis: "
+                    f"{response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
             raise LoggedError(
-                f"Unexpected status on sync client forkchoice updated to genesis: "
-                f"{forkchoice_response}"
-            )
+                f"Timed out waiting for sync client forkchoice update to genesis: {e}"
+            ) from None
 
     # Add peer using admin_addPeer This seems to be required... TODO: we can
     # maybe improve flow here if not required
@@ -458,44 +442,25 @@ def test_blockchain_via_sync(
             f"(hash: {last_valid_block_hash})"
         )
 
-        # Start monitoring sync progress
-        sync_start_time = time.time()
-        last_forkchoice_time = time.time()
-        forkchoice_interval = 2.0  # Send forkchoice updates every 2 seconds
-
-        while time.time() - sync_start_time < 15:  # 15 second timeout
-            # Send periodic forkchoice updates to keep sync alive
-            if time.time() - last_forkchoice_time >= forkchoice_interval:
-                try:
-                    # Send forkchoice update to sync client to trigger/maintain
-                    # sync
-                    assert sync_engine_rpc is not None, (
-                        "sync_engine_rpc is required"
-                    )
-                    sync_fc_response = sync_engine_rpc.forkchoice_updated(
-                        forkchoice_state=last_valid_block_forkchoice_state,
-                        payload_attributes=None,
-                        version=fixture.sync_payload.forkchoice_updated_version
-                        if fixture.sync_payload
-                        else fixture.payloads[-1].forkchoice_updated_version,
-                    )
-                    status = sync_fc_response.payload_status.status
-                    logger.debug(
-                        f"Periodic forkchoice update status: {status}"
-                    )
-                    if status.VALID:
-                        break
-                    last_forkchoice_time = time.time()
-                except Exception as fc_err:
-                    logger.debug(
-                        f"Periodic forkchoice update failed: {fc_err}"
-                    )
-            time.sleep(0.5)
-        else:
-            raise LoggedError(
-                f"Sync client failed to synchronize to block {last_valid_block_hash} "
-                f"within timeout"
+        try:
+            response = forkchoice_updated_with_retry(
+                engine_rpc=sync_engine_rpc,
+                forkchoice_state=last_valid_block_forkchoice_state,
+                forkchoice_version=fixture.sync_payload.forkchoice_updated_version
+                if fixture.sync_payload
+                else fixture.payloads[-1].forkchoice_updated_version,
+                max_attempts=30,
+                wait_fixed=0.5,
             )
+            if response.payload_status.status != PayloadStatusEnum.VALID:
+                raise LoggedError(
+                    f"Sync client failed to sync to block {last_valid_block_hash}: "
+                    f"unexpected status {response.payload_status.status}"
+                )
+        except ForkchoiceUpdateTimeoutError as e:
+            raise LoggedError(
+                f"Sync client timed out syncing to block {last_valid_block_hash}: {e}"
+            ) from None
 
         logger.info("Sync verification successful! FCU returned VALID.")
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -21,6 +21,7 @@ from execution_testing.fixtures import BlockchainEngineSyncFixture
 from execution_testing.logging import get_logger
 from execution_testing.rpc import (
     AdminRPC,
+    BlockNotAvailableError,
     EngineRPC,
     EthRPC,
     ForkchoiceUpdateTimeoutError,
@@ -464,71 +465,53 @@ def test_blockchain_via_sync(
 
         logger.info("Sync verification successful! FCU returned VALID.")
 
-        # Verify the final state but give a few tries
-        assert eth_rpc is not None, "eth_rpc is required"
-        assert sync_eth_rpc is not None, "sync_eth_rpc is required"
+        # Verify the final state by fetching blocks from both clients
+        # Note: Block unavailability is acceptable - FCU VALID is authoritative
+        client_block = None
+        sync_block = None
 
-        max_attempts = 5  # 5 attempts with 1 second wait between
-        for attempt in range(max_attempts):
-            try:
-                sync_block = sync_eth_rpc.get_block_by_hash(
-                    last_valid_block_hash
+        try:
+            client_block = eth_rpc.get_block_by_hash_with_retry(
+                last_valid_block_hash,
+                max_attempts=5,
+                wait_fixed=1.0,
+            )
+        except BlockNotAvailableError as e:
+            logger.debug(
+                f"Block not available on client under test (acceptable): {e}"
+            )
+
+        try:
+            sync_block = sync_eth_rpc.get_block_by_hash_with_retry(
+                last_valid_block_hash,
+                max_attempts=5,
+                wait_fixed=1.0,
+            )
+        except BlockNotAvailableError as e:
+            logger.debug(
+                f"Block not available on sync client (acceptable): {e}"
+            )
+
+        if sync_block is not None and client_block is not None:
+            if sync_block["stateRoot"] != client_block["stateRoot"]:
+                raise LoggedError(
+                    f"State root mismatch after sync. "
+                    f"Sync client: {sync_block['stateRoot']}, "
+                    f"Client under test: {client_block['stateRoot']}"
                 )
-                client_block = eth_rpc.get_block_by_hash(last_valid_block_hash)
 
-                if sync_block is not None and client_block is not None:
-                    # If we have both blocks, verify they match
-                    if sync_block["stateRoot"] != client_block["stateRoot"]:
-                        raise LoggedError(
-                            f"State root mismatch after sync. "
-                            f"Sync client: {sync_block['stateRoot']}, "
-                            f"Client under test: {client_block['stateRoot']}"
-                        )
-
-                    if fixture.post_state_hash:
-                        if sync_block["stateRoot"] != str(
-                            fixture.post_state_hash
-                        ):
-                            raise LoggedError(
-                                f"Final state root mismatch. "
-                                f"Expected: {fixture.post_state_hash}, "
-                                f"Got: {sync_block['stateRoot']}"
-                            )
-
-                    logger.info(
-                        f"Block state verified via eth_getBlockByHash (attempt {attempt + 1}): "
-                        f"{sync_block['stateRoot']}"
+            # Verify against expected post-state hash if provided
+            if fixture.post_state_hash:
+                if sync_block["stateRoot"] != str(fixture.post_state_hash):
+                    raise LoggedError(
+                        f"Final state root mismatch. "
+                        f"Expected: {fixture.post_state_hash}, "
+                        f"Got: {sync_block['stateRoot']}"
                     )
-                    break
-                else:
-                    missing = []
-                    if sync_block is None:
-                        missing.append("sync_client")
-                    if client_block is None:
-                        missing.append("client_under_test")
 
-                    if attempt < max_attempts - 1:
-                        logger.debug(
-                            f"Block {last_valid_block_hash} not yet available on {', '.join(missing)} "
-                            f"(attempt {attempt + 1}/{max_attempts})"
-                        )
-                        time.sleep(1)
-                    else:
-                        # Final attempt and blocks still not available
-                        logger.debug(
-                            f"Block {last_valid_block_hash} not available via eth_getBlockByHash "
-                            f"after {max_attempts} attempts (missing from: {', '.join(missing)}). "
-                            f"This is acceptable as FCU VALID is the authoritative success signal."
-                        )
-            except LoggedError:
-                # Re-raise validation errors immediately with no retry
-                raise
-            except Exception as e:
-                # Log other errors without failing the test
-                logger.debug(
-                    f"Error fetching blocks for verification (attempt {attempt + 1}): {e}"
-                )
-                if attempt < max_attempts - 1:
-                    time.sleep(1)
+            logger.info(
+                f"Block state verified via eth_getBlockByHash: "
+                f"{sync_block['stateRoot']}"
+            )
 
     logger.info("Sync test completed successfully!")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -25,7 +25,6 @@ from execution_testing.rpc import (
     ForkchoiceUpdateTimeoutError,
     NetRPC,
     PeerConnectionTimeoutError,
-    forkchoice_updated_with_retry,
 )
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
@@ -69,8 +68,7 @@ def test_blockchain_via_sync(
     with timing_data.time("Initialize client under test"):
         logger.info("Initializing client under test with genesis block...")
         try:
-            response = forkchoice_updated_with_retry(
-                engine_rpc=engine_rpc,
+            response = engine_rpc.forkchoice_updated_with_retry(
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),
@@ -287,8 +285,7 @@ def test_blockchain_via_sync(
     with timing_data.time("Initialize sync client"):
         logger.info("Initializing sync client with genesis block...")
         try:
-            response = forkchoice_updated_with_retry(
-                engine_rpc=sync_engine_rpc,
+            response = sync_engine_rpc.forkchoice_updated_with_retry(
                 forkchoice_state=ForkchoiceState(
                     head_block_hash=fixture.genesis.block_hash,
                 ),
@@ -442,8 +439,7 @@ def test_blockchain_via_sync(
         )
 
         try:
-            response = forkchoice_updated_with_retry(
-                engine_rpc=sync_engine_rpc,
+            response = sync_engine_rpc.forkchoice_updated_with_retry(
                 forkchoice_state=last_valid_block_forkchoice_state,
                 forkchoice_version=fixture.sync_payload.forkchoice_updated_version
                 if fixture.sync_payload

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -26,19 +26,13 @@ from execution_testing.rpc.rpc_types import (
 )
 
 from execution_testing.logging import get_logger
-from ..helpers.exceptions import GenesisBlockMismatchExceptionError
+from ..helpers.exceptions import (
+    GenesisBlockMismatchExceptionError,
+    LoggedError,
+)
 from ..helpers.timing import TimingData
 
 logger = get_logger(__name__)
-
-
-class LoggedError(Exception):
-    """Exception that uses the logger to log the failure."""
-
-    def __init__(self, *args: object) -> None:
-        """Initialize the exception and log the failure."""
-        super().__init__(*args)
-        logger.fail(str(self))
 
 
 def test_blockchain_via_sync(

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -8,8 +8,10 @@ from .rpc import (
     DebugRPC,
     EngineRPC,
     EthRPC,
+    ForkchoiceUpdateTimeoutError,
     NetRPC,
     SendTransactionExceptionError,
+    forkchoice_updated_with_retry,
 )
 from .rpc_types import (
     BlobAndProofV1,
@@ -31,7 +33,9 @@ __all__ = [
     "EthRPC",
     "ForkConfig",
     "ForkConfigBlobSchedule",
+    "ForkchoiceUpdateTimeoutError",
     "NetRPC",
     "SendTransactionExceptionError",
     "TransactionProtocol",
+    "forkchoice_updated_with_retry",
 ]

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -4,6 +4,7 @@ JSON-RPC methods and helper functions for EEST consume based hive simulators.
 
 from .rpc import (
     AdminRPC,
+    BlockNotAvailableError,
     BlockNumberType,
     DebugRPC,
     EngineRPC,
@@ -26,6 +27,7 @@ __all__ = [
     "AdminRPC",
     "BlobAndProofV1",
     "BlobAndProofV2",
+    "BlockNotAvailableError",
     "BlockNumberType",
     "DebugRPC",
     "EngineRPC",

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -13,7 +13,6 @@ from .rpc import (
     NetRPC,
     PeerConnectionTimeoutError,
     SendTransactionExceptionError,
-    forkchoice_updated_with_retry,
 )
 from .rpc_types import (
     BlobAndProofV1,
@@ -41,5 +40,4 @@ __all__ = [
     "PeerConnectionTimeoutError",
     "SendTransactionExceptionError",
     "TransactionProtocol",
-    "forkchoice_updated_with_retry",
 ]

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -11,6 +11,7 @@ from .rpc import (
     EthRPC,
     ForkchoiceUpdateTimeoutError,
     NetRPC,
+    PeerConnectionTimeoutError,
     SendTransactionExceptionError,
     forkchoice_updated_with_retry,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "ForkConfigBlobSchedule",
     "ForkchoiceUpdateTimeoutError",
     "NetRPC",
+    "PeerConnectionTimeoutError",
     "SendTransactionExceptionError",
     "TransactionProtocol",
     "forkchoice_updated_with_retry",

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -859,79 +859,77 @@ class EngineRPC(BaseRPC):
             context=self.response_validation_context,
         )
 
+    def forkchoice_updated_with_retry(
+        self,
+        forkchoice_state: ForkchoiceState,
+        forkchoice_version: int,
+        *,
+        max_attempts: int = 30,
+        wait_fixed: float = 1.0,
+        on_retry: Callable[[RetryCallState], None] | None = None,
+    ) -> ForkchoiceUpdateResponse:
+        """
+        Send forkchoice update, retrying while SYNCING until a terminal status.
 
-def forkchoice_updated_with_retry(
-    engine_rpc: EngineRPC,
-    forkchoice_state: ForkchoiceState,
-    forkchoice_version: int,
-    *,
-    max_attempts: int = 30,
-    wait_fixed: float = 1.0,
-    on_retry: Callable[[RetryCallState], None] | None = None,
-) -> ForkchoiceUpdateResponse:
-    """
-    Send forkchoice update, retrying while SYNCING until a terminal status.
+        Retries only while the client returns SYNCING status. Returns immediately
+        on any terminal status (VALID, INVALID, ACCEPTED, etc.) - the caller is
+        responsible for checking if the returned status matches expectations.
 
-    Retries only while the client returns SYNCING status. Returns immediately
-    on any terminal status (VALID, INVALID, ACCEPTED, etc.) - the caller is
-    responsible for checking if the returned status matches expectations.
+        Args:
+            forkchoice_state: The forkchoice state to send.
+            forkchoice_version: The forkchoice updated version (e.g., 1, 2, 3).
+            max_attempts: Maximum number of attempts before giving up.
+            wait_fixed: Fixed interval in seconds between retries.
+            on_retry: Optional callback invoked before each retry sleep.
+                Receives tenacity RetryCallState. If None, logs at debug level.
 
-    Args:
-        engine_rpc: The EngineRPC instance to use.
-        forkchoice_state: The forkchoice state to send.
-        forkchoice_version: The forkchoice updated version (e.g., 1, 2, 3).
-        max_attempts: Maximum number of attempts before giving up.
-        wait_fixed: Fixed interval in seconds between retries.
-        on_retry: Optional callback invoked before each retry sleep.
-            Receives tenacity RetryCallState. If None, logs at debug level.
+        Returns:
+            ForkchoiceUpdateResponse with a terminal status (VALID, INVALID, etc.).
 
-    Returns:
-        ForkchoiceUpdateResponse with a terminal status (VALID, INVALID, etc.).
+        Raises:
+            ForkchoiceUpdateTimeoutError: If still SYNCING after max_attempts.
+        """
+        # Track state for exception message in the case of timeout
+        attempts = 0
+        start_time = time.time()
+        last_response: ForkchoiceUpdateResponse | None = None
 
-    Raises:
-        ForkchoiceUpdateTimeoutError: If still SYNCING after max_attempts.
-    """
-    # Track state for exception message in the case of timeout
-    attempts = 0
-    start_time = time.time()
-    last_response: ForkchoiceUpdateResponse | None = None
-
-    def default_on_retry(retry_state: RetryCallState) -> None:
-        logger.debug(
-            f"Forkchoice update attempt {retry_state.attempt_number}: "
-            f"status={last_response.payload_status.status if last_response else 'N/A'}, "
-            f"retrying in {wait_fixed}s..."
-        )
-
-    retry_callback = on_retry if on_retry is not None else default_on_retry
-
-    @retry(
-        stop=stop_after_attempt(max_attempts),
-        wait=wait_fixed_tenacity(wait_fixed),
-        before_sleep=retry_callback,
-        reraise=True,
-    )
-    def _do_forkchoice_update() -> ForkchoiceUpdateResponse:
-        nonlocal attempts, last_response
-        attempts += 1
-        response = engine_rpc.forkchoice_updated(
-            forkchoice_state=forkchoice_state,
-            payload_attributes=None,
-            version=forkchoice_version,
-        )
-        last_response = response
-        status = response.payload_status.status
-        logger.info(f"Forkchoice update attempt {attempts}: {status}")
-        if status == PayloadStatusEnum.SYNCING:
-            raise ForkchoiceUpdateTimeoutError(
-                attempts=attempts,
-                elapsed=time.time() - start_time,
-                interval=wait_fixed,
-                final_status=status,
+        def default_on_retry(retry_state: RetryCallState) -> None:
+            logger.debug(
+                f"Forkchoice update attempt {retry_state.attempt_number}: "
+                f"status={last_response.payload_status.status if last_response else 'N/A'}, "
+                f"retrying in {wait_fixed}s..."
             )
-        return response
 
-    return _do_forkchoice_update()
+        retry_callback = on_retry if on_retry is not None else default_on_retry
+
+        @retry(
+            stop=stop_after_attempt(max_attempts),
+            wait=wait_fixed_tenacity(wait_fixed),
+            before_sleep=retry_callback,
+            reraise=True,
+        )
+        def _do_forkchoice_update() -> ForkchoiceUpdateResponse:
+            nonlocal attempts, last_response
+            attempts += 1
+            response = self.forkchoice_updated(
+                forkchoice_state=forkchoice_state,
+                payload_attributes=None,
+                version=forkchoice_version,
+            )
+            last_response = response
+            status = response.payload_status.status
+            logger.info(f"Forkchoice update attempt {attempts}: {status}")
+            if status == PayloadStatusEnum.SYNCING:
+                raise ForkchoiceUpdateTimeoutError(
+                    attempts=attempts,
+                    elapsed=time.time() - start_time,
+                    interval=wait_fixed,
+                    final_status=status,
+                )
+            return response
+
+        return _do_forkchoice_update()
 
 
 class NetRPC(BaseRPC):

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -7,17 +7,19 @@ import os
 import time
 from itertools import count
 from pprint import pprint
-from typing import Any, ClassVar, Dict, List, Literal, Sequence
+from typing import Any, Callable, ClassVar, Dict, List, Literal, Sequence
 
 import requests
 from jwt import encode
 from pydantic import ValidationError
 from tenacity import (
+    RetryCallState,
     before_sleep_log,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
+    wait_fixed as wait_fixed_tenacity,
 )
 
 from execution_testing.base_types import Address, Bytes, Hash, to_json
@@ -34,6 +36,7 @@ from .rpc_types import (
     JSONRPCError,
     PayloadAttributes,
     PayloadStatus,
+    PayloadStatusEnum,
     TransactionByHashResponse,
     TransactionProtocol,
 )
@@ -72,6 +75,27 @@ class SendTransactionExceptionError(Exception):
         elif self.tx_rlp is not None:
             return f"{base} Transaction RLP={self.tx_rlp.hex()}"
         return base
+
+
+class ForkchoiceUpdateTimeoutError(Exception):
+    """Raised when forkchoice update doesn't reach VALID within retry limits."""
+
+    def __init__(
+        self,
+        attempts: int,
+        elapsed: float,
+        interval: float,
+        final_status: PayloadStatusEnum,
+    ):
+        """Initialize with retry statistics and final status."""
+        self.attempts = attempts
+        self.elapsed = elapsed
+        self.interval = interval
+        self.final_status = final_status
+        super().__init__(
+            f"Forkchoice update failed to reach VALID after {attempts} attempts "
+            f"over {elapsed:.1f}s (interval: {interval}s), final status: {final_status}"
+        )
 
 
 class BaseRPC:
@@ -732,6 +756,80 @@ class EngineRPC(BaseRPC):
             response,
             context=self.response_validation_context,
         )
+
+
+def forkchoice_updated_with_retry(
+    engine_rpc: EngineRPC,
+    forkchoice_state: ForkchoiceState,
+    forkchoice_version: int,
+    *,
+    max_attempts: int = 30,
+    wait_fixed: float = 1.0,
+    on_retry: Callable[[RetryCallState], None] | None = None,
+) -> ForkchoiceUpdateResponse:
+    """
+    Send forkchoice update, retrying while SYNCING until a terminal status.
+
+    Retries only while the client returns SYNCING status. Returns immediately
+    on any terminal status (VALID, INVALID, ACCEPTED, etc.) - the caller is
+    responsible for checking if the returned status matches expectations.
+
+    Args:
+        engine_rpc: The EngineRPC instance to use.
+        forkchoice_state: The forkchoice state to send.
+        forkchoice_version: The forkchoice updated version (e.g., 1, 2, 3).
+        max_attempts: Maximum number of attempts before giving up.
+        wait_fixed: Fixed interval in seconds between retries.
+        on_retry: Optional callback invoked before each retry sleep.
+            Receives tenacity RetryCallState. If None, logs at debug level.
+
+    Returns:
+        ForkchoiceUpdateResponse with a terminal status (VALID, INVALID, etc.).
+
+    Raises:
+        ForkchoiceUpdateTimeoutError: If still SYNCING after max_attempts.
+    """
+    # Track state for exception message in the case of timeout
+    attempts = 0
+    start_time = time.time()
+    last_response: ForkchoiceUpdateResponse | None = None
+
+    def default_on_retry(retry_state: RetryCallState) -> None:
+        logger.debug(
+            f"Forkchoice update attempt {retry_state.attempt_number}: "
+            f"status={last_response.payload_status.status if last_response else 'N/A'}, "
+            f"retrying in {wait_fixed}s..."
+        )
+
+    retry_callback = on_retry if on_retry is not None else default_on_retry
+
+    @retry(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_fixed_tenacity(wait_fixed),
+        before_sleep=retry_callback,
+        reraise=True,
+    )
+    def _do_forkchoice_update() -> ForkchoiceUpdateResponse:
+        nonlocal attempts, last_response
+        attempts += 1
+        response = engine_rpc.forkchoice_updated(
+            forkchoice_state=forkchoice_state,
+            payload_attributes=None,
+            version=forkchoice_version,
+        )
+        last_response = response
+        status = response.payload_status.status
+        logger.info(f"Forkchoice update attempt {attempts}: {status}")
+        if status == PayloadStatusEnum.SYNCING:
+            raise ForkchoiceUpdateTimeoutError(
+                attempts=attempts,
+                elapsed=time.time() - start_time,
+                interval=wait_fixed,
+                final_status=status,
+            )
+        return response
+
+    return _do_forkchoice_update()
 
 
 class NetRPC(BaseRPC):

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -119,6 +119,30 @@ class ForkchoiceUpdateTimeoutError(Exception):
         )
 
 
+class PeerConnectionTimeoutError(Exception):
+    """Raised when peer connection is not established within retry limits."""
+
+    def __init__(
+        self,
+        attempts: int,
+        elapsed: float,
+        interval: float,
+        expected_peers: int,
+        actual_peers: int,
+    ):
+        """Initialize with retry statistics and peer counts."""
+        self.attempts = attempts
+        self.elapsed = elapsed
+        self.interval = interval
+        self.expected_peers = expected_peers
+        self.actual_peers = actual_peers
+        super().__init__(
+            f"Peer connection not established after {attempts} attempts "
+            f"over {elapsed:.1f}s (interval: {interval}s), "
+            f"expected >= {expected_peers} peers, got {actual_peers}"
+        )
+
+
 class BaseRPC:
     """
     Represents a base RPC class for every RPC call used within EEST based hive
@@ -917,6 +941,66 @@ class NetRPC(BaseRPC):
         """`net_peerCount`: Get the number of peers connected to the client."""
         response = self.post_request(method="peerCount")
         return int(response, 16)  # hex -> int
+
+    def wait_for_peer_connection(
+        self,
+        *,
+        min_peers: int = 1,
+        max_attempts: int = 15,
+        wait_fixed: float = 0.1,
+        on_retry: Callable[[RetryCallState], None] | None = None,
+    ) -> int:
+        """
+        Wait for peer connections to be established.
+
+        Args:
+            min_peers: Minimum number of peers required.
+            max_attempts: Maximum number of attempts before giving up.
+            wait_fixed: Fixed interval in seconds between retries.
+            on_retry: Optional callback invoked before each retry sleep.
+                Receives tenacity RetryCallState. If None, logs at debug level.
+
+        Returns:
+            The peer count once min_peers threshold is reached.
+
+        Raises:
+            PeerConnectionTimeoutError: If min_peers not reached within limits.
+        """
+        attempts = 0
+        start_time = time.time()
+        last_peer_count = 0
+
+        def default_on_retry(retry_state: RetryCallState) -> None:
+            logger.debug(
+                f"Waiting for peer connection, attempt {retry_state.attempt_number}: "
+                f"{last_peer_count} peers, need >= {min_peers}, "
+                f"retrying in {wait_fixed}s..."
+            )
+
+        retry_callback = on_retry if on_retry is not None else default_on_retry
+
+        @retry(
+            stop=stop_after_attempt(max_attempts),
+            wait=wait_fixed_tenacity(wait_fixed),
+            before_sleep=retry_callback,
+            reraise=True,
+        )
+        def _wait_for_peers() -> int:
+            nonlocal attempts, last_peer_count
+            attempts += 1
+            peer_count = self.peer_count()
+            last_peer_count = peer_count
+            if peer_count < min_peers:
+                raise PeerConnectionTimeoutError(
+                    attempts=attempts,
+                    elapsed=time.time() - start_time,
+                    interval=wait_fixed,
+                    expected_peers=min_peers,
+                    actual_peers=peer_count,
+                )
+            return peer_count
+
+        return _wait_for_peers()
 
 
 class AdminRPC(BaseRPC):

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -77,6 +77,27 @@ class SendTransactionExceptionError(Exception):
         return base
 
 
+class BlockNotAvailableError(Exception):
+    """Raised when block is not available after retry attempts."""
+
+    def __init__(
+        self,
+        block_hash: Hash,
+        attempts: int,
+        elapsed: float,
+        interval: float,
+    ):
+        """Initialize with retry statistics."""
+        self.block_hash = block_hash
+        self.attempts = attempts
+        self.elapsed = elapsed
+        self.interval = interval
+        super().__init__(
+            f"Block {block_hash} not available after {attempts} attempts "
+            f"over {elapsed:.1f}s (interval: {interval}s)"
+        )
+
+
 class ForkchoiceUpdateTimeoutError(Exception):
     """Raised when forkchoice update doesn't reach VALID within retry limits."""
 
@@ -329,6 +350,63 @@ class EthRPC(BaseRPC):
         params = [f"{block_hash}", full_txs]
         response = self.post_request(method="getBlockByHash", params=params)
         return response
+
+    def get_block_by_hash_with_retry(
+        self,
+        block_hash: Hash,
+        *,
+        max_attempts: int = 5,
+        wait_fixed: float = 1.0,
+        on_retry: Callable[[RetryCallState], None] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get block by hash, retrying if not yet available.
+
+        Args:
+            block_hash: The hash of the block to retrieve.
+            max_attempts: Maximum number of attempts before giving up.
+            wait_fixed: Fixed interval in seconds between retries.
+            on_retry: Optional callback invoked before each retry sleep.
+                Receives tenacity RetryCallState. If None, logs at debug level.
+
+        Returns:
+            Block data as a dictionary.
+
+        Raises:
+            BlockNotAvailableError: If block not available after max_attempts.
+        """
+        attempts = 0
+        start_time = time.time()
+
+        def default_on_retry(retry_state: RetryCallState) -> None:
+            logger.debug(
+                f"Block {block_hash} not available, "
+                f"attempt {retry_state.attempt_number}, "
+                f"retrying in {wait_fixed}s..."
+            )
+
+        retry_callback = on_retry if on_retry is not None else default_on_retry
+
+        @retry(
+            stop=stop_after_attempt(max_attempts),
+            wait=wait_fixed_tenacity(wait_fixed),
+            before_sleep=retry_callback,
+            reraise=True,
+        )
+        def _get_block() -> dict[str, Any]:
+            nonlocal attempts
+            attempts += 1
+            block = self.get_block_by_hash(block_hash)
+            if block is None:
+                raise BlockNotAvailableError(
+                    block_hash=block_hash,
+                    attempts=attempts,
+                    elapsed=time.time() - start_time,
+                    interval=wait_fixed,
+                )
+            return block
+
+        return _get_block()
 
     def get_balance(
         self, address: Address, block_number: BlockNumberType = "latest"


### PR DESCRIPTION
## 🗒️ Description

This PR was intended to be a pure refactor, but streamlining the simulator retry logic was more involved than expected: 

- Add tenacity-based retry helpers to the RPC module for:
  -  forkchoice updates, 
  - block retrieval,
  - peer connection waiting.
- Consolidate duplicate `LoggedError` definitions into `helpers/exceptions.py`.
- Refactor `test_via_engine.py` and `test_via_sync.py` to use the new helpers, reducing boilerplate retry code.

**Note:** This is not a pure refactor. The retry mechanism in `test_via_sync.py` changes from exponential backoff to fixed intervals for simplicity and consistency; see "Retry Behavior Changes".

#### Bug Fixes

An incorrect enum comparison in the `consume sync` sync wait loop has been fixed: `if status.VALID:` → `if status == PayloadStatusEnum.VALID`. The old code accessed the enum class attribute via the instance (`status.VALID` returns `PayloadStatusEnum.VALID`), which is always truthy - causing the loop to break immediately regardless of the actual status.

TIL: Python enums allow accessing class members through instances. status.VALID is equivalent to type(status).VALID.

#### Speed-up

Speed-up in `consume sync` test execution, `consume sync -k "fork_Osaka-blockchain_test_sync" --input=develop@v5.4.0` with go-ethereum, [before](https://github.com/ethereum/execution-specs/commit/cafe03264f4629f179a1a8fdf9e5437dd3612654): ~30 seconds, after: ~17 seconds for 4 tests. 8 seconds come from removing two hard-coded 1 second sleeps which was to allow time for peers to connect. I think the rest might come from faster polling in the initial genesis fcu update, but didn't check more closely.

### Changes

#### RPC Module (`rpc/rpc.py`)

- Add `forkchoice_updated_with_retry()` function that retries while status is `SYNCING` and returns on any terminal status (`VALID`, `INVALID`, `ACCEPTED`).
- Add `EthRPC.get_block_by_hash_with_retry()` method that retries while block is `None`.
- Add `NetRPC.wait_for_peer_connection()` method that polls `net_peerCount` until peers are connected.
- Add exceptions with diagnostic info: `ForkchoiceUpdateTimeoutError`, `BlockNotAvailableError`, `PeerConnectionTimeoutError`.

#### Simulator Logic

- Replace manual retry loops with tenacity-based helpers.
- Replace `time.sleep(1)` peer connection waits with `wait_for_peer_connection()`.
- Differentiate error messages: "Unexpected status" vs "Timed out waiting".

### Retry Behavior Changes

| Location | Before | After | Notes |
|----------|--------|-------|-------|
| `test_via_sync.py`: Init client FCU | 3 attempts, exponential (~1.5s total wait) | 4 attempts, fixed 0.5s (~1.5s total wait) | Parity maintained |
| `test_via_sync.py`: Init sync client FCU | 3 attempts, exponential (~1.5s total wait) | 4 attempts, fixed 0.5s (~1.5s total wait) | Parity maintained |
| `test_via_sync.py`: Peer connection wait | `time.sleep(1)` fixed wait | `wait_for_peer_connection()` polling (up to 1.5s) | Polls every 100ms, may return earlier |
| `test_via_engine.py`: Init FCU | 30 attempts, fixed 1.0s | 30 attempts, fixed 1.0s | No change |
| `test_via_sync.py`: Sync wait FCU | 15s timeout, 0.5s poll, 2s FCU interval | 30 attempts, fixed 0.5s (~15s timeout) | Simplified, sends FCU every attempt |
| `test_via_sync.py`: Block verification | 5 attempts, 1.0s interval | 5 attempts, 1.0s interval | No change |

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

#### Cute Animal Picture

<img width="400" alt="image" src="https://github.com/user-attachments/assets/500cd00c-c218-4d64-bb71-e4367f852499" />
