### PR TITLE
feat(benchmark): support tx gas limit cap in stateful benchmarks

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -83,7 +83,6 @@ def test_bloatnet_balance_extcodesize(
     # Setup overhead (before loop): STATICCALL + result handling + memory setup
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
-        + 100  # STATICCALL base cost
         + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
         + gas_costs.G_HIGH  # JUMPI (10)
@@ -273,7 +272,6 @@ def test_bloatnet_balance_extcodecopy(
     # Setup overhead (before loop): STATICCALL + result handling + memory setup
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
-        + 100  # STATICCALL base cost
         + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
         + gas_costs.G_HIGH  # JUMPI (10)
@@ -470,7 +468,6 @@ def test_bloatnet_balance_extcodehash(
     # Setup overhead (before loop): STATICCALL + result handling + memory setup
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
-        + 100  # STATICCALL base cost
         + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
         + gas_costs.G_HIGH  # JUMPI (10)
@@ -774,7 +771,7 @@ def test_mixed_sload_sstore(
         + gas_costs.G_VERY_LOW  # MLOAD for While condition check (3)
         + gas_costs.G_BASE  # ISZERO (2)
         + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_HIGH  # JUMPI (10)
         + gas_costs.G_BASE  # POP to clean up at end (2)
     )
 

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -84,11 +84,11 @@ def test_bloatnet_balance_extcodesize(
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
         + 100  # STATICCALL base cost
-        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
-        + gas_costs.G_MID  # JUMPI (10)
-        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
-        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_HIGH  # JUMPI (10)
+        + gas_costs.G_VERY_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_VERY_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
         + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
         + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
     )
@@ -98,14 +98,14 @@ def test_bloatnet_balance_extcodesize(
 
     # While loop condition overhead per iteration
     loop_condition_overhead = (
-        gas_costs.G_BASE  # DUP1 (3)
+        gas_costs.G_VERY_LOW  # DUP1 (3)
         + gas_costs.G_VERY_LOW  # PUSH1 (3)
         + gas_costs.G_VERY_LOW  # SWAP1 (3)
         + gas_costs.G_VERY_LOW  # SUB (3)
-        + gas_costs.G_BASE  # DUP1 (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_VERY_LOW  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
     )
 
     # Cost per contract access with CREATE2 address generation
@@ -116,10 +116,10 @@ def test_bloatnet_balance_extcodesize(
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
         + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (2)
-        + gas_costs.G_LOW  # MLOAD for salt (3)
+        + gas_costs.G_VERY_LOW  # DUP1 before first op (3)
+        + gas_costs.G_VERY_LOW  # MLOAD for salt (3)
         + gas_costs.G_VERY_LOW  # ADD for increment (3)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
+        + gas_costs.G_VERY_LOW  # MSTORE salt back (3)
         + loop_condition_overhead  # While loop condition
     )
 
@@ -274,11 +274,11 @@ def test_bloatnet_balance_extcodecopy(
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
         + 100  # STATICCALL base cost
-        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
-        + gas_costs.G_MID  # JUMPI (10)
-        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
-        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_HIGH  # JUMPI (10)
+        + gas_costs.G_VERY_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_VERY_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
         + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
         + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
     )
@@ -288,14 +288,14 @@ def test_bloatnet_balance_extcodecopy(
 
     # While loop condition overhead per iteration
     loop_condition_overhead = (
-        gas_costs.G_BASE  # DUP1 (3)
+        gas_costs.G_VERY_LOW  # DUP1 (3)
         + gas_costs.G_VERY_LOW  # PUSH1 (3)
         + gas_costs.G_VERY_LOW  # SWAP1 (3)
         + gas_costs.G_VERY_LOW  # SUB (3)
-        + gas_costs.G_BASE  # DUP1 (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_VERY_LOW  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
     )
 
     # Cost per contract with EXTCODECOPY and CREATE2 address generation
@@ -306,10 +306,10 @@ def test_bloatnet_balance_extcodecopy(
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access base (100)
         + gas_costs.G_COPY * 1  # Copy cost for 1 byte (3)
-        + gas_costs.G_BASE * 2  # DUP1 before first op, DUP4 for address (6)
-        + gas_costs.G_LOW * 2  # MLOAD for salt twice (6)
+        + gas_costs.G_VERY_LOW * 2  # DUP1 + DUP4 for address (6)
+        + gas_costs.G_VERY_LOW * 2  # MLOAD for salt twice (6)
         + gas_costs.G_VERY_LOW * 2  # ADD operations (6)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
+        + gas_costs.G_VERY_LOW  # MSTORE salt back (3)
         + gas_costs.G_BASE  # POP after second op (2)
         + loop_condition_overhead  # While loop condition
     )
@@ -471,11 +471,11 @@ def test_bloatnet_balance_extcodehash(
     setup_overhead = (
         gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
         + 100  # STATICCALL base cost
-        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
         + gas_costs.G_VERY_LOW  # PUSH2 (3)
-        + gas_costs.G_MID  # JUMPI (10)
-        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
-        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_HIGH  # JUMPI (10)
+        + gas_costs.G_VERY_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_VERY_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
         + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
         + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
     )
@@ -485,14 +485,14 @@ def test_bloatnet_balance_extcodehash(
 
     # While loop condition overhead per iteration
     loop_condition_overhead = (
-        gas_costs.G_BASE  # DUP1 (3)
+        gas_costs.G_VERY_LOW  # DUP1 (3)
         + gas_costs.G_VERY_LOW  # PUSH1 (3)
         + gas_costs.G_VERY_LOW  # SWAP1 (3)
         + gas_costs.G_VERY_LOW  # SUB (3)
-        + gas_costs.G_BASE  # DUP1 (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_BASE  # ISZERO (3)
-        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_VERY_LOW  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
     )
 
     # Cost per contract access with CREATE2 address generation
@@ -503,10 +503,10 @@ def test_bloatnet_balance_extcodehash(
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
         + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (2)
-        + gas_costs.G_LOW  # MLOAD for salt (3)
+        + gas_costs.G_VERY_LOW  # DUP1 before first op (3)
+        + gas_costs.G_VERY_LOW  # MLOAD for salt (3)
         + gas_costs.G_VERY_LOW  # ADD for increment (3)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
+        + gas_costs.G_VERY_LOW  # MSTORE salt back (3)
         + loop_condition_overhead  # While loop condition
     )
 
@@ -690,9 +690,9 @@ def test_mixed_sload_sstore(
         + gas_costs.G_VERY_LOW * 2  # MSTORE selector (3*2)
         + gas_costs.G_VERY_LOW * 3  # MLOAD + MSTORE address (3*3)
         + gas_costs.G_BASE  # POP (2)
-        + gas_costs.G_BASE * 3  # SUB + MLOAD + MSTORE counter decrement
-        + gas_costs.G_BASE * 2  # ISZERO * 2 for loop condition (2*2)
-        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_VERY_LOW * 3  # SUB + MLOAD + MSTORE decrement (3*3)
+        + gas_costs.G_VERY_LOW * 2  # ISZERO * 2 for loop condition (3*2)
+        + gas_costs.G_HIGH  # JUMPI (10)
     )
 
     # ERC20 balanceOf internal gas
@@ -712,19 +712,19 @@ def test_mixed_sload_sstore(
     sstore_loop_overhead = (
         # Attack contract loop body operations
         gas_costs.G_VERY_LOW  # MSTORE selector at memory[32] (3)
-        + gas_costs.G_LOW  # MLOAD counter (5)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
         + gas_costs.G_VERY_LOW  # MSTORE spender at memory[64] (3)
         + gas_costs.G_BASE  # POP call result (2)
         # Counter decrement
-        + gas_costs.G_LOW  # MLOAD counter (5)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
         + gas_costs.G_VERY_LOW  # PUSH1 1 (3)
         + gas_costs.G_VERY_LOW  # SUB (3)
         + gas_costs.G_VERY_LOW  # MSTORE counter back (3)
         # While loop condition check
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI back to loop start (8)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI back to loop start (10)
     )
 
     # ERC20 approve internal gas

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -80,29 +80,55 @@ def test_bloatnet_balance_extcodesize(
     # Calculate gas costs
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
 
+    # Setup overhead (before loop): STATICCALL + result handling + memory setup
+    setup_overhead = (
+        gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
+        + 100  # STATICCALL base cost
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # PUSH2 (3)
+        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
+    )
+
+    # Cleanup overhead (after loop)
+    cleanup_overhead = gas_costs.G_BASE  # POP counter (2)
+
+    # While loop condition overhead per iteration
+    loop_condition_overhead = (
+        gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 (3)
+        + gas_costs.G_VERY_LOW  # SWAP1 (3)
+        + gas_costs.G_VERY_LOW  # SUB (3)
+        + gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_MID  # JUMPI (10)
+    )
+
     # Cost per contract access with CREATE2 address generation
     cost_per_contract = (
         gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
+        + gas_costs.G_KECCAK_256_WORD * 3  # SHA3 dynamic (85 bytes = 3 words)
         + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
         + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (3)
-        + gas_costs.G_VERY_LOW * 4  # PUSH1 operations (4 * 3)
+        + gas_costs.G_BASE  # DUP1 before first op (2)
         + gas_costs.G_LOW  # MLOAD for salt (3)
         + gas_costs.G_VERY_LOW  # ADD for increment (3)
         + gas_costs.G_LOW  # MSTORE salt back (3)
-        + 10  # While loop overhead
+        + loop_condition_overhead  # While loop condition
     )
 
     # Calculate how many transactions we need to fill the block
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate how many contracts to access per transaction
-    # Reserve 1000 gas for cleanup
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    total_overhead = setup_overhead + cleanup_overhead
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - total_overhead
     contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract - NO HARDCODED VALUES
@@ -244,29 +270,56 @@ def test_bloatnet_balance_extcodecopy(
     # Calculate costs
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
 
+    # Setup overhead (before loop): STATICCALL + result handling + memory setup
+    setup_overhead = (
+        gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
+        + 100  # STATICCALL base cost
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # PUSH2 (3)
+        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
+    )
+
+    # Cleanup overhead (after loop)
+    cleanup_overhead = gas_costs.G_BASE  # POP counter (2)
+
+    # While loop condition overhead per iteration
+    loop_condition_overhead = (
+        gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 (3)
+        + gas_costs.G_VERY_LOW  # SWAP1 (3)
+        + gas_costs.G_VERY_LOW  # SUB (3)
+        + gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_MID  # JUMPI (10)
+    )
+
     # Cost per contract with EXTCODECOPY and CREATE2 address generation
     cost_per_contract = (
         gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
+        + gas_costs.G_KECCAK_256_WORD * 3  # SHA3 dynamic (85 bytes = 3 words)
         + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access base (100)
         + gas_costs.G_COPY * 1  # Copy cost for 1 byte (3)
         + gas_costs.G_BASE * 2  # DUP1 before first op, DUP4 for address (6)
-        + gas_costs.G_VERY_LOW * 8  # PUSH operations (8 * 3 = 24)
         + gas_costs.G_LOW * 2  # MLOAD for salt twice (6)
         + gas_costs.G_VERY_LOW * 2  # ADD operations (6)
         + gas_costs.G_LOW  # MSTORE salt back (3)
         + gas_costs.G_BASE  # POP after second op (2)
-        + 10  # While loop overhead
+        + loop_condition_overhead  # While loop condition
     )
 
     # Calculate how many transactions we need to fill the block
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate how many contracts to access per transaction
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    total_overhead = setup_overhead + cleanup_overhead
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - total_overhead
     contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract - NO HARDCODED VALUES
@@ -414,29 +467,55 @@ def test_bloatnet_balance_extcodehash(
     # Calculate gas costs
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
 
+    # Setup overhead (before loop): STATICCALL + result handling + memory setup
+    setup_overhead = (
+        gas_costs.G_COLD_ACCOUNT_ACCESS  # STATICCALL to factory (2600)
+        + 100  # STATICCALL base cost
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # PUSH2 (3)
+        + gas_costs.G_MID  # JUMPI (10)
+        + gas_costs.G_LOW * 2  # MLOAD × 2 for factory results (3 * 2)
+        + gas_costs.G_LOW * 3  # MSTORE × 3 for memory setup (3 * 3)
+        + gas_costs.G_VERY_LOW  # MSTORE8 for 0xFF prefix (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 for memory position (3)
+    )
+
+    # Cleanup overhead (after loop)
+    cleanup_overhead = gas_costs.G_BASE  # POP counter (2)
+
+    # While loop condition overhead per iteration
+    loop_condition_overhead = (
+        gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_VERY_LOW  # PUSH1 (3)
+        + gas_costs.G_VERY_LOW  # SWAP1 (3)
+        + gas_costs.G_VERY_LOW  # SUB (3)
+        + gas_costs.G_BASE  # DUP1 (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_BASE  # ISZERO (3)
+        + gas_costs.G_MID  # JUMPI (10)
+    )
+
     # Cost per contract access with CREATE2 address generation
     cost_per_contract = (
         gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
+        + gas_costs.G_KECCAK_256_WORD * 3  # SHA3 dynamic (85 bytes = 3 words)
         + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
         + gas_costs.G_BASE  # POP first result (2)
         + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
         + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (3)
-        + gas_costs.G_VERY_LOW * 4  # PUSH1 operations (4 * 3)
+        + gas_costs.G_BASE  # DUP1 before first op (2)
         + gas_costs.G_LOW  # MLOAD for salt (3)
         + gas_costs.G_VERY_LOW  # ADD for increment (3)
         + gas_costs.G_LOW  # MSTORE salt back (3)
-        + 10  # While loop overhead
+        + loop_condition_overhead  # While loop condition
     )
 
     # Calculate how many transactions we need to fill the block
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate how many contracts to access per transaction
-    # Reserve 1000 gas for cleanup
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    total_overhead = setup_overhead + cleanup_overhead
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - total_overhead
     contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -747,11 +747,25 @@ def test_mixed_sload_sstore(
         + gas_costs.G_VERY_LOW  # PUSH1 0 for return offset (3)
     )
 
+    # Per-contract fixed overhead (setup + teardown for each contract's loop)
+    overhead_per_contract = (
+        gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
+        + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
+        + gas_costs.G_VERY_LOW  # MLOAD for While condition check (3)
+        + gas_costs.G_BASE  # ISZERO (2)
+        + gas_costs.G_BASE  # ISZERO (2)
+        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_BASE  # POP to clean up at end (2)
+    )
+
     # Calculate how many transactions we need to fill the block
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate gas budget per contract per transaction
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas
+    total_overhead_per_tx = intrinsic_gas + (
+        overhead_per_contract * num_contracts
+    )
+    available_gas_per_tx = tx_gas_limit - total_overhead_per_tx
     gas_per_contract_per_tx = available_gas_per_tx // num_contracts
 
     # For each contract, split gas by percentage

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -764,17 +764,6 @@ def test_mixed_sload_sstore(
         + gas_costs.G_VERY_LOW  # PUSH1 0 for return offset (3)
     )
 
-    # Per-contract fixed overhead (setup + teardown for each contract's loop)
-    overhead_per_contract = (
-        gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
-        + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
-        + gas_costs.G_VERY_LOW  # MLOAD for While condition check (3)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_HIGH  # JUMPI (10)
-        + gas_costs.G_BASE  # POP to clean up at end (2)
-    )
-
     # Calculate how many transactions we need to fill the block
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -683,6 +683,26 @@ def test_mixed_sload_sstore(
     # Calculate gas costs
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
 
+    # Per-contract fixed overhead (setup + teardown for each contract's loops)
+    # Each contract has two loops: SLOAD (balanceOf) and SSTORE (approve)
+    overhead_per_contract = (
+        # SLOAD loop setup/teardown
+        gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
+        + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
+        + gas_costs.G_VERY_LOW  # MLOAD for While condition (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
+        # SSTORE loop setup/teardown
+        + gas_costs.G_VERY_LOW  # MSTORE selector (3)
+        + gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
+        + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
+        + gas_costs.G_VERY_LOW  # MLOAD for While condition (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
+    )
+
     # Fixed overhead for SLOAD loop
     sload_loop_overhead = (
         # Attack contract loop overhead
@@ -751,7 +771,10 @@ def test_mixed_sload_sstore(
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate gas budget per contract per transaction
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas
+    total_overhead_per_tx = intrinsic_gas + (
+        overhead_per_contract * num_contracts
+    )
+    available_gas_per_tx = tx_gas_limit - total_overhead_per_tx
     gas_per_contract_per_tx = available_gas_per_tx // num_contracts
 
     # For each contract, split gas by percentage

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -62,6 +62,7 @@ def test_bloatnet_balance_extcodesize(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
     """
@@ -96,11 +97,13 @@ def test_bloatnet_balance_extcodesize(
         + 10  # While loop overhead
     )
 
-    # Calculate how many contracts to access based on available gas
-    available_gas = (
-        gas_benchmark_value - intrinsic_gas - 1000
-    )  # Reserve for cleanup
-    contracts_needed = int(available_gas // cost_per_contract)
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate how many contracts to access per transaction
+    # Reserve 1000 gas for cleanup
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract - NO HARDCODED VALUES
     # The stub "bloatnet_factory" must be provided via --address-stubs flag
@@ -114,8 +117,9 @@ def test_bloatnet_balance_extcodesize(
 
     # Log test requirements - deployed count read from factory storage
     print(
-        f"Test needs {contracts_needed} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas. "
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
+        f"Contracts per tx: {contracts_per_tx}. "
         f"Factory storage will be checked during execution."
     )
 
@@ -187,12 +191,16 @@ def test_bloatnet_balance_extcodesize(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state: just verify attack contract exists
     post = {
@@ -201,7 +209,7 @@ def test_bloatnet_balance_extcodesize(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )
 
@@ -217,6 +225,7 @@ def test_bloatnet_balance_extcodecopy(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
     """
@@ -253,9 +262,12 @@ def test_bloatnet_balance_extcodecopy(
         + 10  # While loop overhead
     )
 
-    # Calculate how many contracts to access
-    available_gas = gas_benchmark_value - intrinsic_gas - 1000
-    contracts_needed = int(available_gas // cost_per_contract)
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate how many contracts to access per transaction
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract - NO HARDCODED VALUES
     # The stub "bloatnet_factory" must be provided via --address-stubs flag
@@ -269,8 +281,9 @@ def test_bloatnet_balance_extcodecopy(
 
     # Log test requirements - deployed count read from factory storage
     print(
-        f"Test needs {contracts_needed} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas. "
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
+        f"Contracts per tx: {contracts_per_tx}. "
         f"Factory storage will be checked during execution."
     )
 
@@ -349,12 +362,16 @@ def test_bloatnet_balance_extcodecopy(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state
     post = {
@@ -363,7 +380,7 @@ def test_bloatnet_balance_extcodecopy(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )
 
@@ -379,6 +396,7 @@ def test_bloatnet_balance_extcodehash(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
     """
@@ -413,11 +431,13 @@ def test_bloatnet_balance_extcodehash(
         + 10  # While loop overhead
     )
 
-    # Calculate how many contracts to access based on available gas
-    available_gas = (
-        gas_benchmark_value - intrinsic_gas - 1000
-    )  # Reserve for cleanup
-    contracts_needed = int(available_gas // cost_per_contract)
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate how many contracts to access per transaction
+    # Reserve 1000 gas for cleanup
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas - 1000
+    contracts_per_tx = int(available_gas_per_tx // cost_per_contract)
 
     # Deploy factory using stub contract
     factory_address = pre.deploy_contract(
@@ -427,8 +447,9 @@ def test_bloatnet_balance_extcodehash(
 
     # Log test requirements
     print(
-        f"Test needs {contracts_needed} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas. "
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
+        f"Contracts per tx: {contracts_per_tx}. "
         f"Factory storage will be checked during execution."
     )
 
@@ -489,12 +510,16 @@ def test_bloatnet_balance_extcodehash(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state
     post = {
@@ -503,7 +528,7 @@ def test_bloatnet_balance_extcodehash(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )
 
@@ -530,6 +555,7 @@ def test_mixed_sload_sstore(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     address_stubs: AddressStubs | None,
     num_contracts: int,
     sload_percent: int,
@@ -642,13 +668,16 @@ def test_mixed_sload_sstore(
         + gas_costs.G_VERY_LOW  # PUSH1 0 for return offset (3)
     )
 
-    # Calculate gas budget per contract
-    available_gas = gas_benchmark_value - intrinsic_gas
-    gas_per_contract = available_gas // num_contracts
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate gas budget per contract per transaction
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas
+    gas_per_contract_per_tx = available_gas_per_tx // num_contracts
 
     # For each contract, split gas by percentage
-    sload_gas_per_contract = (gas_per_contract * sload_percent) // 100
-    sstore_gas_per_contract = (gas_per_contract * sstore_percent) // 100
+    sload_gas_per_contract = (gas_per_contract_per_tx * sload_percent) // 100
+    sstore_gas_per_contract = (gas_per_contract_per_tx * sstore_percent) // 100
 
     # Account for cold/warm transitions in CALL costs
     # First SLOAD call is COLD (2600), rest are WARM (100)
@@ -686,9 +715,11 @@ def test_mixed_sload_sstore(
     # Log test requirements
     print(
         f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas. "
-        f"~{gas_per_contract / 1_000_000:.1f}M gas per contract "
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
+        f"~{gas_per_contract_per_tx / 1_000_000:.2f}M gas per contract per tx "
         f"({sload_percent}% SLOAD, {sstore_percent}% SSTORE). "
-        f"Per contract: {sload_calls_per_contract} balanceOf calls, "
+        f"Per contract per tx: {sload_calls_per_contract} balanceOf calls, "
         f"{sstore_calls_per_contract} approve calls."
     )
 
@@ -763,12 +794,16 @@ def test_mixed_sload_sstore(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state
     post = {
@@ -777,6 +812,6 @@ def test_mixed_sload_sstore(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -699,7 +699,7 @@ def test_mixed_sload_sstore(
     sload_erc20_internal = (
         gas_costs.G_VERY_LOW  # PUSH4 selector (3)
         + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
+        + gas_costs.G_HIGH  # JUMPI to function (10)
         + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
         + gas_costs.G_VERY_LOW * 2  # CALLDATALOAD arg (3*2)
         + gas_costs.G_KECCAK_256  # keccak256 static (30)
@@ -732,7 +732,7 @@ def test_mixed_sload_sstore(
     sstore_erc20_internal = (
         gas_costs.G_VERY_LOW  # PUSH4 selector (3)
         + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
+        + gas_costs.G_HIGH  # JUMPI to function (10)
         + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
         + gas_costs.G_VERY_LOW  # CALLDATALOAD spender (3)
         + gas_costs.G_VERY_LOW  # CALLDATALOAD amount (3)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -156,7 +156,7 @@ def test_sload_empty_erc20_balanceof(
     erc20_internal_gas = (
         gas_costs.G_VERY_LOW  # PUSH4 selector (3)
         + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
+        + gas_costs.G_HIGH  # JUMPI to function (10)
         + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
         + gas_costs.G_VERY_LOW * 2  # CALLDATALOAD arg (3*2)
         + gas_costs.G_KECCAK_256  # keccak256 static (30)
@@ -363,7 +363,7 @@ def test_sstore_erc20_approve(
     erc20_internal_gas = (
         gas_costs.G_VERY_LOW  # PUSH4 selector (3)
         + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
+        + gas_costs.G_HIGH  # JUMPI to function (10)
         + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
         + gas_costs.G_VERY_LOW  # CALLDATALOAD spender (3)
         + gas_costs.G_VERY_LOW  # CALLDATALOAD amount (3)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -129,6 +129,17 @@ def test_sload_empty_erc20_balanceof(
     # Calculate gas costs
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
 
+    # Per-contract fixed overhead (setup + teardown for each contract's loop)
+    overhead_per_contract = (
+        gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
+        + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
+        + gas_costs.G_LOW  # MLOAD for While condition check (3)
+        + gas_costs.G_BASE  # ISZERO (2)
+        + gas_costs.G_BASE  # ISZERO (2)
+        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_BASE  # POP to clean up counter at end (2)
+    )
+
     # Fixed overhead per iteration (loop mechanics, independent of warm/cold)
     loop_overhead = (
         # Attack contract loop overhead
@@ -167,7 +178,10 @@ def test_sload_empty_erc20_balanceof(
     num_txs = max(1, gas_benchmark_value // tx_gas_limit)
 
     # Calculate gas budget per contract per transaction
-    available_gas_per_tx = tx_gas_limit - intrinsic_gas
+    total_overhead_per_tx = intrinsic_gas + (
+        overhead_per_contract * num_contracts
+    )
+    available_gas_per_tx = tx_gas_limit - total_overhead_per_tx
     gas_per_contract_per_tx = available_gas_per_tx // num_contracts
 
     # Solve for calls_per_contract per tx:
@@ -194,6 +208,7 @@ def test_sload_empty_erc20_balanceof(
         f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas. "
         f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
         f"Number of txs: {num_txs}. "
+        f"Overhead per contract: {overhead_per_contract}. "
         f"~{gas_per_contract_per_tx / 1_000_000:.2f}M gas/contract/tx, "
         f"{calls_per_contract} balanceOf calls/contract/tx."
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -133,10 +133,10 @@ def test_sload_empty_erc20_balanceof(
     overhead_per_contract = (
         gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
         + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
-        + gas_costs.G_LOW  # MLOAD for While condition check (3)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_VERY_LOW  # MLOAD for While condition check (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
         + gas_costs.G_BASE  # POP to clean up counter at end (2)
     )
 
@@ -147,9 +147,9 @@ def test_sload_empty_erc20_balanceof(
         + gas_costs.G_VERY_LOW * 2  # MSTORE selector (3*2)
         + gas_costs.G_VERY_LOW * 3  # MLOAD + MSTORE address (3*3)
         + gas_costs.G_BASE  # POP (2)
-        + gas_costs.G_BASE * 3  # SUB + MLOAD + MSTORE counter decrement
-        + gas_costs.G_BASE * 2  # ISZERO * 2 for loop condition (2*2)
-        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_VERY_LOW * 3  # SUB + MLOAD + MSTORE decrement (3*3)
+        + gas_costs.G_VERY_LOW * 2  # ISZERO * 2 for loop condition (3*2)
+        + gas_costs.G_HIGH  # JUMPI (10)
     )
 
     # ERC20 internal gas (same for all calls)
@@ -331,30 +331,30 @@ def test_sstore_erc20_approve(
         gas_costs.G_VERY_LOW  # MSTORE to initialize counter (3)
         + memory_expansion_cost  # Memory expansion (15)
         + gas_costs.G_JUMPDEST  # JUMPDEST at loop start (1)
-        + gas_costs.G_LOW  # MLOAD for While condition check (5)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI (8)
+        + gas_costs.G_VERY_LOW  # MLOAD for While condition check (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI (10)
         + gas_costs.G_BASE  # POP to clean up counter at end (2)
-    )  # = 38
+    )  # = 40
 
     # Fixed overhead per iteration (loop mechanics, independent of warm/cold)
     loop_overhead = (
         # Attack contract loop body operations
         gas_costs.G_VERY_LOW  # MSTORE selector at memory[32] (3)
-        + gas_costs.G_LOW  # MLOAD counter (5)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
         + gas_costs.G_VERY_LOW  # MSTORE spender at memory[64] (3)
         + gas_costs.G_BASE  # POP call result (2)
         # Counter decrement: MSTORE(0, SUB(MLOAD(0), 1))
-        + gas_costs.G_LOW  # MLOAD counter (5)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
         + gas_costs.G_VERY_LOW  # PUSH1 1 (3)
         + gas_costs.G_VERY_LOW  # SUB (3)
         + gas_costs.G_VERY_LOW  # MSTORE counter back (3)
         # While loop condition check
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI back to loop start (8)
+        + gas_costs.G_VERY_LOW  # MLOAD counter (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_VERY_LOW  # ISZERO (3)
+        + gas_costs.G_HIGH  # JUMPI back to loop start (10)
     )
 
     # ERC20 internal gas (same for all calls)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -84,6 +84,7 @@ def test_sload_empty_erc20_balanceof(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     address_stubs: AddressStubs | None,
     num_contracts: int,
     request: pytest.FixtureRequest,
@@ -154,14 +155,7 @@ def test_sload_empty_erc20_balanceof(
         # RETURN costs 0 gas
     )
 
-    # Calculate gas budget per contract
-    available_gas = gas_benchmark_value - intrinsic_gas
-    gas_per_contract = available_gas // num_contracts
-
     # For each contract: first call is COLD (2600), subsequent are WARM (100)
-    # Solve for calls_per_contract:
-    # gas_per_contract = cold_call + (calls-1) * warm_call
-    # Simplifies to: gas = cold_warm_diff + calls * warm_call_cost
     warm_call_cost = (
         loop_overhead + gas_costs.G_WARM_ACCOUNT_ACCESS + erc20_internal_gas
     )
@@ -169,8 +163,18 @@ def test_sload_empty_erc20_balanceof(
         gas_costs.G_COLD_ACCOUNT_ACCESS - gas_costs.G_WARM_ACCOUNT_ACCESS
     )
 
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate gas budget per contract per transaction
+    available_gas_per_tx = tx_gas_limit - intrinsic_gas
+    gas_per_contract_per_tx = available_gas_per_tx // num_contracts
+
+    # Solve for calls_per_contract per tx:
+    # gas_per_contract_per_tx = cold_call + (calls-1) * warm_call
+    # Simplifies to: gas = cold_warm_diff + calls * warm_call_cost
     calls_per_contract = int(
-        (gas_per_contract - cold_warm_diff) // warm_call_cost
+        (gas_per_contract_per_tx - cold_warm_diff) // warm_call_cost
     )
 
     # Deploy selected ERC20 contracts using stubs
@@ -188,8 +192,10 @@ def test_sload_empty_erc20_balanceof(
     # Log test requirements
     print(
         f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas. "
-        f"~{gas_per_contract / 1_000_000:.1f}M gas per contract, "
-        f"{calls_per_contract} balanceOf calls per contract."
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
+        f"~{gas_per_contract_per_tx / 1_000_000:.2f}M gas/contract/tx, "
+        f"{calls_per_contract} balanceOf calls/contract/tx."
     )
 
     # Build attack code that loops through each contract
@@ -230,12 +236,16 @@ def test_sload_empty_erc20_balanceof(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state
     post = {
@@ -244,7 +254,7 @@ def test_sload_empty_erc20_balanceof(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )
 
@@ -256,6 +266,7 @@ def test_sstore_erc20_approve(
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     address_stubs: AddressStubs | None,
     num_contracts: int,
     request: pytest.FixtureRequest,
@@ -353,10 +364,6 @@ def test_sstore_erc20_approve(
         # RETURN costs 0 gas
     )
 
-    # Calculate total gas needed
-    total_overhead = intrinsic_gas + (overhead_per_contract * num_contracts)
-    available_gas_for_iterations = gas_benchmark_value - total_overhead
-
     # For each contract: first call is COLD (2600), subsequent are WARM (100)
     # Solve for calls per contract accounting for cold/warm transition
     warm_call_cost = (
@@ -366,10 +373,19 @@ def test_sstore_erc20_approve(
         gas_costs.G_COLD_ACCOUNT_ACCESS - gas_costs.G_WARM_ACCOUNT_ACCESS
     )
 
-    # Per contract: gas_available = cold_warm_diff + calls * warm_call_cost
-    gas_per_contract = available_gas_for_iterations // num_contracts
+    # Calculate how many transactions we need to fill the block
+    num_txs = max(1, gas_benchmark_value // tx_gas_limit)
+
+    # Calculate gas budget per contract per transaction
+    total_overhead_per_tx = intrinsic_gas + (
+        overhead_per_contract * num_contracts
+    )
+    available_gas_per_tx = tx_gas_limit - total_overhead_per_tx
+    gas_per_contract_per_tx = available_gas_per_tx // num_contracts
+
+    # Per contract per tx: gas = cold_warm_diff + calls * warm_call_cost
     calls_per_contract = int(
-        (gas_per_contract - cold_warm_diff) // warm_call_cost
+        (gas_per_contract_per_tx - cold_warm_diff) // warm_call_cost
     )
 
     # Deploy selected ERC20 contracts using stubs
@@ -384,10 +400,11 @@ def test_sstore_erc20_approve(
     # Log test requirements
     print(
         f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas. "
-        f"Intrinsic: {intrinsic_gas}, "
+        f"Tx gas limit: {tx_gas_limit / 1_000_000:.1f}M gas. "
+        f"Number of txs: {num_txs}. "
         f"Overhead per contract: {overhead_per_contract}, "
         f"Warm call cost: {warm_call_cost}. "
-        f"{calls_per_contract} approve calls per contract "
+        f"{calls_per_contract} approve calls per contract per tx "
         f"({num_contracts} contracts)."
     )
 
@@ -433,12 +450,16 @@ def test_sstore_erc20_approve(
     # Deploy attack contract
     attack_address = pre.deploy_contract(code=attack_code)
 
-    # Run the attack
-    attack_tx = Transaction(
-        to=attack_address,
-        gas_limit=gas_benchmark_value,
-        sender=pre.fund_eoa(),
-    )
+    # Create multiple attack transactions to fill the block
+    sender = pre.fund_eoa()
+    attack_txs = [
+        Transaction(
+            to=attack_address,
+            gas_limit=tx_gas_limit,
+            sender=sender,
+        )
+        for _ in range(num_txs)
+    ]
 
     # Post-state
     post = {
@@ -447,6 +468,6 @@ def test_sstore_erc20_approve(
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[attack_tx])],
+        blocks=[Block(txs=attack_txs)],
         post=post,
     )


### PR DESCRIPTION
## 🗒️ Description

Update SLOAD/SSTORE and multi-opcode stateful benchmark tests to support Fusaka's 16M transaction gas limit. Tests now split large attack transactions into multiple smaller ones that each respect the `tx_gas_limit` cap while still filling the entire block gas budget.

Changes:
- Added `tx_gas_limit` fixture parameter to all affected test functions in `test_single_opcode.py` and `test_multi_opcode.py`
- Calculate `num_txs = max(1, gas_benchmark_value // tx_gas_limit)` to determine how many transactions are needed
- Split single large attack transaction into multiple smaller transactions in a list
- Updated gas calculations to be per-transaction rather than per-block

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: PR title adheres to the repo standard - it will be used as the squash commit message and should start `type(scope):`.
- [x] Tests: Verified SLOAD and SSTORE benchmarks work with `--transaction-gas-limit 16000000` and `--gas-benchmark-values 34` on Anvil

#### Cute Animal Picture

<img width="1024" height="559" alt="image" src="https://github.com/user-attachments/assets/74848c55-a2a3-4867-958d-26a457349d92" />
