### PR TITLE
feat(test-tests) add testcase for calldata/codecopy OOG

### DIFF
--- a/docs/writing_tests/post_mortems.md
+++ b/docs/writing_tests/post_mortems.md
@@ -8,6 +8,42 @@ Each entry must include an explanation of why the test case was missed plus the 
 
 ## List
 
+## 2025-01 - Data Copy Word Cost Gas Calculation - Byzantium+
+
+### Description
+
+A bug was discovered in Nethermind's implementation of CALLDATACOPY and CODECOPY opcodes where the word copy cost (3 gas per 32-byte word) was not being correctly charged. The issue was identified during internal fuzz testing and fixed in [Nethermind PR #10116](https://github.com/NethermindEth/nethermind/pull/10116).
+
+The EVM specification requires data copy operations to charge:
+
+- Static cost: 3 gas
+- Word copy cost: 3 * ceil(size/32) gas
+- Memory expansion cost (if applicable)
+
+The bug allowed these operations to complete successfully even when insufficient gas was provided for the word copy cost component.
+
+### Root Cause Analysis
+
+- The word copy cost is a well-documented part of the EVM specification, but existing test coverage did not specifically isolate this gas component.
+- Tests typically provided ample gas, which masked potential issues with individual gas cost components.
+- The scenario of having exactly enough gas for memory expansion but not for word copy cost was not explicitly tested.
+
+### Steps Taken To Avoid Recurrence
+
+- Added regression tests that use sub-calls with controlled gas limits to isolate specific gas cost components.
+- Tests verify both the success case (sufficient gas) and failure case (insufficient gas for word copy cost).
+
+### Implemented Test Case
+
+- `tests/frontier/opcodes/test_data_copy_oog.py::test_calldatacopy_word_copy_oog`
+- `tests/frontier/opcodes/test_data_copy_oog.py::test_codecopy_word_copy_oog`
+
+### Framework/Documentation Changes
+
+None required - the existing framework supported writing these tests.
+
+---
+
 ## TEMPLATE
 
 ## Date - Title - Fork

--- a/docs/writing_tests/post_mortems.md
+++ b/docs/writing_tests/post_mortems.md
@@ -8,7 +8,7 @@ Each entry must include an explanation of why the test case was missed plus the 
 
 ## List
 
-## 2025-01 - Data Copy Word Cost Gas Calculation - Byzantium+
+## 2026-01 - Data Copy Word Cost Gas Calculation - Byzantium+
 
 ### Description
 

--- a/tests/frontier/opcodes/test_data_copy_oog.py
+++ b/tests/frontier/opcodes/test_data_copy_oog.py
@@ -35,11 +35,6 @@ pytestmark = pytest.mark.valid_from("Byzantium")
 COPY_SIZE = 0x400  # 1024 bytes = 32 words
 
 
-@pytest.mark.ported_from(
-    [
-        "https://github.com/NethermindEth/nethermind/pull/10116",
-    ],
-)
 @pytest.mark.parametrize(
     "subcall_gas,expect_success",
     [
@@ -125,11 +120,6 @@ def test_calldatacopy_word_copy_oog(
     )
 
 
-@pytest.mark.ported_from(
-    [
-        "https://github.com/NethermindEth/nethermind/pull/10116",
-    ],
-)
 @pytest.mark.parametrize(
     "subcall_gas,expect_success",
     [

--- a/tests/frontier/opcodes/test_data_copy_oog.py
+++ b/tests/frontier/opcodes/test_data_copy_oog.py
@@ -1,0 +1,235 @@
+"""
+Test data copy OOG regression.
+
+This test is a regression test for:
+https://github.com/NethermindEth/nethermind/pull/10116
+
+The bug was in `ConsumeDataCopyGas` where `UpdateGas` (which returns a bool
+indicating if sufficient gas is available) was called instead of `Consume`
+(which actually consumes gas). Since the bool return value wasn't checked,
+execution would continue even when there wasn't enough gas for the data
+copy word cost.
+
+Key insight: Memory expansion OOG is handled separately and correctly.
+The bug triggers when:
+1. Memory expansion check passes (enough gas for memory expansion)
+2. But NOT enough gas for the data copy word cost (3 gas per 32-byte word)
+
+This affects: CALLDATACOPY, CODECOPY, EXTCODECOPY, RETURNDATACOPY
+
+Only CALLDATACOPY and CODECOPY are tested here. EXTCODECOPY and RETURNDATACOPY
+are omitted because:
+- EXTCODECOPY: Address access costs vary by fork (700 pre-Berlin, 2600 cold /
+  100 warm in Berlin+ per EIP-2929), making gas calibration complex
+- RETURNDATACOPY: Requires nested CALLs to populate return data, adding gas
+  accounting complexity (63/64 rule, call overhead, etc.)
+Since all four opcodes use the same ConsumeDataCopyGas function, testing
+CALLDATACOPY and CODECOPY adequately covers the word copy cost bug.
+
+Test approach: Use a sub-call with controlled gas to isolate the word copy
+cost from intrinsic gas costs that vary across forks.
+
+Why sub-calls work for isolation:
+- Intrinsic gas (21000 base + calldata cost) only applies to top-level tx
+- The 63/64 rule (EIP-150) doesn't reduce gas when passing small amounts
+  with plenty of remaining gas (e.g., passing 150 with 500k remaining)
+- CALL costs (base + address access) are paid by caller, not callee
+- EIP-150 also ensures caller retains 1/64 of gas after CALL; with 500k gas
+  and small subcall amounts, plenty remains for post-call SSTORE (~20k max)
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Environment,
+    Op,
+    StateTestFiller,
+    Storage,
+    Transaction,
+)
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-211.md"
+REFERENCE_SPEC_VERSION = "1.0.0"
+
+pytestmark = pytest.mark.valid_from("Byzantium")
+
+# Gas costs for data copy operations:
+# - Static cost: 3 gas
+# - Word copy cost: 3 * ceil(size/32) gas
+# - Memory expansion: 3 * words + words^2/512
+
+# For 0x400 (1024) bytes = 32 words:
+# - Word copy cost: 3 * 32 = 96 gas
+# - Memory expansion (from 0): 3 * 32 + 32^2/512 = 96 + 2 = 98 gas
+# - Static cost: 3 gas
+# - Total CALLDATACOPY: ~200 gas (with memory expansion)
+
+# We give enough gas for memory expansion but not for word copy cost
+# to trigger the bug.
+
+COPY_SIZE = 0x400  # 1024 bytes = 32 words
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/NethermindEth/nethermind/pull/10116",
+    ],
+)
+@pytest.mark.parametrize(
+    "subcall_gas,expect_success",
+    [
+        pytest.param(
+            5000,
+            True,
+            id="sufficient_gas",
+        ),
+        pytest.param(
+            # Enough for: MSTORE + memory expansion to COPY_SIZE + static CALLDATACOPY
+            # But NOT enough for word copy cost
+            150,
+            False,
+            id="insufficient_gas_for_word_copy_cost",
+        ),
+    ],
+)
+def test_calldatacopy_word_copy_oog(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    subcall_gas: int,
+    expect_success: bool,
+) -> None:
+    """
+    Test that CALLDATACOPY properly consumes gas for word copy cost.
+
+    Uses a sub-call with controlled gas to isolate the test from intrinsic
+    gas costs that vary across forks.
+    """
+    storage = Storage()
+    storage_key = storage.store_next(1 if expect_success else 0)
+
+    # Inner contract: performs CALLDATACOPY and stores success marker
+    inner_code = (
+        # Pre-expand memory to cover COPY_SIZE
+        Op.MSTORE(COPY_SIZE - 0x20, 0)
+        # CALLDATACOPY - should consume word copy gas
+        + Op.CALLDATACOPY(dest_offset=0, offset=0, size=COPY_SIZE)
+        # If we reach here, sufficient gas was available
+        + Op.MSTORE8(0, 1)
+        + Op.RETURN(0, 1)
+    )
+    inner_address = pre.deploy_contract(inner_code)
+
+    # Outer contract: calls inner with controlled gas, stores call success
+    # CALL pushes 1 on success, 0 on OOG/revert
+    # Stack after CALL: [success]
+    # PUSH key, then SSTORE pops [key, value] -> storage[key] = value
+    outer_code = (
+        Op.CALL(
+            gas=subcall_gas,
+            address=inner_address,
+            value=0,
+            args_offset=0,
+            args_size=0,
+            ret_offset=0,
+            ret_size=1,
+        )
+        # Stack: [success (0 or 1)]
+        + Op.PUSH1[storage_key]
+        # Stack: [storage_key, success]
+        + Op.SSTORE
+        # Stores storage[storage_key] = success
+        + Op.STOP
+    )
+    outer_address = pre.deploy_contract(outer_code)
+
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        to=outer_address,
+        sender=sender,
+        gas_limit=500_000,  # Plenty of gas for outer call
+    )
+
+    post = {outer_address: Account(storage=storage)}
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        post=post,
+        tx=tx,
+    )
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/NethermindEth/nethermind/pull/10116",
+    ],
+)
+@pytest.mark.parametrize(
+    "subcall_gas,expect_success",
+    [
+        pytest.param(
+            5000,
+            True,
+            id="sufficient_gas",
+        ),
+        pytest.param(
+            150,
+            False,
+            id="insufficient_gas_for_word_copy_cost",
+        ),
+    ],
+)
+def test_codecopy_word_copy_oog(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    subcall_gas: int,
+    expect_success: bool,
+) -> None:
+    """
+    Test that CODECOPY properly consumes gas for word copy cost.
+    """
+    storage = Storage()
+    storage_key = storage.store_next(1 if expect_success else 0)
+
+    inner_code = (
+        Op.MSTORE(COPY_SIZE - 0x20, 0)
+        + Op.CODECOPY(dest_offset=0, offset=0, size=COPY_SIZE)
+        + Op.MSTORE8(0, 1)
+        + Op.RETURN(0, 1)
+    )
+    inner_address = pre.deploy_contract(inner_code)
+
+    outer_code = (
+        Op.CALL(
+            gas=subcall_gas,
+            address=inner_address,
+            value=0,
+            args_offset=0,
+            args_size=0,
+            ret_offset=0,
+            ret_size=1,
+        )
+        + Op.PUSH1[storage_key]
+        + Op.SSTORE
+        + Op.STOP
+    )
+    outer_address = pre.deploy_contract(outer_code)
+
+    sender = pre.fund_eoa()
+
+    tx = Transaction(
+        to=outer_address,
+        sender=sender,
+        gas_limit=500_000,
+    )
+
+    post = {outer_address: Account(storage=storage)}
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        post=post,
+        tx=tx,
+    )

--- a/tests/frontier/opcodes/test_data_copy_oog.py
+++ b/tests/frontier/opcodes/test_data_copy_oog.py
@@ -1,41 +1,5 @@
 """
 Test data copy OOG regression.
-
-This test is a regression test for:
-https://github.com/NethermindEth/nethermind/pull/10116
-
-The bug was in `ConsumeDataCopyGas` where `UpdateGas` (which returns a bool
-indicating if sufficient gas is available) was called instead of `Consume`
-(which actually consumes gas). Since the bool return value wasn't checked,
-execution would continue even when there wasn't enough gas for the data
-copy word cost.
-
-Key insight: Memory expansion OOG is handled separately and correctly.
-The bug triggers when:
-1. Memory expansion check passes (enough gas for memory expansion)
-2. But NOT enough gas for the data copy word cost (3 gas per 32-byte word)
-
-This affects: CALLDATACOPY, CODECOPY, EXTCODECOPY, RETURNDATACOPY
-
-Only CALLDATACOPY and CODECOPY are tested here. EXTCODECOPY and RETURNDATACOPY
-are omitted because:
-- EXTCODECOPY: Address access costs vary by fork (700 pre-Berlin, 2600 cold /
-  100 warm in Berlin+ per EIP-2929), making gas calibration complex
-- RETURNDATACOPY: Requires nested CALLs to populate return data, adding gas
-  accounting complexity (63/64 rule, call overhead, etc.)
-Since all four opcodes use the same ConsumeDataCopyGas function, testing
-CALLDATACOPY and CODECOPY adequately covers the word copy cost bug.
-
-Test approach: Use a sub-call with controlled gas to isolate the word copy
-cost from intrinsic gas costs that vary across forks.
-
-Why sub-calls work for isolation:
-- Intrinsic gas (21000 base + calldata cost) only applies to top-level tx
-- The 63/64 rule (EIP-150) doesn't reduce gas when passing small amounts
-  with plenty of remaining gas (e.g., passing 150 with 500k remaining)
-- CALL costs (base + address access) are paid by caller, not callee
-- EIP-150 also ensures caller retains 1/64 of gas after CALL; with 500k gas
-  and small subcall amounts, plenty remains for post-call SSTORE (~20k max)
 """
 
 import pytest

--- a/tests/frontier/opcodes/test_data_copy_oog.py
+++ b/tests/frontier/opcodes/test_data_copy_oog.py
@@ -85,8 +85,8 @@ COPY_SIZE = 0x400  # 1024 bytes = 32 words
             id="sufficient_gas",
         ),
         pytest.param(
-            # Enough for: MSTORE + memory expansion to COPY_SIZE + static CALLDATACOPY
-            # But NOT enough for word copy cost
+            # Enough for: MSTORE + memory expansion + static CALLDATACOPY
+            # But NOT enough for word copy cost (3 gas per 32-byte word)
             150,
             False,
             id="insufficient_gas_for_word_copy_cost",

--- a/uv.lock
+++ b/uv.lock
@@ -10,8 +10,13 @@ resolution-markers = [
 members = [
     "ethereum-execution",
     "ethereum-execution-testing",
-    "ethereum-execution-tests",
 ]
+
+[[package]]
+name = "actionlint-py"
+version = "1.7.10.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/01/790379bf4cab91a272421a39b3d80f4a0d1a1ed753c00176be28b7d6adc6/actionlint_py-1.7.10.24.tar.gz", hash = "sha256:bac4e74e944c692fc7c65661009caebf14621bb33d937127ee5df8ac0693736a", size = 12057, upload-time = "2026-01-01T17:06:36.282Z" }
 
 [[package]]
 name = "annotated-types"
@@ -831,7 +836,13 @@ optimized = [
 ]
 
 [package.dev-dependencies]
+actionlint = [
+    { name = "actionlint-py" },
+    { name = "pyflakes" },
+    { name = "shellcheck-py" },
+]
 dev = [
+    { name = "actionlint-py" },
     { name = "cairosvg" },
     { name = "codespell" },
     { name = "docc" },
@@ -858,6 +869,7 @@ dev = [
     { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pillow" },
+    { name = "pyflakes" },
     { name = "pyspelling" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -865,6 +877,7 @@ dev = [
     { name = "requests" },
     { name = "requests-cache" },
     { name = "ruff" },
+    { name = "shellcheck-py" },
     { name = "types-requests" },
     { name = "vulture" },
 ]
@@ -929,7 +942,13 @@ requires-dist = [
 provides-extras = ["optimized"]
 
 [package.metadata.requires-dev]
+actionlint = [
+    { name = "actionlint-py", specifier = ">=1.7" },
+    { name = "pyflakes", specifier = ">=3.0" },
+    { name = "shellcheck-py", specifier = ">=0.10" },
+]
 dev = [
+    { name = "actionlint-py", specifier = ">=1.7" },
     { name = "cairosvg", specifier = ">=2.7.0,<3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
@@ -957,6 +976,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.0.0,<2" },
     { name = "mypy", specifier = "==1.17.0" },
     { name = "pillow", specifier = ">=10.0.1,<11" },
+    { name = "pyflakes", specifier = ">=3.0" },
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
@@ -964,6 +984,7 @@ dev = [
     { name = "requests" },
     { name = "requests-cache", specifier = ">=1.2.1,<2" },
     { name = "ruff", specifier = "==0.13.2" },
+    { name = "shellcheck-py", specifier = ">=0.10" },
     { name = "types-requests", specifier = ">=2.31,<2.33" },
     { name = "vulture", specifier = "==2.14.0" },
 ]
@@ -1117,132 +1138,6 @@ lint = [
     { name = "types-requests", specifier = ">=2.31,<2.33" },
 ]
 test = [{ name = "pytest-cov", specifier = ">=4.1.0,<5" }]
-
-[[package]]
-name = "ethereum-execution-tests"
-version = "1.0.0"
-source = { editable = "packages/tests" }
-dependencies = [
-    { name = "ckzg" },
-    { name = "click" },
-    { name = "coincurve" },
-    { name = "colorlog" },
-    { name = "eth-abi" },
-    { name = "ethereum-execution" },
-    { name = "ethereum-hive" },
-    { name = "ethereum-rlp" },
-    { name = "ethereum-types" },
-    { name = "filelock" },
-    { name = "gitpython" },
-    { name = "joblib" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "pytest" },
-    { name = "pytest-custom-report" },
-    { name = "pytest-html" },
-    { name = "pytest-json-report" },
-    { name = "pytest-metadata" },
-    { name = "pytest-regex" },
-    { name = "pytest-xdist" },
-    { name = "pyyaml" },
-    { name = "questionary" },
-    { name = "requests" },
-    { name = "requests-unixsocket2" },
-    { name = "rich" },
-    { name = "semver" },
-    { name = "tenacity" },
-    { name = "trie" },
-    { name = "types-pyyaml" },
-    { name = "typing-extensions" },
-]
-
-[package.optional-dependencies]
-docs = [
-    { name = "cairosvg" },
-    { name = "codespell" },
-    { name = "lxml" },
-    { name = "markdown" },
-    { name = "mike" },
-    { name = "mkdocs" },
-    { name = "mkdocs-click" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-git-authors-plugin" },
-    { name = "mkdocs-glightbox" },
-    { name = "mkdocs-literate-nav" },
-    { name = "mkdocs-material" },
-    { name = "mkdocs-material-extensions" },
-    { name = "mkdocstrings" },
-    { name = "mkdocstrings-python" },
-    { name = "pillow" },
-    { name = "pyspelling" },
-    { name = "setuptools" },
-]
-lint = [
-    { name = "mypy" },
-    { name = "ruff" },
-    { name = "types-requests" },
-]
-test = [
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "cairosvg", marker = "extra == 'docs'", specifier = ">=2.7.0,<3" },
-    { name = "ckzg", specifier = ">=2.1.3,<3" },
-    { name = "click", specifier = ">=8.1.0,<9" },
-    { name = "codespell", marker = "extra == 'docs'", specifier = ">=2.4.1,<3" },
-    { name = "coincurve", specifier = ">=20.0.0,<21" },
-    { name = "colorlog", specifier = ">=6.7.0,<7" },
-    { name = "eth-abi", specifier = ">=5.2.0" },
-    { name = "ethereum-execution", editable = "." },
-    { name = "ethereum-hive", specifier = ">=0.1.0a1,<1.0.0" },
-    { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
-    { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
-    { name = "filelock", specifier = ">=3.15.1,<4" },
-    { name = "gitpython", specifier = ">=3.1.31,<4" },
-    { name = "joblib", specifier = ">=1.4.2" },
-    { name = "lxml", marker = "extra == 'docs'", specifier = ">=6.0.0,<7" },
-    { name = "markdown", marker = "extra == 'docs'", specifier = "==3.8" },
-    { name = "mike", marker = "extra == 'docs'", specifier = ">=1.1.2,<2" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.4.3,<2" },
-    { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8,<1" },
-    { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0,<1" },
-    { name = "mkdocs-git-authors-plugin", marker = "extra == 'docs'", specifier = ">=0.7.1,<1" },
-    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = ">=0.3.4,<1" },
-    { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = ">=0.6.0,<1" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.1.14,<10" },
-    { name = "mkdocs-material-extensions", marker = "extra == 'docs'", specifier = ">=1.1.1,<2" },
-    { name = "mkdocstrings", marker = "extra == 'docs'", specifier = ">=0.21.2,<1" },
-    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.0.0,<2" },
-    { name = "mypy", marker = "extra == 'lint'", specifier = "==1.17.0" },
-    { name = "pillow", marker = "extra == 'docs'", specifier = ">=10.0.1,<11" },
-    { name = "pydantic", specifier = ">=2.11.0,<3" },
-    { name = "pyjwt", specifier = ">=2.3.0,<3" },
-    { name = "pyspelling", marker = "extra == 'docs'", specifier = ">=2.8.2,<3" },
-    { name = "pytest", specifier = ">=8,<9" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0,<5" },
-    { name = "pytest-custom-report", specifier = ">=1.0.1,<2" },
-    { name = "pytest-html", specifier = ">=4.1.0,<5" },
-    { name = "pytest-json-report", specifier = ">=1.5.0,<2" },
-    { name = "pytest-metadata", specifier = ">=3,<4" },
-    { name = "pytest-regex", specifier = ">=0.2.0,<0.3" },
-    { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
-    { name = "pyyaml", specifier = ">=6.0.2,<7" },
-    { name = "questionary", specifier = ">=2.1.0,<3" },
-    { name = "requests", specifier = ">=2.31.0,<3" },
-    { name = "requests-unixsocket2", specifier = ">=0.4.0" },
-    { name = "rich", specifier = ">=13.7.0,<14" },
-    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.13.2" },
-    { name = "semver", specifier = ">=3.0.1,<4" },
-    { name = "setuptools", marker = "extra == 'docs'", specifier = "==78.0.2" },
-    { name = "tenacity", specifier = ">=9.0.0,<10" },
-    { name = "trie", specifier = ">=3.1.0,<4" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
-    { name = "types-requests", marker = "extra == 'lint'", specifier = ">=2.31,<2.33" },
-    { name = "typing-extensions", specifier = ">=4.12.2,<5" },
-]
-provides-extras = ["test", "lint", "docs"]
 
 [[package]]
 name = "ethereum-hive"
@@ -2221,6 +2116,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2751,12 +2655,15 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "78.0.2"
+name = "shellcheck-py"
+version = "0.11.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/f4/aa8d364f0dc1f33b2718938648c31202e2db5cd6479a73f0a9ca5a88372d/setuptools-78.0.2.tar.gz", hash = "sha256:137525e6afb9022f019d6e884a319017f9bf879a0d8783985d32cbc8683cab93", size = 1367747, upload-time = "2025-03-24T19:50:41.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/455b097417b3df3d330eff029c72c32f08b25739e3010acb30ad06d268ef/shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc", size = 3139, upload-time = "2025-08-09T17:53:42.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/db/2fd473dfe436ad19fda190f4079162d400402aedfcc41e048d38c0a375c6/setuptools-78.0.2-py3-none-any.whl", hash = "sha256:4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d", size = 1255965, upload-time = "2025-03-24T19:50:39.943Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/d75b03e5458cefdb6d3b674566cd20476c3e4d3fe6cc9d68b7e3b854b296/shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8", size = 6774472, upload-time = "2025-08-09T17:53:34.573Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ac/2a84c37171c0cf5a10ea4b0a27d43eb0a1d29bd98b49c2c5ffe17ad24bbe/shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0", size = 11381835, upload-time = "2025-08-09T17:53:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/96/55/250e0e3367613a5c22bd82e33b16b889287d81ab0f7dda67e6514a4cccf4/shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05", size = 3800600, upload-time = "2025-08-09T17:53:38.643Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5b/bb14c0a7474463b1aa3c09e866cb172dffc66ed2993b7ea8f1db581e86ee/shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759", size = 8027541, upload-time = "2025-08-09T17:53:40.889Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,13 +10,8 @@ resolution-markers = [
 members = [
     "ethereum-execution",
     "ethereum-execution-testing",
+    "ethereum-execution-tests",
 ]
-
-[[package]]
-name = "actionlint-py"
-version = "1.7.10.24"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/01/790379bf4cab91a272421a39b3d80f4a0d1a1ed753c00176be28b7d6adc6/actionlint_py-1.7.10.24.tar.gz", hash = "sha256:bac4e74e944c692fc7c65661009caebf14621bb33d937127ee5df8ac0693736a", size = 12057, upload-time = "2026-01-01T17:06:36.282Z" }
 
 [[package]]
 name = "annotated-types"
@@ -836,13 +831,7 @@ optimized = [
 ]
 
 [package.dev-dependencies]
-actionlint = [
-    { name = "actionlint-py" },
-    { name = "pyflakes" },
-    { name = "shellcheck-py" },
-]
 dev = [
-    { name = "actionlint-py" },
     { name = "cairosvg" },
     { name = "codespell" },
     { name = "docc" },
@@ -869,7 +858,6 @@ dev = [
     { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pillow" },
-    { name = "pyflakes" },
     { name = "pyspelling" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -877,7 +865,6 @@ dev = [
     { name = "requests" },
     { name = "requests-cache" },
     { name = "ruff" },
-    { name = "shellcheck-py" },
     { name = "types-requests" },
     { name = "vulture" },
 ]
@@ -942,13 +929,7 @@ requires-dist = [
 provides-extras = ["optimized"]
 
 [package.metadata.requires-dev]
-actionlint = [
-    { name = "actionlint-py", specifier = ">=1.7" },
-    { name = "pyflakes", specifier = ">=3.0" },
-    { name = "shellcheck-py", specifier = ">=0.10" },
-]
 dev = [
-    { name = "actionlint-py", specifier = ">=1.7" },
     { name = "cairosvg", specifier = ">=2.7.0,<3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
@@ -976,7 +957,6 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.0.0,<2" },
     { name = "mypy", specifier = "==1.17.0" },
     { name = "pillow", specifier = ">=10.0.1,<11" },
-    { name = "pyflakes", specifier = ">=3.0" },
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
@@ -984,7 +964,6 @@ dev = [
     { name = "requests" },
     { name = "requests-cache", specifier = ">=1.2.1,<2" },
     { name = "ruff", specifier = "==0.13.2" },
-    { name = "shellcheck-py", specifier = ">=0.10" },
     { name = "types-requests", specifier = ">=2.31,<2.33" },
     { name = "vulture", specifier = "==2.14.0" },
 ]
@@ -1138,6 +1117,132 @@ lint = [
     { name = "types-requests", specifier = ">=2.31,<2.33" },
 ]
 test = [{ name = "pytest-cov", specifier = ">=4.1.0,<5" }]
+
+[[package]]
+name = "ethereum-execution-tests"
+version = "1.0.0"
+source = { editable = "packages/tests" }
+dependencies = [
+    { name = "ckzg" },
+    { name = "click" },
+    { name = "coincurve" },
+    { name = "colorlog" },
+    { name = "eth-abi" },
+    { name = "ethereum-execution" },
+    { name = "ethereum-hive" },
+    { name = "ethereum-rlp" },
+    { name = "ethereum-types" },
+    { name = "filelock" },
+    { name = "gitpython" },
+    { name = "joblib" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pytest" },
+    { name = "pytest-custom-report" },
+    { name = "pytest-html" },
+    { name = "pytest-json-report" },
+    { name = "pytest-metadata" },
+    { name = "pytest-regex" },
+    { name = "pytest-xdist" },
+    { name = "pyyaml" },
+    { name = "questionary" },
+    { name = "requests" },
+    { name = "requests-unixsocket2" },
+    { name = "rich" },
+    { name = "semver" },
+    { name = "tenacity" },
+    { name = "trie" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+docs = [
+    { name = "cairosvg" },
+    { name = "codespell" },
+    { name = "lxml" },
+    { name = "markdown" },
+    { name = "mike" },
+    { name = "mkdocs" },
+    { name = "mkdocs-click" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-git-authors-plugin" },
+    { name = "mkdocs-glightbox" },
+    { name = "mkdocs-literate-nav" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-material-extensions" },
+    { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
+    { name = "pillow" },
+    { name = "pyspelling" },
+    { name = "setuptools" },
+]
+lint = [
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "types-requests" },
+]
+test = [
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cairosvg", marker = "extra == 'docs'", specifier = ">=2.7.0,<3" },
+    { name = "ckzg", specifier = ">=2.1.3,<3" },
+    { name = "click", specifier = ">=8.1.0,<9" },
+    { name = "codespell", marker = "extra == 'docs'", specifier = ">=2.4.1,<3" },
+    { name = "coincurve", specifier = ">=20.0.0,<21" },
+    { name = "colorlog", specifier = ">=6.7.0,<7" },
+    { name = "eth-abi", specifier = ">=5.2.0" },
+    { name = "ethereum-execution", editable = "." },
+    { name = "ethereum-hive", specifier = ">=0.1.0a1,<1.0.0" },
+    { name = "ethereum-rlp", specifier = ">=0.1.3,<0.2" },
+    { name = "ethereum-types", specifier = ">=0.2.1,<0.3" },
+    { name = "filelock", specifier = ">=3.15.1,<4" },
+    { name = "gitpython", specifier = ">=3.1.31,<4" },
+    { name = "joblib", specifier = ">=1.4.2" },
+    { name = "lxml", marker = "extra == 'docs'", specifier = ">=6.0.0,<7" },
+    { name = "markdown", marker = "extra == 'docs'", specifier = "==3.8" },
+    { name = "mike", marker = "extra == 'docs'", specifier = ">=1.1.2,<2" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.4.3,<2" },
+    { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8,<1" },
+    { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0,<1" },
+    { name = "mkdocs-git-authors-plugin", marker = "extra == 'docs'", specifier = ">=0.7.1,<1" },
+    { name = "mkdocs-glightbox", marker = "extra == 'docs'", specifier = ">=0.3.4,<1" },
+    { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = ">=0.6.0,<1" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.1.14,<10" },
+    { name = "mkdocs-material-extensions", marker = "extra == 'docs'", specifier = ">=1.1.1,<2" },
+    { name = "mkdocstrings", marker = "extra == 'docs'", specifier = ">=0.21.2,<1" },
+    { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.0.0,<2" },
+    { name = "mypy", marker = "extra == 'lint'", specifier = "==1.17.0" },
+    { name = "pillow", marker = "extra == 'docs'", specifier = ">=10.0.1,<11" },
+    { name = "pydantic", specifier = ">=2.11.0,<3" },
+    { name = "pyjwt", specifier = ">=2.3.0,<3" },
+    { name = "pyspelling", marker = "extra == 'docs'", specifier = ">=2.8.2,<3" },
+    { name = "pytest", specifier = ">=8,<9" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0,<5" },
+    { name = "pytest-custom-report", specifier = ">=1.0.1,<2" },
+    { name = "pytest-html", specifier = ">=4.1.0,<5" },
+    { name = "pytest-json-report", specifier = ">=1.5.0,<2" },
+    { name = "pytest-metadata", specifier = ">=3,<4" },
+    { name = "pytest-regex", specifier = ">=0.2.0,<0.3" },
+    { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
+    { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "questionary", specifier = ">=2.1.0,<3" },
+    { name = "requests", specifier = ">=2.31.0,<3" },
+    { name = "requests-unixsocket2", specifier = ">=0.4.0" },
+    { name = "rich", specifier = ">=13.7.0,<14" },
+    { name = "ruff", marker = "extra == 'lint'", specifier = "==0.13.2" },
+    { name = "semver", specifier = ">=3.0.1,<4" },
+    { name = "setuptools", marker = "extra == 'docs'", specifier = "==78.0.2" },
+    { name = "tenacity", specifier = ">=9.0.0,<10" },
+    { name = "trie", specifier = ">=3.1.0,<4" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20240917,<7" },
+    { name = "types-requests", marker = "extra == 'lint'", specifier = ">=2.31,<2.33" },
+    { name = "typing-extensions", specifier = ">=4.12.2,<5" },
+]
+provides-extras = ["test", "lint", "docs"]
 
 [[package]]
 name = "ethereum-hive"
@@ -2116,15 +2221,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2655,15 +2751,12 @@ wheels = [
 ]
 
 [[package]]
-name = "shellcheck-py"
-version = "0.11.0.1"
+name = "setuptools"
+version = "78.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/55/455b097417b3df3d330eff029c72c32f08b25739e3010acb30ad06d268ef/shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc", size = 3139, upload-time = "2025-08-09T17:53:42.492Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f4/aa8d364f0dc1f33b2718938648c31202e2db5cd6479a73f0a9ca5a88372d/setuptools-78.0.2.tar.gz", hash = "sha256:137525e6afb9022f019d6e884a319017f9bf879a0d8783985d32cbc8683cab93", size = 1367747, upload-time = "2025-03-24T19:50:41.896Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/27/d75b03e5458cefdb6d3b674566cd20476c3e4d3fe6cc9d68b7e3b854b296/shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8", size = 6774472, upload-time = "2025-08-09T17:53:34.573Z" },
-    { url = "https://files.pythonhosted.org/packages/61/ac/2a84c37171c0cf5a10ea4b0a27d43eb0a1d29bd98b49c2c5ffe17ad24bbe/shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0", size = 11381835, upload-time = "2025-08-09T17:53:36.852Z" },
-    { url = "https://files.pythonhosted.org/packages/96/55/250e0e3367613a5c22bd82e33b16b889287d81ab0f7dda67e6514a4cccf4/shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05", size = 3800600, upload-time = "2025-08-09T17:53:38.643Z" },
-    { url = "https://files.pythonhosted.org/packages/15/5b/bb14c0a7474463b1aa3c09e866cb172dffc66ed2993b7ea8f1db581e86ee/shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759", size = 8027541, upload-time = "2025-08-09T17:53:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/db/2fd473dfe436ad19fda190f4079162d400402aedfcc41e048d38c0a375c6/setuptools-78.0.2-py3-none-any.whl", hash = "sha256:4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d", size = 1255965, upload-time = "2025-03-24T19:50:39.943Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add regression tests for CALLDATACOPY and CODECOPY gas consumption, specifically targeting the word copy cost calculation. These tests are ported from a Nethermind fix ([PR #10116](https://github.com/NethermindEth/nethermind/pull/10116)).

The tests verify that:
- With sufficient gas: the data copy operation succeeds and storage write occurs
- With insufficient gas for word copy cost: the transaction runs out of gas and storage write does not occur

## Related Issues or PRs

Ported from: https://github.com/NethermindEth/nethermind/pull/10116

## Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Cute capybara](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Capybara_%28Hydrochoerus_hydrochaeris%29.JPG/1200px-Capybara_%28Hydrochoerus_hydrochaeris%29.JPG)