### PR TITLE
fix(test-rpc): handle extra fields in TransactionByHashResponse after CamelModel extra="forbid"

### DIFF
--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -6,7 +6,12 @@ from enum import Enum
 from hashlib import sha256
 from typing import Annotated, Any, Dict, List, Protocol, Self
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    ValidatorFunctionWrapHandler,
+    model_validator,
+)
 
 from execution_testing.base_types import (
     Address,
@@ -59,9 +64,16 @@ class TransactionByHashResponse(Transaction):
 
     block_hash: Hash | None = None
     block_number: HexNumber | None = None
+    transaction_index: HexNumber | None = None
 
     gas_limit: HexNumber = Field(HexNumber(21_000), alias="gas")
-    transaction_hash: Hash = Field(..., alias="hash")
+    # Use validation_alias with _preserved_hash as fallback because parent's
+    # strip_hash_from_t8n_output validator removes "hash" before we can use it.
+    transaction_hash: Hash = Field(
+        ...,
+        alias="hash",
+        validation_alias=AliasChoices("hash", "_preserved_hash"),
+    )
     sender: EOA | None = Field(None, alias="from")
 
     # The to field can have different names in different clients, so we use
@@ -72,18 +84,32 @@ class TransactionByHashResponse(Transaction):
 
     v: HexNumber = Field(0, validation_alias=AliasChoices("v", "yParity"))  # type: ignore
 
-    @model_validator(mode="before")
+    @model_validator(mode="wrap")
     @classmethod
-    def adapt_clients_response(cls, data: Any) -> Any:
+    def adapt_clients_response(
+        cls, data: Any, handler: ValidatorFunctionWrapHandler
+    ) -> "TransactionByHashResponse":
         """
         Perform modifications necessary to adapt the response returned by
         clients so it can be parsed by our model.
+
+        Uses mode="wrap" to run BEFORE parent's strip_hash_from_t8n_output
+        validator which would otherwise remove the hash field we need.
         """
         if isinstance(data, dict):
+            # Preserve hash under a different key because parent's
+            # strip_hash_from_t8n_output will remove "hash".
+            if "hash" in data:
+                data["_preserved_hash"] = data["hash"]
+
             if "gasPrice" in data and "maxFeePerGas" in data:
                 # Keep only one of the gas price fields.
                 del data["gasPrice"]
-        return data
+            # Modern clients return both 'v' and 'yParity' for EIP-1559+ txs.
+            # Remove 'yParity' since we parse 'v' (which uses AliasChoices for both).
+            if "yParity" in data and "v" in data:
+                del data["yParity"]
+        return handler(data)
 
     def model_post_init(self, __context: Any) -> None:
         """


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fixes `TransactionByHashResponse` to work correctly after #1989 added `extra="forbid"` to `CamelModel`

After #1989, `CamelModel` now rejects extra fields. This broke `TransactionByHashResponse` when parsing RPC responses from execution clients because:

  1. Missing `transactionIndex` field: Standard field returned by all clients per the Ethereum JSON-RPC spec
  2. Duplicate `yParity`/`v` fields: Modern clients return both for EIP-1559+ transactions
  3. Parent validator strips `hash`: `Transaction.strip_hash_from_t8n_output` removes the `hash` field before `TransactionByHashResponse` can use it

  ## Solution

  - Add `transaction_index` field to match the standard RPC response
  - Use `mode="wrap"` validator to run BEFORE parent's validators, preserving `hash` under `_preserved_hash`
  - Strip duplicate `yParity` when both `v` and `yParity` are present
  - Use `validation_alias=AliasChoices("hash", "_preserved_hash")` as fallback for the hash field

Verified with:
```bash
# create anvil node first
anvil --accounts 1 --balance 30000000

# Run the benchmark
execute remote --rpc-endpoint=http://127.0.0.1:8545 --fork Prague -m stateful tests/benchmark/stateful/bloatnet/test_multi_opcode.py::test_bloatnet_balance_extcodecopy -s
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
