### PR TITLE
feat(test): Turn on filling static tests for bal releases

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -23,5 +23,6 @@ benchmark_fast:
 
 bal:
   evm-type: develop
-  fill-params: --fork=Amsterdam ./tests/amsterdam/eip7928_block_level_access_lists
+  # TODO: Turn on block rlp limit tests after making filling them more flexible.
+  fill-params: --fork=Amsterdam -k "not eip7934" --fill-static-tests
   feature_only: true

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
@@ -498,8 +498,11 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_OSAKA_TIMESTAMP": 0,
         "HIVE_BPO1_TIMESTAMP": 0,
         "HIVE_BPO2_TIMESTAMP": 0,
-        "HIVE_BPO3_TIMESTAMP": 0,
-        "HIVE_BPO4_TIMESTAMP": 0,
+        # TODO: So far only BPOs 1 and 2 are active. This may have to be
+        #  tweaked as more BPOs get activated and the Amsterdam fork
+        #  starts inheriting these params.
+        # "HIVE_BPO3_TIMESTAMP": 0,
+        # "HIVE_BPO4_TIMESTAMP": 0,
         "HIVE_AMSTERDAM_TIMESTAMP": 0,
         **get_blob_schedule_entries(Amsterdam),
     },


### PR DESCRIPTION
## 🗒️ Description

- Turn on filling all static tests for the next `bal` release for Amsterdam.
- Turn on hive BPO1 and BPO2 timestamps as `Amsterdam` fork now inherits from `BPO2` fork and we fill with BPO2 params. Clients need to turn this on in order to pass blob-related tests.

### Unrelated

- ~~Fix initial balance for blob tests that need to account for higher balance based on increased blob params. These were failing to fill for Amsterdam as well now that we inherit from BPO2.~~ [this change should be in `forks/amsterdam` instead, PR created [here](https://github.com/ethereum/execution-specs/pull/1975). With these two PRs together, all tests, including static tests, fill for Amsterdam].

---
Note: These changes will need to be rebased onto `eips/amsterdam/eip-7928`. I'll do this once this and #1975 are merged.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="692" height="577" alt="Screenshot 2026-01-05 at 10 12 17" src="https://github.com/user-attachments/assets/4b33c194-9f5e-4999-8fa0-05e5636fb195" />
