### PR TITLE
feat(test-benchmark): fixed precompile count support

### DIFF
--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -371,6 +371,7 @@ def test_alt_bn128(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,
@@ -418,7 +419,7 @@ def _generate_bn128_pairs(n: int, seed: int = 0) -> Bytes:
 def test_bn128_pairings_amortized(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
-    gas_benchmark_value: int,
+    tx_gas_limit: int,
 ) -> None:
     """Test running a block with as many BN128 pairings as possible."""
     base_cost = 45_000
@@ -432,9 +433,7 @@ def test_bn128_pairings_amortized(
     # This is a theoretical maximum number of pairings that can be done in a
     # block. It is only used for an upper bound for calculating the optimal
     # number of pairings below.
-    maximum_number_of_pairings = (
-        gas_benchmark_value - base_cost
-    ) // pairing_cost
+    maximum_number_of_pairings = (tx_gas_limit - base_cost) // pairing_cost
 
     # Discover the optimal number of pairings balancing two dimensions:
     # 1. Amortize the precompile base cost as much as possible.
@@ -444,7 +443,7 @@ def test_bn128_pairings_amortized(
     for i in range(1, maximum_number_of_pairings + 1):
         # We'll pass all pairing arguments via calldata.
         available_gas_after_intrinsic = (
-            gas_benchmark_value
+            tx_gas_limit
             - intrinsic_gas_calculator(
                 calldata=[0xFF]
                 * size_per_pairing
@@ -480,6 +479,7 @@ def test_bn128_pairings_amortized(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=setup,
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_blake2f.py
+++ b/tests/benchmark/compute/precompile/test_blake2f.py
@@ -47,6 +47,7 @@ def test_blake2f(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -115,6 +115,7 @@ def test_bls12_381(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -48,6 +48,7 @@ def test_ecrecover(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_modexp.py
+++ b/tests/benchmark/compute/precompile/test_modexp.py
@@ -408,6 +408,7 @@ def test_modexp(
         )
     )
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_p256verify.py
+++ b/tests/benchmark/compute/precompile/test_p256verify.py
@@ -79,6 +79,7 @@ def test_p256verify(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_point_evaluation.py
+++ b/tests/benchmark/compute/precompile/test_point_evaluation.py
@@ -48,6 +48,7 @@ def test_point_evaluation(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
             attack_block=attack_block,

--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -1,5 +1,6 @@
 """Benchmark RIPEMD-160 precompile."""
 
+import pytest
 from execution_testing import (
     BenchmarkTestFiller,
     Fork,
@@ -34,8 +35,26 @@ def test_ripemd160(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CODECOPY(0, 0, optimal_input_length),
             attack_block=attack_block,
+        ),
+    )
+
+
+@pytest.mark.parametrize("size", [0, 32, 256, 1024])
+def test_ripemd160_fixed_size(
+    benchmark_test: BenchmarkTestFiller, size: int
+) -> None:
+    """Benchmark RIPEMD160 with fixed size input."""
+    attack_block = Op.POP(
+        Op.STATICCALL(Op.GAS, 0x03, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CODECOPY(0, 0, size), attack_block=attack_block
         ),
     )

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -1,5 +1,6 @@
 """Benchmark SHA256 precompile."""
 
+import pytest
 from execution_testing import (
     BenchmarkTestFiller,
     Fork,
@@ -34,8 +35,26 @@ def test_sha256(
     )
 
     benchmark_test(
+        target_opcode=Op.STATICCALL,
         code_generator=JumpLoopGenerator(
             setup=Op.CODECOPY(0, 0, optimal_input_length),
             attack_block=attack_block,
+        ),
+    )
+
+
+@pytest.mark.parametrize("size", [0, 32, 256, 1024])
+def test_sha256_fixed_size(
+    benchmark_test: BenchmarkTestFiller, size: int
+) -> None:
+    """Benchmark SHA256 with fixed size input."""
+    attack_block = Op.POP(
+        Op.STATICCALL(Op.GAS, 0x02, Op.PUSH0, size, Op.PUSH0, Op.PUSH0)
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CODECOPY(0, 0, size), attack_block=attack_block
         ),
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This is for the gas repricing analysis effort. Our version 1 benchmark infra only supports the opcode (`tests/benchmark/compute/instruction`) scenario, and this adds support to the precompiles (`tests/benchmark/compute/precompiles`). Now we are able to support most of the precompiles, but still a subset of them are failling.
- Modexp: 54 fails
- BLS381: 8 fails
- BN128 12 fails

The issue seems to related to  insufficient gas consider the current block gas limit, but more in-depth analysis is required.

Other benchmark tests are running correctly under fill mode, we will later configure the `fixed_opcode_count.json` configuration for this after PR #1946 done.

Other enhancement:
- Add missing memory configurations for `IDENTITY`, `SHA256`, `RIPEMD160` precompiles.
- Fix broken benchmark by updating `gas_benchmark_value` to `tx_gas_limit` to consider eip-7825.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
