### PR TITLE
feat(spec-tests): update json infra test version

### DIFF
--- a/tests/json_infra/__init__.py
+++ b/tests/json_infra/__init__.py
@@ -31,7 +31,7 @@ TEST_FIXTURES: Dict[str, _FixtureSource] = {
         "fixture_path": "tests/json_infra/fixtures/latest_fork_tests",
     },
     "amsterdam_tests": {
-        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v1.8.0/fixtures_bal.tar.gz",
+        "url": "https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v3.0.1/fixtures_bal.tar.gz",
         "fixture_path": "tests/json_infra/fixtures/amsterdam_tests",
     },
 }


### PR DESCRIPTION
## 🗒️ Description

- This is a `feat` / `fix` as the json infra tests are currently not working since we were not generating the bal hash appropriately. This is likely fixed in the new tests version, so updating this here and putting up a PR to run the CI and double check. We should address any remaining issues in this PR, if any.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
See #1844 for more context

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
