### PR TITLE
feat(spec-tests): add basic eip7778 test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🧪 Test Cases
 
+- ✨ Add test cases for eip7778 ([#2045](https://github.com/ethereum/execution-specs/pull/2045)).
 - ✨ Add missing fuzzy-compute benchmark configurations for `KECCAK256`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`, `MLOAD`, `MSTORE`, `MSTORE8`, `MCOPY`, `LOG*`, `CALLDATASIZE`, `CALLDATALOAD`, and `RETURNDATASIZE` opcodes ([#1956](https://github.com/ethereum/execution-specs/pull/1956)).
 - ✨ Add precompile benchmark configurations for `ecPairing`, `blake2f`, `BLS12_G1_MSM`, `BLS12_G2_MSM` and `BLS12_PAIRING` to unblock repricing analysis ([#2003](https://github.com/ethereum/execution-specs/pull/2003)).
 - 🔀 Relabel `@pytest.mark.repricing` markers in benchmark tests to reflect configurations requested for gas repricing analysis ([#1971](https://github.com/ethereum/execution-specs/pull/1971)).

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -196,6 +196,31 @@ def test_something_with_all_system_contracts(
 
 In this example, the test will be parameterized for parameter `system_contract` with value `[0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02]` for fork Cancun.
 
+### `@pytest.mark.with_all_refund_types`
+
+This marker is used to automatically parameterize a test with all types of refunds that are valid for the fork being tested.
+
+Useful to mark tests to fail if a new refund type is introduced by a future fork and the test needs to be kept up to date and maintained.
+
+```python
+import pytest
+
+from execution_testing import Address, Alloc, RefundType, StateTestFiller
+
+@pytest.mark.with_all_refund_types
+@pytest.mark.valid_from("Prague")
+def test_something_with_all_refund_types(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    refund_type: RefundTypes,
+):
+    pass
+
+```
+
+In this example, the test will be parameterized for parameter `refund_type` with value `[RefundTypes.STORAGE_CLEAR, RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY]` for fork Prague.
+
+
 ### Covariant Marker Keyword Arguments
 
 All fork covariant markers accept the following keyword arguments:

--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -220,7 +220,6 @@ def test_something_with_all_refund_types(
 
 In this example, the test will be parameterized for parameter `refund_type` with value `[RefundTypes.STORAGE_CLEAR, RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY]` for fork Prague.
 
-
 ### Covariant Marker Keyword Arguments
 
 All fork covariant markers accept the following keyword arguments:

--- a/packages/testing/src/execution_testing/__init__.py
+++ b/packages/testing/src/execution_testing/__init__.py
@@ -30,7 +30,7 @@ from .exceptions import (
     TransactionException,
 )
 from .fixtures import BaseFixture, FixtureCollector
-from .forks import Fork, GasCosts
+from .forks import Fork, GasCosts, RefundTypes
 from .specs import (
     BaseTest,
     BenchmarkTest,
@@ -171,6 +171,7 @@ __all__ = (
     "ParameterSet",
     "ReferenceSpec",
     "ReferenceSpecTypes",
+    "RefundTypes",
     "Removable",
     "Requests",
     "StateTest",

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -448,6 +448,15 @@ fork_covariant_decorators: List[Type[CovariantDecorator]] = [
         fork_attribute_name="system_contracts",
         argnames=["system_contract"],
     ),
+    covariant_decorator(
+        marker_name="with_all_refund_types",
+        description=(
+            "marks a test to be parametrized for all refund types at "
+            "parameter named refund_type"
+        ),
+        fork_attribute_name="refund_types",
+        argnames=["refund_type"],
+    ),
 ]
 
 

--- a/packages/testing/src/execution_testing/forks/__init__.py
+++ b/packages/testing/src/execution_testing/forks/__init__.py
@@ -1,6 +1,6 @@
 """Ethereum test fork definitions."""
 
-from .base_fork import ForkAttribute
+from .base_fork import ForkAttribute, RefundTypes
 from .forks.forks import (
     BPO1,
     BPO2,
@@ -86,6 +86,7 @@ __all__ = [
     "TransitionForkAdapter",
     "TransitionForkOrNoneAdapter",
     "ForkAttribute",
+    "RefundTypes",
     "Amsterdam",
     "ArrowGlacier",
     "Berlin",

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -1,6 +1,7 @@
 """Abstract base class for Ethereum forks."""
 
 from abc import ABCMeta, abstractmethod
+from enum import Enum, auto
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -182,6 +183,13 @@ class ExcessBlobGasCalculator(Protocol):
         gas used.
         """
         pass
+
+
+class RefundTypes(Enum):
+    """Enum used to describe all refund types a fork can have."""
+
+    STORAGE_CLEAR = auto()
+    AUTHORIZATION_EXISTING_AUTHORITY = auto()
 
 
 class BaseForkMeta(ABCMeta):
@@ -885,6 +893,17 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int:
         """Return max request type supported by the fork."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def refund_types(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Set[RefundTypes]:
+        """
+        Return the list of refund types that are possible given current
+        fork logic.
+        """
         pass
 
     # Meta information about the fork

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -899,7 +899,7 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
     @abstractmethod
     def refund_types(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> Set[RefundTypes]:
+    ) -> List[RefundTypes]:
         """
         Return the list of refund types that are possible given current
         fork logic.

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -14,6 +14,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Set,
     Sized,
 )
 
@@ -43,6 +44,7 @@ from ..base_fork import (
     CalldataGasCalculator,
     ExcessBlobGasCalculator,
     MemoryExpansionGasCalculator,
+    RefundTypes,
     TransactionDataFloorCostCalculator,
     TransactionIntrinsicCostCalculator,
 )
@@ -1342,6 +1344,17 @@ class Frontier(BaseFork, solc_name="homestead"):
         return -1
 
     @classmethod
+    def refund_types(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Set[RefundTypes]:
+        """
+        Return the list of refund types that are possible given current
+        fork logic.
+        """
+        del block_number, timestamp
+        return set()
+
+    @classmethod
     def pre_allocation(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Mapping:
@@ -1671,6 +1684,20 @@ class Byzantium(SpuriousDragon):
             G_PRECOMPILE_ECPAIRING_BASE=100_000,
             G_PRECOMPILE_ECPAIRING_PER_POINT=80_000,
         )
+
+    @classmethod
+    def refund_types(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Set[RefundTypes]:
+        """
+        Return the list of refund types that are possible given current
+        fork logic.
+        """
+        refunds = super(Byzantium, cls).refund_types(
+            block_number=block_number, timestamp=timestamp
+        )
+        refunds.add(RefundTypes.STORAGE_CLEAR)
+        return refunds
 
 
 class Constantinople(Byzantium):
@@ -2739,6 +2766,20 @@ class Prague(Cancun):
         """
         del block_number, timestamp
         return 2
+
+    @classmethod
+    def refund_types(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Set[RefundTypes]:
+        """
+        Return the list of refund types that are possible given current
+        fork logic.
+        """
+        refunds = super(Prague, cls).refund_types(
+            block_number=block_number, timestamp=timestamp
+        )
+        refunds.add(RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY)
+        return refunds
 
     @classmethod
     def calldata_gas_calculator(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -14,7 +14,6 @@ from typing import (
     Literal,
     Mapping,
     Optional,
-    Set,
     Sized,
 )
 
@@ -1346,12 +1345,12 @@ class Frontier(BaseFork, solc_name="homestead"):
     @classmethod
     def refund_types(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> Set[RefundTypes]:
+    ) -> List[RefundTypes]:
         """
         At genesis, storage clearing refund is introduced.
         """
         del block_number, timestamp
-        return {RefundTypes.STORAGE_CLEAR}
+        return [RefundTypes.STORAGE_CLEAR]
 
     @classmethod
     def pre_allocation(
@@ -2755,14 +2754,14 @@ class Prague(Cancun):
     @classmethod
     def refund_types(
         cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> Set[RefundTypes]:
+    ) -> List[RefundTypes]:
         """
         At Prague, existing authorization refund is introduced.
         """
         refunds = super(Prague, cls).refund_types(
             block_number=block_number, timestamp=timestamp
         )
-        refunds.add(RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY)
+        refunds.append(RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY)
         return refunds
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1348,11 +1348,10 @@ class Frontier(BaseFork, solc_name="homestead"):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Set[RefundTypes]:
         """
-        Return the list of refund types that are possible given current
-        fork logic.
+        At genesis, storage clearing refund is introduced.
         """
         del block_number, timestamp
-        return set()
+        return {RefundTypes.STORAGE_CLEAR}
 
     @classmethod
     def pre_allocation(
@@ -1684,20 +1683,6 @@ class Byzantium(SpuriousDragon):
             G_PRECOMPILE_ECPAIRING_BASE=100_000,
             G_PRECOMPILE_ECPAIRING_PER_POINT=80_000,
         )
-
-    @classmethod
-    def refund_types(
-        cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> Set[RefundTypes]:
-        """
-        Return the list of refund types that are possible given current
-        fork logic.
-        """
-        refunds = super(Byzantium, cls).refund_types(
-            block_number=block_number, timestamp=timestamp
-        )
-        refunds.add(RefundTypes.STORAGE_CLEAR)
-        return refunds
 
 
 class Constantinople(Byzantium):
@@ -2772,8 +2757,7 @@ class Prague(Cancun):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Set[RefundTypes]:
         """
-        Return the list of refund types that are possible given current
-        fork logic.
+        At Prague, existing authorization refund is introduced.
         """
         refunds = super(Prague, cls).refund_types(
             block_number=block_number, timestamp=timestamp

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -281,6 +281,8 @@ class Block(Header):
     """Post state for verification after block execution in BlockchainTest"""
     block_access_list: Bytes | None = Field(None)
     """EIP-7928: Block-level access lists (serialized)."""
+    expected_gas_used: int | None = None
+    """Expected gas used for the block."""
 
     def set_environment(self, env: Environment) -> Environment:
         """
@@ -477,7 +479,6 @@ class BlockchainTest(BaseTest):
     genesis_environment: Environment = Field(default_factory=Environment)
     chain_id: int = 1
     exclude_full_post_state_in_output: bool = False
-    expected_gas_used: int | None = None
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -657,12 +658,12 @@ class BlockchainTest(BaseTest):
                     f"Verification of block {int(env.number)} failed"
                 ) from e
 
-        if last_block and self.expected_gas_used is not None:
+        if block.expected_gas_used is not None:
             gas_used = int(transition_tool_output.result.gas_used)
-            assert gas_used == self.expected_gas_used, (
+            assert gas_used == block.expected_gas_used, (
                 f"gas_used ({gas_used}) does not match expected_gas_used "
-                f"({self.expected_gas_used})"
-                f", difference: {gas_used - self.expected_gas_used}"
+                f"({block.expected_gas_used})"
+                f", difference: {gas_used - block.expected_gas_used}"
             )
 
         if last_block and self._operation_mode == OpMode.BENCHMARKING:

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -477,6 +477,7 @@ class BlockchainTest(BaseTest):
     genesis_environment: Environment = Field(default_factory=Environment)
     chain_id: int = 1
     exclude_full_post_state_in_output: bool = False
+    expected_gas_used: int | None = None
     """
     Exclude the post state from the fixture output. In this case, the state
     verification is only performed based on the state root.
@@ -659,6 +660,14 @@ class BlockchainTest(BaseTest):
                 raise Exception(
                     f"Verification of block {int(env.number)} failed"
                 ) from e
+
+        if last_block and self.expected_gas_used is not None:
+            gas_used = int(transition_tool_output.result.gas_used)
+            assert gas_used == self.expected_gas_used, (
+                f"gas_used ({gas_used}) does not match expected_gas_used "
+                f"({self.expected_gas_used})"
+                f", difference: {gas_used - self.expected_gas_used}"
+            )
 
         if last_block and self._operation_mode == OpMode.BENCHMARKING:
             expected_benchmark_gas_used = self.expected_benchmark_gas_used

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -478,10 +478,6 @@ class BlockchainTest(BaseTest):
     chain_id: int = 1
     exclude_full_post_state_in_output: bool = False
     expected_gas_used: int | None = None
-    """
-    Exclude the post state from the fixture output. In this case, the state
-    verification is only performed based on the state root.
-    """
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -479,6 +479,10 @@ class BlockchainTest(BaseTest):
     genesis_environment: Environment = Field(default_factory=Environment)
     chain_id: int = 1
     exclude_full_post_state_in_output: bool = False
+    """
+    Exclude the post state from the fixture output. In this case, the state
+    verification is only performed based on the state root.
+    """
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -19,8 +19,8 @@ from execution_testing import (
 )
 from execution_testing.vm import Op
 
-REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7928.md"
-REFERENCE_SPEC_VERSION = "DUMMY_VERSION"
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
+REFERENCE_SPEC_VERSION = "54fba02495a05b57acd3f27473d0493b40a9d920"
 
 
 @pytest.mark.valid_from("Amsterdam")

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -1,0 +1,239 @@
+"""
+Test cases for
+[EIP-7778 Block Gas Accounting without Refunds](https://eips.ethereum.org/EIPS/eip-7778).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    BlockException,
+    Bytecode,
+    Environment,
+    Fork,
+    Hash,
+    Transaction,
+    TransactionException,
+)
+from execution_testing.vm import Op
+
+REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7928.md"
+REFERENCE_SPEC_VERSION = "DUMMY_VERSION"
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_simple_gas_accounting(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """Test gas accounting when SSTORE refunds."""
+    gsc = fork.gas_costs()
+    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    max_refund_quotient = fork.max_refund_quotient()
+
+    num_slot = 10
+
+    # gas cost for SSTORE(slot, 0), resetting storage to zero
+    per_slot_cost = (
+        gsc.G_BASE + gsc.G_VERY_LOW + gsc.G_COLD_SLOAD + gsc.G_STORAGE_RESET
+    )
+    gas_used_pre_refund = intrinsic_cost_calc() + per_slot_cost * num_slot
+
+    # Calculate refund (still applied to user's balance)
+    refund_counter = gsc.R_STORAGE_CLEAR * num_slot
+    effective_refund = min(
+        refund_counter, gas_used_pre_refund // max_refund_quotient
+    )
+    gas_used_post_refund = gas_used_pre_refund - effective_refund
+
+    initial_fund = 10**18
+    sender = pre.fund_eoa(initial_fund)
+
+    storage_slots = list(range(num_slot))
+
+    code = Bytecode()
+    for slot in storage_slots:
+        code += Op.SSTORE(slot, Op.PUSH0)
+
+    contract_address = pre.deploy_contract(
+        code=code,
+        storage=dict.fromkeys(storage_slots, 1),
+    )
+
+    tx = Transaction(
+        to=contract_address,
+        gas_limit=fork.transaction_gas_limit_cap(),
+        sender=sender,
+        expected_receipt={
+            "gas_used": gas_used_pre_refund,
+            "gas_spent": gas_used_post_refund,
+        },
+    )
+
+    assert tx.gas_price is not None, "tx.gas_price should not be None"
+    expected_balance = initial_fund - gas_used_post_refund * tx.gas_price
+
+    post = {
+        contract_address: Account(
+            storage=dict.fromkeys(storage_slots, 0),
+        ),
+        sender: Account(balance=expected_balance),
+    }
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post=post,
+        expected_gas_used=gas_used_pre_refund,
+    )
+
+
+@pytest.mark.parametrize(
+    "exceed_block_gas_limit",
+    [
+        pytest.param(True, marks=pytest.mark.exception_test),
+        False,
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_multi_block_gas_accounting(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    env: Environment,
+    exceed_block_gas_limit: bool,
+) -> None:
+    """
+    Test block gas accounting with refunds per EIP-7778.
+
+    When exceed_block_gas_limit=True, we create a scenario where:
+    - Pre-refund gas (gas_used) > block_gas_limit - intrinsic_cost
+      (no room for another tx with correct EIP-7778 accounting)
+    - Post-refund gas (gas_spent) <= block_gas_limit - intrinsic_cost
+      (appears to have room with old refund-based accounting)
+
+    This tests that clients correctly use pre-refund gas for block accounting.
+    """
+    gas_costs = fork.gas_costs()
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    max_refund_quotient = fork.max_refund_quotient()
+
+    # Base Operation: SSTORE(slot, 0) - clearing storage
+    iteration_cost = (
+        gas_costs.G_COLD_SLOAD
+        + gas_costs.G_STORAGE_RESET
+        + gas_costs.G_BASE
+        + gas_costs.G_VERY_LOW
+    )
+    refund_per_slot = gas_costs.R_STORAGE_CLEAR
+
+    txs = []
+    post = {}
+    total_gas_used = 0  # Pre-refund (for block gas accounting per EIP-7778)
+    total_gas_spent = 0  # Post-refund (what users actually pay)
+
+    assert env.gas_limit is not None, "env.gas_limit must be set"
+    assert tx_gas_limit_cap is not None, "tx_gas_limit_cap must be set"
+
+    block_gas_limit: int = env.gas_limit
+    tx_intrinsic = intrinsic_cost_calc()
+
+    # Target gas to use (pre-refund)
+    # For exceed_block_gas_limit: 
+    # - pre-refund > (block_gas_limit - tx_intrinsic)
+    # - post-refund <= (block_gas_limit - tx_intrinsic)
+    target_gas_pre_refund = block_gas_limit
+
+    gas_remaining = target_gas_pre_refund
+
+    while gas_remaining > 0:
+        if gas_remaining < tx_intrinsic:
+            break
+
+        max_tx_gas = min(gas_remaining, tx_gas_limit_cap)
+        execution_gas = max_tx_gas - tx_intrinsic
+
+        iteration_count = min(
+            execution_gas // iteration_cost,
+            fork.max_code_size() // len(Op.SSTORE(0xFFFF, Op.PUSH0)),
+        )
+
+        if iteration_count == 0:
+            break
+
+        opcode = sum(
+            (Op.SSTORE(i, Op.PUSH0) for i in range(iteration_count)),
+            Bytecode(),
+        )
+
+        contract = pre.deploy_contract(
+            code=opcode,
+            storage={i: Hash(1) for i in range(iteration_count)},
+        )
+
+        actual_execution_gas = iteration_cost * iteration_count
+        tx_gas_pre_refund = tx_intrinsic + actual_execution_gas
+
+        # Calculate effective refund (capped at gas_used / max_refund_quotient)
+        refund_counter = refund_per_slot * iteration_count
+        effective_refund = min(
+            refund_counter, tx_gas_pre_refund // max_refund_quotient
+        )
+        tx_gas_post_refund = tx_gas_pre_refund - effective_refund
+
+        total_gas_used += tx_gas_pre_refund
+        total_gas_spent += tx_gas_post_refund
+        gas_remaining -= tx_gas_pre_refund
+
+        tx = Transaction(
+            to=contract,
+            sender=pre.fund_eoa(),
+            gas_limit=tx_gas_pre_refund,
+            expected_receipt={
+                "gas_used": total_gas_used,
+                "gas_spent": tx_gas_post_refund,
+            },
+        )
+
+        txs.append(tx)
+        post[contract] = Account(
+            storage={i: Hash(0) for i in range(iteration_count)}
+        )
+
+    if exceed_block_gas_limit:
+        threshold = block_gas_limit - tx_intrinsic
+        assert total_gas_used > threshold, (
+            f"Pre-refund gas {total_gas_used} <= threshold {threshold}"
+        )
+        assert total_gas_spent <= threshold, (
+            f"Post-refund gas {total_gas_spent} > threshold {threshold}"
+        )
+
+        tx = Transaction(
+            to=pre.fund_eoa(),
+            sender=pre.fund_eoa(),
+            gas_limit=tx_intrinsic,
+            value=1,
+            error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
+        )
+        txs.append(tx)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=txs,
+                exception=BlockException.GAS_USED_OVERFLOW
+                if exceed_block_gas_limit
+                else None,
+            )
+        ],
+        post=post if not exceed_block_gas_limit else {},
+        expected_gas_used=total_gas_used
+        if not exceed_block_gas_limit
+        else None,
+    )

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -143,7 +143,7 @@ def test_multi_block_gas_accounting(
     tx_intrinsic = intrinsic_cost_calc()
 
     # Target gas to use (pre-refund)
-    # For exceed_block_gas_limit: 
+    # For exceed_block_gas_limit:
     # - pre-refund > (block_gas_limit - tx_intrinsic)
     # - post-refund <= (block_gas_limit - tx_intrinsic)
     target_gas_pre_refund = block_gas_limit

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -41,7 +41,7 @@ def test_simple_gas_accounting(
     refund_type: RefundTypes,
     refund_tx_reverts: bool,
 ) -> None:
-    """Test gas accounting when SSTORE refunds."""
+    """Test gas accounting for all refund types available in the given fork."""
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
     max_refund_quotient = fork.max_refund_quotient()
 
@@ -90,7 +90,7 @@ def test_simple_gas_accounting(
 
             refund_tx = Transaction(
                 to=contract_address,
-                gas_limit=1_000_000,
+                gas_limit=refund_tx_gas_used,
                 sender=refund_tx_sender,
                 expected_receipt={
                     "gas_used": refund_tx_gas_used,
@@ -148,7 +148,7 @@ def test_simple_gas_accounting(
 
             refund_tx = Transaction(
                 to=contract_address,
-                gas_limit=1_000_000,
+                gas_limit=refund_tx_gas_used,
                 sender=refund_tx_sender,
                 authorization_list=authorization_list,
                 expected_receipt={

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -126,7 +126,6 @@ def test_simple_gas_accounting(
                 )
                 for _ in range(refunds_count)
             ]
-            # TODO: Same test with a revert at the end
             gas_used_pre_refund = intrinsic_cost_calc(
                 authorization_list_or_count=authorization_list
             ) + code.gas_cost(fork)

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -7,13 +7,14 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     BlockException,
     Bytecode,
     Environment,
     Fork,
-    Hash,
+    RefundTypes,
     Transaction,
     TransactionException,
 )
@@ -23,74 +24,188 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
 REFERENCE_SPEC_VERSION = "54fba02495a05b57acd3f27473d0493b40a9d920"
 
 
+@pytest.mark.parametrize(
+    "refund_tx_reverts",
+    [
+        pytest.param(True, id="refund_tx_reverts"),
+        pytest.param(False, id=""),
+    ],
+)
+@pytest.mark.with_all_refund_types()
+@pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
 @pytest.mark.valid_from("Amsterdam")
 def test_simple_gas_accounting(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
+    refund_type: RefundTypes,
+    refund_tx_reverts: bool,
 ) -> None:
     """Test gas accounting when SSTORE refunds."""
-    gsc = fork.gas_costs()
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
     max_refund_quotient = fork.max_refund_quotient()
 
-    num_slot = 10
-
-    # gas cost for SSTORE(slot, 0), resetting storage to zero
-    per_slot_cost = (
-        gsc.G_BASE + gsc.G_VERY_LOW + gsc.G_COLD_SLOAD + gsc.G_STORAGE_RESET
-    )
-    gas_used_pre_refund = intrinsic_cost_calc() + per_slot_cost * num_slot
-
-    # Calculate refund (still applied to user's balance)
-    refund_counter = gsc.R_STORAGE_CLEAR * num_slot
-    effective_refund = min(
-        refund_counter, gas_used_pre_refund // max_refund_quotient
-    )
-    gas_used_post_refund = gas_used_pre_refund - effective_refund
-
+    refunds_count = 10
     initial_fund = 10**18
-    sender = pre.fund_eoa(initial_fund)
+    refund_tx_sender = pre.fund_eoa(initial_fund)
 
-    storage_slots = list(range(num_slot))
+    post = {}
 
-    code = Bytecode()
-    for slot in storage_slots:
-        code += Op.SSTORE(slot, Op.PUSH0)
+    match refund_type:
+        case RefundTypes.STORAGE_CLEAR:
+            storage_slots = list(range(refunds_count))
 
-    contract_address = pre.deploy_contract(
-        code=code,
-        storage=dict.fromkeys(storage_slots, 1),
+            code = Bytecode()
+            for slot in storage_slots:
+                code += Op.SSTORE(
+                    slot,
+                    Op.PUSH0,
+                    # Gas accounting
+                    original_value=1,
+                    new_value=0,
+                )
+            if refund_tx_reverts:
+                code += Op.REVERT(0, 0)
+
+            contract_address = pre.deploy_contract(
+                code=code,
+                storage=dict.fromkeys(storage_slots, 1),
+            )
+            gas_used_pre_refund = intrinsic_cost_calc() + code.gas_cost(fork)
+
+            # Calculate refund (still applied to user's balance)
+            refund_counter = code.refund(fork)
+            effective_refund = min(
+                refund_counter, gas_used_pre_refund // max_refund_quotient
+            )
+            assert effective_refund > 0, (
+                f"effective_refund ({effective_refund}) must be greater than 0"
+            )
+            gas_used_post_refund = gas_used_pre_refund - effective_refund
+            refund_tx_gas_used = gas_used_pre_refund
+            refund_tx_gas_spent = gas_used_post_refund
+
+            if refund_tx_reverts:
+                refund_tx_gas_spent = refund_tx_gas_used
+
+            refund_tx = Transaction(
+                to=contract_address,
+                gas_limit=1_000_000,
+                sender=refund_tx_sender,
+                expected_receipt={
+                    "gas_used": refund_tx_gas_used,
+                    "gas_spent": refund_tx_gas_spent,
+                },
+            )
+            refund_tx_gas_price = refund_tx.gas_price
+
+            if refund_tx_reverts:
+                post[contract_address] = Account(
+                    storage=dict.fromkeys(storage_slots, 1),
+                )
+            else:
+                post[contract_address] = Account(
+                    storage=dict.fromkeys(storage_slots, 0),
+                )
+
+        case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
+            if refund_tx_reverts:
+                code = Op.REVERT(0, 0)
+            else:
+                code = Op.STOP
+
+            contract_address = pre.deterministic_deploy_contract(
+                deploy_code=code
+            )
+
+            authorization_list = [
+                AuthorizationTuple(
+                    address=contract_address,
+                    nonce=0,
+                    signer=pre.fund_eoa(amount=1),
+                )
+                for _ in range(refunds_count)
+            ]
+            # TODO: Same test with a revert at the end
+            gas_used_pre_refund = intrinsic_cost_calc(
+                authorization_list_or_count=authorization_list
+            ) + code.gas_cost(fork)
+
+            # Calculate refund (still applied to user's balance)
+            gsc = fork.gas_costs()
+            refund_counter = (
+                gsc.R_AUTHORIZATION_EXISTING_AUTHORITY * refunds_count
+            )
+            effective_refund = min(
+                refund_counter, gas_used_pre_refund // max_refund_quotient
+            )
+            assert effective_refund > 0, (
+                f"effective_refund ({effective_refund}) must be greater than 0"
+            )
+            gas_used_post_refund = gas_used_pre_refund - effective_refund
+
+            refund_tx_gas_used = gas_used_pre_refund
+            refund_tx_gas_spent = gas_used_post_refund
+
+            refund_tx = Transaction(
+                to=contract_address,
+                gas_limit=1_000_000,
+                sender=refund_tx_sender,
+                authorization_list=authorization_list,
+                expected_receipt={
+                    "gas_used": refund_tx_gas_used,
+                    "gas_spent": refund_tx_gas_spent,
+                },
+            )
+            refund_tx_gas_price = refund_tx.max_fee_per_gas
+
+        case _:
+            raise ValueError(
+                f"Unknown refund type: {refund_type} (Test needs update)"
+            )
+
+    assert refund_tx_gas_price is not None, (
+        "refund_tx_gas_price should not be None"
+    )
+    expected_balance = initial_fund - (
+        refund_tx_gas_spent * refund_tx_gas_price
     )
 
-    tx = Transaction(
-        to=contract_address,
-        gas_limit=fork.transaction_gas_limit_cap(),
-        sender=sender,
-        expected_receipt={
-            "gas_used": gas_used_pre_refund,
-            "gas_spent": gas_used_post_refund,
-        },
-    )
-
-    assert tx.gas_price is not None, "tx.gas_price should not be None"
-    expected_balance = initial_fund - gas_used_post_refund * tx.gas_price
-
-    post = {
-        contract_address: Account(
-            storage=dict.fromkeys(storage_slots, 0),
-        ),
-        sender: Account(balance=expected_balance),
-    }
+    post[refund_tx_sender] = Account(balance=expected_balance)
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx])],
+        blocks=[
+            Block(
+                txs=[refund_tx],
+                expected_gas_used=gas_used_pre_refund,
+            )
+        ],
         post=post,
-        expected_gas_used=gas_used_pre_refund,
     )
 
 
+@pytest.mark.parametrize(
+    "refund_tx_reverts",
+    [
+        pytest.param(True, id="refund_tx_reverts"),
+        pytest.param(False, id=""),
+    ],
+)
+@pytest.mark.parametrize(
+    "refund_tx_has_extra_gas_limit",
+    [
+        pytest.param(True, id="refund_tx_has_extra_gas"),
+        pytest.param(False, id=""),
+    ],
+)
+@pytest.mark.parametrize(
+    "extra_tx_data_floor",
+    [
+        pytest.param(True, id=""),
+        pytest.param(False, id="extra_tx_hits_data_floor"),
+    ],
+)
 @pytest.mark.parametrize(
     "exceed_block_gas_limit",
     [
@@ -98,13 +213,18 @@ def test_simple_gas_accounting(
         False,
     ],
 )
+@pytest.mark.with_all_refund_types()
+@pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
 @pytest.mark.valid_from("Amsterdam")
-def test_multi_block_gas_accounting(
+def test_multi_transaction_gas_accounting(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
-    env: Environment,
+    refund_type: RefundTypes,
+    refund_tx_has_extra_gas_limit: bool,
     exceed_block_gas_limit: bool,
+    extra_tx_data_floor: bool,
+    refund_tx_reverts: bool,
 ) -> None:
     """
     Test block gas accounting with refunds per EIP-7778.
@@ -117,110 +237,169 @@ def test_multi_block_gas_accounting(
 
     This tests that clients correctly use pre-refund gas for block accounting.
     """
-    gas_costs = fork.gas_costs()
-    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
     max_refund_quotient = fork.max_refund_quotient()
 
-    # Base Operation: SSTORE(slot, 0) - clearing storage
-    iteration_cost = (
-        gas_costs.G_COLD_SLOAD
-        + gas_costs.G_STORAGE_RESET
-        + gas_costs.G_BASE
-        + gas_costs.G_VERY_LOW
-    )
-    refund_per_slot = gas_costs.R_STORAGE_CLEAR
+    environment_gas_limit = 0
+    refunds_count = 10
+    initial_fund = 10**18
 
-    txs = []
+    refund_tx_sender = pre.fund_eoa(initial_fund)
+    refund_tx_extra_gas = 1 if refund_tx_has_extra_gas_limit else 0
+
+    stop_bytecode = Op.STOP
+    stop_address = pre.deterministic_deploy_contract(deploy_code=stop_bytecode)
+
     post = {}
-    total_gas_used = 0  # Pre-refund (for block gas accounting per EIP-7778)
-    total_gas_spent = 0  # Post-refund (what users actually pay)
 
-    assert env.gas_limit is not None, "env.gas_limit must be set"
-    assert tx_gas_limit_cap is not None, "tx_gas_limit_cap must be set"
+    match refund_type:
+        case RefundTypes.STORAGE_CLEAR:
+            # Refund happens due to a storage clearing
+            storage_slots = list(range(refunds_count))
 
-    block_gas_limit: int = env.gas_limit
-    tx_intrinsic = intrinsic_cost_calc()
+            code = Bytecode()
+            for slot in storage_slots:
+                code += Op.SSTORE(
+                    slot,
+                    Op.PUSH0,
+                    # Gas accounting
+                    original_value=1,
+                    new_value=0,
+                )
+            if refund_tx_reverts:
+                code += Op.REVERT(0, 0)
 
-    # Target gas to use (pre-refund)
-    # For exceed_block_gas_limit:
-    # - pre-refund > (block_gas_limit - tx_intrinsic)
-    # - post-refund <= (block_gas_limit - tx_intrinsic)
-    target_gas_pre_refund = block_gas_limit
+            contract_address = pre.deploy_contract(
+                code=code,
+                storage=dict.fromkeys(storage_slots, 1),
+            )
 
-    gas_remaining = target_gas_pre_refund
+            gas_used_pre_refund = intrinsic_cost_calc() + code.gas_cost(fork)
 
-    while gas_remaining > 0:
-        if gas_remaining < tx_intrinsic:
-            break
+            # Calculate refund (still applied to user's balance)
+            refund_counter = code.refund(fork)
+            effective_refund = min(
+                refund_counter, gas_used_pre_refund // max_refund_quotient
+            )
+            assert effective_refund > 0, (
+                f"effective_refund ({effective_refund}) must be greater than 0"
+            )
+            gas_used_post_refund = gas_used_pre_refund - effective_refund
 
-        max_tx_gas = min(gas_remaining, tx_gas_limit_cap)
-        execution_gas = max_tx_gas - tx_intrinsic
+            refund_tx_gas_used = gas_used_pre_refund
+            refund_tx_gas_spent = gas_used_post_refund
 
-        iteration_count = min(
-            execution_gas // iteration_cost,
-            fork.max_code_size() // len(Op.SSTORE(0xFFFF, Op.PUSH0)),
-        )
+            if refund_tx_reverts:
+                refund_tx_gas_spent = refund_tx_gas_used
 
-        if iteration_count == 0:
-            break
+            refund_tx = Transaction(
+                to=contract_address,
+                gas_limit=gas_used_pre_refund + refund_tx_extra_gas,
+                sender=refund_tx_sender,
+                expected_receipt={
+                    "gas_used": refund_tx_gas_used,
+                    "gas_spent": refund_tx_gas_spent,
+                },
+            )
 
-        opcode = sum(
-            (Op.SSTORE(i, Op.PUSH0) for i in range(iteration_count)),
-            Bytecode(),
-        )
+            refund_tx_gas_price = refund_tx.gas_price
 
-        contract = pre.deploy_contract(
-            code=opcode,
-            storage={i: Hash(1) for i in range(iteration_count)},
-        )
+            if exceed_block_gas_limit or refund_tx_reverts:
+                post[contract_address] = Account(
+                    storage=dict.fromkeys(storage_slots, 1),
+                )
+            else:
+                post[contract_address] = Account(
+                    storage=dict.fromkeys(storage_slots, 0),
+                )
 
-        actual_execution_gas = iteration_cost * iteration_count
-        tx_gas_pre_refund = tx_intrinsic + actual_execution_gas
+        case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
+            if refund_tx_reverts:
+                code = Op.REVERT(0, 0)
+                contract_address = pre.deterministic_deploy_contract(
+                    deploy_code=code
+                )
+            else:
+                code = stop_bytecode
+                contract_address = stop_address
+            authorization_list = [
+                AuthorizationTuple(
+                    address=contract_address,
+                    nonce=0,
+                    signer=pre.fund_eoa(amount=1),
+                )
+                for _ in range(refunds_count)
+            ]
+            gas_used_pre_refund = intrinsic_cost_calc(
+                authorization_list_or_count=authorization_list
+            ) + code.gas_cost(fork)
 
-        # Calculate effective refund (capped at gas_used / max_refund_quotient)
-        refund_counter = refund_per_slot * iteration_count
-        effective_refund = min(
-            refund_counter, tx_gas_pre_refund // max_refund_quotient
-        )
-        tx_gas_post_refund = tx_gas_pre_refund - effective_refund
+            # Calculate refund (still applied to user's balance)
+            gsc = fork.gas_costs()
+            refund_counter = (
+                gsc.R_AUTHORIZATION_EXISTING_AUTHORITY * refunds_count
+            )
+            effective_refund = min(
+                refund_counter, gas_used_pre_refund // max_refund_quotient
+            )
+            assert effective_refund > 0, (
+                f"effective_refund ({effective_refund}) must be greater than 0"
+            )
+            gas_used_post_refund = gas_used_pre_refund - effective_refund
 
-        total_gas_used += tx_gas_pre_refund
-        total_gas_spent += tx_gas_post_refund
-        gas_remaining -= tx_gas_pre_refund
+            refund_tx_gas_used = gas_used_pre_refund
+            refund_tx_gas_spent = gas_used_post_refund
 
-        tx = Transaction(
-            to=contract,
-            sender=pre.fund_eoa(),
-            gas_limit=tx_gas_pre_refund,
-            expected_receipt={
-                "gas_used": total_gas_used,
-                "gas_spent": tx_gas_post_refund,
-            },
-        )
+            refund_tx = Transaction(
+                to=contract_address,
+                gas_limit=gas_used_pre_refund + refund_tx_extra_gas,
+                sender=refund_tx_sender,
+                authorization_list=authorization_list,
+                expected_receipt={
+                    "gas_used": refund_tx_gas_used,
+                    "gas_spent": refund_tx_gas_spent,
+                },
+            )
+            refund_tx_gas_price = refund_tx.max_fee_per_gas
+        case _:
+            raise ValueError(
+                f"Unknown refund type: {refund_type} (Test needs update)"
+            )
 
-        txs.append(tx)
-        post[contract] = Account(
-            storage={i: Hash(0) for i in range(iteration_count)}
-        )
+    assert refund_tx_gas_price is not None, (
+        "refund_tx_gas_price should not be None"
+    )
+    expected_balance = initial_fund - (
+        refund_tx_gas_spent * refund_tx_gas_price
+    )
 
+    extra_tx_sender = pre.fund_eoa()
+    extra_tx_calldata = b"\xff" if extra_tx_data_floor else b""
+    extra_tx_intrinsic_gas_cost = intrinsic_cost_calc(
+        calldata=extra_tx_calldata
+    )
+
+    extra_tx = Transaction(
+        to=stop_address,
+        data=extra_tx_calldata,
+        gas_limit=extra_tx_intrinsic_gas_cost,
+        sender=extra_tx_sender,
+        expected_receipt={
+            "gas_used": refund_tx_gas_used + extra_tx_intrinsic_gas_cost,
+        },
+        error=TransactionException.GAS_ALLOWANCE_EXCEEDED
+        if exceed_block_gas_limit
+        else None,
+    )
+
+    total_gas_used = refund_tx_gas_used + extra_tx_intrinsic_gas_cost
     if exceed_block_gas_limit:
-        threshold = block_gas_limit - tx_intrinsic
-        assert total_gas_used > threshold, (
-            f"Pre-refund gas {total_gas_used} <= threshold {threshold}"
-        )
-        assert total_gas_spent <= threshold, (
-            f"Post-refund gas {total_gas_spent} > threshold {threshold}"
-        )
+        environment_gas_limit = total_gas_used - 1
+    else:
+        environment_gas_limit = total_gas_used
+        post[refund_tx_sender] = Account(balance=expected_balance)
 
-        tx = Transaction(
-            to=pre.fund_eoa(),
-            sender=pre.fund_eoa(),
-            gas_limit=tx_intrinsic,
-            value=1,
-            error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
-        )
-        txs.append(tx)
+    txs = [refund_tx, extra_tx]
 
     blockchain_test(
         pre=pre,
@@ -230,10 +409,12 @@ def test_multi_block_gas_accounting(
                 exception=BlockException.GAS_USED_OVERFLOW
                 if exceed_block_gas_limit
                 else None,
+                expected_gas_used=total_gas_used
+                if not exceed_block_gas_limit
+                else None,
+                gas_limit=environment_gas_limit,
             )
         ],
-        post=post if not exceed_block_gas_limit else {},
-        expected_gas_used=total_gas_used
-        if not exceed_block_gas_limit
-        else None,
+        post=post,
+        genesis_environment=Environment(gas_limit=environment_gas_limit),
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Due to an incorrect git operation, PR #2026 was closed. I’ve recreated the PR with the same content and updated the related links to point to this new PR.

Implement eip-7778 test cases.

- `test_simple_gas_accounting`: User should receive the refund, block accounting should exclude refund.
- `test_multi_block_gas_accounting`: Block accounting should exclude refund, and the transaction receipt should reflect the cumulative gas usage.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->

Require PR https://github.com/ethereum/execution-specs/pull/1401
Tracker:
- https://github.com/ethereum/execution-specs/issues/1874

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
