### PR TITLE
fix(test-tests): prevent race condition in gentest tests w/xdist

### DIFF
--- a/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
+++ b/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
@@ -90,6 +90,7 @@ def format_code(code: str) -> str:
                 "format",
                 str(input_file_path),
                 "--quiet",
+                "--no-cache",
                 "--config",
                 str(config_path),
             ],

--- a/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
+++ b/packages/testing/src/execution_testing/cli/gentest/source_code_generator.py
@@ -84,22 +84,23 @@ def format_code(code: str) -> str:
         # Call ruff to format the file
         config_path = AppConfig().ROOT_DIR.parent / "pyproject.toml"
 
-        try:
-            subprocess.run(
-                [
-                    str(formatter_path),
-                    "format",
-                    str(input_file_path),
-                    "--quiet",
-                    "--config",
-                    str(config_path),
-                ],
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
+        result = subprocess.run(
+            [
+                str(formatter_path),
+                "format",
+                str(input_file_path),
+                "--quiet",
+                "--config",
+                str(config_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
             raise Exception(
-                f"Error formatting code using formatter '{formatter_path}'"
-            ) from e
+                f"Error formatting code using formatter '{formatter_path}': "
+                f"{result.stderr}"
+            )
 
         # Return the formatted source code
         return input_file_path.read_text()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
- Adds `--no-cache` flag to ruff invocation in `format_code()` to prevent race conditions when pytest-xdist runs tests with multiple workers (observed in CI for #1803).

## Problem

The `test_tx_type` tests fail intermittently in CI with error:
```
Error formatting code using formatter '.../bin/ruff'
```

When multiple pytest-xdist workers run in parallel, they all invoke ruff which tries to read/write the same `.ruff_cache` directory, causing race conditions. 

This is the likely culprit for these fails (https://github.com/ethereum/execution-specs/actions/runs/20916668952/job/60091856756?pr=1803):

```
=================================== FAILURES ===================================
_______________________________ test_tx_type[0] ________________________________
[gw1] linux -- Python 3.11.14 /opt/actions-runner/_work/execution-specs/execution-specs/.tox/tests_pytest_py3/bin/python3

pytester = <Pytester PosixPath('/opt/actions-runner/_work/execution-specs/execution-specs/.tox/.tmp/pytest/popen-gw1/test_tx_type0')>
tmp_path = PosixPath('/opt/actions-runner/_work/execution-specs/execution-specs/.tox/.tmp/pytest/popen-gw1/test_tx_type_0_0')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7ab64149b550>
tx_type = 0
transaction_hash = '0xa41f343be7a150b740e5c939fa4d89f3a2850dbe21715df96b612fc20d1906be'

    @pytest.mark.parametrize("tx_type", list(transactions_by_type.keys()))
    def test_tx_type(
        pytester: pytest.Pytester,
        tmp_path: Path,
        monkeypatch: Any,
        tx_type: int,
        transaction_hash: str,
    ) -> None:
        """Generates a test case for any transaction type."""
        # This test is run in a CI environment, where connection to a
        # node could be unreliable. Therefore, we mock the RPC request to avoid any
        # network issues. This is done by patching the `get_context` method of the
        # `StateTestProvider`.
        runner = CliRunner()
        tmp_path_tests = tmp_path / "tests"
        tmp_path_tests.mkdir()
        tmp_path_output = tmp_path / "output"
        tmp_path_output.mkdir()
        generated_py_file = str(tmp_path_tests / f"gentest_type_{tx_type}.py")
    
        tx = transactions_by_type[tx_type]
    
        def get_mock_context(self: StateTestProvider) -> dict:
            del self
            return tx
    
        monkeypatch.setattr(StateTestProvider, "get_context", get_mock_context)
    
        ## Generate ##
        gentest_result = runner.invoke(
            generate, [transaction_hash, generated_py_file]
        )
>       assert gentest_result.exit_code == 0
E       assert 1 == 0
E        +  where 1 = <Result Exception("Error formatting code using formatter '/opt/actions-runner/_work/execution-specs/execution-specs/.tox/tests_pytest_py3/bin/ruff'")>.exit_code

/opt/actions-runner/_work/execution-specs/execution-specs/packages/testing/src/execution_testing/cli/gentest/tests/test_cli.py:145: AssertionError
```

## Investigation

Initial hypothesis was that Click's `CliRunner` might be causing issues, since its documentation states:

> "This only works in single-threaded systems without any concurrency as it changes the global interpreter state."

However, investigation revealed this warning doesn't apply here:

1. **pytest-xdist uses processes, not threads** - Each worker (`gw0`, `gw1`, etc.) runs in a separate Python process with isolated interpreter state
2. **CliRunner's global state modifications** (`sys.stdin`, `sys.stdout`, `os.environ`) are confined to each worker's process
3. **Process isolation does NOT protect shared filesystem resources** - All workers share the same `.ruff_cache` directory

This pointed back to the ruff cache as the likely culprit, but without stderr capture we can't be sure.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Sporadic fail seen in:
- #1803

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] ~~All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).~~ skipped
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="611" height="413" alt="image" src="https://github.com/user-attachments/assets/6a8f0dcb-b379-4589-81b7-bd375e01090a" />
