### PR TITLE
fix(docs): fix reference to `master` branch; use `mainnet` instead

### DIFF
--- a/EIP_AUTHORS_MANUAL.md
+++ b/EIP_AUTHORS_MANUAL.md
@@ -39,13 +39,13 @@ For example, at the time of writing, the Prague Fork is still under development 
 
 #### Forks live on mainnet
 
-The final stable specification for all forks that are currently live on mainnet are in the `master` branch.
+The final stable specification for all forks that are currently live on mainnet are in the `mainnet` branch.
 
 #### Fork under development
 
 At any given time, there can only be one fork under active development. The branch structure for the fork under development is as follows:
 
-- `forks/<FORK_NAME>`: The main branch for the fork under development. For example, `forks/prague` is the branch for the Prague fork. This branch will  be merged into `master` after the fork has gone live on mainnet.
+- `forks/<FORK_NAME>`: The main branch for the fork under development. For example, `forks/prague` is the branch for the Prague fork. This branch will  be merged into `mainnet` after the fork has gone live on mainnet.
 - `eips/<FORK_NAME>/<EIP_NUMBER>`: Branches for each EIP within the fork under development. For example, `eips/prague/eip-7702` is the branch for EIP-7702 for the Prague fork. This branch will be merged into `forks/prague` after the EIP has been confirmed for release in the fork.
 
 ## Writing New EIPS


### PR DESCRIPTION
## 🗒️ Description

Fixes references to `master` branch in the EIP Author Manual. We use `mainnet` now.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


#### Cute Animal Picture

<img height="256" alt="image" src="https://github.com/user-attachments/assets/efbd2b7d-3d59-46c3-87a5-eeeb9c490ea4" />

