### PR TITLE
chore(tooling): run codespell on all files; improve skip config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,22 +380,35 @@ ignore = [
 ]
 
 [tool.codespell]
-builtin = "clear,code,usage"    # Built-in dictionaries to use
-skip = [                        # Don't check these files/folders
-    ".git/*",
-    ".tox/*",
-    ".venv/*",
-    "build/*",
-    "dist/*",
-    "*.pyc",
-    "ethereum_execution.egg-info/*",
-    "*.coverage*",
-    "__pycache__",
+builtin = "clear,code,usage"
+# Version control & tooling, build artifacts, data files, test fixtures, temp files, lock files
+skip = [
+    ".git",
+    ".tox",
+    ".venv",
     ".ruff_cache",
-    "fixtures.*",
+    ".mypy_cache",
+    ".pytest_cache",
+    "__pycache__",
+    "*.pyc",
+    "build",
+    "cov",
+    "dist",
+    "logs",
+    "site",
+    "*.egg-info",
+    "*.json",
+    "*.log",
+    "*.xml",
+    "*.csv",
+    "*.tar.gz",
+    "*.png",
     "tests/fixtures",
     "tests/json_infra/fixtures",
-    "src/ethereum_spec_tools/evm_tools/t8n" # Temporary while being re-written
+    "fixtures.*",
+    "tmp",
+    "*.coverage*",
+    "uv.lock",
 ]
 ignore-words = "whitelist.txt"  # Custom whitelist file
 count = true                    # Display counts of errors

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ wheel_build_env = .pkg
 [testenv:static]
 description = Run spelling, lint, typechecking and dependency checks
 commands =
-    codespell docs src packages tests
+    codespell
     ruff check 
     ruff format --check
     mypy


### PR DESCRIPTION
## 🗒️ Description

This PR extends spellchecking to **all sources files not included in its configured skip list**.

In particular, it extends `codespell` coverage to:
  - Root-level markdown files (*.md)
  - .github/ directory

**Motivation:** PR #1950 highlighted that root markdown files were not being spellchecked. This change ensures documentation in the repository root and GitHub workflows are spellchecked in CI.

This change will potentially annoy people with a lot of stray files in their repo.

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1970c2b2-bab2-47fc-836f-98481c027b0e" />
