### PR TITLE
bug(test-benchmark): update code padding in fixed opcode count mode

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -210,9 +210,9 @@ class BenchmarkCodeGenerator(ABC):
             )
         # Pad the code to the maximum code size.
         if self.code_padding_opcode is not None:
-            padding_size = max_code_size - len(code)
+            padding_size = max_code_size - len(code) - 1
             if padding_size > 0:
-                code += self.code_padding_opcode * padding_size
+                code += Op.STOP + self.code_padding_opcode * padding_size
         self._validate_code_size(code, fork)
 
         return code


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

**Summary**
 - Fix benchmark tests hitting `INVALID` opcode when using `--fixed-opcode-count`
 - Add STOP instruction before padding in `generate_repeated_code` to ensure clean termination

**Problem**
 - When `fixed_opcode_count` is set, the generated code was:
 - `setup + JUMPDEST + attack_block * N + INVALID padding`

After executing all iterations, execution fell through into `INVALID` padding.

 **Solution**
 - Insert STOP before padding:
 - `setup + JUMPDEST + attack_block * N + STOP + INVALID padding`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
