### PR TITLE
fix(test-types): Loosen pydantic strictness on internal pydantic models

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -67,6 +67,8 @@ class RejectedTransaction(CamelModel):
 class TraceLine(CamelModel):
     """Single trace line contained in the traces output."""
 
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     pc: int
     op: int
     gas: HexNumber

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -64,6 +64,7 @@ class TransactionByHashResponse(Transaction):
 
     gas_limit: HexNumber = Field(HexNumber(21_000), alias="gas")
     transaction_hash: Hash = Field(..., alias="hash")
+    transaction_index: HexNumber | None = None
     sender: EOA | None = Field(None, alias="from")
 
     # The to field can have different names in different clients, so we use

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -57,6 +57,8 @@ class JSONRPCError(Exception):
 class TransactionByHashResponse(Transaction):
     """Represents the response of a transaction by hash request."""
 
+    model_config = Transaction.model_config | {"extra": "ignore"}
+
     block_hash: Hash | None = None
     block_number: HexNumber | None = None
 

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -305,7 +305,10 @@ class Transaction(
     def strip_hash_from_t8n_output(cls, data: Any) -> Any:
         """Strip the hash field which may be included in t8n tool output."""
         if isinstance(data, dict):
-            data.pop("hash", None)
+            # If the class has a transaction_hash, keep it. This is likely
+            # an internal RPC class that extends from Transaction.
+            if "transaction_hash" not in cls.model_fields:
+                data.pop("hash", None)
         return data
 
     gas_limit: HexNumber = Field(


### PR DESCRIPTION
## 🗒️ Description

Alternate solution to #1997.

Fix #1998 and #1999 by loosening restrictions on internal models. The goal of keeping some models strict and explicitly turning strictness off is so test writers have their code raise errors if they provide incorrect fields, not so we can be sticklers on internal models. This will only cause headaches I believe.

## 🔗 Related Issues or PRs

closes #1998
closes #1999

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.explicit.bing.net%2Fth%2Fid%2FOIP.-iPUatUY6NEpOMk8Z_dl4gHaFS%3Fpid%3DApi&f=1&ipt=cda614b138a95e6eb86bdde87c9f500f8b01d31d6e8633869a7ac11176c0ad27&ipo=images)
