### PR TITLE
feat(fill): Customize fill with `--chain-id`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 #### `fill`
 
+- ✨ Allow command to customize `--chain-id` used for filling ([#2016](https://github.com/ethereum/execution-specs/pull/2016)).
+
 #### `consume`
 
 - ✨ Add Besu `evmtool` support for `consume direct` via `state-test` and `block-test` subcommands ([#2219](https://github.com/ethereum/execution-specs/pull/2219)).

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -582,7 +582,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         dest="chain_id",
         type=int,
         default=None,
-        help=("Specify the chain ID for the test filling."),
+        help=(
+            "Specify the chain ID for the test filling. "
+            f"Default: {ChainConfigDefaults.chain_id}."
+        ),
     )
     evm_group.addoption(
         "--traces",

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -69,6 +69,7 @@ from execution_testing.forks import (
 from execution_testing.specs import BaseTest
 from execution_testing.specs.base import FillResult, OpMode
 from execution_testing.test_types import EnvironmentDefaults
+from execution_testing.test_types.chain_config_types import ChainConfigDefaults
 from execution_testing.tools.utility.versioning import (
     generate_github_url,
     get_current_commit_hash_or_tag,
@@ -576,6 +577,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
     evm_group.addoption(
+        "--chain-id",
+        action="store",
+        dest="chain_id",
+        type=str,
+        default=None,
+        help=("Specify the chain ID for the test filling."),
+    )
+    evm_group.addoption(
         "--traces",
         action="store_true",
         dest="evm_collect_traces",
@@ -926,6 +935,16 @@ def pytest_configure(config: pytest.Config) -> None:
         config.t8n_cache_stats_aggregated = (  # type: ignore[attr-defined]
             TransitionToolCacheStats()
         )
+
+    chain_id = config.getoption("chain_id")
+
+    if chain_id is None:
+        # Try to get the chain ID from the environment variable
+        chain_id = os.environ.get("CHAIN_ID")
+
+    # write to config
+    if chain_id is not None:
+        ChainConfigDefaults.chain_id = chain_id
 
 
 @pytest.hookimpl(trylast=True)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -580,7 +580,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--chain-id",
         action="store",
         dest="chain_id",
-        type=str,
+        type=int,
         default=None,
         help=("Specify the chain ID for the test filling."),
     )
@@ -939,10 +939,10 @@ def pytest_configure(config: pytest.Config) -> None:
     chain_id = config.getoption("chain_id")
 
     if chain_id is None:
-        # Try to get the chain ID from the environment variable
-        chain_id = os.environ.get("CHAIN_ID")
+        env_chain_id = os.environ.get("CHAIN_ID")
+        if env_chain_id is not None:
+            chain_id = int(env_chain_id)
 
-    # write to config
     if chain_id is not None:
         ChainConfigDefaults.chain_id = chain_id
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -87,6 +87,7 @@ from execution_testing.test_types.block_access_list import (
     BlockAccessList,
     BlockAccessListExpectation,
 )
+from execution_testing.test_types.chain_config_types import ChainConfigDefaults
 
 from .base import BaseTest, FillResult, OpMode, verify_result
 from .debugging import print_traces
@@ -504,7 +505,10 @@ class BlockchainTest(BaseTest):
     post: Alloc
     blocks: List[Block]
     genesis_environment: Environment = Field(default_factory=Environment)
-    chain_id: int = 1
+    chain_id: int = Field(
+        default_factory=lambda: ChainConfigDefaults.chain_id,
+        validate_default=True,
+    )
     include_full_post_state_in_output: bool = True
     """
     Include the post state in the fixture output. Otherwise, the state

--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -44,7 +44,7 @@ class TransactionLoad:
 
     def json_to_chain_id(self) -> U64:
         """Get chain ID for the transaction."""
-        return U64(1)
+        return hex_to_u64(self.raw.get("chainId", "0x01"))
 
     def json_to_nonce(self) -> U256:
         """Get the nonce for the transaction."""

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -221,7 +221,8 @@ class Txs:
                     signing_hash = t8n.fork.signing_hash_155(
                         tx_decoded, self.t8n.chain_id
                     )
-                    v_addend = U256(36) + U256(self.t8n.chain_id)
+                    # EIP-155: CHAIN_ID * 2 + 35
+                    v_addend = U256(self.t8n.chain_id) * U256(2) + U256(35)
                 else:
                     signing_hash = t8n.fork.signing_hash_pre155(tx_decoded)
                     v_addend = U256(27)

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -219,9 +219,9 @@ class Txs:
             if t8n.fork.has_signing_hash_155:
                 if protected:
                     signing_hash = t8n.fork.signing_hash_155(
-                        tx_decoded, U64(1)
+                        tx_decoded, self.t8n.chain_id
                     )
-                    v_addend = U256(37)  # Assuming chain_id = 1
+                    v_addend = U256(36) + U256(self.t8n.chain_id)
                 else:
                     signing_hash = t8n.fork.signing_hash_pre155(tx_decoded)
                     v_addend = U256(27)


### PR DESCRIPTION
## 🗒️ Description

YMMV but this works for me if I want to fill for chainid other than `1`. 

## 🔗 Related Issues or PRs

Maybe closes #1394 , please verify. There are two links posted in the description there, the latter is handled, ~the former I think also seems like should be doable, but I'm not sure if that `secretKey` is used anywhere at all, please advise~ I think the latter one is also handled, CI made me do it.

## ✅ Checklist

- [x] All: Ran fast `tox` 
- [x] All: PR title adheres 
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
