### PR TITLE
fix(tests): fix legacy tests to run with eip-7778

### DIFF
--- a/packages/testing/src/execution_testing/specs/helpers.py
+++ b/packages/testing/src/execution_testing/specs/helpers.py
@@ -261,6 +261,16 @@ def verify_transaction_receipt(
             expected_value=expected_receipt.gas_used,
             actual_value=actual_receipt.gas_used,
         )
+    if (
+        expected_receipt.gas_spent is not None
+        and actual_receipt.gas_spent != expected_receipt.gas_spent
+    ):
+        raise TransactionReceiptMismatchError(
+            index=transaction_index,
+            field_name="gas_spent",
+            expected_value=expected_receipt.gas_spent,
+            actual_value=actual_receipt.gas_spent,
+        )
     # TODO: Add more fields as needed
 
 

--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -70,3 +70,4 @@ class TransactionReceipt(CamelModel):
     blob_gas_used: HexNumber | None = None
     blob_gas_price: HexNumber | None = None
     delegations: List[ReceiptDelegation] | None = None
+    gas_spent: HexNumber | None = None

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -416,6 +416,9 @@ class Result:
             receipt_dict["gasUsed"] = hex(receipt.cumulative_gas_used)
             receipt_dict["bloom"] = "0x" + receipt.bloom.hex()
 
+            if hasattr(receipt, "gas_spent"):
+                receipt_dict["gasSpent"] = hex(receipt.gas_spent)
+
             receipts_json.append(receipt_dict)
 
         return receipts_json

--- a/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
@@ -17,7 +17,7 @@ from execution_testing import (
     Transaction,
     TransactionReceipt,
 )
-from execution_testing.forks import Prague
+from execution_testing.forks import Amsterdam, Prague
 
 from .helpers import DataTestType
 from .spec import ref_spec_7623
@@ -298,6 +298,7 @@ def test_gas_refunds_from_data_floor(
     execution_gas_used: int,
     refund: int,
     refund_test_type: RefundTestType,
+    fork: Fork,
 ) -> None:
     """
     Test gas refunds deducted from the execution gas cost and not the data
@@ -330,7 +331,11 @@ def test_gas_refunds_from_data_floor(
     #     (t8n) is verified against the expected receipt.
     #   - During test consumption, this is reflected in the balance difference
     #     and the state root.
-    tx.expected_receipt = TransactionReceipt(gas_used=gas_used)
+    if fork >= Amsterdam:
+        tx.expected_receipt = TransactionReceipt(gas_spent=gas_used)
+    else:
+        tx.expected_receipt = TransactionReceipt(gas_used=gas_used)
+
     state_test(
         pre=pre,
         post={

--- a/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
@@ -304,37 +304,48 @@ def test_gas_refunds_from_data_floor(
     Test gas refunds deducted from the execution gas cost and not the data
     floor.
     """
-    gas_used = (
+    gas_used_after_refund = (
         tx_intrinsic_gas_cost_before_execution + execution_gas_used - refund
+    )
+    gas_used_before_refund = (
+        tx_intrinsic_gas_cost_before_execution + execution_gas_used
     )
     if (
         refund_test_type
         == RefundTestType.EXECUTION_GAS_MINUS_REFUND_LESS_THAN_DATA_FLOOR
     ):
-        assert gas_used < tx_floor_data_cost
+        assert gas_used_after_refund < tx_floor_data_cost
     elif (
         refund_test_type
         == RefundTestType.EXECUTION_GAS_MINUS_REFUND_GREATER_THAN_DATA_FLOOR
     ):
-        assert gas_used > tx_floor_data_cost
+        assert gas_used_after_refund > tx_floor_data_cost
     elif (
         refund_test_type
         == RefundTestType.EXECUTION_GAS_MINUS_REFUND_EQUAL_TO_DATA_FLOOR
     ):
-        assert gas_used == tx_floor_data_cost
+        assert gas_used_after_refund == tx_floor_data_cost
     else:
         raise ValueError("Invalid refund test type")
-    if gas_used < tx_floor_data_cost:
-        gas_used = tx_floor_data_cost
+    if gas_used_after_refund < tx_floor_data_cost:
+        gas_used_after_refund = tx_floor_data_cost
+
+    if gas_used_before_refund < tx_floor_data_cost:
+        gas_used_before_refund = tx_floor_data_cost
+
     # This is the actual test verification:
     #   - During test filling, the receipt returned by the transition tool
     #     (t8n) is verified against the expected receipt.
     #   - During test consumption, this is reflected in the balance difference
     #     and the state root.
     if fork >= Amsterdam:
-        tx.expected_receipt = TransactionReceipt(gas_spent=gas_used)
+        tx.expected_receipt = TransactionReceipt(
+            gas_spent=gas_used_after_refund, gas_used=gas_used_before_refund
+        )
     else:
-        tx.expected_receipt = TransactionReceipt(gas_used=gas_used)
+        tx.expected_receipt = TransactionReceipt(
+            gas_used=gas_used_after_refund
+        )
 
     state_test(
         pre=pre,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2926,7 +2926,8 @@ def test_set_code_to_precompile_not_enough_gas_for_precompile_execution(
 
     if fork >= Amsterdam:
         expected_receipt = TransactionReceipt(
-            gas_spent=intrinsic_gas - discount
+            gas_spent=intrinsic_gas - discount,
+            gas_used=intrinsic_gas,
         )
     else:
         expected_receipt = TransactionReceipt(

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -42,6 +42,7 @@ from execution_testing import (
 )
 from execution_testing import Macros as Om
 from execution_testing.base_types import HexNumber
+from execution_testing.forks import Amsterdam
 
 from ...cancun.eip4844_blobs.spec import Spec as Spec4844
 from ..eip6110_deposits.helpers import DepositRequest
@@ -2923,6 +2924,15 @@ def test_set_code_to_precompile_not_enough_gas_for_precompile_execution(
         intrinsic_gas // 5,  # max discount EIP-3529
     )
 
+    if fork >= Amsterdam:
+        expected_receipt = TransactionReceipt(
+            gas_spent=intrinsic_gas - discount
+        )
+    else:
+        expected_receipt = TransactionReceipt(
+            gas_used=intrinsic_gas - discount
+        )
+
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=auth_signer,
@@ -2930,7 +2940,7 @@ def test_set_code_to_precompile_not_enough_gas_for_precompile_execution(
         value=1,
         authorization_list=[auth],
         # explicitly check expected gas, no precompile code executed
-        expected_receipt=TransactionReceipt(gas_used=intrinsic_gas - discount),
+        expected_receipt=expected_receipt,
     )
 
     state_test(


### PR DESCRIPTION
## 🗒️ Description
Fix legacy tests to run with EIP-7778

## 🔗 Related Issues or PRs
#1401

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


#### Cute Animal Picture

![Cute Animals - 2 of 12](https://github.com/user-attachments/assets/4a907bb6-ad6f-439b-8998-e452134349d4)

