### PR TITLE
chore: fix typos

### DIFF
--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -371,7 +371,7 @@ class FixIndexTransform(Transform):
     identifiers specific to the diff.
 
     Without fixing these identifiers, every Python class would be defined
-    multiples times (the actual definition and then again in each diff),
+    multiple times (the actual definition and then again in each diff),
     cluttering up tables of contents.
     """
 

--- a/src/ethereum_spec_tools/lint/__init__.py
+++ b/src/ethereum_spec_tools/lint/__init__.py
@@ -18,7 +18,7 @@ from ..forks import Hardfork
 
 def compare_ast(old: ast.AST, new: ast.AST) -> bool:
     """
-    Check if two nodes are the equal.
+    Check if two nodes are equal.
     """
     if type(old) is not type(new):
         return False


### PR DESCRIPTION
multiples times -> multiple times
are the equal -> are equal