### PR TITLE
fix(test-types,ci): use `evm` in `packages/test` unit tests & fix `TransactionReceipt`

### DIFF
--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -49,6 +49,9 @@ class TransactionReceipt(CamelModel):
             # t8n tool may return 'post_state' which is not part of this model
             data.pop("post_state", None)
             data.pop("postState", None)
+            # geth (1.16+) returns extra fields in receipts
+            data.pop("type", None)
+            data.pop("blockNumber", None)
         return data
 
     transaction_hash: Hash | None = None


### PR DESCRIPTION
## 🗒️ Description

<del>
- Replace hardcoded geth v1.10.8 with dynamic lookup via GitHub API in download geth script. This ensures CI uses the latest stable geth release.
- Added `--alltools` command-line flag to not only download the `geth` binary but additional tools (for `evm`).
- Updated the workflow to use `--alltools` so that `tests_pytest_py3` has the latest geth `evm` binary available.
- This triggered the fail in CI that I was seeing locally from `tests_pytest_py3` in  `src/execution_testing/client_clis/tests/test_transition_tools_support.py::test_t8n_support[GethTransitionTool-*]`:
  ```python
   E       pydantic_core._pydantic_core.ValidationError: 1 validation error for Result
   E       receipts.0.blockNumber
   E         Extra inputs are not permitted [type=extra_forbidden, input_value='0x1', input_type=str]
   E           For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
  ```
</del>

- Fix: Remove `blockNumber` and `type` before validation in `TransactionReceipt`. 

I think this behavior changed due to:
- #1989

I only noticed it locally as I had `evm` in my PATH, but we didn't have an `evm` available in the PATH when `tests_pytest_py3` env ran.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. --> 
- #1989
- #2000

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img height="256" alt="image" src="https://github.com/user-attachments/assets/eeaa09c6-96a4-41ac-a0a2-9b8a5ded1e1d" />

