### PR TITLE
chore(test-types): Add `extra="forbid"` to `CamelModel`; fix errors

### DIFF
--- a/packages/testing/src/execution_testing/base_types/pydantic.py
+++ b/packages/testing/src/execution_testing/base_types/pydantic.py
@@ -32,7 +32,14 @@ class CopyValidateModel(EthereumTestBaseModel):
         """
         Create a copy of the model with the updated fields that are validated.
         """
-        return self.__class__(**(self.model_dump(exclude_unset=True) | kwargs))
+        # Only include actual model fields, not computed fields
+        model_field_names = set(self.__class__.model_fields.keys())
+        dumped = {
+            k: v
+            for k, v in self.model_dump(exclude_unset=True).items()
+            if k in model_field_names
+        }
+        return self.__class__(**(dumped | kwargs))
 
 
 class CamelModel(CopyValidateModel):
@@ -47,4 +54,5 @@ class CamelModel(CopyValidateModel):
         alias_generator=to_camel,
         populate_by_name=True,
         validate_default=True,
+        extra="forbid",
     )

--- a/packages/testing/src/execution_testing/cli/eofwrap.py
+++ b/packages/testing/src/execution_testing/cli/eofwrap.py
@@ -355,8 +355,8 @@ class EofWrapper:
                     fixture_tx_dump.pop("ty")
                     fixture_tx_dump.pop("data")
                     tx = Transaction(
-                        type=fixture_tx.ty,
-                        input=fixture_tx.data,
+                        ty=fixture_tx.ty,
+                        data=fixture_tx.data,
                         **fixture_tx_dump,
                     )
                     block.txs.append(tx)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/execute_types.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/execute_types.py
@@ -333,6 +333,8 @@ class GenesisConfig(CamelModel):
                         if synonym:
                             stripped_key = synonym
                         else:
+                            # Remove deprecated fork keys that have no synonym
+                            data.pop(key)
                             continue
                     fork_activation_times[stripped_key] = data.pop(key)
             if fork_activation_times:
@@ -360,7 +362,8 @@ class Genesis(CamelModel):
     def hash(self) -> Hash:
         """Calculate the genesis hash."""
         dumped_genesis = self.model_dump(
-            mode="json", exclude={"config", "alloc"}
+            mode="json",
+            exclude={"config", "alloc", "nonce", "mixhash", "parent_hash"},
         )
         genesis_fork = self.config.fork()
         env = Environment(**dumped_genesis).set_fork_requirements(genesis_fork)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/tests/test_genesis.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/eth_config/tests/test_genesis.py
@@ -76,28 +76,44 @@ def genesis_contents(genesis_file_name: str) -> str:
                 ),
                 blob_schedule={
                     Cancun: ForkConfigBlobSchedule(
-                        target=3, max=6, baseFeeUpdateFraction=3338477
+                        target_blobs_per_block=3,
+                        max_blobs_per_block=6,
+                        base_fee_update_fraction=3338477,
                     ),
                     Prague: ForkConfigBlobSchedule(
-                        target=6, max=9, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=6,
+                        max_blobs_per_block=9,
+                        base_fee_update_fraction=5007716,
                     ),
                     Osaka: ForkConfigBlobSchedule(
-                        target=6, max=9, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=6,
+                        max_blobs_per_block=9,
+                        base_fee_update_fraction=5007716,
                     ),
                     BPO1: ForkConfigBlobSchedule(
-                        target=9, max=12, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=9,
+                        max_blobs_per_block=12,
+                        base_fee_update_fraction=5007716,
                     ),
                     BPO2: ForkConfigBlobSchedule(
-                        target=12, max=15, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=12,
+                        max_blobs_per_block=15,
+                        base_fee_update_fraction=5007716,
                     ),
                     BPO3: ForkConfigBlobSchedule(
-                        target=15, max=18, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=15,
+                        max_blobs_per_block=18,
+                        base_fee_update_fraction=5007716,
                     ),
                     BPO4: ForkConfigBlobSchedule(
-                        target=6, max=9, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=6,
+                        max_blobs_per_block=9,
+                        base_fee_update_fraction=5007716,
                     ),
                     BPO5: ForkConfigBlobSchedule(
-                        target=15, max=20, baseFeeUpdateFraction=5007716
+                        target_blobs_per_block=15,
+                        max_blobs_per_block=20,
+                        base_fee_update_fraction=5007716,
                     ),
                 },
             ),

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filling_session.py
@@ -86,8 +86,8 @@ class TestFillingSession:
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
-            .model_dump(mode="json"),
-            network=Prague.name(),
+            .model_dump(mode="json", exclude={"parent_hash"}),
+            fork=Prague.name(),
         )
         test_group = test_group_builder.build()
         mock_groups = PreAllocGroups(root={"test_hash": test_group})
@@ -171,8 +171,8 @@ class TestFillingSession:
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
-            .model_dump(mode="json"),
-            network=Prague.name(),
+            .model_dump(mode="json", exclude={"parent_hash"}),
+            fork=Prague.name(),
         )
         test_group = test_group_builder.build()
         mock_groups = PreAllocGroups(root={"test_hash": test_group})
@@ -239,8 +239,8 @@ class TestFillingSession:
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
-            .model_dump(mode="json"),
-            network=Prague.name(),
+            .model_dump(mode="json", exclude={"parent_hash"}),
+            fork=Prague.name(),
         )
         session.update_pre_alloc_group_builder("test_hash", test_group_builder)
 
@@ -265,8 +265,8 @@ class TestFillingSession:
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
-            .model_dump(mode="json"),
-            network=Prague.name(),
+            .model_dump(mode="json", exclude={"parent_hash"}),
+            fork=Prague.name(),
         )
         with pytest.raises(
             ValueError,
@@ -291,8 +291,8 @@ class TestFillingSession:
             pre=Alloc().model_dump(mode="json"),
             environment=Environment()
             .set_fork_requirements(Prague)
-            .model_dump(mode="json"),
-            network=Prague.name(),
+            .model_dump(mode="json", exclude={"parent_hash"}),
+            fork=Prague.name(),
         )
         session.update_pre_alloc_group_builder("test_hash", test_group_builder)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/hive_info.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/hive_info.py
@@ -49,6 +49,10 @@ class ClientFile(RootModel, YAMLModel):
 class HiveInfo(CamelModel):
     """Hive instance information."""
 
+    # Allow extra fields: HiveInfo parses external hive API responses which
+    # may include fields not defined in this model.
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     command: List[str]
     client_file: ClientFile = Field(
         default_factory=lambda: ClientFile(root=[])

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -77,6 +77,7 @@ class TraceLine(CamelModel):
     refund: int
     op_name: str
     error: str | None = None
+    return_data: str | None = None
 
     def are_equivalent(self, other: Self) -> bool:
         """Return True if the only difference is the gas counter."""

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -198,9 +198,6 @@ def test_evm_t8n(
             for key in missing_receipt_fields:
                 for i, _ in enumerate(expected.get("result")["receipts"]):
                     del expected.get("result")["receipts"][i][key]
-            for i, receipt in enumerate(expected.get("result")["receipts"]):
-                if int(receipt["logsBloom"], 16) == 0:
-                    del expected.get("result")["receipts"][i]["logsBloom"]
 
             t8n_result = to_json(t8n_output.result)
             for i, _ in enumerate(expected.get("result")["rejected"]):

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -23,7 +23,6 @@ import pytest
 from ethereum_types.numeric import Uint
 from pydantic import (
     AliasChoices,
-    ConfigDict,
     Field,
     PlainSerializer,
     computed_field,
@@ -146,7 +145,7 @@ class FixtureHeader(CamelModel):
 
     # Allow extra fields: FixtureHeader is constructed from merged Result and
     # Environment data via model_dump(), which includes fields not in this model.
-    model_config = ConfigDict(extra="ignore")
+    model_config = CamelModel.model_config | {"extra": "ignore"}
 
     parent_hash: Hash = Hash(0)
     ommers_hash: Hash = Field(Hash(EmptyOmmersRoot), alias="uncleHash")
@@ -702,6 +701,10 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
     Uses pre-allocation groups (and a single client instance) for efficient
     test execution without client restarts.
     """
+
+    # Allow extra fields: BlockchainEngineXFixture is constructed from shared
+    # fixture_data that includes fields for other fixture formats (e.g. genesis).
+    model_config = CamelModel.model_config | {"extra": "ignore"}
 
     format_name: ClassVar[str] = "blockchain_test_engine_x"
     description: ClassVar[str] = (

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -23,6 +23,7 @@ import pytest
 from ethereum_types.numeric import Uint
 from pydantic import (
     AliasChoices,
+    ConfigDict,
     Field,
     PlainSerializer,
     computed_field,
@@ -142,6 +143,10 @@ class FixtureHeader(CamelModel):
 
     We combine the `Environment` and `Result` contents to create this model.
     """
+
+    # Allow extra fields: FixtureHeader is constructed from merged Result and
+    # Environment data via model_dump(), which includes fields not in this model.
+    model_config = ConfigDict(extra="ignore")
 
     parent_hash: Hash = Hash(0)
     ommers_hash: Hash = Field(Hash(EmptyOmmersRoot), alias="uncleHash")
@@ -293,6 +298,10 @@ class FixtureExecutionPayload(CamelModel):
     Representation of an Ethereum execution payload within a test Fixture.
     """
 
+    # Allow extra fields: FixtureExecutionPayload is constructed from
+    # FixtureHeader via model_dump(), which includes fields not in this model.
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     parent_hash: Hash
     fee_recipient: Address
     state_root: Hash
@@ -333,7 +342,7 @@ class FixtureExecutionPayload(CamelModel):
         transactions, a list of withdrawals, and an optional block access list.
         """
         return cls(
-            **header.model_dump(exclude={"rlp"}, exclude_none=True),
+            **header.model_dump(exclude_none=True),
             transactions=[tx.rlp() for tx in transactions],
             withdrawals=withdrawals,
             block_access_list=block_access_list,
@@ -460,6 +469,10 @@ class FixtureTransaction(
 ):
     """Representation of an Ethereum transaction within a test Fixture."""
 
+    # Allow extra fields: FixtureTransaction is constructed from
+    # Transaction via model_dump(), which includes fields not in this model.
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     authorization_list: List[FixtureAuthorizationTuple] | None = None
     initcodes: List[Bytes] | None = None
 
@@ -505,6 +518,18 @@ class FixtureBlockBase(CamelModel):
     bytes.
     """
 
+    @model_validator(mode="before")
+    @classmethod
+    def strip_block_number_computed_field(cls, data: Any) -> Any:
+        """
+        Strip the block_number computed field which gets included in model_dump()
+        but is not a valid input field.
+        """
+        if isinstance(data, dict):
+            data.pop("blocknumber", None)
+            data.pop("block_number", None)
+        return data
+
     header: FixtureHeader = Field(..., alias="blockHeader")
     txs: List[FixtureTransaction] = Field(
         default_factory=list, alias="transactions"
@@ -517,6 +542,7 @@ class FixtureBlockBase(CamelModel):
     block_access_list: BlockAccessList | None = Field(
         None, description="EIP-7928 Block Access List"
     )
+    fork: Fork | None = Field(None, exclude=True)
 
     @computed_field(alias="blocknumber")  # type: ignore[prop-decorator]
     @cached_property

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -257,8 +257,6 @@ class PreAllocGroup(PreAllocGroupBuilder):
     pre-allocation group optimization.
     """
 
-    # Allow both field names and aliases
-    model_config = {"populate_by_name": True}
     pre: GroupPreAlloc
     genesis: FixtureHeader
     pre_account_count: int

--- a/packages/testing/src/execution_testing/fixtures/state.py
+++ b/packages/testing/src/execution_testing/fixtures/state.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar, List, Mapping, Sequence
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from execution_testing.base_types import (
     AccessList,
@@ -30,7 +30,7 @@ class FixtureEnvironment(EnvironmentGeneric[ZeroPaddedHexNumber]):
 
     # Allow extra fields: FixtureEnvironment is constructed from Environment
     # via model_dump(), which includes many fields not in EnvironmentGeneric.
-    model_config = ConfigDict(extra="ignore")
+    model_config = CamelModel.model_config | {"extra": "ignore"}
 
     prev_randao: Hash | None = Field(None, alias="currentRandom")  # type: ignore
 
@@ -40,7 +40,7 @@ class FixtureTransaction(TransactionFixtureConverter):
 
     # Allow extra fields: FixtureTransaction is constructed from Transaction
     # via model_dump(), which includes many fields not in this model.
-    model_config = ConfigDict(extra="ignore")
+    model_config = CamelModel.model_config | {"extra": "ignore"}
 
     nonce: ZeroPaddedHexNumber
     gas_price: ZeroPaddedHexNumber | None = None

--- a/packages/testing/src/execution_testing/fixtures/state.py
+++ b/packages/testing/src/execution_testing/fixtures/state.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar, List, Mapping, Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from execution_testing.base_types import (
     AccessList,
@@ -28,11 +28,19 @@ from .common import FixtureAuthorizationTuple, FixtureBlobSchedule
 class FixtureEnvironment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     """Type used to describe the environment of a state test."""
 
+    # Allow extra fields: FixtureEnvironment is constructed from Environment
+    # via model_dump(), which includes many fields not in EnvironmentGeneric.
+    model_config = ConfigDict(extra="ignore")
+
     prev_randao: Hash | None = Field(None, alias="currentRandom")  # type: ignore
 
 
 class FixtureTransaction(TransactionFixtureConverter):
     """Type used to describe a transaction in a state test."""
+
+    # Allow extra fields: FixtureTransaction is constructed from Transaction
+    # via model_dump(), which includes many fields not in this model.
+    model_config = ConfigDict(extra="ignore")
 
     nonce: ZeroPaddedHexNumber
     gas_price: ZeroPaddedHexNumber | None = None

--- a/packages/testing/src/execution_testing/fixtures/tests/test_base.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_base.py
@@ -11,7 +11,7 @@ from ..transaction import FixtureResult, TransactionFixture
 def test_json_dict() -> None:
     """Test that the json_dict property does not include the info field."""
     fixture = TransactionFixture(
-        txbytes="0x1234",
+        transaction="0x1234",
         result={"Paris": FixtureResult(intrinsic_gas=0)},
     )
     assert "_info" not in fixture.json_dict, (

--- a/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
@@ -396,7 +396,7 @@ fixture_header_ones = FixtureHeader(
                     blob_gas_used=17,
                     excess_blob_gas=18,
                 ),
-                transactions=[
+                txs=[
                     FixtureTransaction.from_transaction(
                         Transaction().with_signature_and_sender()
                     )
@@ -470,7 +470,7 @@ fixture_header_ones = FixtureHeader(
                     blob_gas_used=17,
                     excess_blob_gas=18,
                 ),
-                transactions=[
+                txs=[
                     FixtureTransaction.from_transaction(
                         Transaction(to=None).with_signature_and_sender()
                     )

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -149,6 +149,8 @@ class PayloadAttributes(CamelModel):
     suggested_fee_recipient: Address
     withdrawals: List[Withdrawal] | None = None
     parent_beacon_block_root: Hash | None = None
+    target_blobs_per_block: HexNumber | None = None
+    max_blobs_per_block: HexNumber | None = None
 
 
 class BlobsBundle(CamelModel):

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -181,7 +181,10 @@ class Header(CamelModel):
     ```
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        **CamelModel.model_config,
+        arbitrary_types_allowed=True,
+    )
 
     @model_serializer(mode="wrap", when_used="json")
     def _serialize_model(self, serializer: Any, info: Any) -> Dict[str, Any]:

--- a/packages/testing/src/execution_testing/test_types/block_access_list/account_absent_values.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/account_absent_values.py
@@ -74,8 +74,6 @@ class BalAccountAbsentValues(CamelModel):
 
     """
 
-    model_config = CamelModel.model_config | {"extra": "forbid"}
-
     nonce_changes: List[BalNonceChange] = Field(
         default_factory=list,
         description="List of nonce changes that should NOT exist in the BAL. "

--- a/packages/testing/src/execution_testing/test_types/block_access_list/account_changes.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/account_changes.py
@@ -22,8 +22,6 @@ from execution_testing.base_types import (
 class BalNonceChange(CamelModel, RLPSerializable):
     """Represents a nonce change in the block access list."""
 
-    model_config = CamelModel.model_config | {"extra": "forbid"}
-
     tx_index: HexNumber = Field(
         HexNumber(1),
         description="Transaction index where the change occurred",
@@ -37,8 +35,6 @@ class BalNonceChange(CamelModel, RLPSerializable):
 
 class BalBalanceChange(CamelModel, RLPSerializable):
     """Represents a balance change in the block access list."""
-
-    model_config = CamelModel.model_config | {"extra": "forbid"}
 
     tx_index: HexNumber = Field(
         HexNumber(1),
@@ -54,8 +50,6 @@ class BalBalanceChange(CamelModel, RLPSerializable):
 class BalCodeChange(CamelModel, RLPSerializable):
     """Represents a code change in the block access list."""
 
-    model_config = CamelModel.model_config | {"extra": "forbid"}
-
     tx_index: HexNumber = Field(
         HexNumber(1),
         description="Transaction index where the change occurred",
@@ -67,8 +61,6 @@ class BalCodeChange(CamelModel, RLPSerializable):
 
 class BalStorageChange(CamelModel, RLPSerializable):
     """Represents a change to a specific storage slot."""
-
-    model_config = CamelModel.model_config | {"extra": "forbid"}
 
     tx_index: HexNumber = Field(
         HexNumber(1),
@@ -84,8 +76,6 @@ class BalStorageChange(CamelModel, RLPSerializable):
 class BalStorageSlot(CamelModel, RLPSerializable):
     """Represents all changes to a specific storage slot."""
 
-    model_config = CamelModel.model_config | {"extra": "forbid"}
-
     slot: StorageKey = Field(..., description="Storage slot key")
     slot_changes: List[BalStorageChange] = Field(
         default_factory=list, description="List of changes to this slot"
@@ -96,8 +86,6 @@ class BalStorageSlot(CamelModel, RLPSerializable):
 
 class BalAccountChange(CamelModel, RLPSerializable):
     """Represents all changes to a specific account in a block."""
-
-    model_config = CamelModel.model_config | {"extra": "forbid"}
 
     address: Address = Field(..., description="Account address")
     nonce_changes: List[BalNonceChange] = Field(

--- a/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/expectations.py
@@ -32,8 +32,6 @@ class BalAccountExpectation(CamelModel):
     used for expectations.
     """
 
-    model_config = CamelModel.model_config | {"extra": "forbid"}
-
     nonce_changes: List[BalNonceChange] = Field(
         default_factory=list, description="List of expected nonce changes"
     )
@@ -118,8 +116,6 @@ class BlockAccessListExpectation(CamelModel):
         )
 
     """
-
-    model_config = CamelModel.model_config | {"extra": "forbid"}
 
     account_expectations: Dict[Address, BalAccountExpectation | None] = Field(
         default_factory=dict,

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Generic, List, Sequence
 
 import ethereum_rlp as eth_rlp
 from ethereum_types.numeric import Uint
-from pydantic import Field, computed_field
+from pydantic import Field, computed_field, model_validator
 from trie import HexaryTrie
 
 from execution_testing.base_types import (
@@ -116,6 +116,15 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     Structure used to keep track of the context in which a block must be
     executed.
     """
+
+    @model_validator(mode="before")
+    @classmethod
+    def strip_computed_fields(cls, data: Any) -> Any:
+        """Strip computed fields that are not valid input fields."""
+        if isinstance(data, dict):
+            data.pop("parent_hash", None)
+            data.pop("parentHash", None)
+        return data
 
     blob_gas_used: ZeroPaddedHexNumber | None = Field(
         None, alias="currentBlobGasUsed"

--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -1,8 +1,8 @@
 """Transaction receipt and log types for Ethereum tests."""
 
-from typing import List
+from typing import Any, List
 
-from pydantic import Field
+from pydantic import AliasChoices, Field, model_validator
 
 from execution_testing.base_types import (
     Address,
@@ -39,12 +39,26 @@ class ReceiptDelegation(CamelModel):
 class TransactionReceipt(CamelModel):
     """Transaction receipt."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def strip_extra_fields(cls, data: Any) -> Any:
+        """Strip extra fields from t8n tool output that are not part of the model."""
+        if isinstance(data, dict):
+            # t8n tool returns 'succeeded' which is redundant with 'status'
+            data.pop("succeeded", None)
+            # t8n tool may return 'post_state' which is not part of this model
+            data.pop("post_state", None)
+            data.pop("postState", None)
+        return data
+
     transaction_hash: Hash | None = None
     gas_used: HexNumber | None = None
     root: Bytes | None = None
     status: HexNumber | None = None
     cumulative_gas_used: HexNumber | None = None
-    logs_bloom: Bloom | None = None
+    logs_bloom: Bloom | None = Field(
+        None, validation_alias=AliasChoices("logs_bloom", "logsBloom", "bloom")
+    )
     logs: List[TransactionLog] | None = None
     contract_address: Address | None = None
     effective_gas_price: HexNumber | None = None

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -300,7 +300,19 @@ class Transaction(
 ):
     """Generic object that can represent all Ethereum transaction types."""
 
-    gas_limit: HexNumber = Field(HexNumber(21_000), serialization_alias="gas")
+    @model_validator(mode="before")
+    @classmethod
+    def strip_hash_from_t8n_output(cls, data: Any) -> Any:
+        """Strip the hash field which may be included in t8n tool output."""
+        if isinstance(data, dict):
+            data.pop("hash", None)
+        return data
+
+    gas_limit: HexNumber = Field(
+        HexNumber(21_000),
+        serialization_alias="gas",
+        validation_alias=AliasChoices("gas_limit", "gasLimit", "gas"),
+    )
     to: Address | None = Field(Address(0xAA))
     data: Bytes = Field(Bytes(b""), alias="input")
 

--- a/tests/cancun/eip4844_blobs/test_blob_txs_full.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs_full.py
@@ -179,7 +179,6 @@ def txs(  # noqa: D103
             access_list=[],
             blob_versioned_hashes=tx_versioned_hashes,
             error=tx_error,
-            wrapped_blob_transaction=tx_wrapped_blobs,
         )
         if tx_wrapped_blobs:
             network_wrapped_tx = NetworkWrappedTransaction(

--- a/tests/frontier/scenarios/test_scenarios.py
+++ b/tests/frontier/scenarios/test_scenarios.py
@@ -278,7 +278,7 @@ def test_scenarios(
         )
 
         post[runner_contract] = Account(storage=post_storage)
-        blocks.append(Block(txs=[tx], post=post))
+        blocks.append(Block(txs=[tx], expected_post_state=post))
 
     if tests > 0:
         blockchain_test(

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -78,16 +78,16 @@ def create_test_header(gas_used: int) -> FixtureHeader:
         number="0x1",
         gas_limit=hex(BLOCK_GAS_LIMIT),
         timestamp=hex(HEADER_TIMESTAMP),
-        coinbase="0x" + "00" * 20,
+        fee_recipient="0x" + "00" * 20,
         parent_hash="0x" + "00" * 32,
-        uncle_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
         state_root="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
         transactions_trie="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-        receiptTrie="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-        bloom="0x" + "00" * 256,
+        receipts_root="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        logs_bloom="0x" + "00" * 256,
         gas_used=hex(gas_used),
         extra_data=EXTRA_DATA_AT_LIMIT.hex(),
-        mix_hash="0x" + "00" * 32,
+        prev_randao="0x" + "00" * 32,
         nonce="0x0000000000000042",
         base_fee_per_gas="0x0",
         withdrawals_root="0x" + "00" * 32,
@@ -132,9 +132,7 @@ def get_block_rlp_size(
             )
             for w in withdrawals
         ]
-    test_block = FixtureBlockBase(
-        blockHeader=header, withdrawals=block_withdrawals
-    )
+    test_block = FixtureBlockBase(header=header, withdrawals=block_withdrawals)
     return len(test_block.with_rlp(txs=transactions).rlp)
 
 

--- a/tests/paris/eip7610_create_collision/test_initcollision.py
+++ b/tests/paris/eip7610_create_collision/test_initcollision.py
@@ -73,7 +73,7 @@ def test_init_collision_create_tx(
     """
     tx = Transaction(
         sender=pre.fund_eoa(),
-        type=tx_type,
+        ty=tx_type,
         to=None,
         data=initcode,
         gas_limit=200_000,

--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_contract_deployment.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_contract_deployment.py
@@ -4,7 +4,7 @@ Tests [EIP-2935: Serve historical block hashes from state](https://eips.ethereum
 
 from os.path import realpath
 from pathlib import Path
-from typing import Any, Dict, Generator
+from typing import Dict, Generator
 
 import pytest
 from execution_testing import (
@@ -17,7 +17,7 @@ from execution_testing import (
     Transaction,
     generate_system_contract_deploy_test,
 )
-from execution_testing.forks import Prague
+from execution_testing.forks import Fork, Prague
 
 from .spec import Spec, ref_spec_2935
 
@@ -37,10 +37,10 @@ REFERENCE_SPEC_VERSION = ref_spec_2935.version
 )
 def test_system_contract_deployment(
     *,
+    fork: Fork,
     pre: Alloc,
     post: Alloc,
     test_type: DeploymentTestType,
-    **kwargs: Any,
 ) -> Generator[Block, None, None]:
     """Verify deployment of the block hashes system contract."""
     # Deploy a contract that calls the history contract and verifies the block

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
@@ -12,7 +12,6 @@ from execution_testing import (
     Alloc,
     Block,
     Fork,
-    Header,
     Requests,
     Transaction,
     generate_system_contract_deploy_test,
@@ -66,7 +65,5 @@ def test_system_contract_deployment(
 
     yield Block(
         txs=[test_transaction],
-        header=Header(
-            requests_hash=Requests(withdrawal_request),
-        ),
+        requests_hash=Requests(withdrawal_request),
     )

--- a/tests/prague/eip7251_consolidations/test_contract_deployment.py
+++ b/tests/prague/eip7251_consolidations/test_contract_deployment.py
@@ -12,7 +12,6 @@ from execution_testing import (
     Alloc,
     Block,
     Fork,
-    Header,
     Requests,
     Transaction,
     generate_system_contract_deploy_test,
@@ -68,7 +67,5 @@ def test_system_contract_deployment(
 
     yield Block(
         txs=[test_transaction],
-        header=Header(
-            requests_hash=Requests(consolidation_request),
-        ),
+        requests_hash=Requests(consolidation_request),
     )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -3095,7 +3095,7 @@ def test_eoa_tx_after_set_code(
             follow_up_eoa_txs.extend(
                 [
                     Transaction(
-                        type=tx_type,
+                        ty=tx_type,
                         sender=auth_signer,
                         gas_limit=500_000,
                         to=auth_signer,
@@ -3103,7 +3103,7 @@ def test_eoa_tx_after_set_code(
                         protected=True,
                     ),
                     Transaction(
-                        type=tx_type,
+                        ty=tx_type,
                         sender=auth_signer,
                         gas_limit=500_000,
                         to=auth_signer,
@@ -3115,7 +3115,7 @@ def test_eoa_tx_after_set_code(
         case 1:
             follow_up_eoa_txs.append(
                 Transaction(
-                    type=tx_type,
+                    ty=tx_type,
                     sender=auth_signer,
                     gas_limit=500_000,
                     to=auth_signer,
@@ -3131,7 +3131,7 @@ def test_eoa_tx_after_set_code(
         case 2:
             follow_up_eoa_txs.append(
                 Transaction(
-                    type=tx_type,
+                    ty=tx_type,
                     sender=auth_signer,
                     gas_limit=500_000,
                     to=auth_signer,
@@ -3143,7 +3143,7 @@ def test_eoa_tx_after_set_code(
         case 3:
             follow_up_eoa_txs.append(
                 Transaction(
-                    type=tx_type,
+                    ty=tx_type,
                     sender=auth_signer,
                     gas_limit=500_000,
                     to=auth_signer,


### PR DESCRIPTION
## 🗒️ Description

I'm still seeing issues from time to time where test writers (including myself) can misspell a kwarg to a test class which could go unnoticed with unintended consequences. This is an attempt to tighten up the pydantic models in our testing framework and prevent these sorts of issues.

- Use `extra="forbid"` in `CamelModel` which our test types inherit from
- Fix serialization issues by removing computed fields from input dicts on relevant models with singular field issues. For internal fixture models that use combined models to build a simpler model (many fields don't exist), explicitly turn on `extra="allow"` with a clarifying message on why we want to / need to do it here.
- Remove redundant `model_config` for classes that inherit from `CamelModel`

## 🔗 Related Issues or PRs

- Closes #1612 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%2Fid%2FOIP.c96pZS4IykTyyy1dEB2jPwHaEK%3Fcb%3Ddefcachec2%26pid%3DApi&f=1&ipt=49b942ff8bcefd530fcab5697d1b1a60f691c6a39a537f7b4f383f2578019061&ipo=images)
