### PR TITLE
feat(test-benchmark): add terminating opcode benchmark

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).
 - ✨ New EIP-7702 test cases added ([#1974](https://github.com/ethereum/execution-specs/pull/1974)).
 - ✨ Add missing benchmark configurations / opcode to benchmark tests for repricing analysis([#2006](https://github.com/ethereum/execution-specs/pull/2006)).
+- ✨ Add terminating opcode benchmark in mix scenario ([#2027](https://github.com/ethereum/execution-specs/pull/2027)).
 
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 

--- a/tests/benchmark/compute/instruction/test_stack.py
+++ b/tests/benchmark/compute/instruction/test_stack.py
@@ -139,3 +139,12 @@ def test_push(
             attack_block=opcode[1] if opcode.has_data_portion() else opcode
         ),
     )
+
+
+@pytest.mark.repricing
+def test_pop(benchmark_test: BenchmarkTestFiller) -> None:
+    """Benchmark POP instruction."""
+    benchmark_test(
+        target_opcode=Op.POP,
+        code_generator=JumpLoopGenerator(attack_block=Op.POP(Op.PUSH0)),
+    )

--- a/tests/benchmark/compute/scenario/test_mix_operations.py
+++ b/tests/benchmark/compute/scenario/test_mix_operations.py
@@ -4,6 +4,7 @@ import pytest
 from execution_testing import (
     BenchmarkTestFiller,
     Bytecode,
+    ExtCallGenerator,
     Fork,
     JumpLoopGenerator,
     Op,
@@ -83,5 +84,30 @@ def test_jumpdest_analysis(
             setup=setup,
             attack_block=attack_block,
             tx_kwargs={"data": tx_data},
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("return_size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("opcode", [Op.INVALID, Op.STOP, Op.RETURN, Op.REVERT])
+def test_terminate_ops(
+    benchmark_test: BenchmarkTestFiller,
+    opcode: Op,
+    return_size: int,
+    mem_size: int,
+) -> None:
+    """Benchmark Terminating Operations."""
+    setup = Op.MSTORE8(mem_size - 1, 1) if mem_size > 0 else Bytecode()
+
+    attack_block = (
+        opcode(0, return_size) if opcode.popped_stack_items > 0 else opcode
+    )
+
+    benchmark_test(
+        code_generator=ExtCallGenerator(
+            setup=setup,
+            attack_block=attack_block,
         ),
     )

--- a/tests/benchmark/compute/scenario/test_mix_operations.py
+++ b/tests/benchmark/compute/scenario/test_mix_operations.py
@@ -2,8 +2,10 @@
 
 import pytest
 from execution_testing import (
+    Alloc,
     BenchmarkTestFiller,
     Bytecode,
+    Environment,
     ExtCallGenerator,
     Fork,
     JumpLoopGenerator,
@@ -91,19 +93,30 @@ def test_jumpdest_analysis(
 @pytest.mark.repricing
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
 @pytest.mark.parametrize("return_size", [0, 32, 256, 1024])
-@pytest.mark.parametrize("opcode", [Op.INVALID, Op.STOP, Op.RETURN, Op.REVERT])
+@pytest.mark.parametrize(
+    "opcode", [Op.INVALID, Op.STOP, Op.RETURN, Op.REVERT, Op.SELFDESTRUCT]
+)
 def test_terminate_ops(
     benchmark_test: BenchmarkTestFiller,
     opcode: Op,
     return_size: int,
     mem_size: int,
+    pre: Alloc,
+    env: Environment,
 ) -> None:
     """Benchmark Terminating Operations."""
+    fee_recipient = pre.fund_eoa(amount=1)
+    env.fee_recipient = fee_recipient
+
     setup = Op.MSTORE8(mem_size - 1, 1) if mem_size > 0 else Bytecode()
 
-    attack_block = (
-        opcode(0, return_size) if opcode.popped_stack_items > 0 else opcode
-    )
+    attack_block = Bytecode()
+    if opcode == Op.SELFDESTRUCT:
+        attack_block = Op.SELFDESTRUCT(Op.COINBASE)
+    elif opcode.popped_stack_items > 0:
+        attack_block = opcode(Op.PUSH0, return_size)
+    else:
+        attack_block = opcode
 
     benchmark_test(
         code_generator=ExtCallGenerator(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add new benchmark test for repricing analysis:
- `POP`
- `INVALID`, `RETURN`, `REVERT`, `STOP`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-spec-tests/blob/main/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-spec-tests/blob/main/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
