### PR TITLE
refactor(test-benchmark): update repricing label

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🧪 Test Cases
 
 - ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
+- 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).
 
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -71,7 +71,6 @@ def test_codesize(
     )
 
 
-@pytest.mark.repricing(max_code_size_ratio=0, fixed_src_dst=True)
 @pytest.mark.parametrize(
     "max_code_size_ratio",
     [
@@ -114,6 +113,7 @@ def test_codecopy(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("code_size", [0, 32, 256, 1024, 24576])
 def test_codecopy_benchmark(

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -48,7 +48,7 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(calldata_size=1024)
+@pytest.mark.repricing(zero_data=True)
 @pytest.mark.parametrize("calldata_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("zero_data", [True, False])
 def test_calldatasize(
@@ -118,6 +118,7 @@ def test_callvalue_from_call(
     )
 
 
+@pytest.mark.repricing(zero_data=True)
 @pytest.mark.parametrize("calldata_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("zero_data", [True, False])
 def test_calldataload(
@@ -138,7 +139,7 @@ def test_calldataload(
     )
 
 
-@pytest.mark.repricing(size=0, fixed_src_dst=True, non_zero_data=False)
+@pytest.mark.repricing(fixed_src_dst=True)
 @pytest.mark.parametrize(
     "mem_size",
     [
@@ -278,7 +279,6 @@ def test_calldatacopy_from_call(
 
 
 @pytest.mark.repricing(
-    returned_size=0,
     return_data_style=ReturnDataStyle.IDENTITY,
 )
 @pytest.mark.parametrize(
@@ -325,7 +325,6 @@ def test_returndatasize_nonzero(
     )
 
 
-@pytest.mark.repricing
 def test_returndatasize_zero(
     benchmark_test: BenchmarkTestFiller,
 ) -> None:
@@ -336,7 +335,7 @@ def test_returndatasize_zero(
     )
 
 
-@pytest.mark.repricing(size=0, fixed_dst=True)
+@pytest.mark.repricing(fixed_dst=True)
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(
     "return_size",

--- a/tests/benchmark/compute/instruction/test_keccak.py
+++ b/tests/benchmark/compute/instruction/test_keccak.py
@@ -19,7 +19,6 @@ from execution_testing import (
 KECCAK_RATE = 136
 
 
-@pytest.mark.repricing
 def test_keccak_max_permutations(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
@@ -90,6 +89,7 @@ def test_keccak(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("msg_size", [0, 32, 256, 1024])
 def test_keccak_diff_mem_msg_sizes(

--- a/tests/benchmark/compute/instruction/test_log.py
+++ b/tests/benchmark/compute/instruction/test_log.py
@@ -18,12 +18,6 @@ from execution_testing import (
 )
 
 
-@pytest.mark.repricing(
-    size=0,
-    non_zero_data=True,
-    zeros_topic=0,
-    fixed_offset=False,
-)
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -90,6 +84,7 @@ def test_log(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -36,11 +36,7 @@ def test_msize(
     )
 
 
-@pytest.mark.repricing(
-    offset=0,
-    offset_initialized=True,
-    big_memory_expansion=True,
-)
+@pytest.mark.repricing(offset=0, offset_initialized=True)
 @pytest.mark.parametrize("opcode", [Op.MLOAD, Op.MSTORE, Op.MSTORE8])
 @pytest.mark.parametrize("offset", [0, 1, 31])
 @pytest.mark.parametrize("offset_initialized", [True, False])
@@ -73,7 +69,7 @@ def test_memory_access(
     )
 
 
-@pytest.mark.repricing(size=0, fixed_src_dst=True)
+@pytest.mark.repricing(fixed_src_dst=True)
 @pytest.mark.parametrize(
     "mem_size",
     [

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -40,7 +40,6 @@ from execution_testing import (
 from tests.benchmark.compute.helpers import XOR_TABLE
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [
@@ -686,7 +685,6 @@ def test_selfdestruct_existing(
     )
 
 
-@pytest.mark.repricing(value_bearing=True)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_created(
     benchmark_test: BenchmarkTestFiller,
@@ -818,7 +816,6 @@ def test_selfdestruct_created(
     )
 
 
-@pytest.mark.repricing(value_bearing=False)
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_initcode(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -30,6 +30,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="bn128_add",
+            marks=pytest.mark.repricing,
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L326
@@ -44,6 +45,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="bn128_add_infinities",
+            marks=pytest.mark.repricing,
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L329
@@ -95,6 +97,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="bn128_mul_infinities_32_byte_scalar",
+            marks=pytest.mark.repricing,
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L341
@@ -134,6 +137,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="bn128_mul_32_byte_coord_and_2_scalar",
+            marks=pytest.mark.repricing,
         ),
         # Ported from
         # https://github.com/NethermindEth/nethermind/blob/ceb8d57b8530ce8181d7427c115ca593386909d6/tools/EngineRequestsGenerator/TestCase.cs#L350
@@ -147,6 +151,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="bn128_mul_32_byte_coord_and_scalar",
+            marks=pytest.mark.repricing,
         ),
         pytest.param(
             0x08,

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -25,6 +25,7 @@ from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
                 ]
             ),
             id="bls12_g1add",
+            marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.G1MSM,
@@ -48,6 +49,7 @@ from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
                 ]
             ),
             id="bls12_g2add",
+            marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.G2MSM,
@@ -84,6 +86,7 @@ from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
                 ]
             ),
             id="bls12_fp_to_g1",
+            marks=pytest.mark.repricing,
         ),
         pytest.param(
             bls12381_spec.Spec.MAP_FP2_TO_G2,
@@ -95,6 +98,7 @@ from tests.prague.eip2537_bls_12_381_precompiles import spec as bls12381_spec
                 ]
             ),
             id="bls12_fp_to_g2",
+            marks=pytest.mark.repricing,
         ),
     ],
 )

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -28,6 +28,7 @@ from tests.benchmark.compute.helpers import concatenate_parameters
                 ]
             ),
             id="ecrecover",
+            marks=pytest.mark.repricing,
         )
     ],
 )

--- a/tests/benchmark/compute/precompile/test_identity.py
+++ b/tests/benchmark/compute/precompile/test_identity.py
@@ -43,6 +43,7 @@ def test_identity(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("size", [0, 32, 256, 1024])
 def test_identity_fixed_size(
     benchmark_test: BenchmarkTestFiller, size: int

--- a/tests/benchmark/compute/precompile/test_p256verify.py
+++ b/tests/benchmark/compute/precompile/test_p256verify.py
@@ -31,7 +31,8 @@ from tests.osaka.eip7951_p256verify_precompiles import spec as p256verify_spec
             marks=[
                 pytest.mark.eip_checklist(
                     "precompile/test/excessive_gas_usage", eip=[7951]
-                )
+                ),
+                pytest.mark.repricing,
             ],
         ),
         pytest.param(

--- a/tests/benchmark/compute/precompile/test_point_evaluation.py
+++ b/tests/benchmark/compute/precompile/test_point_evaluation.py
@@ -28,6 +28,7 @@ from tests.cancun.eip4844_blobs.spec import Spec as BlobsSpec
                 ]
             ),
             id="point_evaluation",
+            marks=pytest.mark.repricing,
         ),
     ],
 )

--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -43,6 +43,7 @@ def test_ripemd160(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("size", [0, 32, 256, 1024])
 def test_ripemd160_fixed_size(
     benchmark_test: BenchmarkTestFiller, size: int

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -43,6 +43,7 @@ def test_sha256(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("size", [0, 32, 256, 1024])
 def test_sha256_fixed_size(
     benchmark_test: BenchmarkTestFiller, size: int


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Originally, we label the worst performance benchmark with the repricing marker. That is, when adding `-m repricing`, we are running a subset of benchmark that is least performant for each opcode/precompiles.

After clarifying the intention with Maria and Kamil, we reach the consensus to label the repricing marker based on the configurations Maria request for further analysis.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![dog](https://github.com/user-attachments/assets/1e64afe4-6af3-4ebe-853f-da867c894299)

