### PR TITLE
chore(tox): remove hardcoded fork and fetch latest

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🛠️ Framework
 
 #### `fill`
+- 🔀 Remove hardcoded fork names in `tox.ini` commands and fetch the latest fork using `ethereum-spec-forks` CLI tool ([#1945](https://github.com/ethereum/execution-specs/pull/1945)).
 
 #### `consume`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ ethereum-spec-sync = "ethereum_spec_tools.sync:main"
 ethereum-spec-new-fork = "ethereum_spec_tools.new_fork.cli:main"
 ethereum-spec-patch = "ethereum_spec_tools.patch_tool:main"
 ethereum-spec-evm = "ethereum_spec_tools.evm_tools:main"
+ethereum-spec-forks = "ethereum_spec_tools.cli_forks:main"
 whitelist = "ethereum_spec_tools.whitelist:main"
 
 [project.entry-points."docc.plugins"]

--- a/src/ethereum_spec_tools/cli_forks.py
+++ b/src/ethereum_spec_tools/cli_forks.py
@@ -1,0 +1,168 @@
+"""CLI tool that queries Ethereum hardfork information."""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from ethereum_spec_tools.forks import Hardfork
+else:
+    try:
+        from ethereum_spec_tools.forks import Hardfork
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).parent.parent))
+        from hardfork import Hardfork  # type: ignore[import-not-found]
+
+
+def fork_by_index(forks: List[Hardfork], index: int) -> Optional[Hardfork]:
+    """
+    Get fork by index, where 0 being Frontier and -1 being the most recent.
+    """
+    if not forks:
+        return None
+
+    if index < 0:
+        # Negative indexing: -1 is last, -2 is second last, etc.
+        if abs(index) <= len(forks):
+            return forks[index]
+        else:
+            return None
+    else:
+        # Positive indexing: 0 is first (Frontier), 1 is second, etc.
+        if index < len(forks):
+            return forks[index]
+        else:
+            return None
+
+
+def format_fork_info(fork: Hardfork, format_type: str) -> str:
+    """
+    Format fork information based on the requested format type.
+    """
+    if format_type == "name":
+        return fork.short_name
+    elif format_type == "title":
+        return fork.title_case_name
+    elif format_type == "full-name":
+        return fork.name
+    elif format_type == "test-name":
+        return f"test_{fork.short_name}"
+    elif format_type == "criteria":
+        return str(fork.criteria)
+    elif format_type == "consensus":
+        return fork.consensus.name.lower()
+    else:
+        return fork.short_name
+
+
+def main() -> None:
+    """
+    Main entry point for the CLI.
+    """
+    parser = argparse.ArgumentParser(
+        prog="ethereum-spec-forks",
+        description=(
+            "Query Ethereum hardfork information for testing and development"
+        ),
+    )
+
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument(
+        "-n",
+        "--fork-number",
+        type=int,
+        help="Fork number (0=Frontier, -1=most recent, etc.)",
+    )
+
+    # Format options (mutually exclusive)
+    format_group = parser.add_mutually_exclusive_group()
+
+    format_group.add_argument(
+        "--name",
+        action="store_true",
+        help="Output short name (default)",
+    )
+
+    format_group.add_argument(
+        "--title",
+        action="store_true",
+        help="Output title case name",
+    )
+
+    format_group.add_argument(
+        "--full-name",
+        action="store_true",
+        help="Output full module name",
+    )
+
+    format_group.add_argument(
+        "--test-name",
+        action="store_true",
+        help="Output test name format",
+    )
+
+    format_group.add_argument(
+        "--criteria",
+        action="store_true",
+        help="Output fork criteria",
+    )
+
+    format_group.add_argument(
+        "--consensus",
+        action="store_true",
+        help="Output consensus type",
+    )
+
+    # Base path option for development
+    parser.add_argument(
+        "--base-path",
+        type=Path,
+        help="Base path to ethereum module (for development)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        if args.base_path:
+            forks = Hardfork.discover(
+                submodule_search_locations=[str(args.base_path)]
+            )
+        else:
+            forks = Hardfork.discover()
+    except Exception as e:
+        print(f"Error discovering forks: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not forks:
+        print("No forks found", file=sys.stderr)
+        sys.exit(1)
+
+    if args.fork_number is not None:
+        fork = fork_by_index(forks, args.fork_number)
+        if fork is None:
+            print(f"Fork index {args.fork_number} not found", file=sys.stderr)
+            sys.exit(1)
+
+        if args.title:
+            format_type = "title"
+        elif args.full_name:
+            format_type = "full-name"
+        elif args.test_name:
+            format_type = "test-name"
+        elif args.criteria:
+            format_type = "criteria"
+        elif args.consensus:
+            format_type = "consensus"
+        else:
+            format_type = "name"
+
+        print(format_fork_info(fork, format_type))
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@ requires =
     tox-uv>=1.29,<2
 # Get a description of all available environments with `uvx tox -av`
 envlist =
-    py3
-    pypy3
+    py3_unix
+    py3_win
+    pypy3_unix
+    pypy3_win
     json_infra
     static
     optimized
@@ -71,8 +73,11 @@ commands =
         {posargs} \
         tests/json_infra
 
-[testenv:py3]
-description = Fill the tests using EELS (with Python)
+[testenv:py3_unix]
+platform = linux|darwin
+description = Fill the tests using EELS (with Python on Unix)
+allowlist_externals = 
+    bash
 commands =
     fill \
         -m "not slow and not zkevm and not benchmark" \
@@ -86,18 +91,57 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \
-        --until BPO4 \
         {posargs} \
         tests
+    bash -c 'fill \
+        -m "not slow and not zkevm and not benchmark" \
+        -n auto --maxprocesses 10 --dist=loadgroup \
+        --cov-config=pyproject.toml \
+        --cov=ethereum \
+        --cov-report=term \
+        --cov-report "xml:{toxworkdir}/coverage.xml" \
+        --no-cov-on-fail \
+        --cov-branch \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        --fork "$(ethereum-spec-forks -n -1 --title)" \
+        {posargs} \
+        "tests/$(ethereum-spec-forks -n -1 --name)"'
 
-[testenv:pypy3]
-description = Fill the tests using EELS (with PyPy)
+[testenv:py3_win]
+platform = win32
+description = Fill the tests using EELS (with Python on Windows)
+allowlist_externals = 
+    powershell
+commands =
+    fill \
+        -m "not slow and not zkevm and not benchmark" \
+        -n auto --maxprocesses 10 --dist=loadgroup \
+        --cov-config=pyproject.toml \
+        --cov=ethereum \
+        --cov-report=term \
+        --cov-report "xml:{toxworkdir}/coverage.xml" \
+        --no-cov-on-fail \
+        --cov-branch \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        {posargs} \
+        tests
+    powershell -c "$title = ethereum-spec-forks -n -1 --title; $name = ethereum-spec-forks -n -1 --name; fill -m 'not slow and not zkevm and not benchmark' -n auto --maxprocesses 10 --dist=loadgroup --cov-config=pyproject.toml --cov=ethereum --cov-report=term --cov-report 'xml:{toxworkdir}/coverage.xml' --no-cov-on-fail --cov-branch --basetemp='{temp_dir}/pytest' --log-to '{toxworkdir}/logs' --clean --fork \"$title\" {posargs} \"tests/$name\""
+
+[testenv:pypy3_unix]
+platform = linux|darwin
+description = Fill the tests using EELS (with PyPy on Unix)
 # see comment for tests_pytest_pypy3
 dependency_groups =
     test
 passenv =
     PYPY_GC_MAX
     PYPY_GC_MIN
+allowlist_externals = 
+    bash
 commands =
     fill \
         --skip-index \
@@ -113,6 +157,48 @@ commands =
         --until BPO4 \
         {posargs} \
         tests
+    bash -c 'fill \
+        --skip-index \
+        --no-html \
+        --tb=no \
+        --show-capture=no \
+        --disable-warnings \
+        -m "not slow and not zkevm and not benchmark" \
+        -n auto --maxprocesses 7 --dist=loadgroup \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        --fork "$(ethereum-spec-forks -n -1 --title)" \
+        {posargs} \
+        "tests/$(ethereum-spec-forks -n -1 --name)"'
+
+[testenv:pypy3_win]
+platform = win32
+description = Fill the tests using EELS (with PyPy on Windows)
+# see comment for tests_pytest_pypy3
+dependency_groups =
+    test
+passenv =
+    PYPY_GC_MAX
+    PYPY_GC_MIN
+allowlist_externals = 
+    powershell
+commands =
+    fill \
+        --skip-index \
+        --no-html \
+        --tb=no \
+        --show-capture=no \
+        --disable-warnings \
+        -m "not slow and not zkevm and not benchmark" \
+        -n auto --maxprocesses 7 --dist=loadgroup \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        --until BPO4 \
+        {posargs} \
+        tests
+    powershell -c "$title = ethereum-spec-forks -n -1 --title; $name = ethereum-spec-forks -n -1 --name; fill --skip-index --no-html --tb=no --show-capture=no --disable-warnings -m 'not slow and not zkevm and not benchmark' -n auto --maxprocesses 7 --dist=loadgroup --basetemp='{temp_dir}/pytest' --log-to '{toxworkdir}/logs' --clean --fork \"$title\" {posargs} \"tests/$name\""
 
 [testenv:benchmark]
 description = Fill the benchmark tests using evmone-t8n (with Python)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Here a CLI command has been implemented called ethereum-spec-forks to fetch hardfork information. I've used it in `tox.ini` to fetch the latest fork.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Related to Issue #1330 and previously opened PR #1337 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2020/06/30/22/34/dog-5357794_1280.jpg)
