### PR TITLE
feat(src): add binary tree

### DIFF
--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from blake3 import blake3
-from collection.abc import Sequence
+from collections.abc import Sequence
 from ethereum_types.bytes import Bytes32
 
 # from ethereum.forks.bpo5 import trie as previous_trie

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 from blake3 import blake3
+from collection.abs import Sequence
 from ethereum_types.bytes import Bytes32
 
 # from ethereum.forks.bpo5 import trie as previous_trie
@@ -32,29 +33,29 @@ STEM_SUBTREE_WIDTH = 256
 MAIN_STORAGE_OFFSET = 1 << 240
 
 
-def old_style_address_to_address32(address: Address) -> Address32:
-    return Address32(b"\\x00" * 12 + address)
+def old_style_address_to_address32(address: Address) -> Bytes32:
+    return Bytes32(b"\\x00" * 12 + address)
 
 
-def tree_hash(inp: bytes) -> bytes32:
-    return bytes32(blake3(inp).digest())
+def tree_hash(inp: bytes) -> Bytes32:
+    return Bytes32(blake3(inp).digest())
 
 
-def get_tree_key(address: Address32, tree_index: int, sub_index: int):
+def get_tree_key(address: Bytes32, tree_index: int, sub_index: int):
     # Assumes STEM_NODE_WIDTH = 256
     return tree_hash(address + tree_index.to_bytes(32, "little"))[:31] + bytes(
         [sub_index]
     )
 
-def get_tree_key_for_basic_data(address: Address32):
+def get_tree_key_for_basic_data(address: Bytes32):
     return get_tree_key(address, 0, BASIC_DATA_LEAF_KEY)
 
 
-def get_tree_key_for_code_hash(address: Address32):
+def get_tree_key_for_code_hash(address: Bytes32):
     return get_tree_key(address, 0, CODE_HASH_LEAF_KEY)
 
 
-def get_tree_key_for_storage_slot(address: Address32, storage_key: int):
+def get_tree_key_for_storage_slot(address: Bytes32, storage_key: int):
     if storage_key < (CODE_OFFSET - HEADER_STORAGE_OFFSET):
         pos = HEADER_STORAGE_OFFSET + storage_key
     else:
@@ -62,7 +63,7 @@ def get_tree_key_for_storage_slot(address: Address32, storage_key: int):
     return get_tree_key(address, pos // STEM_SUBTREE_WIDTH, pos % STEM_SUBTREE_WIDTH)
 
 
-def get_tree_key_for_code_chunk(address: Address32, chunk_id: int):
+def get_tree_key_for_code_chunk(address: Bytes32, chunk_id: int):
     return get_tree_key(
         address,
         (CODE_OFFSET + chunk_id) // STEM_SUBTREE_WIDTH,
@@ -73,7 +74,7 @@ PUSH_OFFSET = 95
 PUSH1 = PUSH_OFFSET + 1
 PUSH32 = PUSH_OFFSET + 32
 
-def chunkify_code(code: bytes) -> Sequence[bytes32]:
+def chunkify_code(code: bytes) -> Sequence[Bytes32]:
     # Pad to multiple of 31 bytes
     if len(code) % 31 != 0:
         code += b"\\x00" * (31 - (len(code) % 31))
@@ -91,7 +92,7 @@ def chunkify_code(code: bytes) -> Sequence[bytes32]:
         pos += pushdata_bytes
     # Output chunks
     return [
-        bytes32(bytes([min(bytes_to_exec_data[pos], 31)]) + code[pos : pos + 31])
+        Bytes32(bytes([min(bytes_to_exec_data[pos], 31)]) + code[pos : pos + 31])
         for pos in range(0, len(code), 31)
     ]
 

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -34,7 +34,7 @@ MAIN_STORAGE_OFFSET = 1 << 240
 
 
 def old_style_address_to_address32(address: Address) -> Bytes32:
-    return Bytes32(b"\\x00" * 12 + address)
+    return Bytes32(b"\x00" * 12 + address)
 
 
 def tree_hash(inp: bytes) -> Bytes32:
@@ -77,7 +77,7 @@ PUSH32 = PUSH_OFFSET + 32
 def chunkify_code(code: bytes) -> Sequence[Bytes32]:
     # Pad to multiple of 31 bytes
     if len(code) % 31 != 0:
-        code += b"\\x00" * (31 - (len(code) % 31))
+        code += b"\x00" * (31 - (len(code) % 31))
     # Figure out how much pushdata there is after+including each byte
     bytes_to_exec_data = [0] * (len(code) + 32)
     pos = 0
@@ -195,9 +195,9 @@ class BinaryTree:
 
         bit = stem_bits[depth]
         if bit == 0:
-            return self._get(self.left, stem, subindex, depth+1)
+            return self._get(node.left, stem, subindex, depth+1)
         else:
-            return self._get(self.right, stem, subindex, depth+1)
+            return self._get(node.right, stem, subindex, depth+1)
 
     def _split_leaf(
         self, leaf, stem_bits, existing_stem_bits, subindex, value, depth

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -1,5 +1,5 @@
 """
-State Trie.
+Binary Trie.
 
 .. contents:: Table of Contents
     :backlinks: none
@@ -12,39 +12,19 @@ The state trie is the structure responsible for storing
 `.fork_types.Account` objects.
 """
 
-import copy
-from dataclasses import dataclass, field
+# import copy
 from typing import (
     Callable,
-    Dict,
-    Generic,
-    List,
-    Mapping,
-    MutableMapping,
     Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    cast,
 )
 
-from ethereum_rlp import Extended, rlp
-from ethereum_types.bytes import Bytes
-from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U256, Uint
-from typing_extensions import assert_type
+from ethereum_types.bytes import Bytes32
 
-from ethereum.crypto.hash import keccak256
-from ethereum.forks.bpo5 import trie as previous_trie
-from ethereum.utils.hexadecimal import hex_to_bytes
+# from ethereum.forks.bpo5 import trie as previous_trie
 
-from .blocks import Receipt, Withdrawal
-from .fork_types import Account, Address, Root, encode_account
-from .transactions import LegacyTransaction
+from .fork_types import Account, Address, Root
 
-from typing import Optional
 from blake3 import blake3
-
 
 class StemNode:
     def __init__(self, stem: bytes):
@@ -111,7 +91,7 @@ class BinaryTree:
         assert len(key) == 32, "key must be 32 bytes"
 
         if self.root is None:
-            return 0
+            return None
 
         return self._get(self.root, key[:31], key[31], 0)
 
@@ -136,8 +116,8 @@ class BinaryTree:
             return self._get(self.right, stem, subindex, depth+1)
 
     def _split_leaf(self, leaf, stem_bits, existing_stem_bits, subindex, value, depth):
-        # If the stem bits are the same up to this depth, we need to create another
-        # internal node and recurse.
+        # If the stem bits are the same up to this depth, we need to create
+        # another internal node and recurse.
         if stem_bits[depth] == existing_stem_bits[depth]:
             new_internal = InternalNode()
             bit = stem_bits[depth]
@@ -225,14 +205,15 @@ class BinaryTree:
 #     """
 #     return Trie(trie.secured, trie.default, copy.copy(trie._data))
 
-
-def trie_set(trie: Trie[K, V], key: K, value: V) -> None:
+# TODO replace value : bytes by several types: accounts or slots
+def trie_set(trie: BinaryTree, key: Bytes32, value: bytes) -> None:
     """
     """
+    # TODO compute key using get_tree_key
     trie.insert(key, value)
 
 
-def trie_get(trie: Trie[K, V], key: K) -> V:
+def trie_get(trie: BinaryTree, key: Bytes32) -> Bytes32:
     """
     """
     v = trie.get(key)
@@ -242,8 +223,8 @@ def trie_get(trie: Trie[K, V], key: K) -> V:
 
 
 def root(
-    trie: Trie[K, V],
-    get_storage_root: Optional[Callable[[Address], Root]] = None,
+    trie: BinaryTree,
+    _: Optional[Callable[[Address], Root]] = None,
 ) -> Root:
     """
     """

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -18,36 +18,44 @@ from typing import (
     Optional,
 )
 
+from blake3 import blake3
 from ethereum_types.bytes import Bytes32
 
 # from ethereum.forks.bpo5 import trie as previous_trie
+from .fork_types import Address, Root
 
-from .fork_types import Account, Address, Root
-
-from blake3 import blake3
 
 class StemNode:
+    """A leaf node in the binary tree that holds a stem and 256 values."""
+
     def __init__(self, stem: bytes):
         assert len(stem) == 31, "stem must be 31 bytes"
         self.stem = stem
         self.values: list[Optional[bytes]] = [None] * 256
 
-    def set_value(self, index: int, value: bytes):
+    def set_value(self, index: int, value: bytes) -> None:
+        """Set a value at the given index in this stem node."""
         self.values[index] = value
 
     def get_value(self, index: int) -> Optional[bytes]:
+        """Get the value at the given index in this stem node."""
         return self.values[index]
 
 class InternalNode:
+    """An internal node in the binary tree with left and right children."""
+
     def __init__(self):
         self.left = None
         self.right = None
 
 class BinaryTree:
+    """A binary trie for storing key-value pairs with 32-byte keys."""
+
     def __init__(self):
         self.root = None
 
-    def insert(self, key: bytes, value: bytes):
+    def insert(self, key: bytes, value: bytes) -> None:
+        """Insert a key-value pair into the binary tree."""
         assert len(key) == 32, "key must be 32 bytes"
         assert len(value) == 32, "value must be 32 bytes"
         stem = key[:31]
@@ -82,12 +90,17 @@ class BinaryTree:
         # We're in an internal node, go left or right based on the bit.
         bit = stem_bits[depth]
         if bit == 0:
-            node.left = self._insert(node.left, stem, subindex, value, depth + 1)
+            node.left = self._insert(
+                node.left, stem, subindex, value, depth + 1
+            )
         else:
-            node.right = self._insert(node.right, stem, subindex, value, depth + 1)
+            node.right = self._insert(
+                node.right, stem, subindex, value, depth + 1
+            )
         return node
 
     def get(self, key: bytes) -> Optional[bytes]:
+        """Retrieve a value by key from the binary tree."""
         assert len(key) == 32, "key must be 32 bytes"
 
         if self.root is None:
@@ -115,7 +128,9 @@ class BinaryTree:
         else:
             return self._get(self.right, stem, subindex, depth+1)
 
-    def _split_leaf(self, leaf, stem_bits, existing_stem_bits, subindex, value, depth):
+    def _split_leaf(
+        self, leaf, stem_bits, existing_stem_bits, subindex, value, depth
+    ):
         # If the stem bits are the same up to this depth, we need to create
         # another internal node and recurse.
         if stem_bits[depth] == existing_stem_bits[depth]:
@@ -123,11 +138,13 @@ class BinaryTree:
             bit = stem_bits[depth]
             if bit == 0:
                 new_internal.left = self._split_leaf(
-                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
+                    leaf, stem_bits, existing_stem_bits,
+                    subindex, value, depth + 1,
                 )
             else:
                 new_internal.right = self._split_leaf(
-                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
+                    leaf, stem_bits, existing_stem_bits,
+                    subindex, value, depth + 1,
                 )
             return new_internal
         else:
@@ -164,10 +181,13 @@ class BinaryTree:
         if data in (None, b"\x00" * 64):
             return b"\x00" * 32
 
-        assert len(data) == 64 or len(data) == 32, "data must be 32 or 64 bytes"
+        assert (
+            len(data) == 64 or len(data) == 32
+        ), "data must be 32 or 64 bytes"
         return blake3(data).digest()
 
     def merkelize(self):
+        """Compute the merkle root hash of the tree."""
         def _merkelize(node):
             if node is None:
                 return b"\x00" * 32
@@ -189,8 +209,8 @@ class BinaryTree:
 
 # def copy_trie(trie: Trie[K, V]) -> Trie[K, V]:
 #     """
-#     Create a copy of `trie`. Since only frozen objects may be stored in tries,
-#     the contents are reused.
+#     Create a copy of `trie`. Since only frozen objects may be stored
+#     in tries, the contents are reused.
 
 #     Parameters
 #     ----------
@@ -207,15 +227,13 @@ class BinaryTree:
 
 # TODO replace value : bytes by several types: accounts or slots
 def trie_set(trie: BinaryTree, key: Bytes32, value: bytes) -> None:
-    """
-    """
+    """Set a value in the trie at the given key."""
     # TODO compute key using get_tree_key
     trie.insert(key, value)
 
 
 def trie_get(trie: BinaryTree, key: Bytes32) -> Bytes32:
-    """
-    """
+    """Get a value from the trie at the given key."""
     v = trie.get(key)
     if v is None:
         v = 0
@@ -226,6 +244,5 @@ def root(
     trie: BinaryTree,
     _: Optional[Callable[[Address], Root]] = None,
 ) -> Root:
-    """
-    """
-    return Root(trie.merkleize())
+    """Compute and return the root hash of the trie."""
+    return Root(trie.merkelize())

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from blake3 import blake3
-from collection.abs import Sequence
+from collection.abc import Sequence
 from ethereum_types.bytes import Bytes32
 
 # from ethereum.forks.bpo5 import trie as previous_trie

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -1,0 +1,250 @@
+"""
+State Trie.
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+The state trie is the structure responsible for storing
+`.fork_types.Account` objects.
+"""
+
+import copy
+from dataclasses import dataclass, field
+from typing import (
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    cast,
+)
+
+from ethereum_rlp import Extended, rlp
+from ethereum_types.bytes import Bytes
+from ethereum_types.frozen import slotted_freezable
+from ethereum_types.numeric import U256, Uint
+from typing_extensions import assert_type
+
+from ethereum.crypto.hash import keccak256
+from ethereum.forks.bpo5 import trie as previous_trie
+from ethereum.utils.hexadecimal import hex_to_bytes
+
+from .blocks import Receipt, Withdrawal
+from .fork_types import Account, Address, Root, encode_account
+from .transactions import LegacyTransaction
+
+from typing import Optional
+from blake3 import blake3
+
+
+class StemNode:
+    def __init__(self, stem: bytes):
+        assert len(stem) == 31, "stem must be 31 bytes"
+        self.stem = stem
+        self.values: list[Optional[bytes]] = [None] * 256
+
+    def set_value(self, index: int, value: bytes):
+        self.values[index] = value
+
+    def get_value(self, index: int) -> Optional[bytes]:
+        return self.values[index]
+
+class InternalNode:
+    def __init__(self):
+        self.left = None
+        self.right = None
+
+class BinaryTree:
+    def __init__(self):
+        self.root = None
+
+    def insert(self, key: bytes, value: bytes):
+        assert len(key) == 32, "key must be 32 bytes"
+        assert len(value) == 32, "value must be 32 bytes"
+        stem = key[:31]
+        subindex = key[31]
+
+        if self.root is None:
+            self.root = StemNode(stem)
+            self.root.set_value(subindex, value)
+            return
+
+        self.root = self._insert(self.root, stem, subindex, value, 0)
+
+    def _insert(self, node, stem, subindex, value, depth):
+        assert depth < 248, "depth must be less than 248"
+
+        if node is None:
+            node = StemNode(stem)
+            node.set_value(subindex, value)
+            return node
+
+        stem_bits = self._bytes_to_bits(stem)
+        if isinstance(node, StemNode):
+            # If the stem already exists, update the value.
+            if node.stem == stem:
+                node.set_value(subindex, value)
+                return node
+            existing_stem_bits = self._bytes_to_bits(node.stem)
+            return self._split_leaf(
+                node, stem_bits, existing_stem_bits, subindex, value, depth
+            )
+
+        # We're in an internal node, go left or right based on the bit.
+        bit = stem_bits[depth]
+        if bit == 0:
+            node.left = self._insert(node.left, stem, subindex, value, depth + 1)
+        else:
+            node.right = self._insert(node.right, stem, subindex, value, depth + 1)
+        return node
+
+    def get(self, key: bytes) -> Optional[bytes]:
+        assert len(key) == 32, "key must be 32 bytes"
+
+        if self.root is None:
+            return 0
+
+        return self._get(self.root, key[:31], key[31], 0)
+
+    def _get(self, node, stem, subindex, depth) -> Optional[bytes]:
+        assert depth < 248, "depth must be less than 248"
+
+        if node is None:
+            return None
+
+        stem_bits = self._bytes_to_bits(stem)
+        if isinstance(node, StemNode):
+            if node.stem == stem:
+                return node.get_value(subindex)
+
+            # Stems differ, value is missing
+            return None
+
+        bit = stem_bits[depth]
+        if bit == 0:
+            return self._get(self.left, stem, subindex, depth+1)
+        else:
+            return self._get(self.right, stem, subindex, depth+1)
+
+    def _split_leaf(self, leaf, stem_bits, existing_stem_bits, subindex, value, depth):
+        # If the stem bits are the same up to this depth, we need to create another
+        # internal node and recurse.
+        if stem_bits[depth] == existing_stem_bits[depth]:
+            new_internal = InternalNode()
+            bit = stem_bits[depth]
+            if bit == 0:
+                new_internal.left = self._split_leaf(
+                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
+                )
+            else:
+                new_internal.right = self._split_leaf(
+                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
+                )
+            return new_internal
+        else:
+            new_internal = InternalNode()
+            bit = stem_bits[depth]
+            stem = self._bits_to_bytes(stem_bits)
+            if bit == 0:
+                new_internal.left = StemNode(stem)
+                new_internal.left.set_value(subindex, value)
+                new_internal.right = leaf
+            else:
+                new_internal.right = StemNode(stem)
+                new_internal.right.set_value(subindex, value)
+                new_internal.left = leaf
+            return new_internal
+
+    def _bytes_to_bits(self, byte_data):
+        bits = []
+        for byte in byte_data:
+            for i in range(8):
+                bits.append((byte >> (7 - i)) & 1)
+        return bits
+
+    def _bits_to_bytes(self, bits):
+        byte_data = bytearray()
+        for i in range(0, len(bits), 8):
+            byte = 0
+            for j in range(8):
+                byte |= bits[i + j] << (7 - j)
+            byte_data.append(byte)
+        return bytes(byte_data)
+
+    def _hash(self, data):
+        if data in (None, b"\x00" * 64):
+            return b"\x00" * 32
+
+        assert len(data) == 64 or len(data) == 32, "data must be 32 or 64 bytes"
+        return blake3(data).digest()
+
+    def merkelize(self):
+        def _merkelize(node):
+            if node is None:
+                return b"\x00" * 32
+            if isinstance(node, InternalNode):
+                left_hash = _merkelize(node.left)
+                right_hash = _merkelize(node.right)
+                return self._hash(left_hash + right_hash)
+
+            level = [self._hash(x) for x in node.values]
+            while len(level) > 1:
+                new_level = []
+                for i in range(0, len(level), 2):
+                    new_level.append(self._hash(level[i] + level[i + 1]))
+                level = new_level
+
+            return self._hash(node.stem + b"\0" + level[0])
+
+        return _merkelize(self.root)
+
+# def copy_trie(trie: Trie[K, V]) -> Trie[K, V]:
+#     """
+#     Create a copy of `trie`. Since only frozen objects may be stored in tries,
+#     the contents are reused.
+
+#     Parameters
+#     ----------
+#     trie: `Trie`
+#         Trie to copy.
+
+#     Returns
+#     -------
+#     new_trie : `Trie[K, V]`
+#         A copy of the trie.
+
+#     """
+#     return Trie(trie.secured, trie.default, copy.copy(trie._data))
+
+
+def trie_set(trie: Trie[K, V], key: K, value: V) -> None:
+    """
+    """
+    trie.insert(key, value)
+
+
+def trie_get(trie: Trie[K, V], key: K) -> V:
+    """
+    """
+    v = trie.get(key)
+    if v is None:
+        v = 0
+    return v
+
+
+def root(
+    trie: Trie[K, V],
+    get_storage_root: Optional[Callable[[Address], Root]] = None,
+) -> Root:
+    """
+    """
+    return Root(trie.merkleize())

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -24,6 +24,76 @@ from ethereum_types.bytes import Bytes32
 # from ethereum.forks.bpo5 import trie as previous_trie
 from .fork_types import Address, Root
 
+BASIC_DATA_LEAF_KEY = 0
+CODE_HASH_LEAF_KEY = 1
+HEADER_STORAGE_OFFSET = 64
+CODE_OFFSET = 128
+STEM_SUBTREE_WIDTH = 256
+MAIN_STORAGE_OFFSET = 1 << 240
+
+
+def old_style_address_to_address32(address: Address) -> Address32:
+    return Address32(b"\\x00" * 12 + address)
+
+
+def tree_hash(inp: bytes) -> bytes32:
+    return bytes32(blake3(inp).digest())
+
+
+def get_tree_key(address: Address32, tree_index: int, sub_index: int):
+    # Assumes STEM_NODE_WIDTH = 256
+    return tree_hash(address + tree_index.to_bytes(32, "little"))[:31] + bytes(
+        [sub_index]
+    )
+
+def get_tree_key_for_basic_data(address: Address32):
+    return get_tree_key(address, 0, BASIC_DATA_LEAF_KEY)
+
+
+def get_tree_key_for_code_hash(address: Address32):
+    return get_tree_key(address, 0, CODE_HASH_LEAF_KEY)
+
+
+def get_tree_key_for_storage_slot(address: Address32, storage_key: int):
+    if storage_key < (CODE_OFFSET - HEADER_STORAGE_OFFSET):
+        pos = HEADER_STORAGE_OFFSET + storage_key
+    else:
+        pos = MAIN_STORAGE_OFFSET + storage_key
+    return get_tree_key(address, pos // STEM_SUBTREE_WIDTH, pos % STEM_SUBTREE_WIDTH)
+
+
+def get_tree_key_for_code_chunk(address: Address32, chunk_id: int):
+    return get_tree_key(
+        address,
+        (CODE_OFFSET + chunk_id) // STEM_SUBTREE_WIDTH,
+        (CODE_OFFSET + chunk_id) % STEM_SUBTREE_WIDTH,
+    )
+
+PUSH_OFFSET = 95
+PUSH1 = PUSH_OFFSET + 1
+PUSH32 = PUSH_OFFSET + 32
+
+def chunkify_code(code: bytes) -> Sequence[bytes32]:
+    # Pad to multiple of 31 bytes
+    if len(code) % 31 != 0:
+        code += b"\\x00" * (31 - (len(code) % 31))
+    # Figure out how much pushdata there is after+including each byte
+    bytes_to_exec_data = [0] * (len(code) + 32)
+    pos = 0
+    while pos < len(code):
+        if PUSH1 <= code[pos] <= PUSH32:
+            pushdata_bytes = code[pos] - PUSH_OFFSET
+        else:
+            pushdata_bytes = 0
+        pos += 1
+        for x in range(pushdata_bytes):
+            bytes_to_exec_data[pos + x] = pushdata_bytes - x
+        pos += pushdata_bytes
+    # Output chunks
+    return [
+        bytes32(bytes([min(bytes_to_exec_data[pos], 31)]) + code[pos : pos + 31])
+        for pos in range(0, len(code), 31)
+    ]
 
 class StemNode:
     """A leaf node in the binary tree that holds a stem and 256 values."""

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -12,7 +12,7 @@ The state trie is the structure responsible for storing
 `.fork_types.Account` objects.
 """
 
-# import copy
+import copy
 from typing import (
     Callable,
     Optional,
@@ -207,23 +207,26 @@ class BinaryTree:
 
         return _merkelize(self.root)
 
-# def copy_trie(trie: Trie[K, V]) -> Trie[K, V]:
-#     """
-#     Create a copy of `trie`. Since only frozen objects may be stored
-#     in tries, the contents are reused.
+def copy_tree(tree: BinaryTree) -> BinaryTree:
+    """
+    Create a deep copy of a BinaryTree for snapshotting.
 
-#     Parameters
-#     ----------
-#     trie: `Trie`
-#         Trie to copy.
+    Parameters
+    ----------
+    tree :
+        The BinaryTree to copy.
 
-#     Returns
-#     -------
-#     new_trie : `Trie[K, V]`
-#         A copy of the trie.
+    Returns
+    -------
+    new_tree : BinaryTree
+        A deep copy of the tree.
 
-#     """
-#     return Trie(trie.secured, trie.default, copy.copy(trie._data))
+    """
+    new_tree = BinaryTree()
+    if tree.root is not None:
+        new_tree.root = copy.deepcopy(tree.root)
+    return new_tree
+
 
 # TODO replace value : bytes by several types: accounts or slots
 def trie_set(trie: BinaryTree, key: Bytes32, value: bytes) -> None:

--- a/src/ethereum/forks/amsterdam/bintrie.py
+++ b/src/ethereum/forks/amsterdam/bintrie.py
@@ -310,7 +310,7 @@ def trie_get(trie: BinaryTree, key: Bytes32) -> Bytes32:
     """Get a value from the trie at the given key."""
     v = trie.get(key)
     if v is None:
-        v = 0
+        return Bytes32(b'\x00' * 32)
     return v
 
 

--- a/src/ethereum/forks/amsterdam/transition_trie.py
+++ b/src/ethereum/forks/amsterdam/transition_trie.py
@@ -1,0 +1,149 @@
+"""
+Transition Trie.
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+A transition trie that overlays a BinaryTree on top of a base Trie.
+Reads check the overlay first, then fall back to the base.
+Writes always go to the overlay.
+"""
+
+from typing import Callable, Optional
+
+from ethereum_types.bytes import Bytes32
+
+from .bintrie import BinaryTree
+from .fork_types import Address, Root
+from .trie import Trie
+from .trie import trie_get as base_trie_get
+
+
+class TransitionTree:
+    """A tree that overlays a BinaryTree on top of a base Trie."""
+
+    def __init__(self, base: Trie, overlay: BinaryTree):
+        """
+        Initialize a TransitionTree.
+
+        Parameters
+        ----------
+        base :
+            The base Trie for fallback reads.
+        overlay :
+            The overlay BinaryTree for writes and primary reads.
+
+        """
+        self.base = base
+        self.overlay = overlay
+
+    def get(self, key: Bytes32) -> Optional[bytes]:
+        """
+        Get a value by key, checking overlay first then base.
+
+        Parameters
+        ----------
+        key :
+            The 32-byte key to look up.
+
+        Returns
+        -------
+        value : Optional[bytes]
+            The value if found, or None if not found in either tree.
+
+        """
+        # Check overlay first
+        value = self.overlay.get(key)
+        if value is not None:
+            return value
+
+        # Fall back to base trie
+        base_value = base_trie_get(self.base, key)
+        if base_value is None or base_value == self.base.default:
+            return None
+
+        # Convert to bytes if needed
+        if isinstance(base_value, bytes):
+            return base_value
+        return None
+
+    def insert(self, key: Bytes32, value: bytes) -> None:
+        """
+        Insert a key-value pair into the overlay.
+
+        Parameters
+        ----------
+        key :
+            The 32-byte key.
+        value :
+            The value to store (must be 32 bytes for BinaryTree).
+
+        """
+        self.overlay.insert(key, value)
+
+
+def trie_get(trie: TransitionTree, key: Bytes32) -> Bytes32:
+    """
+    Get a value from the transition trie at the given key.
+
+    Parameters
+    ----------
+    trie :
+        The TransitionTree to read from.
+    key :
+        The 32-byte key to look up.
+
+    Returns
+    -------
+    value : Bytes32
+        The value at the key, or 0 if not found.
+
+    """
+    v = trie.get(key)
+    if v is None:
+        return 0
+    return v
+
+
+def trie_set(trie: TransitionTree, key: Bytes32, value: bytes) -> None:
+    """
+    Set a value in the transition trie at the given key.
+
+    Parameters
+    ----------
+    trie :
+        The TransitionTree to write to.
+    key :
+        The 32-byte key.
+    value :
+        The value to store.
+
+    """
+    trie.insert(key, value)
+
+
+def root(
+    trie: TransitionTree,
+    _: Optional[Callable[[Address], Root]] = None,
+) -> Root:
+    """
+    Compute and return the root hash of the overlay tree.
+
+    Parameters
+    ----------
+    trie :
+        The TransitionTree to compute the root of.
+    _ :
+        Unused parameter for API compatibility.
+
+    Returns
+    -------
+    root : Root
+        The merkle root of the overlay BinaryTree.
+
+    """
+    return Root(trie.overlay.merkelize())

--- a/src/ethereum/forks/amsterdam/transition_trie.py
+++ b/src/ethereum/forks/amsterdam/transition_trie.py
@@ -105,7 +105,7 @@ def trie_get(trie: TransitionTree, key: Bytes32) -> Bytes32:
     """
     v = trie.get(key)
     if v is None:
-        return 0
+        return Bytes32(b'\x00' * 32)
     return v
 
 

--- a/tests/json_infra/test_bintrie.py
+++ b/tests/json_infra/test_bintrie.py
@@ -1,0 +1,133 @@
+"""
+Tests for the binary trie implementation.
+"""
+
+import pytest
+
+from ethereum.forks.amsterdam.bintrie import (
+    BASIC_DATA_LEAF_KEY,
+    CODE_HASH_LEAF_KEY,
+    BinaryTree,
+    copy_tree,
+    get_tree_key_for_basic_data,
+    get_tree_key_for_code_hash,
+    root,
+    trie_get,
+    trie_set,
+)
+
+
+class TestBinaryTreeOperations:
+    """Test basic insert/get operations."""
+
+    def test_insert_and_get(self):
+        """Insert a key-value pair and retrieve it."""
+        tree = BinaryTree()
+        key = b"\xab" * 32
+        value = b"\xcd" * 32
+        tree.insert(key, value)
+        assert tree.get(key) == value
+
+    def test_get_missing_key(self):
+        """Getting a missing key returns None."""
+        tree = BinaryTree()
+        assert tree.get(b"\x00" * 32) is None
+
+    def test_same_stem_different_suffix(self):
+        """Keys with same stem but different suffix are stored separately."""
+        tree = BinaryTree()
+        stem = b"\xab" * 31
+        tree.insert(stem + b"\x00", b"\x11" * 32)
+        tree.insert(stem + b"\xff", b"\x22" * 32)
+        assert tree.get(stem + b"\x00") == b"\x11" * 32
+        assert tree.get(stem + b"\xff") == b"\x22" * 32
+
+    def test_different_stems(self):
+        """Keys with different stems cause tree to split."""
+        tree = BinaryTree()
+        tree.insert(b"\x00" * 32, b"\x11" * 32)
+        tree.insert(b"\xff" * 32, b"\x22" * 32)
+        assert tree.get(b"\x00" * 32) == b"\x11" * 32
+        assert tree.get(b"\xff" * 32) == b"\x22" * 32
+
+
+class TestMerkleRoot:
+    """Test merkleization."""
+
+    def test_empty_tree(self):
+        """Empty tree has zero root."""
+        tree = BinaryTree()
+        assert tree.merkelize() == b"\x00" * 32
+
+    def test_deterministic(self):
+        """Same tree produces same root."""
+        tree = BinaryTree()
+        tree.insert(b"\x00" * 32, b"\x42" * 32)
+        assert tree.merkelize() == tree.merkelize()
+
+    def test_different_values_different_roots(self):
+        """Different values produce different roots."""
+        t1, t2 = BinaryTree(), BinaryTree()
+        t1.insert(b"\x00" * 32, b"\x11" * 32)
+        t2.insert(b"\x00" * 32, b"\x22" * 32)
+        assert t1.merkelize() != t2.merkelize()
+
+
+class TestCopyTree:
+    """Test tree copying."""
+
+    def test_copy_is_independent(self):
+        """Copied tree is independent of original."""
+        t1 = BinaryTree()
+        t1.insert(b"\x00" * 32, b"\x11" * 32)
+        t2 = copy_tree(t1)
+        t2.insert(b"\x00" * 32, b"\x22" * 32)
+        assert t1.get(b"\x00" * 32) == b"\x11" * 32
+        assert t2.get(b"\x00" * 32) == b"\x22" * 32
+
+
+class TestTreeKeys:
+    """Test tree key computation."""
+
+    def test_basic_data_key(self):
+        """Basic data key has correct suffix."""
+        addr = b"\x00" * 12 + b"\xab" * 20
+        key = get_tree_key_for_basic_data(addr)
+        assert len(key) == 32
+        assert key[31] == BASIC_DATA_LEAF_KEY
+
+    def test_code_hash_key(self):
+        """Code hash key has correct suffix."""
+        addr = b"\x00" * 12 + b"\xab" * 20
+        key = get_tree_key_for_code_hash(addr)
+        assert len(key) == 32
+        assert key[31] == CODE_HASH_LEAF_KEY
+
+    def test_same_address_same_stem(self):
+        """Same address produces same stem for different key types."""
+        addr = b"\x00" * 12 + b"\xab" * 20
+        key1 = get_tree_key_for_basic_data(addr)
+        key2 = get_tree_key_for_code_hash(addr)
+        assert key1[:31] == key2[:31]
+
+
+class TestTrieInterface:
+    """Test trie interface functions."""
+
+    def test_trie_set_get(self):
+        """trie_set and trie_get work together."""
+        tree = BinaryTree()
+        trie_set(tree, b"\xab" * 32, b"\xcd" * 32)
+        assert trie_get(tree, b"\xab" * 32) == b"\xcd" * 32
+
+    def test_trie_get_missing(self):
+        """trie_get returns zero bytes for missing key."""
+        tree = BinaryTree()
+        assert trie_get(tree, b"\x00" * 32) == b"\x00" * 32
+
+    def test_root(self):
+        """root function returns 32 byte hash."""
+        tree = BinaryTree()
+        trie_set(tree, b"\x00" * 32, b"\x42" * 32)
+        r = root(tree)
+        assert len(r) == 32


### PR DESCRIPTION
## 🗒️ Description
Run unit test via `uv add blake3 && uv run pytest tests/json_infra/test_bintrie.py -v -s --noconftest`

## 🔗 Related Issues or PRs
[EIP-7864](https://eip.directory/eips/eip-7864)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
