### PR TITLE
chore(test-forks): update Osaka and BPO fork deployment status

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -2212,14 +2212,6 @@ class Osaka(Prague, solc_name="cancun"):
         return max_block_size - safety_margin
 
     @classmethod
-    def is_deployed(cls) -> bool:
-        """
-        Flag that the fork has not been deployed to mainnet; it is under active
-        development.
-        """
-        return False
-
-    @classmethod
     def valid_opcodes(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> List[Opcodes]:
@@ -2404,6 +2396,11 @@ class BPO3(BPO2, bpo_fork=True):
     Pseudo BPO3 fork - Blob Parameter Only fork 3.
     For testing purposes only.
     """
+
+    @classmethod
+    def is_deployed(cls) -> bool:
+        """BPO3 is a pseudo fork for testing, not deployed to mainnet."""
+        return False
 
     @classmethod
     def blob_base_fee_update_fraction(

--- a/packages/testing/src/execution_testing/forks/helpers.py
+++ b/packages/testing/src/execution_testing/forks/helpers.py
@@ -76,11 +76,12 @@ def get_deployed_forks() -> List[Type[BaseFork]]:
     """
     Return list of all the fork classes implemented by `execution_testing.forks`
     that have been deployed to mainnet, chronologically ordered by deployment.
+    BPO (Blob Parameter Only) forks are excluded as they are handled separately.
     """
     return [
         fork
         for fork in get_forks()
-        if fork.is_deployed() and not fork.ignore()
+        if fork.is_deployed() and not fork.ignore() and not fork.bpo_fork()
     ]
 
 

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from execution_testing.base_types import BlobSchedule
 
 from ..forks.forks import (
+    Amsterdam,
     BPO1,
     BPO2,
     BPO3,
@@ -49,9 +50,9 @@ from ..helpers import (
 from ..transition_base_fork import transition_fork
 
 FIRST_DEPLOYED = Frontier
-LAST_DEPLOYED = Prague
-LAST_DEVELOPMENT = Osaka
-DEVELOPMENT_FORKS = [Osaka]
+LAST_DEPLOYED = Osaka
+LAST_DEVELOPMENT = Amsterdam
+DEVELOPMENT_FORKS = [Amsterdam]
 
 
 def test_transition_forks() -> None:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

### Problem

When running fill without specifying an end fork, the command defaults to Prague as the latest stable fork. However, Osaka and BPO1/BPO2 have since been deployed to mainnet, and Amsterdam is now the development fork.

For example, the following will not fill any Osaka tests:
```bash
uv run fill --from Frontier tests/osaka/ --clean
```

### Solution

Update the fork deployment status to reflect current mainnet state:
- Mark Osaka as deployed (`remove is_deployed() -> False`)
- BPO1 and BPO2 inherit deployed status from Osaka
- Mark BPO3-5 as not deployed (pseudo forks for testing only)
- Amsterdam remains as the development fork

Tests updated slightly to reflect the latter.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

_**Charmander - 0004**_
![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/004.png)
