### PR TITLE
feat(test-benchmark): add missing opcode and configs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
 - 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).
 - ✨ New EIP-7702 test cases added ([#1974](https://github.com/ethereum/execution-specs/pull/1974)).
+- ✨ Add missing benchmark configurations / opcode to benchmark tests for repricing analysis([#2003](https://github.com/ethereum/execution-specs/pull/2003)).
 
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
 - 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).
 - ✨ New EIP-7702 test cases added ([#1974](https://github.com/ethereum/execution-specs/pull/1974)).
-- ✨ Add missing benchmark configurations / opcode to benchmark tests for repricing analysis([#2003](https://github.com/ethereum/execution-specs/pull/2003)).
+- ✨ Add missing benchmark configurations / opcode to benchmark tests for repricing analysis([#2006](https://github.com/ethereum/execution-specs/pull/2006)).
 
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -345,14 +345,9 @@ def test_extcode_ops(
     )
 
 
-@pytest.mark.repricing(copied_size=512)
 @pytest.mark.parametrize(
-    "copied_size",
-    [
-        pytest.param(512, id="512"),
-        pytest.param(1024, id="1KiB"),
-        pytest.param(5 * 1024, id="5KiB"),
-    ],
+    "copy_size",
+    [0, 32, 256, 512, 1024],
 )
 def test_extcodecopy_warm(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -352,17 +352,17 @@ def test_extcode_ops(
 def test_extcodecopy_warm(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
-    copied_size: int,
+    copy_size: int,
 ) -> None:
     """Benchmark EXTCODECOPY instruction."""
     copied_contract_address = pre.deploy_contract(
-        code=Op.JUMPDEST * copied_size,
+        code=Op.JUMPDEST * copy_size,
     )
 
     benchmark_test(
         target_opcode=Op.EXTCODECOPY,
         code_generator=JumpLoopGenerator(
-            setup=Op.PUSH10(copied_size) + Op.PUSH20(copied_contract_address),
+            setup=Op.PUSH10(copy_size) + Op.PUSH20(copied_contract_address),
             attack_block=Op.EXTCODECOPY(Op.DUP4, 0, 0, Op.DUP2),
         ),
     )

--- a/tests/benchmark/compute/instruction/test_bitwise.py
+++ b/tests/benchmark/compute/instruction/test_bitwise.py
@@ -124,7 +124,6 @@ def test_not_op(
     )
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize("opcode", [Op.SHR, Op.SAR])
 def test_shifts(
     benchmark_test: BenchmarkTestFiller,

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -142,14 +142,7 @@ def test_calldataload(
 @pytest.mark.repricing(fixed_src_dst=True)
 @pytest.mark.parametrize(
     "mem_size",
-    [
-        pytest.param(0, id="0 bytes"),
-        pytest.param(32, id="32 bytes"),
-        pytest.param(256, id="256 bytes"),
-        pytest.param(1024, id="1KiB"),
-        pytest.param(10 * 1024, id="10KiB"),
-        pytest.param(1024 * 1024, id="1MiB"),
-    ],
+    [0, 32, 256, 1024, 10 * 1024, 1024 * 1024],
 )
 @pytest.mark.parametrize(
     "fixed_src_dst",
@@ -339,14 +332,7 @@ def test_returndatasize_zero(
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(
     "return_size",
-    [
-        pytest.param(0, id="0 bytes"),
-        pytest.param(32, id="32 bytes"),
-        pytest.param(256, id="256 bytes"),
-        pytest.param(1024, id="1024 bytes"),
-        pytest.param(10 * 1024, id="10KiB"),
-        pytest.param(1024 * 1024, id="1MiB"),
-    ],
+    [0, 32, 256, 1024, 10 * 1024, 1024 * 1024],
 )
 @pytest.mark.parametrize(
     "fixed_dst",

--- a/tests/benchmark/compute/instruction/test_control_flow.py
+++ b/tests/benchmark/compute/instruction/test_control_flow.py
@@ -46,7 +46,6 @@ def test_pc_op(
     )
 
 
-@pytest.mark.repricing
 def test_jumps(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -60,6 +59,19 @@ def test_jumps(
     benchmark_test(
         target_opcode=Op.JUMP,
         tx=tx,
+    )
+
+
+def test_jump_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+) -> None:
+    """Benchmark JUMP instruction with different dest."""
+    benchmark_test(
+        target_opcode=Op.JUMP,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.JUMP(Op.ADD(Op.PC, 3)) + Op.JUMPDEST
+        ),
     )
 
 

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -72,14 +72,7 @@ def test_memory_access(
 @pytest.mark.repricing(fixed_src_dst=True)
 @pytest.mark.parametrize(
     "mem_size",
-    [
-        pytest.param(0, id="0 bytes"),
-        pytest.param(32, id="32 bytes"),
-        pytest.param(256, id="256 bytes"),
-        pytest.param(1024, id="1024 bytes"),
-        pytest.param(10 * 1024, id="10KiB"),
-        pytest.param(1024 * 1024, id="1MiB"),
-    ],
+    [0, 32, 256, 1024, 10 * 1025, 1024 * 1024],
 )
 @pytest.mark.parametrize("copy_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_memory.py
+++ b/tests/benchmark/compute/instruction/test_memory.py
@@ -72,7 +72,7 @@ def test_memory_access(
 @pytest.mark.repricing(fixed_src_dst=True)
 @pytest.mark.parametrize(
     "mem_size",
-    [0, 32, 256, 1024, 10 * 1025, 1024 * 1024],
+    [0, 32, 256, 1024, 10 * 1024, 1024 * 1024],
 )
 @pytest.mark.parametrize("copy_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize(

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -91,9 +91,6 @@ def test_tstore(
     )
 
 
-@pytest.mark.repricing(
-    storage_action=StorageAction.WRITE_SAME_VALUE, absent_slots=False
-)
 @pytest.mark.parametrize(
     "storage_action,tx_result",
     [
@@ -292,7 +289,42 @@ def test_storage_access_cold(
     )
 
 
-@pytest.mark.repricing(storage_action=StorageAction.WRITE_SAME_VALUE)
+@pytest.mark.repricing
+@pytest.mark.parametrize(
+    "storage_action",
+    [
+        pytest.param(StorageAction.READ, id="SLOAD"),
+        pytest.param(StorageAction.WRITE_SAME_VALUE, id="SSTORE_same"),
+        pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE_new"),
+    ],
+)
+def test_storage_access_cold_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    storage_action: StorageAction,
+) -> None:
+    """
+    Benchmark cold storage slot accesses using code generator.
+
+    Each iteration accesses a different storage slot (incrementing key)
+    to ensure cold access costs are measured.
+    """
+    if storage_action == StorageAction.READ:
+        attack_block = Op.SLOAD(Op.GAS)
+    elif storage_action == StorageAction.WRITE_SAME_VALUE:
+        attack_block = Op.SSTORE(Op.GAS, Op.PUSH0)
+    elif storage_action == StorageAction.WRITE_NEW_VALUE:
+        attack_block = Op.SSTORE(Op.GAS, Op.GAS)
+
+    benchmark_test(
+        target_opcode=Op.SLOAD
+        if storage_action == StorageAction.READ
+        else Op.SSTORE,
+        code_generator=ExtCallGenerator(
+            attack_block=attack_block,
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "storage_action",
     [
@@ -305,9 +337,7 @@ def test_storage_access_warm(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     storage_action: StorageAction,
-    fork: Fork,
     gas_benchmark_value: int,
-    env: Environment,
     tx_gas_limit: int,
 ) -> None:
     """
@@ -370,3 +400,40 @@ def test_storage_access_warm(
         blocks.append(Block(txs=txs))
 
     benchmark_test(blocks=blocks)
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize(
+    "storage_action",
+    [
+        pytest.param(StorageAction.READ, id="SLOAD"),
+        pytest.param(StorageAction.WRITE_SAME_VALUE, id="SSTORE same value"),
+        pytest.param(StorageAction.WRITE_NEW_VALUE, id="SSTORE new value"),
+    ],
+)
+def test_storage_access_warm_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    storage_action: StorageAction,
+) -> None:
+    """
+    Benchmark warm storage slot accesses using code generator.
+
+    Each iteration accesses a different storage slot (incrementing key)
+    to ensure cold access costs are measured.
+    """
+    attack_block = Bytecode()
+    if storage_action == StorageAction.WRITE_SAME_VALUE:
+        attack_block = Op.SSTORE(Op.PUSH0, Op.PUSH0)
+    elif storage_action == StorageAction.WRITE_NEW_VALUE:
+        attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)
+    elif storage_action == StorageAction.READ:
+        attack_block = Op.SLOAD(Op.PUSH0)
+
+    benchmark_test(
+        target_opcode=Op.SLOAD
+        if storage_action == StorageAction.READ
+        else Op.SSTORE,
+        code_generator=ExtCallGenerator(
+            attack_block=attack_block,
+        ),
+    )

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -419,7 +419,7 @@ def test_storage_access_warm_benchmark(
     Benchmark warm storage slot accesses using code generator.
 
     Each iteration accesses a different storage slot (incrementing key)
-    to ensure cold access costs are measured.
+    to ensure warm access costs are measured.
     """
     attack_block = Bytecode()
     if storage_action == StorageAction.WRITE_SAME_VALUE:

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -925,3 +925,23 @@ def test_selfdestruct_initcode(
         ],
         expected_benchmark_gas_used=expected_benchmark_gas_used,
     )
+
+
+@pytest.mark.parametrize("value_bearing", [True, False])
+def test_selfdestruct_until_oog(
+    benchmark_test: BenchmarkTestFiller,
+    value_bearing: bool,
+    pre: Alloc,
+    env: Environment,
+) -> None:
+    """Benchmark SELFDESTRUCT instruction destruct itself."""
+    fee_recipient = pre.fund_eoa(amount=1)
+    env.fee_recipient = fee_recipient
+
+    benchmark_test(
+        target_opcode=Op.SELFDESTRUCT,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.SELFDESTRUCT(Op.ADDRESS),
+            contract_balance=1_000_000_000 if value_bearing else 0,
+        ),
+    )

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -925,23 +925,3 @@ def test_selfdestruct_initcode(
         ],
         expected_benchmark_gas_used=expected_benchmark_gas_used,
     )
-
-
-@pytest.mark.parametrize("value_bearing", [True, False])
-def test_selfdestruct_until_oog(
-    benchmark_test: BenchmarkTestFiller,
-    value_bearing: bool,
-    pre: Alloc,
-    env: Environment,
-) -> None:
-    """Benchmark SELFDESTRUCT instruction destruct itself."""
-    fee_recipient = pre.fund_eoa(amount=1)
-    env.fee_recipient = fee_recipient
-
-    benchmark_test(
-        target_opcode=Op.SELFDESTRUCT,
-        code_generator=JumpLoopGenerator(
-            attack_block=Op.SELFDESTRUCT(Op.ADDRESS),
-            contract_balance=1_000_000_000 if value_bearing else 0,
-        ),
-    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Newly Supported Benchmarks
- Cold / warm storage access
- JUMP

Removed Test IDs
- test_mcopy
- test_calldatacopy_from_origin
- test_returndatacopy

Refactored for New Parameters / Opcodes
- test_arithmetic
- test_extcodecopy_warm

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![animal](https://github.com/user-attachments/assets/faa90d83-9564-438e-89a9-f73ed8cd0e50)

