### PR TITLE
tests(eip-7928): remove bal from block body

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -554,9 +554,6 @@ class FixtureBlockBase(CamelModel):
     )
     withdrawals: List[FixtureWithdrawal] | None = None
     execution_witness: WitnessChunk | None = None
-    block_access_list: BlockAccessList | None = Field(
-        None, description="EIP-7928 Block Access List"
-    )
     fork: Fork | None = Field(None, exclude=True)
 
     @computed_field(alias="blocknumber")  # type: ignore[prop-decorator]
@@ -577,9 +574,6 @@ class FixtureBlockBase(CamelModel):
 
         if self.withdrawals is not None:
             block.append([w.to_serializable_list() for w in self.withdrawals])
-
-        if self.block_access_list is not None:
-            block.append(self.block_access_list.to_list())
 
         return FixtureBlock(
             **self.model_dump(),

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -380,9 +380,6 @@ class BuiltBlock(CamelModel):
                 if self.withdrawals is not None
                 else None
             ),
-            block_access_list=self.block_access_list
-            if self.block_access_list
-            else None,
             fork=self.fork,
         ).with_rlp(txs=self.txs)
 
@@ -563,16 +560,11 @@ class BlockchainTest(BaseTest):
         state_root = pre_alloc.state_root()
         genesis = FixtureHeader.genesis(self.fork, env, state_root)
 
-        genesis_bal = None
-        if self.fork.header_bal_hash_required(block_number=0, timestamp=0):
-            genesis_bal = BlockAccessList()
-
         return (
             pre_alloc,
             FixtureBlockBase(
                 header=genesis,
                 withdrawals=None if env.withdrawals is None else [],
-                block_access_list=genesis_bal,
             ).with_rlp(txs=[]),
         )
 

--- a/src/ethereum/genesis.py
+++ b/src/ethereum/genesis.py
@@ -260,7 +260,7 @@ def add_genesis_block(
         fields["requests_hash"] = Hash32(b"\0" * 32)
 
     if has_field(hardfork.Header, "block_access_list_hash"):
-        fields["block_access_list_hash"] = Hash32(b"\0" * 32)
+        fields["block_access_list_hash"] = keccak256(rlp.encode([]))
 
     genesis_header = hardfork.Header(**fields)
 

--- a/src/ethereum/genesis.py
+++ b/src/ethereum/genesis.py
@@ -276,9 +276,6 @@ def add_genesis_block(
     if has_field(hardfork.Block, "requests"):
         block_fields["requests"] = ()
 
-    if has_field(hardfork.Block, "block_access_list"):
-        block_fields["block_access_list"] = rlp.encode([])
-
     genesis_block = hardfork.Block(**block_fields)
 
     chain.blocks.append(genesis_block)

--- a/tests/json_infra/helpers/load_blockchain_tests.py
+++ b/tests/json_infra/helpers/load_blockchain_tests.py
@@ -138,9 +138,6 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
         if hasattr(genesis_header, "requests_root"):
             parameters.append(())
 
-        if hasattr(genesis_header, "block_access_list_hash"):
-            parameters.append([])
-
         genesis_block = load.fork.Block(*parameters)
 
         genesis_header_hash = hex_to_bytes(


### PR DESCRIPTION
## 🗒️ Description
In EIP-7928, the BAL is not expected to be a part of the block body. Although this change was implemented on the specs side, the testing famework still includes the BAL while computing the block RLP

## 🔗 Related Issues or PRs


## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
