### PR TITLE
Claude/grammar check round 7 i a2dc

### DIFF
--- a/grammar_check_prompt.md
+++ b/grammar_check_prompt.md
@@ -1,0 +1,129 @@
+# Grammar Check Task
+
+You will create a PR to the `fix-grammar` branch of `danceratopz/execution-specs`. Your task is to process ONE unchecked item from the grammar checklist.
+
+## Step 1: Setup
+
+```bash
+git fetch origin fix-grammar && git checkout fix-grammar && git pull origin fix-grammar
+```
+
+## Step 2: Find Task
+
+Read `repo_subpaths_for_grammar_check.md`. Find the FIRST item with `[ ]` status.
+
+## Step 3: Ensure Branch is Based on fix-grammar
+
+Your branch must be based on fix-grammar (not main). Rebase if needed:
+
+```bash
+git rebase fix-grammar
+```
+
+**Verify**: Run `ls grammar_check_prompt.md` - if this file doesn't exist, run `git rebase fix-grammar`.
+
+**CRITICAL: Stay on this branch for ALL remaining steps. Do NOT switch or rename branches.**
+
+## Step 4: Process Files
+
+Use Glob to find all files matching the item's pattern(s). For each file:
+
+- **`.py` files**: Check only:
+  - Docstrings (triple-quoted strings)
+  - `#` comments
+  - String messages in `print()`, exceptions, logging, and error messages
+- **`.md` files**: Check prose content, skip code blocks
+
+### What to Fix (HIGH confidence - edit directly)
+
+1. Missing prepositions ("refer the" -> "refer to the", "comply the" -> "comply with the")
+2. Clear subject-verb disagreement
+3. Missing articles where clearly required
+4. Double words ("the the", "is is")
+5. Clear typos in words
+
+### What to Flag (LOW confidence - append to manual verification)
+
+1. Style preferences vs grammar
+2. Technical term ambiguity
+3. Sentence structure that might be intentional
+4. Anything you're uncertain about
+
+### What NOT to Fix
+
+- Variable names, function names, class names, or any identifiers
+- Any source code logic - only modify text inside strings/comments
+- Technical terms that look like typos (e.g., "keccak", "modexp", "precompile")
+- Abbreviated variable references in comments (e.g., "the tx", "the msg")
+- When fixing parallel structure in docstrings (e.g., "Multiply...pushes"), match the style used by OTHER functions in the same file. If neighbors use "Adds", "Subtracts", use "Multiplies...pushes"
+- Capitalization changes unless clearly wrong (don't "fix" consistent lowercase)
+
+## Step 5: Update Manual Verification
+
+Append LOW-confidence issues to `grammar_manual_verification.md` in this format:
+
+```markdown
+- [ ] path/to/file.py:15-17 - "original text"
+  Suggestion: "corrected text"
+  Reason: brief explanation
+```
+
+## Step 6: Format & Lint Check
+
+Before committing, ensure your changes pass formatting checks:
+
+**Line length**: Docstrings and comments must not exceed 79 characters. Ruff cannot auto-fix this for comments or docstrings, so manually wrap long lines.
+
+Run linters on any modified .py files (use `uvx` for speed):
+
+```bash
+uvx ruff format
+uvx ruff check --fix
+```
+
+## Step 7: Complete Task
+
+Change `[ ]` to `[x]` for the item you processed in `repo_subpaths_for_grammar_check.md`.
+
+Commit all changes:
+
+```bash
+git add -A && git commit -m "docs: fix grammar in {subpath description}"
+```
+
+Example: `docs: fix grammar in src/ethereum/forks/*/vm/instructions (arithmetic, comparison, bitwise)`
+
+## Step 8: Push and Create PR
+
+Rebase on latest fix-grammar and push:
+
+```bash
+git fetch origin fix-grammar && git rebase origin/fix-grammar
+git push -u origin HEAD
+```
+
+Provide the PR creation link targeting `fix-grammar` (as clickable link, NOT in a code block):
+
+https://github.com/danceratopz/execution-specs/compare/fix-grammar...{your-branch-name}?expand=1
+
+And provide the PR title for copy-paste:
+
+`docs: fix grammar in {subpath description}`
+
+Example title: `docs: fix grammar in src/ethereum/forks/*/vm/instructions (arithmetic, comparison, bitwise)`
+
+## What to Ignore
+
+- Code syntax and variable names
+- Technical terms, EIP numbers, hex values
+- Content inside code blocks (``` or indented)
+- URLs, file paths, and email addresses
+- Intentional shorthand in inline code comments
+
+## Important Rules
+
+- **Do NOT switch branches** after Step 3 - all work happens on your created branch
+- Be conservative - only fix clear grammatical errors, not style preferences
+- When uncertain, flag for manual review instead of fixing
+- Process ONLY ONE checklist item per session
+- Include a summary at the end: "Fixed N issues in M files. Flagged K items for manual review."

--- a/grammar_manual_verification.md
+++ b/grammar_manual_verification.md
@@ -1,0 +1,15 @@
+# Grammar Manual Verification
+
+Low-confidence grammar issues requiring human review.
+
+Format (but don't add a codeblock for each item):
+
+```markdown
+- [ ] path/to/file.py:15-17 - "original text"
+  Suggestion: "corrected text"
+  Reason: brief explanation
+```
+
+---
+
+<!-- Issues will be appended below by Claude Code -->

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -9,7 +9,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 - [x] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
 - [x] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
 - [x] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
-- [ ] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)
+- [x] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)
 
 ## src/ethereum/forks - VM Core
 

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -14,7 +14,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 ## src/ethereum/forks - VM Core
 
 - [x] `src/ethereum/forks/*/vm/interpreter.py`, `runtime.py` (~48 files)
-- [ ] `src/ethereum/forks/*/vm/gas.py`, `memory.py`, `stack.py`, `exceptions.py` (~96 files)
+- [x] `src/ethereum/forks/*/vm/gas.py`, `memory.py`, `stack.py`, `exceptions.py` (~96 files)
 - [x] `src/ethereum/forks/*/vm/__init__.py` (~24 files)
 
 ## src/ethereum/forks - Precompiled Contracts

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -8,7 +8,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 
 - [x] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
 - [x] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
-- [ ] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
+- [x] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)
 
 ## src/ethereum/forks - VM Core

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -7,7 +7,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 ## src/ethereum/forks - VM Instructions
 
 - [x] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
-- [ ] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
+- [x] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)
 

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -1,0 +1,131 @@
+# Grammar Check Subpaths
+
+Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
+
+---
+
+## src/ethereum/forks - VM Instructions
+
+- [ ] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
+- [ ] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
+- [ ] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
+- [ ] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)
+
+## src/ethereum/forks - VM Core
+
+- [ ] `src/ethereum/forks/*/vm/interpreter.py`, `runtime.py` (~48 files)
+- [ ] `src/ethereum/forks/*/vm/gas.py`, `memory.py`, `stack.py`, `exceptions.py` (~96 files)
+- [ ] `src/ethereum/forks/*/vm/__init__.py` (~24 files)
+
+## src/ethereum/forks - Precompiled Contracts
+
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/__init__.py`, `mapping.py` (~48 files)
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/ecrecover.py`, `sha256.py`, `ripemd160.py`, `identity.py` (~96 files)
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/modexp.py`, `alt_bn128.py` (~38 files)
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/blake2f.py` (~17 files)
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/point_evaluation.py`, `p256verify.py` (~16 files)
+- [ ] `src/ethereum/forks/*/vm/precompiled_contracts/bls12_381/*.py` (~32 files)
+
+## src/ethereum/forks - Utils & State
+
+- [ ] `src/ethereum/forks/*/utils/*.py` (~96 files)
+- [ ] `src/ethereum/forks/*/trie.py`, `state.py` (~48 files)
+
+## src/ethereum/forks - Blocks & Transactions
+
+- [ ] `src/ethereum/forks/*/blocks.py`, `transactions.py`, `bloom.py` (~72 files)
+- [ ] `src/ethereum/forks/*/__init__.py`, `fork.py`, `fork_types.py` (~72 files)
+
+## src/ethereum/forks - Misc
+
+- [ ] `src/ethereum/forks/*/exceptions.py`, `requests.py`, `vm/eoa_delegation.py`, `dao.py` (~40 files)
+
+## src/ethereum (non-forks)
+
+- [ ] `src/ethereum/*.py`, `src/ethereum/crypto/*.py`, `src/ethereum/utils/*.py` (~15 files)
+
+## src/ethereum_spec_tools
+
+- [ ] `src/ethereum_spec_tools/**/*.py` (~39 files)
+
+## src/ethereum_optimized
+
+- [ ] `src/ethereum_optimized/**/*.py` (~4 files)
+
+---
+
+## packages/testing - CLI Plugins
+
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**/*.py` (~32 files)
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/**/*.py` (~27 files)
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/**/*.py` (~21 files)
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/**/*.py`, `shared/**/*.py`, `help/**/*.py` (~16 files)
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/plugins/*.py` (root plugins, ~6 files)
+
+## packages/testing - CLI Core
+
+- [ ] `packages/testing/src/execution_testing/cli/pytest_commands/*.py` (~10 files)
+- [ ] `packages/testing/src/execution_testing/cli/gentest/**/*.py`, `fuzzer_bridge/**/*.py` (~15 files)
+- [ ] `packages/testing/src/execution_testing/cli/eest/**/*.py`, `input/**/*.py`, `fillerconvert/**/*.py` (~15 files)
+- [ ] `packages/testing/src/execution_testing/cli/*.py` (root cli files, ~15 files)
+- [ ] `packages/testing/src/execution_testing/cli/tests/**/*.py` (~10 files)
+
+## packages/testing - Core Modules
+
+- [ ] `packages/testing/src/execution_testing/test_types/**/*.py` (~32 files)
+- [ ] `packages/testing/src/execution_testing/specs/**/*.py` (~28 files)
+- [ ] `packages/testing/src/execution_testing/fixtures/**/*.py` (~16 files)
+- [ ] `packages/testing/src/execution_testing/client_clis/**/*.py` (~21 files)
+- [ ] `packages/testing/src/execution_testing/base_types/**/*.py` (~15 files)
+- [ ] `packages/testing/src/execution_testing/forks/**/*.py` (~13 files)
+- [ ] `packages/testing/src/execution_testing/tools/**/*.py`, `exceptions/**/*.py` (~24 files)
+- [ ] `packages/testing/src/execution_testing/vm/**/*.py`, `rpc/**/*.py`, `config/**/*.py` (~17 files)
+- [ ] `packages/testing/src/execution_testing/logging/**/*.py`, `execution/**/*.py`, `checklists/**/*.py`, `benchmark/**/*.py` (~14 files)
+- [ ] `packages/testing/src/execution_testing/*.py` (root files, ~2 files)
+
+---
+
+## tests
+
+- [ ] `tests/static/**/*.py` (~75 files)
+- [ ] `tests/unscheduled/**/*.py` (~73 files)
+- [ ] `tests/prague/**/*.py` (~69 files)
+- [ ] `tests/frontier/**/*.py` (~50 files)
+- [ ] `tests/cancun/**/*.py` (~44 files)
+- [ ] `tests/osaka/**/*.py` (~43 files)
+- [ ] `tests/benchmark/**/*.py` (~36 files)
+- [ ] `tests/json_infra/**/*.py` (~22 files)
+- [ ] `tests/shanghai/**/*.py` (~19 files)
+- [ ] `tests/byzantium/**/*.py` (~11 files)
+- [ ] `tests/istanbul/**/*.py`, `berlin/**/*.py` (~18 files)
+- [ ] `tests/constantinople/**/*.py`, `amsterdam/**/*.py` (~16 files)
+- [ ] `tests/london/**/*.py`, `homestead/**/*.py`, `paris/**/*.py` (~17 files)
+- [ ] `tests/*.py`, `tests/common/**/*.py`, `tests/evm_tools/**/*.py` (~5 files)
+
+---
+
+## docs
+
+- [ ] `docs/running_tests/**/*.md` (~29 files)
+- [ ] `docs/writing_tests/**/*.md` (~20 files)
+- [ ] `docs/library/**/*.md` (~18 files)
+- [ ] `docs/dev/**/*.md`, `docs/filling_tests/**/*.md`, `docs/getting_started/**/*.md` (~25 files)
+- [ ] `docs/*.md` (root docs, ~5 files)
+
+---
+
+## Root Files
+
+- [ ] `*.md`, `*.py` (README, CONTRIBUTING, LICENSE, vulture_whitelist.py, etc.) (~7 files)
+
+---
+
+## .github
+
+- [ ] `.github/**/*.md` (~6 files)
+
+---
+
+## lists, scripts & docs/scripts
+
+- [ ] `lists/**/*.py`, `scripts/**/*.py`, `docs/scripts/**/*.py` (~10 files)

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -15,7 +15,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 
 - [ ] `src/ethereum/forks/*/vm/interpreter.py`, `runtime.py` (~48 files)
 - [ ] `src/ethereum/forks/*/vm/gas.py`, `memory.py`, `stack.py`, `exceptions.py` (~96 files)
-- [ ] `src/ethereum/forks/*/vm/__init__.py` (~24 files)
+- [x] `src/ethereum/forks/*/vm/__init__.py` (~24 files)
 
 ## src/ethereum/forks - Precompiled Contracts
 

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -13,7 +13,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 
 ## src/ethereum/forks - VM Core
 
-- [ ] `src/ethereum/forks/*/vm/interpreter.py`, `runtime.py` (~48 files)
+- [x] `src/ethereum/forks/*/vm/interpreter.py`, `runtime.py` (~48 files)
 - [ ] `src/ethereum/forks/*/vm/gas.py`, `memory.py`, `stack.py`, `exceptions.py` (~96 files)
 - [x] `src/ethereum/forks/*/vm/__init__.py` (~24 files)
 

--- a/repo_subpaths_for_grammar_check.md
+++ b/repo_subpaths_for_grammar_check.md
@@ -6,7 +6,7 @@ Status legend: `[ ]` pending, `[~]` in progress, `[x]` complete
 
 ## src/ethereum/forks - VM Instructions
 
-- [ ] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
+- [x] `src/ethereum/forks/*/vm/instructions/arithmetic.py`, `comparison.py`, `bitwise.py` (~72 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/block.py`, `environment.py`, `control_flow.py` (~72 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/keccak.py`, `log.py`, `memory.py`, `stack.py` (~96 files)
 - [ ] `src/ethereum/forks/*/vm/instructions/storage.py`, `system.py`, `__init__.py` (~72 files)

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/amsterdam/vm/instructions/block.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/amsterdam/vm/instructions/memory.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/amsterdam/vm/instructions/stack.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/amsterdam/vm/runtime.py
+++ b/src/ethereum/forks/amsterdam/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/arrow_glacier/vm/__init__.py
+++ b/src/ethereum/forks/arrow_glacier/vm/__init__.py
@@ -62,7 +62,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/arrow_glacier/vm/gas.py
+++ b/src/ethereum/forks/arrow_glacier/vm/gas.py
@@ -211,7 +211,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/block.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/memory.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/stack.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/arrow_glacier/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/arrow_glacier/vm/runtime.py
+++ b/src/ethereum/forks/arrow_glacier/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/berlin/vm/__init__.py
+++ b/src/ethereum/forks/berlin/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/berlin/vm/gas.py
+++ b/src/ethereum/forks/berlin/vm/gas.py
@@ -212,7 +212,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/berlin/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/berlin/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/berlin/vm/instructions/block.py
+++ b/src/ethereum/forks/berlin/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/berlin/vm/instructions/environment.py
+++ b/src/ethereum/forks/berlin/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/berlin/vm/instructions/memory.py
+++ b/src/ethereum/forks/berlin/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/berlin/vm/instructions/stack.py
+++ b/src/ethereum/forks/berlin/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/berlin/vm/instructions/system.py
+++ b/src/ethereum/forks/berlin/vm/instructions/system.py
@@ -180,8 +180,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/berlin/vm/runtime.py
+++ b/src/ethereum/forks/berlin/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/bpo1/vm/__init__.py
+++ b/src/ethereum/forks/bpo1/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/bpo1/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/bpo1/vm/instructions/block.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/bpo1/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo1/vm/instructions/memory.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo1/vm/instructions/stack.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/bpo1/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo1/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo1/vm/runtime.py
+++ b/src/ethereum/forks/bpo1/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/bpo2/vm/__init__.py
+++ b/src/ethereum/forks/bpo2/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/bpo2/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/bpo2/vm/instructions/block.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/bpo2/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo2/vm/instructions/memory.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo2/vm/instructions/stack.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/bpo2/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo2/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo2/vm/runtime.py
+++ b/src/ethereum/forks/bpo2/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/bpo3/vm/__init__.py
+++ b/src/ethereum/forks/bpo3/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/bpo3/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/bpo3/vm/instructions/block.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/bpo3/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo3/vm/instructions/memory.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo3/vm/instructions/stack.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/bpo3/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo3/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo3/vm/runtime.py
+++ b/src/ethereum/forks/bpo3/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/bpo4/vm/__init__.py
+++ b/src/ethereum/forks/bpo4/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/bpo4/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/bpo4/vm/instructions/block.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/bpo4/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo4/vm/instructions/memory.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo4/vm/instructions/stack.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/bpo4/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo4/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo4/vm/runtime.py
+++ b/src/ethereum/forks/bpo4/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/bpo5/vm/__init__.py
+++ b/src/ethereum/forks/bpo5/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/bpo5/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/bpo5/vm/instructions/block.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/bpo5/vm/instructions/environment.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo5/vm/instructions/memory.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo5/vm/instructions/stack.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/bpo5/vm/instructions/system.py
+++ b/src/ethereum/forks/bpo5/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/bpo5/vm/runtime.py
+++ b/src/ethereum/forks/bpo5/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/byzantium/vm/__init__.py
+++ b/src/ethereum/forks/byzantium/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/byzantium/vm/gas.py
+++ b/src/ethereum/forks/byzantium/vm/gas.py
@@ -211,7 +211,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/byzantium/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/byzantium/vm/instructions/block.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/byzantium/vm/instructions/environment.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/environment.py
@@ -403,7 +403,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/byzantium/vm/instructions/memory.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/byzantium/vm/instructions/stack.py
+++ b/src/ethereum/forks/byzantium/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/byzantium/vm/runtime.py
+++ b/src/ethereum/forks/byzantium/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/cancun/vm/__init__.py
+++ b/src/ethereum/forks/cancun/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/cancun/vm/gas.py
+++ b/src/ethereum/forks/cancun/vm/gas.py
@@ -221,7 +221,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -277,7 +277,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/cancun/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/cancun/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/cancun/vm/instructions/block.py
+++ b/src/ethereum/forks/cancun/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/cancun/vm/instructions/environment.py
+++ b/src/ethereum/forks/cancun/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/cancun/vm/instructions/memory.py
+++ b/src/ethereum/forks/cancun/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/cancun/vm/instructions/stack.py
+++ b/src/ethereum/forks/cancun/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/cancun/vm/instructions/system.py
+++ b/src/ethereum/forks/cancun/vm/instructions/system.py
@@ -191,8 +191,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/cancun/vm/runtime.py
+++ b/src/ethereum/forks/cancun/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/constantinople/vm/__init__.py
+++ b/src/ethereum/forks/constantinople/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/constantinople/vm/gas.py
+++ b/src/ethereum/forks/constantinople/vm/gas.py
@@ -212,7 +212,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/constantinople/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/constantinople/vm/instructions/block.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/constantinople/vm/instructions/environment.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/environment.py
@@ -406,7 +406,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/constantinople/vm/instructions/memory.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/constantinople/vm/instructions/stack.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/constantinople/vm/instructions/system.py
+++ b/src/ethereum/forks/constantinople/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/constantinople/vm/runtime.py
+++ b/src/ethereum/forks/constantinople/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/dao_fork/vm/__init__.py
+++ b/src/ethereum/forks/dao_fork/vm/__init__.py
@@ -60,7 +60,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/dao_fork/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/dao_fork/vm/instructions/block.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/dao_fork/vm/instructions/memory.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/dao_fork/vm/instructions/stack.py
+++ b/src/ethereum/forks/dao_fork/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/dao_fork/vm/runtime.py
+++ b/src/ethereum/forks/dao_fork/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/frontier/vm/__init__.py
+++ b/src/ethereum/forks/frontier/vm/__init__.py
@@ -60,7 +60,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/frontier/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/frontier/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/frontier/vm/instructions/block.py
+++ b/src/ethereum/forks/frontier/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/frontier/vm/instructions/memory.py
+++ b/src/ethereum/forks/frontier/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/frontier/vm/instructions/stack.py
+++ b/src/ethereum/forks/frontier/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/frontier/vm/runtime.py
+++ b/src/ethereum/forks/frontier/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/gray_glacier/vm/__init__.py
+++ b/src/ethereum/forks/gray_glacier/vm/__init__.py
@@ -62,7 +62,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/gray_glacier/vm/gas.py
+++ b/src/ethereum/forks/gray_glacier/vm/gas.py
@@ -211,7 +211,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/gray_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/gray_glacier/vm/instructions/block.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/gray_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/gray_glacier/vm/instructions/memory.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/gray_glacier/vm/instructions/stack.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/gray_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/gray_glacier/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/gray_glacier/vm/runtime.py
+++ b/src/ethereum/forks/gray_glacier/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/homestead/vm/__init__.py
+++ b/src/ethereum/forks/homestead/vm/__init__.py
@@ -60,7 +60,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/homestead/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/homestead/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/homestead/vm/instructions/block.py
+++ b/src/ethereum/forks/homestead/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/homestead/vm/instructions/memory.py
+++ b/src/ethereum/forks/homestead/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/homestead/vm/instructions/stack.py
+++ b/src/ethereum/forks/homestead/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/homestead/vm/runtime.py
+++ b/src/ethereum/forks/homestead/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/istanbul/vm/__init__.py
+++ b/src/ethereum/forks/istanbul/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/istanbul/vm/gas.py
+++ b/src/ethereum/forks/istanbul/vm/gas.py
@@ -214,7 +214,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/istanbul/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/istanbul/vm/instructions/block.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/istanbul/vm/instructions/environment.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/environment.py
@@ -407,7 +407,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/istanbul/vm/instructions/memory.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/istanbul/vm/instructions/stack.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/istanbul/vm/instructions/system.py
+++ b/src/ethereum/forks/istanbul/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/istanbul/vm/runtime.py
+++ b/src/ethereum/forks/istanbul/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/london/vm/__init__.py
+++ b/src/ethereum/forks/london/vm/__init__.py
@@ -62,7 +62,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/london/vm/gas.py
+++ b/src/ethereum/forks/london/vm/gas.py
@@ -211,7 +211,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/london/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/london/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/london/vm/instructions/block.py
+++ b/src/ethereum/forks/london/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/london/vm/instructions/environment.py
+++ b/src/ethereum/forks/london/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/london/vm/instructions/memory.py
+++ b/src/ethereum/forks/london/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/london/vm/instructions/stack.py
+++ b/src/ethereum/forks/london/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/london/vm/instructions/system.py
+++ b/src/ethereum/forks/london/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/london/vm/runtime.py
+++ b/src/ethereum/forks/london/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/muir_glacier/vm/__init__.py
+++ b/src/ethereum/forks/muir_glacier/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/muir_glacier/vm/gas.py
+++ b/src/ethereum/forks/muir_glacier/vm/gas.py
@@ -214,7 +214,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/muir_glacier/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/muir_glacier/vm/instructions/block.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/muir_glacier/vm/instructions/environment.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/environment.py
@@ -407,7 +407,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/muir_glacier/vm/instructions/memory.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/muir_glacier/vm/instructions/stack.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/muir_glacier/vm/instructions/system.py
+++ b/src/ethereum/forks/muir_glacier/vm/instructions/system.py
@@ -179,8 +179,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/muir_glacier/vm/runtime.py
+++ b/src/ethereum/forks/muir_glacier/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/osaka/vm/__init__.py
+++ b/src/ethereum/forks/osaka/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -232,7 +232,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -288,7 +288,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/osaka/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/osaka/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/osaka/vm/instructions/block.py
+++ b/src/ethereum/forks/osaka/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/osaka/vm/instructions/environment.py
+++ b/src/ethereum/forks/osaka/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/osaka/vm/instructions/memory.py
+++ b/src/ethereum/forks/osaka/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/osaka/vm/instructions/stack.py
+++ b/src/ethereum/forks/osaka/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/osaka/vm/instructions/system.py
+++ b/src/ethereum/forks/osaka/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/osaka/vm/runtime.py
+++ b/src/ethereum/forks/osaka/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/paris/vm/__init__.py
+++ b/src/ethereum/forks/paris/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/paris/vm/gas.py
+++ b/src/ethereum/forks/paris/vm/gas.py
@@ -211,7 +211,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/paris/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/paris/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/paris/vm/instructions/block.py
+++ b/src/ethereum/forks/paris/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/paris/vm/instructions/environment.py
+++ b/src/ethereum/forks/paris/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/paris/vm/instructions/memory.py
+++ b/src/ethereum/forks/paris/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/paris/vm/instructions/stack.py
+++ b/src/ethereum/forks/paris/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/paris/vm/instructions/system.py
+++ b/src/ethereum/forks/paris/vm/instructions/system.py
@@ -178,8 +178,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/paris/vm/runtime.py
+++ b/src/ethereum/forks/paris/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/prague/vm/__init__.py
+++ b/src/ethereum/forks/prague/vm/__init__.py
@@ -63,7 +63,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -228,7 +228,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------
@@ -284,7 +284,7 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
 def calculate_excess_blob_gas(parent_header: Header) -> U64:
     """
-    Calculated the excess blob gas for the current block based
+    Calculates the excess blob gas for the current block based
     on the gas used in the parent block.
 
     Parameters

--- a/src/ethereum/forks/prague/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/prague/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/prague/vm/instructions/block.py
+++ b/src/ethereum/forks/prague/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/prague/vm/instructions/environment.py
+++ b/src/ethereum/forks/prague/vm/instructions/environment.py
@@ -426,7 +426,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/prague/vm/instructions/memory.py
+++ b/src/ethereum/forks/prague/vm/instructions/memory.py
@@ -93,7 +93,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def msize(evm: Evm) -> None:
 
 def mcopy(evm: Evm) -> None:
     """
-    Copy the bytes in memory from one location to another.
+    Copies the bytes in memory from one location to another.
 
     Parameters
     ----------

--- a/src/ethereum/forks/prague/vm/instructions/stack.py
+++ b/src/ethereum/forks/prague/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/prague/vm/instructions/system.py
+++ b/src/ethereum/forks/prague/vm/instructions/system.py
@@ -193,8 +193,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/prague/vm/runtime.py
+++ b/src/ethereum/forks/prague/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/shanghai/vm/__init__.py
+++ b/src/ethereum/forks/shanghai/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/shanghai/vm/gas.py
+++ b/src/ethereum/forks/shanghai/vm/gas.py
@@ -212,7 +212,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/shanghai/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/shanghai/vm/instructions/block.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/block.py
@@ -101,7 +101,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/shanghai/vm/instructions/environment.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/environment.py
@@ -423,7 +423,7 @@ def returndatasize(evm: Evm) -> None:
 
 def returndatacopy(evm: Evm) -> None:
     """
-    Copies data from the return data buffer code to memory.
+    Copies data from the return data buffer to memory.
 
     Parameters
     ----------

--- a/src/ethereum/forks/shanghai/vm/instructions/memory.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/shanghai/vm/instructions/stack.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack. Push zero if num_bytes is zero.
+    Pushes an N-byte immediate onto the stack. Push zero if num_bytes is zero.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -107,7 +107,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/shanghai/vm/instructions/system.py
+++ b/src/ethereum/forks/shanghai/vm/instructions/system.py
@@ -190,8 +190,8 @@ def create2(evm: Evm) -> None:
     """
     Creates a new account with associated code.
 
-    It's similar to CREATE opcode except that the address of new account
-    depends on the init_code instead of the nonce of sender.
+    It's similar to the CREATE opcode except that the address of the new
+    account depends on the init_code instead of the nonce of sender.
 
     Parameters
     ----------

--- a/src/ethereum/forks/shanghai/vm/runtime.py
+++ b/src/ethereum/forks/shanghai/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/spurious_dragon/vm/__init__.py
+++ b/src/ethereum/forks/spurious_dragon/vm/__init__.py
@@ -61,7 +61,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/spurious_dragon/vm/gas.py
+++ b/src/ethereum/forks/spurious_dragon/vm/gas.py
@@ -210,7 +210,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/block.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/memory.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/spurious_dragon/vm/instructions/stack.py
+++ b/src/ethereum/forks/spurious_dragon/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/spurious_dragon/vm/runtime.py
+++ b/src/ethereum/forks/spurious_dragon/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.

--- a/src/ethereum/forks/tangerine_whistle/vm/__init__.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/__init__.py
@@ -60,7 +60,7 @@ class BlockOutput:
     receipts_trie : `ethereum.fork_types.Root`
         Trie root of all the receipts in the block.
     receipt_keys :
-        Key of all the receipts in the block.
+        Keys of all the receipts in the block.
     block_logs : `Bloom`
         Logs bloom of all the logs included in all the transactions of the
         block.

--- a/src/ethereum/forks/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/gas.py
@@ -210,7 +210,7 @@ def calculate_message_call_gas(
         account inside a message call.
     call_stipend :
         The amount of stipend provided to a message call to execute code while
-        transferring value(ETH).
+        transferring value (ETH).
 
     Returns
     -------

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/arithmetic.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/arithmetic.py
@@ -84,7 +84,7 @@ def sub(evm: Evm) -> None:
 
 def mul(evm: Evm) -> None:
     """
-    Multiply the top two elements of the stack, and pushes the result back
+    Multiplies the top two elements of the stack, and pushes the result back
     on the stack.
 
     Parameters
@@ -353,7 +353,7 @@ def signextend(evm: Evm) -> None:
         # Can't extend any further
         result = value
     else:
-        # U256(0).to_be_bytes() gives b'' instead b'\x00'.
+        # U256(0).to_be_bytes() gives b'' instead of b'\x00'.
         value_bytes = Bytes(value.to_be_bytes32())
         # Now among the obtained value bytes, consider only
         # N `least significant bytes`, where N is `byte_num + 1`.

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/block.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/block.py
@@ -87,7 +87,7 @@ def coinbase(evm: Evm) -> None:
 def timestamp(evm: Evm) -> None:
     """
     Push the current block's timestamp onto the stack. Here the timestamp
-    being referred is actually the unix timestamp in seconds.
+    being referred to is actually the unix timestamp in seconds.
 
     Here the current block refers to the block in which the currently
     executing transaction/call resides.

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/memory.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/memory.py
@@ -90,7 +90,7 @@ def mstore8(evm: Evm) -> None:
 
 def mload(evm: Evm) -> None:
     """
-    Load word from memory.
+    Loads a word from memory.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def mload(evm: Evm) -> None:
 
 def msize(evm: Evm) -> None:
     """
-    Push the size of active memory in bytes onto the stack.
+    Pushes the size of active memory in bytes onto the stack.
 
     Parameters
     ----------

--- a/src/ethereum/forks/tangerine_whistle/vm/instructions/stack.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/instructions/stack.py
@@ -23,7 +23,7 @@ from ..memory import buffer_read
 
 def pop(evm: Evm) -> None:
     """
-    Remove item from stack.
+    Removes an item from the stack.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def pop(evm: Evm) -> None:
 
 def push_n(evm: Evm, num_bytes: int) -> None:
     """
-    Pushes a N-byte immediate onto the stack.
+    Pushes an N-byte immediate onto the stack.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def push_n(evm: Evm, num_bytes: int) -> None:
 
 def dup_n(evm: Evm, item_number: int) -> None:
     """
-    Duplicate the Nth stack item (from top of the stack) to the top of stack.
+    Duplicates the Nth stack item (from top of the stack) to the top of stack.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ def dup_n(evm: Evm, item_number: int) -> None:
 
 def swap_n(evm: Evm, item_number: int) -> None:
     """
-    Swap the top and the `item_number` element of the stack, where
+    Swaps the top and the `item_number` element of the stack, where
     the top of the stack is position zero.
 
     If `item_number` is zero, this function does nothing (which should not be

--- a/src/ethereum/forks/tangerine_whistle/vm/runtime.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/runtime.py
@@ -21,7 +21,7 @@ from .instructions import Ops
 
 def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
     """
-    Analyze the evm code to obtain the set of valid jump destinations.
+    Analyze the EVM code to obtain the set of valid jump destinations.
 
     Valid jump destinations are defined as follows:
         * The jump destination is less than the length of the code.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
