### PR TITLE
fix(tests-execute): relax pydantic checks on `GetPayloadResponse`

### DIFF
--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -194,6 +194,8 @@ class BlobAndProofV2(CamelModel):
 class GetPayloadResponse(CamelModel):
     """Represents the response of a get payload request."""
 
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     execution_payload: FixtureExecutionPayload
     blobs_bundle: BlobsBundle | None = None
     execution_requests: List[Bytes] | None = None


### PR DESCRIPTION
## 🗒️ Description

Following stricter checks in #2000, this fixes the pydantic error below when running:

```bash
uv run execute hive --fork=Prague -v -m blob_transaction_test
```

Note, more fixes will be required for `blob_transaction_test` working with `execute` (WIP), but they have different root causes.

#### Error

```bash
__________________________________________ ERROR at setup of test_get_blobs[fork_Prague-single_blob_transaction-blob_transaction_test] ___________________________________________
packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py:212: in execute_required_contracts
    deploy_deterministic_factory_contract(
packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/contracts.py:82: in deploy_deterministic_factory_contract
    eth_rpc.send_wait_transaction(fund_tx)
packages/testing/src/execution_testing/rpc/rpc.py:720: in send_wait_transaction
    self.send_transaction(transaction)
packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py:372: in send_transaction
    self.generate_block()
packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py:326: in generate_block
    new_payload = self.engine_rpc.get_payload(
packages/testing/src/execution_testing/rpc/rpc.py:862: in get_payload
    return GetPayloadResponse.model_validate(
E   pydantic_core._pydantic_core.ValidationError: 2 validation errors for GetPayloadResponse
E   blockValue
E     Extra inputs are not permitted [type=extra_forbidden, input_value='0x7558cd118', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
E   shouldOverrideBuilder
E     Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
E       For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden

The above exception was the direct cause of the following exception:
packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py:218: in execute_required_contracts
    raise RuntimeError(
E   RuntimeError: Error deploying deterministic deployment contract:
E   2 validation errors for GetPayloadResponse
E   blockValue
E     Extra inputs are not permitted [type=extra_forbidden, input_value='0x7558cd118', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
E   shouldOverrideBuilder
E     Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
E       For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
E   Try deploying the contract manually using a different RPC endpoint with the following command:
E   uv run execute deploy-required-contracts
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Stricter pydantic checks were enabled in:
- #2000

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):

    ```console
    uvx tox -e static
    ```

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="250" height="175" alt="image" src="https://github.com/user-attachments/assets/4bfe3b50-9496-45e4-80d8-75dc6a411295" />

