### PR TITLE
chore(ci): add all EL clients to hive master config

### DIFF
--- a/.github/configs/hive/master.yaml
+++ b/.github/configs/hive/master.yaml
@@ -1,9 +1,61 @@
-# Hive client configuration file with master/nightly images for CI
-# Uses ethpandaops mirror for faster pulls in CI environments
+# This is a Hive client configuration file that uses master/main client builds
+# from the ethquokkaops / ethpandaops container registry.
+#
+# The latest available configurations are here:
+# https://github.com/ethpandaops/eth-client-docker-image-builder/blob/master/branches.yaml
+
+# Besu
+# https://github.com/hyperledger/besu
+- client: besu
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/besu
+    tag: main
+
+# Erigon
+# https://github.com/erigontech/erigon
+- client: erigon
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/erigon
+    tag: main
+
+# Ethrex
+# https://github.com/lambdaclass/ethrex
+- client: ethrex
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/ethrex
+    tag: main
 
 # Geth (Go-Ethereum)
+# https://github.com/ethereum/go-ethereum
 - client: go-ethereum
   nametag: default
   build_args:
     baseimage: docker.ethquokkaops.io/dh/ethpandaops/geth
     tag: master
+
+# Nethermind
+# https://github.com/NethermindEth/nethermind
+- client: nethermind
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/nethermind
+    tag: master
+
+# Nimbus EL
+# https://github.com/status-im/nimbus-eth1
+- client: nimbus-el
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1
+    tag: master
+
+# Reth
+# https://github.com/paradigmxyz/reth
+- client: reth
+  nametag: default
+  build_args:
+    baseimage: docker.ethquokkaops.io/dh/ethpandaops/reth
+    tag: main


### PR DESCRIPTION
## 🗒️ Description

Add all EL clients to the hive master config for CI testing.

Tested builds in hive:
```
./hive --sim ethereum/eels/consume-rlp --client besu,erigon,ethrex,go-ethereum,nethermind,nimbus-el,reth --client-file ../execution-specs/.github/configs/hive/master.yaml --sim.limit="id:tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid[fork_Osaka-typed_transaction_2-blockchain_test_from_state_test]" --sim.buildarg "fixtures=develop@v5.3.0"
```

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails
- [x] All: PR title adheres to the repo standard

<img height="128" alt="image" src="https://github.com/user-attachments/assets/cd5e63dc-6143-40b0-826f-6dd56ff4fbbc" />
