### PR TITLE
chore(docs): fix spelling and grammar errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ In particular, we appreciate support in the following areas:
 - Improving the documentation.
 
 > [!IMPORTANT]
-> Generally, we do not assign issues to external contributors. If you want to work on an issue, you are very welcome to go ahead and make a pull request. We would, hoever, be happy to answer questions you may have before you start implementing.
+> Generally, we do not assign issues to external contributors. If you want to work on an issue, you are very welcome to go ahead and make a pull request. We would, however, be happy to answer questions you may have before you start implementing.
 
-For details about EELS usage and building, please refer the [README](https://github.com/ethereum/execution-specs/blob/master/README.md#usage)
+For details about EELS usage and building, please refer to the [README](https://github.com/ethereum/execution-specs/blob/master/README.md#usage)
 
 ## Contribution Guidelines
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Ethereum specification is maintained as a Python library, for better integra
 
 Requires Python 3.11+
 
-### Building Specification Doucumentation
+### Building Specification Documentation
 
 Building the spec documentation is most easily done through [`tox`](https://tox.readthedocs.io/en/latest/):
 

--- a/src/ethereum/crypto/blake2.py
+++ b/src/ethereum/crypto/blake2.py
@@ -36,7 +36,7 @@ class Blake2:
     """
     Implementation of the BLAKE2 cryptographic hashing algorithm.
 
-    Please refer the following document for details:
+    Please refer to the following document for details:
     https://datatracker.ietf.org/doc/html/rfc7693
     """
 


### PR DESCRIPTION

Fix typos and missing prepositions in documentation files:

- Fix "Doucumentation" → "Documentation" 
- Fix "hoever" → "however" 
- Fix "refer the" → "refer to the"


