### PR TITLE
chore(ci): reduce docker hub rate limit usage in hive-consume workflow

### DIFF
--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -14,14 +14,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get week number
+      id: week
+      shell: bash
+      run: echo "num=$(date +%U)" >> $GITHUB_OUTPUT
+
     - name: Restore Docker image cache
       id: cache-restore
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ inputs.cache-key-prefix }}-
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}
 
     - name: Pull and save Docker images
       shell: bash
@@ -44,4 +47,4 @@ runs:
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}

--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}
 
     - name: Pull and save Docker images
       shell: bash
@@ -47,4 +47,4 @@ runs:
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}

--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -1,0 +1,47 @@
+name: Cache Docker Images
+description: Cache Docker images to avoid Docker Hub rate limits
+
+inputs:
+  images:
+    description: "Space-separated list of Docker images to cache"
+    required: true
+    default: "docker.io/ethereum/client-go:latest docker.io/alpine:latest docker.io/library/golang:1-alpine"
+  cache-key-prefix:
+    description: "Prefix for the cache key"
+    required: false
+    default: "docker-images"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore Docker image cache
+      id: cache-restore
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/docker-images
+        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-
+
+    - name: Pull and save Docker images
+      shell: bash
+      run: |
+        mkdir -p /tmp/docker-images
+        for image in ${{ inputs.images }}; do
+          # Create a safe filename from image name
+          filename=$(echo "$image" | sed 's/[\/:]/-/g').tar.gz
+          if [ ! -f "/tmp/docker-images/$filename" ]; then
+            echo "Pulling $image..."
+            docker pull "$image"
+            echo "Saving $image to /tmp/docker-images/$filename..."
+            docker save "$image" | gzip > "/tmp/docker-images/$filename"
+          else
+            echo "Cache hit for $image, skipping pull"
+          fi
+        done
+
+    - name: Save Docker image cache
+      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/docker-images
+        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}

--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -43,7 +43,8 @@ runs:
           fi
         done
 
-    - name: Save Docker image cache
+    - name: Save Docker image cache 
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images

--- a/.github/actions/load-docker-images/action.yaml
+++ b/.github/actions/load-docker-images/action.yaml
@@ -1,0 +1,33 @@
+name: Load Cached Docker Images
+description: Load Docker images from cache
+
+inputs:
+  cache-key-prefix:
+    description: "Prefix for the cache key"
+    required: false
+    default: "docker-images"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore Docker image cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: /tmp/docker-images
+        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-
+
+    - name: Load cached Docker images
+      shell: bash
+      run: |
+        if [ -d /tmp/docker-images ]; then
+          for file in /tmp/docker-images/*.tar.gz; do
+            if [ -f "$file" ]; then
+              echo "Loading $file..."
+              gunzip -c "$file" | docker load
+            fi
+          done
+        else
+          echo "No cached images found"
+        fi

--- a/.github/actions/load-docker-images/action.yaml
+++ b/.github/actions/load-docker-images/action.yaml
@@ -19,7 +19,7 @@ runs:
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}
 
     - name: Load cached Docker images
       shell: bash

--- a/.github/actions/load-docker-images/action.yaml
+++ b/.github/actions/load-docker-images/action.yaml
@@ -10,13 +10,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get week number
+      id: week
+      shell: bash
+      run: echo "num=$(date +%U)" >> $GITHUB_OUTPUT
+
     - name: Restore Docker image cache
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/docker-images
-        key: ${{ inputs.cache-key-prefix }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ inputs.cache-key-prefix }}-
+        key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml') }}
 
     - name: Load cached Docker images
       shell: bash
@@ -29,5 +32,6 @@ runs:
             fi
           done
         else
-          echo "No cached images found"
+          echo "::error::No cached images found - cache may not exist yet. Run the cache-docker-images action first."
+          exit 1
         fi

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -1,4 +1,4 @@
-name: Hive Consume Tests
+name: Hive Consume
 
 on:
   push:
@@ -60,16 +60,16 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - name: consume-engine
+          - name: Engine
             mode: simulator
             simulator: ethereum/eels/consume-engine
-          - name: consume-rlp
+          - name: RLP
             mode: simulator
             simulator: ethereum/eels/consume-rlp
-          - name: consume-sync
+          - name: Sync
             mode: simulator
             simulator: ethereum/eels/consume-sync
-          - name: dev-mode
+          - name: Dev Mode
             mode: dev
             consume_command: engine
     steps:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     paths:
       - ".github/workflows/hive-consume.yaml"
+      - ".github/actions/start-hive-dev/**"
+      - ".github/actions/cache-docker-images/**"
+      - ".github/actions/load-docker-images/**"
+      - ".github/configs/hive/**"
       - "packages/testing/src/execution_testing/cli/pytest_commands/consume.py"
       - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini"
       - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**"
@@ -14,6 +18,18 @@ on:
       - "packages/testing/src/execution_testing/fixtures/consume.py"
       - "packages/testing/src/execution_testing/rpc/**"
   workflow_dispatch:
+    inputs:
+      docker_images:
+        description: "Space-separated list of Docker images to cache"
+        required: false
+        default: "docker.io/ethereum/client-go:latest docker.io/alpine:latest docker.io/library/golang:1-alpine"
+  workflow_call:
+    inputs:
+      docker_images:
+        description: "Space-separated list of Docker images to cache"
+        required: false
+        type: string
+        default: "docker.io/ethereum/client-go:latest docker.io/alpine:latest docker.io/library/golang:1-alpine"
 
 concurrency:
   group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -24,8 +40,21 @@ env:
   FIXTURES_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
 
 jobs:
+  cache-docker-images:
+    name: Cache Docker Images
+    runs-on: [self-hosted-ghr, size-l-x64]
+    steps:
+      - name: Checkout execution-specs
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Cache Docker images
+        uses: ./.github/actions/cache-docker-images
+        with:
+          images: ${{ inputs.docker_images || 'docker.io/ethereum/client-go:latest docker.io/alpine:latest docker.io/library/golang:1-alpine' }}
+
   test-hive:
     name: ${{ matrix.name }}
+    needs: cache-docker-images
     runs-on: [self-hosted-ghr, size-l-x64]
     strategy:
       fail-fast: true
@@ -71,6 +100,9 @@ jobs:
           version: ${{ vars.UV_VERSION }}
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
+      - name: Load cached Docker images
+        uses: ./execution-specs/.github/actions/load-docker-images
+
       - name: Build hive
         run: |
           cd hive
@@ -106,3 +138,4 @@ jobs:
         run: |
           uv sync --all-extras
           uv run consume ${{ matrix.consume_command }} --input ${{ env.FIXTURES_URL }} -k "Osaka and test_block_at_rlp_limit_with_logs"
+


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Problem
Docker hub rate limits pulls to 100 every 6hrs when unauthenitcated. Currently we trigger these pulls way to often. This has the result of landing us with the following CI [fails](https://github.com/ethereum/execution-specs/actions/runs/20861109952):
```
Waiting for Hive to be ready (pid=3561, timeout=120s)...
Jan  9 18:10:56.320 INF building image image=hive/hiveproxy nocache=false pull=false
Step 1/14 : FROM golang:1-alpine as builder
1-alpine: Pulling from library/golang
Jan  9 18:10:59.241 ERR image build failed image=hive/hiveproxy err="error from registry: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit"
error from registry: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

### ~~Solution~~ (replaced by solution below)
~~This PR reduces the docker hub rate limit usage in the hive-consume workflow with the following changes:~~
- ~~Docker hub authentication via `--docker.auth` flag to hive commands. Gives us 200 every 6 hrs.~~
  - ~~**Note:** Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to be configured.~~
- ~~`max-parallel: 1` to run matrix jobs sequentially in order to share docker cache (reduces pulls from 12 to 3 per workflow).~~

### Alternative Solution
Use github actions cache for docker images to avoid docker hub pulls entirely:
- **New `cache-docker-images` job** - pulls required images once and caches them via github actions cache
- **New reusable actions:**
  - `.github/actions/cache-docker-images` - pulls and saves images to cache
  - `.github/actions/load-docker-images` - restores and loads images from cache
- **Matrix jobs run in parallel** - each job loads from cache instead of pulling from docker hub
- **Configurable images** - `docker_images` input allows customizing which images to cache (default: `docker.io/ethereum/client-go:latest docker.io/alpine:latest`)


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
#1692 #1855

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

Catching them all for each PR!
**Bulbasaur - 0001**
![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/001.png)
