### PR TITLE
chore(ci): skip redundant checks in workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,9 @@ N/A.
 <!-- Please check off all required items. For those that don't apply remove them accordingly. -->
 
 - [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
-
     ```console
     uvx tox -e static
     ```
-
 - [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
 - [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
 - [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,6 +17,8 @@ on:
       - ".gitignore"
       - ".vscode/**"
       - "whitelist.txt"
+      - "docs/**"                                                                                                                     
+      - "mkdocs.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,6 +11,12 @@ on:
       - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/**"
       - ".github/workflows/benchmark.yaml"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE*"
+      - ".gitignore"
+      - ".vscode/**"
+      - "whitelist.txt"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - "forks/**"
+    paths-ignore:
+      - "**.md"
+      - "LICENSE*"
+      - ".gitignore"
+      - ".vscode/**"
+      - "whitelist.txt"
   pull_request:
     paths:
       - ".github/workflows/hive-consume.yaml"

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -10,6 +10,8 @@ on:
       - ".gitignore"
       - ".vscode/**"
       - "whitelist.txt"
+      - "docs/**"                                                                                                                     
+      - "mkdocs.yml"
   pull_request:
     paths:
       - ".github/workflows/hive-consume.yaml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ on:
       - ".gitignore"
       - ".vscode/**"
       - "whitelist.txt"
+      - "docs/**"                                                                                                                     
+      - "mkdocs.yml"
   workflow_dispatch:
   pull_request:
     paths-ignore:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,20 @@ on:
       - master
       - mainnet
       - "forks/**"
+    paths-ignore:
+      - "**.md"
+      - "LICENSE*"
+      - ".gitignore"
+      - ".vscode/**"
+      - "whitelist.txt"
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "LICENSE*"
+      - ".gitignore"
+      - ".vscode/**"
+      - "whitelist.txt"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,8 @@ on:
       - ".gitignore"
       - ".vscode/**"
       - "whitelist.txt"
+      - "docs/**"                                                                                                                     
+      - "mkdocs.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
                                                                                           
Adds `paths-ignore` filters to CI workflows to skip expensive test runs when only documentation/md files are modified.                                                                                                
                                                                                                                                                                                                                                                                         
### Future improvement                                                                                       
                                                                                                         
Consider using https://github.com/dorny/paths-filter action with a shared config file. This would centralize path patterns in a single `.github/path-filters.yml` file instead of duplicating across workflows.

The downside is that we trigger in CI first before they are skipped. TLDR; its cleaner code to maintain but messier CI logs.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/004.png)
