### PR TITLE
fix(evm): CLZ is not UndefinedOpcodes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🛠️ Framework
 
+- 🐞 Remove `Op.CLZ` from `UndefinedOpcodes` list ([#1970](https://github.com/ethereum/execution-specs/pull/1970)).
+
 #### `fill`
 
 #### `consume`

--- a/packages/testing/src/execution_testing/tools/tests/test_code.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_code.py
@@ -708,7 +708,7 @@ def test_full_opcode_range() -> None:
     """
     assert len(set(Op) & set(UndefinedOpcodes)) == 0
     full_possible_opcode_set = set(Op) | set(UndefinedOpcodes)
-    assert len(full_possible_opcode_set) == 257
+    assert len(full_possible_opcode_set) == 256
     assert {op.hex() for op in full_possible_opcode_set} == {
         f"{i:02x}" for i in range(256)
     }

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -6110,13 +6110,12 @@ class Macros(Macro, Enum):
 
 
 class UndefinedOpcodes(Opcode, Enum):
-    """Enum containing all unknown opcodes (88 at the moment)."""
+    """Enum containing all unknown opcodes (86 at the moment)."""
 
     OPCODE_0C = Opcode(0x0C)
     OPCODE_0D = Opcode(0x0D)
     OPCODE_0E = Opcode(0x0E)
     OPCODE_0F = Opcode(0x0F)
-    OPCODE_1E = Opcode(0x1E)
     OPCODE_1F = Opcode(0x1F)
     OPCODE_21 = Opcode(0x21)
     OPCODE_22 = Opcode(0x22)


### PR DESCRIPTION
## 🗒️ Description

Minor fix to the UndefinedOpcodes list.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
