### PR TITLE
fix(tests): Invalid parameter for `Account` in test

### DIFF
--- a/tests/constantinople/eip1014_create2/test_deterministic_deployment.py
+++ b/tests/constantinople/eip1014_create2/test_deterministic_deployment.py
@@ -52,7 +52,7 @@ def test_deterministic_deployment(
 
     post = {
         contract_address: Account(
-            deploy_code=deploy_code,
+            code=deploy_code,
             storage={
                 1: 1,
             },


### PR DESCRIPTION
## 🗒️ Description
Fixes currently-broken tox for `forks/amsterdam` due to an error introduced by #1934 and only caught when #1989 is also merged.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.tierpark-berlin.de/fileadmin/_processed_/6/8/csm_Nachwuchs_Panzernashorn_Betty_Tierpark_Berlin__19__be161d4601.jpg)
