### PR TITLE
chore(test-fill): fix pytest warnings in console test summary

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -179,6 +179,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "mainnet: Specialty tests crafted for running on mainnet and sanity checking.",
     )
+    config.addinivalue_line(
+        "markers",
+        "fully_tagged: Marks a static test as fully tagged with all metadata.",
+    )
 
 
 @pytest.fixture(scope="function")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-check-eip-versions.ini
@@ -5,14 +5,14 @@ python_files = *.py
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py or
 # src/execution_testing/cli/pytest_commands/plugins/spec_version_checker/spec_version_checker.py
 testpaths = tests/
-addopts =  
+addopts =
+    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.filler.filler
+    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.spec_version_checker.spec_version_checker
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.filler.pre_alloc
-    -p execution_testing.cli.pytest_commands.plugins.filler.filler
-    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
-    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.help.help
     -m eip_version_check
     --tb short

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -6,12 +6,12 @@ testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
 addopts =
     -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.execute.execute
     -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.hive
-    -p execution_testing.cli.pytest_commands.plugins.execute.execute
     -p execution_testing.cli.pytest_commands.plugins.shared.benchmarking
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
     -p execution_testing.cli.pytest_commands.plugins.pytest_hive.pytest_hive

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute-hive.ini
@@ -4,16 +4,16 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
+    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.hive
     -p execution_testing.cli.pytest_commands.plugins.execute.execute
-    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
     -p execution_testing.cli.pytest_commands.plugins.shared.benchmarking
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
-    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.pytest_hive.pytest_hive
     -p execution_testing.cli.pytest_commands.plugins.help.help
     --tb short

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -6,12 +6,12 @@ testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
 addopts =
     -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.execute.execute
     -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.execute.execute_flags.execute_flags
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
-    -p execution_testing.cli.pytest_commands.plugins.execute.execute
     -p execution_testing.cli.pytest_commands.plugins.shared.benchmarking
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.remote_seed_sender

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-execute.ini
@@ -4,18 +4,18 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
+    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.execute.execute_flags.execute_flags
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.execute.sender
     -p execution_testing.cli.pytest_commands.plugins.execute.pre_alloc
     -p execution_testing.cli.pytest_commands.plugins.execute.execute
-    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
     -p execution_testing.cli.pytest_commands.plugins.shared.benchmarking
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.remote_seed_sender
     -p execution_testing.cli.pytest_commands.plugins.execute.rpc.remote
-    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.help.help
     -p execution_testing.cli.pytest_commands.plugins.custom_logging.plugin_logging
     --tb short

--- a/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
@@ -4,17 +4,17 @@ minversion = 7.0
 python_files = test_*.py
 testpaths = tests/
 # Note: register new markers via src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
-addopts = 
+addopts =
+    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
+    -p execution_testing.cli.pytest_commands.plugins.filler.filler
+    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.concurrency
     -p execution_testing.cli.pytest_commands.plugins.filler.pre_alloc
-    -p execution_testing.cli.pytest_commands.plugins.filler.filler
     -p execution_testing.cli.pytest_commands.plugins.filler.witness
-    -p execution_testing.cli.pytest_commands.plugins.shared.execute_fill
     -p execution_testing.cli.pytest_commands.plugins.filler.ported_tests
     -p execution_testing.cli.pytest_commands.plugins.filler.static_filler
     -p execution_testing.cli.pytest_commands.plugins.shared.benchmarking
     -p execution_testing.cli.pytest_commands.plugins.shared.transaction_fixtures
-    -p execution_testing.cli.pytest_commands.plugins.forks.forks
     -p execution_testing.cli.pytest_commands.plugins.help.help
     -p execution_testing.cli.pytest_commands.plugins.custom_logging.plugin_logging
     --tb short


### PR DESCRIPTION
## 🗒️ Description

Fixes pytest warnings triggered when running `fill` (one triggered only with static tests). Alternative approach to #1863, a similar issue was also fixed in #1699, but this applies a gentler approach by re-ordering the plugins.

**Reproduce:**
```bash
uv run fill -k chain --clean --fill-static-tests --fork Prague -m state_test \
  tests/istanbul/eip1344_chainid/test_chainid.py tests/static/state_tests/stChainId/
```

**Warnings before fix:**
```
PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.shared.execute_fill

PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.forks.forks

PytestUnknownMarkWarning: Unknown pytest.mark.fully_tagged - is this a typo?
```

**Root cause:**
- `PytestAssertRewriteWarning`: Plugins like `filler.filler` import from `execute_fill` and `forks.forks` before pytest loads them as plugins. Reordering the plugin list in ini files ensures these modules are loaded first.
- `PytestUnknownMarkWarning`: The `fully_tagged` marker was not registered.

**Fix:**
- Reorder plugins in `pytest-*.ini` files so `execute_fill` and `forks.forks` load before modules that import them.
- Register `fully_tagged` marker in `execute_fill.py`.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img height="400" alt="image" src="https://github.com/user-attachments/assets/7fe293c1-0bda-4968-8c3d-afcf489576ab" />
