### PR TITLE
bug(test-cli): fix extract config

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -26,19 +26,22 @@ def fixture_format_discriminator(v: Any) -> str | None:
     """Discriminator function that returns the model type as a string."""
     if v is None:
         return None
+    info_dict: Dict | None = None
     if isinstance(v, dict):
         info_dict = v.get("_info")
     elif hasattr(v, "info"):
         info_dict = v.info
-    assert info_dict is not None, (
-        f"Fixture does not have an info field, cannot determine fixture format: {v}"
-    )
+    if info_dict is None:
+        raise ValueError(
+            f"Fixture does not have an info field, cannot determine fixture format: {v}"
+        )
     fixture_format = info_dict.get("fixture-format")
     if not fixture_format:
         fixture_format = info_dict.get("fixture_format")
-    assert fixture_format is not None, (
-        f"Fixture format not found in info field: {info_dict}"
-    )
+    if fixture_format is None:
+        raise ValueError(
+            f"Fixture format not found in info field: {info_dict}"
+        )
     return fixture_format
 
 


### PR DESCRIPTION
## 🗒️ Description

Extracts the fix from #1901.

Also creates a GenesisState model for a cleaner code setup.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
