### PR TITLE
tests(eip-7928): generalize eip-7934 tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ Add tests that EIP-1559 and EIP-2930 typed txs are invalid and void before their fork ([#1754](https://github.com/ethereum/execution-specs/pull/1754)).
 - ✨ Add tests for an old validation rule for gas limit above 5000 ([#1731](https://github.com/ethereum/execution-specs/pull/1731)).
 - ✨ Add tests for OOG in EXP, LOG and others ([#1686](https://github.com/ethereum/execution-specs/pull/1686)).
+- ✨ Make EIP-7934 tests more dynamic and able to handle new header fields added in future forks ([#2022](https://github.com/ethereum/execution-specs/pull/2022)).
 
 ## [v5.3.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.3.0) - 2025-10-09
 

--- a/packages/testing/src/execution_testing/base_types/__init__.py
+++ b/packages/testing/src/execution_testing/base_types/__init__.py
@@ -44,6 +44,7 @@ from .conversions import to_bytes, to_hex
 from .pydantic import CamelModel, EthereumTestBaseModel, EthereumTestRootModel
 from .reference_spec import ReferenceSpec
 from .serialization import RLPSerializable, SignableRLPSerializable
+from .typing_utils import unwrap_annotation
 
 __all__ = (
     "AccessList",
@@ -88,4 +89,5 @@ __all__ = (
     "to_bytes",
     "to_hex",
     "to_json",
+    "unwrap_annotation",
 )

--- a/packages/testing/src/execution_testing/base_types/typing_utils.py
+++ b/packages/testing/src/execution_testing/base_types/typing_utils.py
@@ -1,0 +1,33 @@
+"""Utilities for working with Python type annotations."""
+
+from typing import Any, get_args
+
+
+def unwrap_annotation(hint: Any) -> Any:
+    """
+    Recursively unwrap Annotated and Union types to find the actual type.
+
+    This function is useful for introspecting complex type annotations like:
+    - `Annotated[int, ...]` -> `int`
+    - `int | None` -> `int`
+    - `Annotated[int, ...] | None` -> `int`
+
+    Args:
+        hint: Type annotation to unwrap
+
+    Returns:
+        The unwrapped base type
+    """
+    type_args = get_args(hint)
+    if not type_args:
+        # Base case: simple type with no parameters
+        return hint
+
+    # For Union types (including Optional), find the first non-None type
+    for arg in type_args:
+        if arg is not type(None):
+            # Recursively unwrap (handles nested Annotated/Union)
+            return unwrap_annotation(arg)
+
+    # All args were None (shouldn't happen in practice)
+    return hint

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
@@ -296,6 +296,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_OSAKA_TIMESTAMP": 0,
+        **get_blob_schedule_entries(Osaka),
     },
     PragueToOsakaAtTime15k: {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -313,6 +314,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_OSAKA_TIMESTAMP": 15000,
+        **get_blob_schedule_entries(Osaka),
     },
     BPO1: {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -502,5 +504,6 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         # "HIVE_BPO3_TIMESTAMP": 0,
         # "HIVE_BPO4_TIMESTAMP": 0,
         "HIVE_AMSTERDAM_TIMESTAMP": 0,
+        **get_blob_schedule_entries(Amsterdam),
     },
 }

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -28,6 +28,7 @@ from pydantic import (
     computed_field,
     model_validator,
 )
+from pydantic_core import PydanticUndefined
 
 from execution_testing.base_types import (
     Address,
@@ -42,6 +43,7 @@ from execution_testing.base_types import (
     HexNumber,
     Number,
     ZeroPaddedHexNumber,
+    unwrap_annotation,
 )
 from execution_testing.exceptions import (
     EngineAPIError,
@@ -273,6 +275,78 @@ class FixtureHeader(CamelModel):
     def block_hash(self) -> Hash:
         """Compute the RLP of the header."""
         return self.rlp.keccak256()
+
+
+    @classmethod
+    def get_default_from_annotation(
+        cls,
+        fork: Fork,
+        field_name: str,
+        field_hint: Any,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> Any:
+        """
+        Get appropriate default value for a header field based on its type hint.
+
+        This method handles:
+        1. Fork requirement checking - only returns a default if the fork requires the field
+        2. Model-defined defaults - uses the field's default value if available
+        3. Type-based defaults - constructs defaults based on the field type
+
+        Args:
+            fork: Fork to check requirements against
+            field_name: Name of the field
+            field_hint: Type annotation of the field
+            block_number: Block number for fork requirement checking (default: 0)
+            timestamp: Timestamp for fork requirement checking (default: 0)
+
+        Returns:
+            Default value appropriate for the field type, or None if
+            the field is not required by the fork
+
+        Raises:
+            TypeError: If the field type is not supported and no default value
+                is defined in the model. This indicates that support for the type
+                needs to be added or an explicit default must be provided.
+        """
+        # Check if this field has a HeaderForkRequirement annotation
+        header_fork_requirement = HeaderForkRequirement.get_from_annotation(
+            field_hint
+        )
+        if header_fork_requirement is not None:
+            # Only provide a default if the fork requires this field
+            if not header_fork_requirement.required(fork, block_number, timestamp):
+                return None
+
+        # Check if the field has a default value defined in the model
+        if field_name in cls.model_fields:
+            field_info = cls.model_fields[field_name]
+            if field_info.default is not None and field_info.default is not PydanticUndefined:
+                return field_info.default
+            if field_info.default_factory is not None:
+                return field_info.default_factory()  # type: ignore[call-arg]
+
+        # Unwrap type annotations to get the actual type
+        actual_type = unwrap_annotation(field_hint)
+
+        # Construct default based on type
+        if actual_type == ZeroPaddedHexNumber:
+            return ZeroPaddedHexNumber(0)
+        elif actual_type == Hash:
+            return Hash(0)
+        elif actual_type == Address:
+            return Address(0)
+        elif actual_type == Bytes:
+            return Bytes(b"")
+        else:
+            # Unsupported type - raise an error to catch this during development
+            raise TypeError(
+                f"Cannot generate default value for field '{field_name}' "
+                f"with unsupported type '{actual_type}'. "
+                f"Add support for this type or provide a default value explicitly."
+            )
+
 
     @classmethod
     def genesis(cls, fork: Fork, env: Environment, state_root: Hash) -> Self:

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -276,7 +276,6 @@ class FixtureHeader(CamelModel):
         """Compute the RLP of the header."""
         return self.rlp.keccak256()
 
-
     @classmethod
     def get_default_from_annotation(
         cls,
@@ -346,7 +345,6 @@ class FixtureHeader(CamelModel):
                 f"with unsupported type '{actual_type}'. "
                 f"Add support for this type or provide a default value explicitly."
             )
-
 
     @classmethod
     def genesis(cls, fork: Fork, env: Environment, state_root: Hash) -> Self:

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -2,6 +2,7 @@
 
 from abc import ABCMeta, abstractmethod
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -17,6 +18,9 @@ from typing import (
     Type,
     Union,
 )
+
+if TYPE_CHECKING:
+    from execution_testing.fixtures.blockchain import FixtureHeader
 
 from execution_testing.base_types import (
     AccessList,
@@ -978,3 +982,13 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     def children(cls) -> Set[Type["BaseFork"]]:
         """Return the children forks."""
         return set(cls._children)
+
+    @classmethod
+    @abstractmethod
+    def build_default_block_header(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> "FixtureHeader":
+        """
+        Build a default block header for this fork with the given attributes.
+        """
+        pass

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -52,7 +52,6 @@ class StateChanges:
 
     # Pre-state captures (transaction-scoped, only populated at tx frame)
     pre_balances: Dict[Address, U256] = field(default_factory=dict)
-    pre_nonces: Dict[Address, U64] = field(default_factory=dict)
     pre_storage: Dict[Tuple[Address, Bytes32], U256] = field(
         default_factory=dict
     )
@@ -527,11 +526,10 @@ def filter_net_zero_frame_changes(tx_frame: StateChanges) -> None:
         assert (addr, key) in tx_frame.pre_storage
         pre_value = tx_frame.pre_storage[(addr, key)]
         post_value = tx_frame.storage_writes[(addr, key, idx)]
-        if (addr, key) in tx_frame.pre_storage:
-            if pre_value == post_value:
-                # Net-zero write - convert to read
-                del tx_frame.storage_writes[(addr, key, idx)]
-                tx_frame.storage_reads.add((addr, key))
+        if pre_value == post_value:
+            # Net-zero write - convert to read
+            del tx_frame.storage_writes[(addr, key, idx)]
+            tx_frame.storage_reads.add((addr, key))
 
     # Filter balance: compare pre vs post, remove if equal
     addresses_to_check_balance = [

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
@@ -37,7 +37,7 @@ from execution_testing.test_types.block_access_list.modifiers import (
     remove_balances,
     remove_nonces,
     reverse_accounts,
-    swap_tx_indices,
+    swap_bal_indices,
 )
 
 from .spec import ref_spec_7928
@@ -284,7 +284,7 @@ def test_bal_invalid_tx_order(
                             ],
                         ),
                     }
-                ).modify(swap_tx_indices(1, 2)),
+                ).modify(swap_bal_indices(1, 2)),
             )
         ],
     )
@@ -542,7 +542,7 @@ def test_bal_invalid_complex_corruption(
                         contract, block_access_index=1, slot=0x01, value=0xFF
                     ),
                     remove_balances(receiver),
-                    swap_tx_indices(1, 2),
+                    swap_bal_indices(1, 2),
                 ),
             )
         ],

--- a/tests/frontier/create/test_create_deposit_oog.py
+++ b/tests/frontier/create/test_create_deposit_oog.py
@@ -3,7 +3,6 @@ Test CREATE's behavior when running out of gas for code deposit.
 """
 
 import pytest
-
 from execution_testing import (
     Account,
     Alloc,

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -27,7 +27,6 @@ from execution_testing.base_types import (
 )
 from execution_testing.fixtures.blockchain import (
     FixtureBlockBase,
-    FixtureHeader,
     FixtureWithdrawal,
 )
 
@@ -71,34 +70,8 @@ def block_errors() -> List[BlockException]:
     return [BlockException.RLP_BLOCK_LIMIT_EXCEEDED]
 
 
-def create_test_header(gas_used: int) -> FixtureHeader:
-    """Create a standard test header for RLP size calculations."""
-    return FixtureHeader(
-        difficulty="0x0",
-        number="0x1",
-        gas_limit=hex(BLOCK_GAS_LIMIT),
-        timestamp=hex(HEADER_TIMESTAMP),
-        fee_recipient="0x" + "00" * 20,
-        parent_hash="0x" + "00" * 32,
-        ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-        state_root="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-        transactions_trie="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-        receipts_root="0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-        logs_bloom="0x" + "00" * 256,
-        gas_used=hex(gas_used),
-        extra_data=EXTRA_DATA_AT_LIMIT.hex(),
-        prev_randao="0x" + "00" * 32,
-        nonce="0x0000000000000042",
-        base_fee_per_gas="0x0",
-        withdrawals_root="0x" + "00" * 32,
-        blob_gas_used="0x0",
-        excess_blob_gas="0x0",
-        parent_beacon_block_root="0x" + "00" * 32,
-        requests_hash="0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    )
-
-
 def get_block_rlp_size(
+    fork: Fork,
     transactions: List[Transaction],
     gas_used: int,
     withdrawals: List[Withdrawal] | None = None,
@@ -107,7 +80,14 @@ def get_block_rlp_size(
     Calculate the RLP size of a block with given transactions
     and withdrawals.
     """
-    header = create_test_header(gas_used)
+    header = fork.build_default_block_header(
+        block_number=1,
+        timestamp=HEADER_TIMESTAMP,
+    )
+    header.gas_limit = ZeroPaddedHexNumber(BLOCK_GAS_LIMIT)
+    header.gas_used = ZeroPaddedHexNumber(gas_used)
+    header.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
+
     total_gas = sum((tx.gas_limit or 21000) for tx in transactions)
     header.gas_used = ZeroPaddedHexNumber(total_gas)
 
@@ -323,7 +303,7 @@ def _exact_size_transactions_impl(
         total_gas_used += last_tx.gas_limit
 
     current_size = get_block_rlp_size(
-        transactions, gas_used=total_gas_used, withdrawals=withdrawals
+        fork, transactions, gas_used=total_gas_used, withdrawals=withdrawals
     )
     remaining_bytes = block_size_limit - current_size
     remaining_gas = block_gas_limit - total_gas_used
@@ -340,6 +320,7 @@ def _exact_size_transactions_impl(
         )
 
         empty_block_size = get_block_rlp_size(
+            fork,
             transactions + [empty_tx],
             gas_used=total_gas_used + empty_tx.gas_limit,
             withdrawals=withdrawals,
@@ -363,6 +344,7 @@ def _exact_size_transactions_impl(
             )
 
             test_size = get_block_rlp_size(
+                fork,
                 transactions + [test_tx],
                 gas_used=total_gas_used + target_gas,
                 withdrawals=withdrawals,
@@ -397,6 +379,7 @@ def _exact_size_transactions_impl(
                         )
 
                         adjusted_test_size = get_block_rlp_size(
+                            fork,
                             transactions + [adjusted_tx],
                             gas_used=total_gas_used + adjusted_gas,
                             withdrawals=withdrawals,
@@ -421,6 +404,7 @@ def _exact_size_transactions_impl(
             transactions.append(empty_tx)
 
     final_size = get_block_rlp_size(
+        fork,
         transactions,
         gas_used=sum(tx.gas_limit for tx in transactions),
         withdrawals=withdrawals,
@@ -475,7 +459,7 @@ def test_block_at_rlp_size_limit_boundary(
         pre,
         env.gas_limit,
     )
-    block_rlp_size = get_block_rlp_size(transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match "
         f"limit {block_size_limit}, difference: "
@@ -528,7 +512,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
         env.gas_limit,
         specific_transaction_to_include=typed_transaction,
     )
-    block_rlp_size = get_block_rlp_size(transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
         f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
@@ -572,7 +556,7 @@ def test_block_at_rlp_limit_with_logs(
         emit_logs=True,
     )
 
-    block_rlp_size = get_block_rlp_size(transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
         f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
@@ -632,7 +616,7 @@ def test_block_at_rlp_limit_with_withdrawals(
     )
 
     block_rlp_size = get_block_rlp_size(
-        transactions, gas_used=gas_used, withdrawals=withdrawals
+        fork, transactions, gas_used=gas_used, withdrawals=withdrawals
     )
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
@@ -703,8 +687,12 @@ def test_fork_transition_block_rlp_limit(
     )
 
     for fork_block_rlp_size in [
-        get_block_rlp_size(transactions_before, gas_used=gas_used_before),
-        get_block_rlp_size(transactions_at_fork, gas_used=gas_used_at_fork),
+        get_block_rlp_size(
+            fork, transactions_before, gas_used=gas_used_before
+        ),
+        get_block_rlp_size(
+            fork, transactions_at_fork, gas_used=gas_used_at_fork
+        ),
     ]:
         assert fork_block_rlp_size == block_size_limit, (
             f"Block RLP size {fork_block_rlp_size} does not exactly match "

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -73,7 +73,6 @@ def block_errors() -> List[BlockException]:
 def get_block_rlp_size(
     fork: Fork,
     transactions: List[Transaction],
-    gas_used: int,
     withdrawals: List[Withdrawal] | None = None,
 ) -> int:
     """
@@ -85,7 +84,6 @@ def get_block_rlp_size(
         timestamp=HEADER_TIMESTAMP,
     )
     header.gas_limit = ZeroPaddedHexNumber(BLOCK_GAS_LIMIT)
-    header.gas_used = ZeroPaddedHexNumber(gas_used)
     header.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
 
     total_gas = sum((tx.gas_limit or 21000) for tx in transactions)
@@ -303,7 +301,7 @@ def _exact_size_transactions_impl(
         total_gas_used += last_tx.gas_limit
 
     current_size = get_block_rlp_size(
-        fork, transactions, gas_used=total_gas_used, withdrawals=withdrawals
+        fork, transactions, withdrawals=withdrawals
     )
     remaining_bytes = block_size_limit - current_size
     remaining_gas = block_gas_limit - total_gas_used
@@ -322,7 +320,6 @@ def _exact_size_transactions_impl(
         empty_block_size = get_block_rlp_size(
             fork,
             transactions + [empty_tx],
-            gas_used=total_gas_used + empty_tx.gas_limit,
             withdrawals=withdrawals,
         )
         empty_contribution = empty_block_size - current_size
@@ -346,7 +343,6 @@ def _exact_size_transactions_impl(
             test_size = get_block_rlp_size(
                 fork,
                 transactions + [test_tx],
-                gas_used=total_gas_used + target_gas,
                 withdrawals=withdrawals,
             )
 
@@ -381,7 +377,6 @@ def _exact_size_transactions_impl(
                         adjusted_test_size = get_block_rlp_size(
                             fork,
                             transactions + [adjusted_tx],
-                            gas_used=total_gas_used + adjusted_gas,
                             withdrawals=withdrawals,
                         )
 
@@ -406,7 +401,6 @@ def _exact_size_transactions_impl(
     final_size = get_block_rlp_size(
         fork,
         transactions,
-        gas_used=sum(tx.gas_limit for tx in transactions),
         withdrawals=withdrawals,
     )
     final_gas = sum(tx.gas_limit for tx in transactions)
@@ -459,7 +453,7 @@ def test_block_at_rlp_size_limit_boundary(
         pre,
         env.gas_limit,
     )
-    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match "
         f"limit {block_size_limit}, difference: "
@@ -512,7 +506,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
         env.gas_limit,
         specific_transaction_to_include=typed_transaction,
     )
-    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
         f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
@@ -556,7 +550,7 @@ def test_block_at_rlp_limit_with_logs(
         emit_logs=True,
     )
 
-    block_rlp_size = get_block_rlp_size(fork, transactions, gas_used=gas_used)
+    block_rlp_size = get_block_rlp_size(fork, transactions)
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
         f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
@@ -616,7 +610,7 @@ def test_block_at_rlp_limit_with_withdrawals(
     )
 
     block_rlp_size = get_block_rlp_size(
-        fork, transactions, gas_used=gas_used, withdrawals=withdrawals
+        fork, transactions, withdrawals=withdrawals
     )
     assert block_rlp_size == block_size_limit, (
         f"Block RLP size {block_rlp_size} does not exactly match limit "
@@ -687,12 +681,8 @@ def test_fork_transition_block_rlp_limit(
     )
 
     for fork_block_rlp_size in [
-        get_block_rlp_size(
-            fork, transactions_before, gas_used=gas_used_before
-        ),
-        get_block_rlp_size(
-            fork, transactions_at_fork, gas_used=gas_used_at_fork
-        ),
+        get_block_rlp_size(fork, transactions_before),
+        get_block_rlp_size(fork, transactions_at_fork),
     ]:
         assert fork_block_rlp_size == block_size_limit, (
             f"Block RLP size {fork_block_rlp_size} does not exactly match "

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \
-        --until BPO4 \
+        --until Amsterdam \
         {posargs} \
         tests
 


### PR DESCRIPTION
## 🗒️ Description
Adding new fields to block header changes the block rlp size and teh current EIP-7934 tests do not handle this dynamically

## 🔗 Related Issues or PRs
#1972

## ✅ Checklist


- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).

#### Cute Animal Picture

![Cute Animals - 12 of 12](https://github.com/user-attachments/assets/0dba65b4-8851-4a01-bd30-2abad6fd011c)

