### PR TITLE
feat(tests): add new critical test cases for BN254 input validation

### DIFF
--- a/tests/byzantium/eip196_ec_add_mul/test_ecadd.py
+++ b/tests/byzantium/eip196_ec_add_mul/test_ecadd.py
@@ -205,6 +205,46 @@ def test_valid(
             b"",
             id="pt_6_9_plus_pt_0x126198c_0x1e4dc",
         ),
+        pytest.param(
+            PointG1(Spec.G1.x + Spec.P, Spec.G1.y) + Spec.INF_G1,
+            b"",
+            id="Pplus1_2_plus_inf",
+        ),
+        pytest.param(
+            PointG1(Spec.G1.x, Spec.G1.y + Spec.P) + Spec.INF_G1,
+            b"",
+            id="1_Pplus2_plus_inf",
+        ),
+        pytest.param(
+            Spec.INF_G1 + PointG1(Spec.G1.x + Spec.P, Spec.G1.y),
+            b"",
+            id="Pplus1_2_plus_inf",
+        ),
+        pytest.param(
+            Spec.INF_G1 + PointG1(Spec.G1.x, Spec.G1.y + Spec.P),
+            b"",
+            id="inf_plus_1_Pplus2",
+        ),
+        pytest.param(
+            PointG1(Spec.P, 0) + Spec.INF_G1,
+            b"",
+            id="P_0_plus_inf",
+        ),
+        pytest.param(
+            PointG1(0, Spec.P) + Spec.INF_G1,
+            b"",
+            id="0_P_plus_inf",
+        ),
+        pytest.param(
+            Spec.INF_G1 + PointG1(Spec.P, 0),
+            b"",
+            id="inf_plus_P_0",
+        ),
+        pytest.param(
+            Spec.INF_G1 + PointG1(0, Spec.P),
+            b"",
+            id="inf_plus_0_P",
+        ),
     ],
 )
 @pytest.mark.ported_from(


### PR DESCRIPTION
## 🗒️ Description
Add BN254 point validation test cases where at least one of the coordinates is in form (x + P), where x is valid and (x + P) is invalid, but (x + P) mod P becomes valid again. The test cases use ecadd precompile, but similar tests should be added for ecmul and ecpairing.

## 🔗 Related Issues or PRs
These are regression tests for a bug in evmone: https://github.com/ipsilon/evmone/pull/1399.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
