### PR TITLE
fix(test): Increase balance for blob test fails w/ larger blob params

### DIFF
--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -315,7 +315,7 @@ def non_zero_blob_gas_used_genesis_block(
         f"with base_fee_per_gas {block_base_fee_per_gas}"
     )
 
-    sender = pre.fund_eoa(10**27)
+    sender = pre.fund_eoa(10**42)
     empty_account_destination = pre.fund_eoa(0)
     blob_gas_price_calculator = fork.blob_gas_price_calculator(block_number=1)
 


### PR DESCRIPTION
## 🗒️ Description

- Fix initial balance for blob tests that need to account for higher balance based on increased blob params. These were failing to fill for Amsterdam, with balance too low, now that we inherit from BPO2.

We will have to rebase `eips/amsterdam/eip-7928` again to bring this change back up but this seems most appropriate to be put into `forks/amsterdam`. To reproduce, try filling with:

`uv run fill --clean --fork=Amsterdam -k "test_correct_increasing_blob_gas_costs and parent_excess_blobs_4302"` 

... from the `eips/amsterdam/eip-7928` branch.

---
Note: These changes will need to be rebased onto `eips/amsterdam/eip-7928`. I'll do this once this and #1973 are merged.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="407" height="593" alt="Screenshot 2026-01-05 at 11 55 24" src="https://github.com/user-attachments/assets/1ecf69e5-99b0-424d-8a0d-1788bc524bd8" />
