### PR TITLE
feat(test-benchmark): add missing fuzzy-compute configs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
+
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 
 ### 🛠️ Framework

--- a/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
+++ b/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
@@ -83,9 +83,9 @@ class ExtCallGenerator(BenchmarkCodeGenerator):
         code = self.setup + self.attack_block * max_iterations
         # Pad the code to the maximum code size.
         if self.code_padding_opcode is not None:
-            padding_size = fork.max_code_size() - len(code)
+            padding_size = fork.max_code_size() - len(code) - 1
             if padding_size > 0:
-                code += self.code_padding_opcode * padding_size
+                code += Op.STOP + self.code_padding_opcode * padding_size
 
         self._validate_code_size(code, fork)
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -64,7 +64,10 @@ def test_codesize(
     """Benchmark CODESIZE instruction."""
     benchmark_test(
         target_opcode=Op.CODESIZE,
-        code_generator=ExtCallGenerator(attack_block=Op.CODESIZE),
+        code_generator=ExtCallGenerator(
+            attack_block=Op.CODESIZE,
+            code_padding_opcode=Op.INVALID,
+        ),
     )
 
 
@@ -107,6 +110,28 @@ def test_codecopy(
             setup=setup,
             attack_block=attack_block,
             code_padding_opcode=Op.STOP,
+        ),
+    )
+
+
+@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("code_size", [0, 32, 256, 1024, 24576])
+def test_codecopy_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    mem_size: int,
+    code_size: int,
+) -> None:
+    """Benchmark CODECOPY with varying memory and code size config."""
+    setup = Op.MSTORE8(mem_size, 0xFF) if mem_size > 0 else Bytecode()
+
+    attack_block = Op.CODECOPY(Op.PUSH0, Op.PUSH0, code_size)
+
+    benchmark_test(
+        target_opcode=Op.CODECOPY,
+        code_generator=JumpLoopGenerator(
+            setup=setup,
+            attack_block=attack_block,
+            code_padding_opcode=Op.INVALID,
         ),
     )
 

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -58,7 +58,7 @@ def test_calldatasize(
     calldata = (
         b"\x00" * calldata_size
         if zero_data
-        else Bytes([i ^ 256 for i in range(calldata_size)])
+        else Bytes([i % 256 for i in range(calldata_size)])
     )
 
     benchmark_test(

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -125,7 +125,7 @@ def test_calldataload(
 ) -> None:
     """Benchmark CALLDATALOAD instruction."""
     calldata = (
-        b"\00" * calldata_size
+        b"\x00" * calldata_size
         if zero_data
         else Bytes([i % 256 for i in range(calldata_size)])
     )

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -202,17 +202,6 @@ def test_calldatacopy_from_origin(
 
 
 @pytest.mark.parametrize(
-    "mem_size",
-    [
-        pytest.param(0, id="0 bytes"),
-        pytest.param(32, id="32 bytes"),
-        pytest.param(256, id="256 bytes"),
-        pytest.param(1024, id="1KiB"),
-        pytest.param(10 * 1024, id="10KiB"),
-        pytest.param(1024 * 1024, id="1MiB"),
-    ],
-)
-@pytest.mark.parametrize(
     "fixed_src_dst",
     [
         True,

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -48,18 +48,24 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(calldata_length=10_000)
-@pytest.mark.parametrize("calldata_length", [0, 1_000, 10_000])
+@pytest.mark.repricing(calldata_size=10_000)
+@pytest.mark.parametrize("calldata_size", [0, 4, 36, 68, 256, 1024, 10_000])
+@pytest.mark.parametrize("zero_data", [True, False])
 def test_calldatasize(
-    benchmark_test: BenchmarkTestFiller,
-    calldata_length: int,
+    benchmark_test: BenchmarkTestFiller, calldata_size: int, zero_data: bool
 ) -> None:
     """Benchmark CALLDATASIZE instruction."""
+    calldata = (
+        b"\x00" * calldata_size
+        if zero_data
+        else Bytes([i ^ 256 for i in range(calldata_size)])
+    )
+
     benchmark_test(
         target_opcode=Op.CALLDATASIZE,
         code_generator=ExtCallGenerator(
             attack_block=Op.CALLDATASIZE,
-            tx_kwargs={"data": b"\x00" * calldata_length},
+            tx_kwargs={"data": calldata},
         ),
     )
 
@@ -112,25 +118,21 @@ def test_callvalue_from_call(
     )
 
 
-@pytest.mark.repricing(calldata=b"\x00")
-@pytest.mark.parametrize(
-    "calldata",
-    [
-        pytest.param(b"", id="empty"),
-        pytest.param(b"\x00", id="zero-loop"),
-        pytest.param(b"\x00" * 31 + b"\x20", id="one-loop"),
-    ],
-)
+@pytest.mark.parametrize("calldata_size", [0, 4, 36, 68, 256, 1024])
+@pytest.mark.parametrize("zero_data", [True, False])
 def test_calldataload(
-    benchmark_test: BenchmarkTestFiller,
-    calldata: bytes,
+    benchmark_test: BenchmarkTestFiller, calldata_size: int, zero_data: bool
 ) -> None:
     """Benchmark CALLDATALOAD instruction."""
+    calldata = (
+        b"\00" * calldata_size
+        if zero_data
+        else Bytes([i % 256 for i in range(calldata_size)])
+    )
     benchmark_test(
         target_opcode=Op.CALLDATALOAD,
         code_generator=JumpLoopGenerator(
-            setup=Op.PUSH0,
-            attack_block=Op.CALLDATALOAD,
+            attack_block=Op.CALLDATALOAD(Op.PUSH0),
             tx_kwargs={"data": calldata},
         ),
     )
@@ -138,10 +140,12 @@ def test_calldataload(
 
 @pytest.mark.repricing(size=0, fixed_src_dst=True, non_zero_data=False)
 @pytest.mark.parametrize(
-    "size",
+    "mem_size",
     [
         pytest.param(0, id="0 bytes"),
-        pytest.param(100, id="100 bytes"),
+        pytest.param(32, id="32 bytes"),
+        pytest.param(256, id="256 bytes"),
+        pytest.param(1024, id="1KiB"),
         pytest.param(10 * 1024, id="10KiB"),
         pytest.param(1024 * 1024, id="1MiB"),
     ],
@@ -154,50 +158,37 @@ def test_calldataload(
     ],
 )
 @pytest.mark.parametrize(
-    "non_zero_data",
-    [
-        True,
-        False,
-    ],
+    "calldata_size",
+    [0, 4, 36, 68, 256, 1024],
 )
 def test_calldatacopy_from_origin(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
-    size: int,
+    mem_size: int,
     fixed_src_dst: bool,
-    non_zero_data: bool,
+    calldata_size: int,
     tx_gas_limit: int,
 ) -> None:
     """Benchmark CALLDATACOPY instruction."""
-    if size == 0 and non_zero_data:
-        pytest.skip("Non-zero data with size 0 is not applicable.")
-
-    # If `non_zero_data` is True, we fill the calldata with deterministic
-    # random data. Note that if `size == 0` and `non_zero_data` is a skipped
-    # case.
-    data = Bytes([i % 256 for i in range(size)]) if non_zero_data else Bytes()
+    # Generate calldata of the specified size with deterministic data.
+    data = Bytes([i % 256 for i in range(calldata_size)])
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     min_gas = intrinsic_gas_calculator(calldata=data)
     if min_gas > tx_gas_limit:
         pytest.skip(
-            "Minimum gas required for calldata ({min_gas}) is greater "
+            f"Minimum gas required for calldata ({min_gas}) is greater "
             "than the gas limit"
         )
 
-    # We create the contract that will be doing the CALLDATACOPY multiple
-    # times.
-    #
-    # If `non_zero_data` is True, we leverage CALLDATASIZE for the copy
-    # length. Otherwise, since we
-    # don't send zero data explicitly via calldata, PUSH the target size and
-    # use DUP1 to copy it.
-    setup = Op.CALLDATASIZE if non_zero_data or size == 0 else Op.PUSH3(size)
+    # Setup pushes the memory size to copy onto the stack.
+    # The attack block uses DUP1 to reuse this value for the copy length.
+    setup = Op.PUSH3(mem_size) if mem_size > 0 else Op.PUSH0
     src_dst = 0 if fixed_src_dst else Op.AND(Op.GAS, 7)
     attack_block = Op.CALLDATACOPY(
         src_dst,
         src_dst,
-        Op.DUP1,
+        Op.CALLDATASIZE,
     )
 
     benchmark_test(
@@ -211,10 +202,12 @@ def test_calldatacopy_from_origin(
 
 
 @pytest.mark.parametrize(
-    "size",
+    "mem_size",
     [
         pytest.param(0, id="0 bytes"),
-        pytest.param(100, id="100 bytes"),
+        pytest.param(32, id="32 bytes"),
+        pytest.param(256, id="256 bytes"),
+        pytest.param(1024, id="1KiB"),
         pytest.param(10 * 1024, id="10KiB"),
         pytest.param(1024 * 1024, id="1MiB"),
     ],
@@ -233,22 +226,30 @@ def test_calldatacopy_from_origin(
         False,
     ],
 )
+@pytest.mark.parametrize(
+    "calldata_size",
+    [0, 4, 36, 68, 256, 1024],
+)
 def test_calldatacopy_from_call(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
-    size: int,
+    calldata_size: int,
     fixed_src_dst: bool,
     non_zero_data: bool,
     tx_gas_limit: int,
 ) -> None:
     """Benchmark CALLDATACOPY instruction."""
-    if size == 0 and non_zero_data:
+    if calldata_size == 0 and non_zero_data:
         pytest.skip("Non-zero data with size 0 is not applicable.")
 
     # If `non_zero_data` is True, we fill the calldata with deterministic
     # random data. Note that if `size == 0` and `non_zero_data` is a skipped
     # case.
-    data = Bytes([i % 256 for i in range(size)]) if non_zero_data else Bytes()
+    data = (
+        Bytes([i % 256 for i in range(calldata_size)])
+        if non_zero_data
+        else Bytes()
+    )
 
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     min_gas = intrinsic_gas_calculator(calldata=data)
@@ -265,12 +266,16 @@ def test_calldatacopy_from_call(
     # length. Otherwise, since we
     # don't send zero data explicitly via calldata, PUSH the target size and
     # use DUP1 to copy it.
-    setup = Bytecode() if non_zero_data or size == 0 else Op.PUSH3(size)
+    setup = (
+        Bytecode()
+        if non_zero_data or calldata_size == 0
+        else Op.PUSH3(calldata_size)
+    )
     src_dst = 0 if fixed_src_dst else Op.AND(Op.GAS, 7)
     attack_block = Op.CALLDATACOPY(
         src_dst,
         src_dst,
-        Op.CALLDATASIZE if non_zero_data or size == 0 else Op.DUP1,
+        Op.CALLDATASIZE if non_zero_data or calldata_size == 0 else Op.DUP1,
     )
 
     benchmark_test(
@@ -295,7 +300,7 @@ def test_calldatacopy_from_call(
         ReturnDataStyle.IDENTITY,
     ],
 )
-@pytest.mark.parametrize("returned_size", [1, 0])
+@pytest.mark.parametrize("returned_size", [0, 32, 256, 1024])
 def test_returndatasize_nonzero(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -343,11 +348,14 @@ def test_returndatasize_zero(
 
 
 @pytest.mark.repricing(size=0, fixed_dst=True)
+@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(
-    "size",
+    "return_size",
     [
         pytest.param(0, id="0 bytes"),
-        pytest.param(100, id="100 bytes"),
+        pytest.param(32, id="32 bytes"),
+        pytest.param(256, id="256 bytes"),
+        pytest.param(1024, id="1024 bytes"),
         pytest.param(10 * 1024, id="10KiB"),
         pytest.param(1024 * 1024, id="1MiB"),
     ],
@@ -362,7 +370,8 @@ def test_returndatasize_zero(
 def test_returndatacopy(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
-    size: int,
+    mem_size: int,
+    return_size: int,
     fixed_dst: bool,
 ) -> None:
     """Benchmark RETURNDATACOPY instruction."""
@@ -373,14 +382,24 @@ def test_returndatacopy(
     # predictable. If `size` is 0, this helper contract won't be used.
     code = (
         Op.MSTORE8(0, Op.GAS)
-        + Op.MSTORE8(size // 2, Op.GAS)
-        + Op.MSTORE8(size - 1, Op.GAS)
-        + Op.RETURN(0, size)
+        + Op.MSTORE8(return_size // 2, Op.GAS)
+        + Op.MSTORE8(return_size - 1, Op.GAS)
+        + Op.RETURN(0, return_size)
     )
     helper_contract = pre.deploy_contract(code=code)
 
-    returndata_gen = (
-        Op.STATICCALL(address=helper_contract) if size > 0 else Bytecode()
+    setup = Bytecode()
+    setup += Op.MSTORE8(mem_size - 1, 0xFF) if mem_size > 0 else Bytecode()
+    setup += (
+        Op.STATICCALL(address=helper_contract)
+        if return_size > 0
+        else Bytecode()
+    )
+
+    cleanup = (
+        Op.STATICCALL(address=helper_contract)
+        if return_size > 0
+        else Bytecode()
     )
     dst = 0 if fixed_dst else Op.MOD(Op.GAS, 7)
 
@@ -389,8 +408,8 @@ def test_returndatacopy(
     benchmark_test(
         target_opcode=Op.RETURNDATACOPY,
         code_generator=JumpLoopGenerator(
-            setup=returndata_gen,
+            setup=setup,
             attack_block=attack_block,
-            cleanup=returndata_gen,
+            cleanup=cleanup,
         ),
     )

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -48,8 +48,8 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(calldata_size=10_000)
-@pytest.mark.parametrize("calldata_size", [0, 4, 36, 68, 256, 1024, 10_000])
+@pytest.mark.repricing(calldata_size=1024)
+@pytest.mark.parametrize("calldata_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("zero_data", [True, False])
 def test_calldatasize(
     benchmark_test: BenchmarkTestFiller, calldata_size: int, zero_data: bool
@@ -118,7 +118,7 @@ def test_callvalue_from_call(
     )
 
 
-@pytest.mark.parametrize("calldata_size", [0, 4, 36, 68, 256, 1024])
+@pytest.mark.parametrize("calldata_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("zero_data", [True, False])
 def test_calldataload(
     benchmark_test: BenchmarkTestFiller, calldata_size: int, zero_data: bool
@@ -159,7 +159,7 @@ def test_calldataload(
 )
 @pytest.mark.parametrize(
     "calldata_size",
-    [0, 4, 36, 68, 256, 1024],
+    [0, 32, 256, 1024],
 )
 def test_calldatacopy_from_origin(
     benchmark_test: BenchmarkTestFiller,
@@ -217,7 +217,7 @@ def test_calldatacopy_from_origin(
 )
 @pytest.mark.parametrize(
     "calldata_size",
-    [0, 4, 36, 68, 256, 1024],
+    [0, 32, 256, 1024],
 )
 def test_calldatacopy_from_call(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -44,22 +44,20 @@ def test_msize(
 @pytest.mark.parametrize("opcode", [Op.MLOAD, Op.MSTORE, Op.MSTORE8])
 @pytest.mark.parametrize("offset", [0, 1, 31])
 @pytest.mark.parametrize("offset_initialized", [True, False])
-@pytest.mark.parametrize("big_memory_expansion", [True, False])
+@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024, 10 * 1024])
 def test_memory_access(
     benchmark_test: BenchmarkTestFiller,
     opcode: Op,
     offset: int,
     offset_initialized: bool,
-    big_memory_expansion: bool,
+    mem_size: bool,
 ) -> None:
     """Benchmark memory access instructions."""
-    mem_exp_code = (
-        Op.MSTORE8(10 * 1024, 1) if big_memory_expansion else Bytecode()
-    )
-    offset_set_code = (
-        Op.MSTORE(offset, 43) if offset_initialized else Bytecode()
-    )
-    setup = mem_exp_code + offset_set_code + Op.PUSH1(42) + Op.PUSH1(offset)
+    setup = Bytecode()
+
+    setup += Op.MSTORE8(mem_size - 1, 1) if mem_size > 0 else Bytecode()
+    setup += Op.MSTORE(offset, 43) if offset_initialized else Bytecode()
+    setup += Op.PUSH1(42) + Op.PUSH1(offset)
 
     attack_block = (
         Op.POP(Op.MLOAD(Op.DUP1))
@@ -77,14 +75,17 @@ def test_memory_access(
 
 @pytest.mark.repricing(size=0, fixed_src_dst=True)
 @pytest.mark.parametrize(
-    "size",
+    "mem_size",
     [
         pytest.param(0, id="0 bytes"),
-        pytest.param(100, id="100 bytes"),
+        pytest.param(32, id="32 bytes"),
+        pytest.param(256, id="256 bytes"),
+        pytest.param(1024, id="1024 bytes"),
         pytest.param(10 * 1024, id="10KiB"),
         pytest.param(1024 * 1024, id="1MiB"),
     ],
 )
+@pytest.mark.parametrize("copy_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(
     "fixed_src_dst",
     [
@@ -94,18 +95,19 @@ def test_memory_access(
 )
 def test_mcopy(
     benchmark_test: BenchmarkTestFiller,
-    size: int,
+    mem_size: int,
+    copy_size: int,
     fixed_src_dst: bool,
 ) -> None:
     """Benchmark MCOPY instruction."""
     src_dst = 0 if fixed_src_dst else Op.MOD(Op.GAS, 7)
-    attack_block = Op.MCOPY(src_dst, src_dst, size)
+    attack_block = Op.MCOPY(src_dst, src_dst, copy_size)
 
     mem_touch = (
         Op.MSTORE8(0, Op.GAS)
-        + Op.MSTORE8(size // 2, Op.GAS)
-        + Op.MSTORE8(size - 1, Op.GAS)
-        if size > 0
+        + Op.MSTORE8(mem_size // 2, Op.GAS)
+        + Op.MSTORE8(mem_size - 1, Op.GAS)
+        if mem_size > 0
         else Bytecode()
     )
     benchmark_test(

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -50,7 +50,7 @@ def test_memory_access(
     opcode: Op,
     offset: int,
     offset_initialized: bool,
-    mem_size: bool,
+    mem_size: int,
 ) -> None:
     """Benchmark memory access instructions."""
     setup = Bytecode()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Add missing configuration for the fuzzy compute operations.

- keccak256: memory size, keccak message size
- codecopy: memory size, code size
- returndatasize: return data size
- calldatacopy: memory size, calldata size
- returndatacopy: memory size, return data size
- mload, mstore, mstore8: memory size
- mcopy: memory size, copy data size
- log: memory size, log data size
- calldatasize: calldata size
- calldataload: calldatasize

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![cat](https://github.com/user-attachments/assets/2155e835-1c2f-4b75-a951-51271e84041a)

