### PR TITLE
Refactor(test-benchmark): benchmark regex matching logic

### DIFF
--- a/packages/testing/src/execution_testing/cli/benchmark_parser.py
+++ b/packages/testing/src/execution_testing/cli/benchmark_parser.py
@@ -11,12 +11,54 @@ Usage:
 
 import argparse
 import ast
+import re
 import sys
 from pathlib import Path
 
 from execution_testing.cli.pytest_commands.plugins.shared.benchmarking import (
     OpcodeCountsConfig,
 )
+
+
+def is_broader_pattern(pattern: str, detected_patterns: set[str]) -> bool:
+    """
+    Check if a pattern is a broader match that covers any detected patterns.
+
+    A broader pattern like "test_bitwise.*" covers more specific patterns like
+    "test_bitwise.*AND.*". These user-defined broader patterns should be preserved
+    since they provide a convenient way to configure multiple tests at once.
+
+    Returns True if the pattern matches at least one detected pattern.
+    """
+    try:
+        regex = re.compile(pattern)
+        for detected in detected_patterns:
+            # Check if the broader pattern matches the detected pattern string
+            # e.g., "test_bitwise.*" matches "test_bitwise.*AND.*"
+            if regex.search(detected):
+                return True
+    except re.error:
+        pass
+    return False
+
+
+def is_covered_by_broader(pattern: str, broader_patterns: list[str]) -> bool:
+    """
+    Check if a pattern is covered by any of the broader patterns.
+
+    For example, "test_push.*PUSH16.*" is covered by "test_push.*".
+    This is used to skip adding new detected patterns that are already
+    covered by user-defined broader patterns.
+
+    Returns True if the pattern is covered by at least one broader pattern.
+    """
+    for broader in broader_patterns:
+        try:
+            if re.search(broader, pattern):
+                return True
+        except re.error:
+            continue
+    return False
 
 
 def get_repo_root() -> Path:
@@ -243,26 +285,52 @@ def categorize_patterns(
     """
     Categorize patterns by deriving category from source file name.
 
-    Example: test_arithmetic.py -> ARITHMETIC
+    For detected patterns: use source file name (e.g., test_arithmetic.py -> ARITHMETIC)
+    For user-defined broader patterns: find a detected pattern it covers and use that
+    source file (e.g., test_push.* covers test_push.*PUSH0.* -> use test_push.py -> PUSH)
+
+    Categories are ordered by folder structure (instruction, precompile, scenario),
+    then alphabetically within each folder.
     """
-    categories: dict[str, list[str]] = {}
+    # Track category -> (folder, patterns)
+    category_info: dict[str, tuple[str, list[str]]] = {}
 
     for pattern in config.keys():
+        category = "OTHER_CATEGORY"
+        folder = "OTHER_FOLDER"  # Sort last
+
         if pattern in pattern_sources:
+            # Detected pattern: use its source file
             source_file = pattern_sources[pattern]
             file_name = source_file.stem
+            folder = source_file.parent.name
             if file_name.startswith("test_"):
-                category = file_name[5:].upper()  # Remove "test_" prefix
-            else:
-                category = "OTHER"
+                category = file_name[5:].upper()
         else:
-            category = "OTHER"
+            # User-defined pattern: find a detected pattern it covers
+            try:
+                regex = re.compile(pattern)
+                for detected, source_file in pattern_sources.items():
+                    if regex.search(detected):
+                        file_name = source_file.stem
+                        folder = source_file.parent.name
+                        if file_name.startswith("test_"):
+                            category = file_name[5:].upper()
+                        break
+            except re.error:
+                pass
 
-        if category not in categories:
-            categories[category] = []
-        categories[category].append(pattern)
+        if category not in category_info:
+            category_info[category] = (folder, [])
+        category_info[category][1].append(pattern)
 
-    return {k: sorted(v) for k, v in sorted(categories.items())}
+    # Sort by folder first, then by category name within each folder
+    sorted_categories = sorted(
+        category_info.items(),
+        key=lambda item: (item[1][0], item[0]),  # (folder, category_name)
+    )
+
+    return {k: sorted(patterns) for k, (_, patterns) in sorted_categories}
 
 
 def generate_config_json(
@@ -314,13 +382,42 @@ def main() -> int:
 
     detected_keys = set(detected.keys())
     existing_keys = set(existing.keys())
-    new_patterns = sorted(detected_keys - existing_keys)
-    obsolete_patterns = sorted(existing_keys - detected_keys)
+    potentially_obsolete = existing_keys - detected_keys
 
-    merged = detected.copy()
-    for pattern, counts in existing.items():
-        if pattern in detected_keys:
+    # Separate broader patterns (user-defined, cover detected patterns) from truly obsolete
+    broader_patterns: list[str] = []
+    obsolete_patterns: list[str] = []
+    for pattern in potentially_obsolete:
+        if is_broader_pattern(pattern, detected_keys):
+            broader_patterns.append(pattern)
+        else:
+            obsolete_patterns.append(pattern)
+    broader_patterns = sorted(broader_patterns)
+    obsolete_patterns = sorted(obsolete_patterns)
+
+    # Filter new patterns: skip those already covered by broader patterns
+    all_new_patterns = detected_keys - existing_keys
+    new_patterns: list[str] = []
+    skipped_patterns: list[str] = []
+    for pattern in sorted(all_new_patterns):
+        if is_covered_by_broader(pattern, broader_patterns):
+            skipped_patterns.append(pattern)
+        else:
+            new_patterns.append(pattern)
+
+    # Merge: start with detected, preserve existing counts, and keep broader patterns
+    # But skip detected patterns that are covered by broader patterns (unless in existing)
+    merged: dict[str, list[int]] = {}
+    for pattern, counts in detected.items():
+        if pattern in existing_keys:
+            # Preserve existing counts for patterns that were already in config
+            merged[pattern] = existing[pattern]
+        elif not is_covered_by_broader(pattern, broader_patterns):
+            # Add new detected patterns only if not covered by broader patterns
             merged[pattern] = counts
+    # Add broader patterns
+    for pattern in broader_patterns:
+        merged[pattern] = existing[pattern]
 
     print("\n" + "=" * 60)
     print(f"Detected {len(detected)} patterns in tests")
@@ -332,6 +429,21 @@ def main() -> int:
             print(f"    {p}")
         if len(new_patterns) > 15:
             print(f"    ... and {len(new_patterns) - 15} more")
+
+    if skipped_patterns:
+        print(
+            f"\n  Skipped {len(skipped_patterns)} patterns "
+            "(covered by broader patterns)"
+        )
+
+    if broader_patterns:
+        print(
+            f"\n~ Preserving {len(broader_patterns)} BROADER patterns (user-defined):"
+        )
+        for p in broader_patterns[:15]:
+            print(f"    {p}")
+        if len(broader_patterns) > 15:
+            print(f"    ... and {len(broader_patterns) - 15} more")
 
     if obsolete_patterns:
         print(f"\n- Found {len(obsolete_patterns)} OBSOLETE patterns:")

--- a/packages/testing/src/execution_testing/cli/benchmark_parser.py
+++ b/packages/testing/src/execution_testing/cli/benchmark_parser.py
@@ -274,9 +274,10 @@ def generate_config_json(
     categories = categorize_patterns(config, pattern_sources)
 
     scenario_configs: dict[str, list[int]] = {}
+    output = OpcodeCountsConfig(scenario_configs=scenario_configs)
     for _, patterns in categories.items():
         for pattern in patterns:
-            scenario_configs[pattern] = config[pattern]
+            output.scenario_configs[pattern] = config[pattern]
 
     return OpcodeCountsConfig(
         scenario_configs=scenario_configs,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -224,7 +224,7 @@ def pytest_collection_modifyitems(
     #
     # Here we filter out tests that do not use the benchmark_test fixture.
     # Note: At this stage we cannot filter based on whether a code generator is used.
-    if fixed_opcode_count is not None:
+    if fixed_opcode_count:
         filtered = []
         for item in items:
             if (
@@ -234,9 +234,22 @@ def pytest_collection_modifyitems(
                 filtered.append(item)
         items[:] = filtered
 
-    # Extract the specified flag from the command line.
-    # If the `-m repricing` flag is not specified, or is negated,
-    # we skip filtering tests by the repricing marker.
+    # Load config data if --fixed-opcode-count flag provided without value
+    if fixed_opcode_count == "":
+        config_data = load_opcode_counts_config(config)
+        if config_data:
+            config._opcode_counts_config = config_data  # type: ignore[attr-defined]
+        else:
+            warnings.warn(
+                "--fixed-opcode-count was provided without a value, but "
+                ".fixed_opcode_counts.json was not found. "
+                "Run 'uv run benchmark_parser' to generate it, or provide "
+                "explicit values (e.g., --fixed-opcode-count 1,10,100).",
+                UserWarning,
+                stacklevel=1,
+            )
+
+    # Check if -m repricing marker filter was specified
     markexpr = config.getoption("markexpr", "")
     if "repricing" not in markexpr or "not repricing" in markexpr:
         return

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -61,7 +61,7 @@ def pytest_configure(config: pytest.Config) -> None:
     fixed_opcode_count = OpcodeCountsConfig.from_config(config)
     if gas_benchmark_values is not None and fixed_opcode_count is not None:
         raise pytest.UsageError(
-            f"{GasBenchmarkValues.flag} and --fixed-opcode-count are mutually exclusive. "
+            f"{GasBenchmarkValues.flag} and {OpcodeCountsConfig.flag} are mutually exclusive. "
             "Use only one at a time."
         )
 
@@ -182,20 +182,28 @@ class OpcodeCountsConfig(BaseModel, BenchmarkParametrizer):
     def get_test_parameters(self, test_name: str) -> list[ParameterSet]:
         """
         Get opcode counts for a test using regex pattern matching.
+
+        Uses most-specific-match-wins: longer patterns take priority over shorter ones.
+        This allows broad patterns like "test_bitwise.*" to be overridden by more
+        specific patterns like "test_bitwise.*AND.*".
         """
         counts = self.default_counts
-        # Try exact match first (faster)
+        # Try exact match first (most specific possible)
         if test_name in self.scenario_configs:
             counts = self.scenario_configs[test_name]
         else:
-            # Try regex patterns
+            # Find the most specific (longest) matching pattern
+            best_match_length = -1
             for pattern, pattern_counts in self.scenario_configs.items():
                 if pattern == test_name:
                     continue
                 try:
-                    if re.search(pattern, test_name):
+                    if (
+                        re.search(pattern, test_name)
+                        and len(pattern) > best_match_length
+                    ):
+                        best_match_length = len(pattern)
                         counts = pattern_counts
-                        break
                 except re.error:
                     continue
         return [

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -249,7 +249,9 @@ def pytest_collection_modifyitems(
                 stacklevel=1,
             )
 
-    # Check if -m repricing marker filter was specified
+    # Extract the specified flag from the command line.
+    # If the `-m repricing` flag is not specified, or is negated,
+    # we skip filtering tests by the repricing marker.
     markexpr = config.getoption("markexpr", "")
     if "repricing" not in markexpr or "not repricing" in markexpr:
         return
@@ -259,7 +261,6 @@ def pytest_collection_modifyitems(
         # If the test does not have the repricing marker, skip it
         repricing_marker = item.get_closest_marker("repricing")
         if not repricing_marker:
-            filtered.append(item)
             continue
 
         # If the test has the repricing marker but no specific kwargs,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -224,7 +224,7 @@ def pytest_collection_modifyitems(
     #
     # Here we filter out tests that do not use the benchmark_test fixture.
     # Note: At this stage we cannot filter based on whether a code generator is used.
-    if fixed_opcode_count:
+    if fixed_opcode_count or fixed_opcode_count == "":
         filtered = []
         for item in items:
             if (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -246,6 +246,7 @@ def pytest_collection_modifyitems(
         # If the test does not have the repricing marker, skip it
         repricing_marker = item.get_closest_marker("repricing")
         if not repricing_marker:
+            filtered.append(item)
             continue
 
         # If the test has the repricing marker but no specific kwargs,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -224,7 +224,7 @@ def pytest_collection_modifyitems(
     #
     # Here we filter out tests that do not use the benchmark_test fixture.
     # Note: At this stage we cannot filter based on whether a code generator is used.
-    if fixed_opcode_count or fixed_opcode_count == "":
+    if fixed_opcode_count is not None:
         filtered = []
         for item in items:
             if (

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -234,21 +234,6 @@ def pytest_collection_modifyitems(
                 filtered.append(item)
         items[:] = filtered
 
-    # Load config data if --fixed-opcode-count flag provided without value
-    if fixed_opcode_count == "":
-        config_data = load_opcode_counts_config(config)
-        if config_data:
-            config._opcode_counts_config = config_data  # type: ignore[attr-defined]
-        else:
-            warnings.warn(
-                "--fixed-opcode-count was provided without a value, but "
-                ".fixed_opcode_counts.json was not found. "
-                "Run 'uv run benchmark_parser' to generate it, or provide "
-                "explicit values (e.g., --fixed-opcode-count 1,10,100).",
-                UserWarning,
-                stacklevel=1,
-            )
-
     # Extract the specified flag from the command line.
     # If the `-m repricing` flag is not specified, or is negated,
     # we skip filtering tests by the repricing marker.

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -380,7 +380,6 @@ def test_create(
     )
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -498,7 +497,6 @@ def test_return_revert(
     )
 
 
-@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_existing(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -380,6 +380,7 @@ def test_create(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -497,6 +498,7 @@ def test_return_revert(
     )
 
 
+@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_existing(
     benchmark_test: BenchmarkTestFiller,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
None

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
