### PR TITLE
feat(test-benchmark): add missing precompile config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🧪 Test Cases
 
 - ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
+- ✨ Add precompile benchmark configurations for `ecPairing`, `blake2f`, `BLS12_G1_MSM`, `BLS12_G2_MSM` and `BLS12_PAIRING` to unblock repricing analysis ([#2003](https://github.com/ethereum/execution-specs/pull/2003)).
 - 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).
 - ✨ New EIP-7702 test cases added ([#1974](https://github.com/ethereum/execution-specs/pull/1974)).
 

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -62,6 +62,7 @@ class RejectedTransaction(CamelModel):
         TransactionExceptionWithMessage | UndefinedException,
         ExceptionMapperValidator,
     ]
+    hash: Hash | None = None
 
 
 class TraceLine(CamelModel):

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -495,3 +495,30 @@ def test_bn128_pairings_amortized(
             },
         ),
     )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
+def test_alt_bn128_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
+    num_pairs: int,
+) -> None:
+    """Benchmark BN128 pairings precompile with varying number of pairs."""
+    if 0x08 not in fork.precompiles():
+        pytest.skip("Precompile not enabled")
+
+    calldata = _generate_bn128_pairs(num_pairs, seed=42)
+
+    attack_block = Op.POP(
+        Op.STATICCALL(gas=Op.GAS, address=0x08, args_size=Op.CALLDATASIZE),
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -361,14 +361,10 @@ from tests.benchmark.compute.helpers import concatenate_parameters
 )
 def test_alt_bn128(
     benchmark_test: BenchmarkTestFiller,
-    fork: Fork,
     precompile_address: Address,
     calldata: bytes,
 ) -> None:
     """Benchmark ALT_BN128 precompile."""
-    if precompile_address not in fork.precompiles():
-        pytest.skip("Precompile not enabled")
-
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
@@ -501,13 +497,9 @@ def test_bn128_pairings_amortized(
 @pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
 def test_alt_bn128_benchmark(
     benchmark_test: BenchmarkTestFiller,
-    fork: Fork,
     num_pairs: int,
 ) -> None:
     """Benchmark BN128 pairings precompile with varying number of pairs."""
-    if 0x08 not in fork.precompiles():
-        pytest.skip("Precompile not enabled")
-
     calldata = _generate_bn128_pairs(num_pairs, seed=42)
 
     attack_block = Op.POP(

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -164,7 +164,16 @@ def test_bls12_g1_msm(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("k", [1, 16, 64, 128])
+@pytest.mark.parametrize(
+    "k",
+    [
+        1,
+        16,
+        64,
+        # G2 MSM k=128 costs 1.5M gas
+        pytest.param(128, marks=pytest.mark.slow),
+    ],
+)
 def test_bls12_g2_msm(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,

--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -4,6 +4,7 @@ import pytest
 from execution_testing import (
     Address,
     BenchmarkTestFiller,
+    Bytes,
     Fork,
     JumpLoopGenerator,
     Op,
@@ -111,6 +112,107 @@ def test_bls12_381(
     """Benchmark BLS12_381 precompile."""
     if precompile_address not in fork.precompiles():
         pytest.skip("Precompile not enabled")
+
+    attack_block = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
+        ),
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("k", [1, 16, 64, 128])
+def test_bls12_g1_msm(
+    benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
+    k: int,
+) -> None:
+    """Benchmark BLS12_G1_MSM precompile with varying number of points."""
+    precompile_address = bls12381_spec.Spec.G1MSM
+    if precompile_address not in fork.precompiles():
+        pytest.skip("BLS12_G1_MSM precompile not enabled")
+
+    # Generate k pairs of (point, scalar)
+    calldata = Bytes(
+        (bls12381_spec.Spec.P1 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
+        * k
+    )
+
+    attack_block = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
+        ),
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("k", [1, 16, 64, 128])
+def test_bls12_g2_msm(
+    benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
+    k: int,
+) -> None:
+    """Benchmark BLS12_G2_MSM precompile with varying number of points."""
+    precompile_address = bls12381_spec.Spec.G2MSM
+    if precompile_address not in fork.precompiles():
+        pytest.skip("BLS12_G2_MSM precompile not enabled")
+
+    # Generate k pairs of (point, scalar)
+    calldata = Bytes(
+        (bls12381_spec.Spec.P2 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
+        * k
+    )
+
+    attack_block = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
+        ),
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
+def test_bls12_pairing(
+    benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
+    num_pairs: int,
+) -> None:
+    """Benchmark BLS12_PAIRING precompile with varying number of pairs."""
+    precompile_address = bls12381_spec.Spec.PAIRING
+    if precompile_address not in fork.precompiles():
+        pytest.skip("BLS12_PAIRING precompile not enabled")
+
+    # Generate num_pairs pairs of (G1, G2) points
+    calldata = Bytes(
+        (bls12381_spec.Spec.G1 + bls12381_spec.Spec.G2) * num_pairs
+    )
 
     attack_block = Op.POP(
         Op.STATICCALL(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add missing precompile configurations according to issue #1979 

- ecPairing: number of pairs: 1, 3, 6, 12, 24
- blake2f: number of rounds: 1, 6, 12, 24
- BLS12_G1_MSM: k (i.e. the number of points and scalars to multiply) = 1, 16, 64, 128
- BLS12_G2_MSM: k (i.e. the number of points and scalars to multiply) = 1, 16, 64, 128
- BLS12_PAIRING: inputs: number of pairs: 1, 3, 6, 12, 24

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue #1979 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![anima](https://github.com/user-attachments/assets/22cd0f28-9516-4376-beef-30aea8303ad2)

