### PR TITLE
fix(tools): fix remaining lint checks after large ruff refactor

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -33,7 +33,8 @@ def fixture_format_discriminator(v: Any) -> str | None:
         info_dict = v.info
     if info_dict is None:
         raise ValueError(
-            f"Fixture does not have an info field, cannot determine fixture format: {v}"
+            "Fixture does not have an info field, "
+            f"cannot determine fixture format: {v}"
         )
     fixture_format = info_dict.get("fixture-format")
     if not fixture_format:

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -97,11 +97,13 @@ def post_state_validator(
 
                 if field1_value is None and field2_value is None:
                     raise ValueError(
-                        f"Either {field1_name} or {field2_name} must be provided."
+                        f"Either {field1_name} or {field2_name} "
+                        "must be provided."
                     )
                 if field1_value is not None and field2_value is not None:
                     raise ValueError(
-                        f"Only one of {field1_name} or {field2_name} must be provided."
+                        f"Only one of {field1_name} or {field2_name} "
+                        "must be provided."
                     )
             return self
 
@@ -145,8 +147,8 @@ class FixtureHeader(CamelModel):
     We combine the `Environment` and `Result` contents to create this model.
     """
 
-    # Allow extra fields: FixtureHeader is constructed from merged Result and
-    # Environment data via model_dump(), which includes fields not in this model.
+    # Allow extra fields: FixtureHeader is constructed from merged Result
+    # and Environment data via model_dump(), which has extra fields.
     model_config = CamelModel.model_config | {"extra": "ignore"}
 
     parent_hash: Hash = Hash(0)
@@ -286,10 +288,11 @@ class FixtureHeader(CamelModel):
         timestamp: int = 0,
     ) -> Any:
         """
-        Get appropriate default value for a header field based on its type hint.
+        Get default value for a header field based on its type hint.
 
         This method handles:
-        1. Fork requirement checking - only returns a default if the fork requires the field
+        1. Fork requirement checking - only returns a default if the fork
+           requires the field
         2. Model-defined defaults - uses the field's default value if available
         3. Type-based defaults - constructs defaults based on the field type
 
@@ -297,7 +300,8 @@ class FixtureHeader(CamelModel):
             fork: Fork to check requirements against
             field_name: Name of the field
             field_hint: Type annotation of the field
-            block_number: Block number for fork requirement checking (default: 0)
+            block_number: Block number for fork requirement checking
+                (default: 0)
             timestamp: Timestamp for fork requirement checking (default: 0)
 
         Returns:
@@ -305,9 +309,11 @@ class FixtureHeader(CamelModel):
             the field is not required by the fork
 
         Raises:
-            TypeError: If the field type is not supported and no default value
-                is defined in the model. This indicates that support for the type
-                needs to be added or an explicit default must be provided.
+            TypeError: If the field type is not supported and no default
+                value is defined in the model. This indicates that support
+                for the type needs to be added or an explicit default must
+                be provided.
+
         """
         # Check if this field has a HeaderForkRequirement annotation
         header_fork_requirement = HeaderForkRequirement.get_from_annotation(
@@ -315,13 +321,18 @@ class FixtureHeader(CamelModel):
         )
         if header_fork_requirement is not None:
             # Only provide a default if the fork requires this field
-            if not header_fork_requirement.required(fork, block_number, timestamp):
+            if not header_fork_requirement.required(
+                fork, block_number, timestamp
+            ):
                 return None
 
         # Check if the field has a default value defined in the model
         if field_name in cls.model_fields:
             field_info = cls.model_fields[field_name]
-            if field_info.default is not None and field_info.default is not PydanticUndefined:
+            if (
+                field_info.default is not None
+                and field_info.default is not PydanticUndefined
+            ):
                 return field_info.default
             if field_info.default_factory is not None:
                 return field_info.default_factory()  # type: ignore[call-arg]
@@ -339,11 +350,11 @@ class FixtureHeader(CamelModel):
         elif actual_type == Bytes:
             return Bytes(b"")
         else:
-            # Unsupported type - raise an error to catch this during development
+            # Unsupported type - raise error to catch this during development
             raise TypeError(
                 f"Cannot generate default value for field '{field_name}' "
                 f"with unsupported type '{actual_type}'. "
-                f"Add support for this type or provide a default value explicitly."
+                "Add support for this type or provide a default explicitly."
             )
 
     @classmethod
@@ -501,7 +512,8 @@ class FixtureEngineNewPayload(CamelModel):
         ):
             if block_access_list is None:
                 raise ValueError(
-                    f"`block_access_list` is required in engine `ExecutionPayload` for >={fork}."
+                    "`block_access_list` is required in engine "
+                    f"`ExecutionPayload` for >={fork}."
                 )
 
         execution_payload = FixtureExecutionPayload.from_fixture_header(
@@ -609,8 +621,9 @@ class FixtureBlockBase(CamelModel):
     @classmethod
     def strip_block_number_computed_field(cls, data: Any) -> Any:
         """
-        Strip the block_number computed field which gets included in model_dump()
-        but is not a valid input field.
+        Strip the block_number computed field included in model_dump().
+
+        This field is not a valid input field.
         """
         if isinstance(data, dict):
             data.pop("blocknumber", None)
@@ -785,7 +798,7 @@ class BlockchainEngineXFixture(BlockchainEngineFixtureCommon):
     """
 
     # Allow extra fields: BlockchainEngineXFixture is constructed from shared
-    # fixture_data that includes fields for other fixture formats (e.g. genesis).
+    # fixture_data that has fields for other fixture formats (e.g. genesis).
     model_config = CamelModel.model_config | {"extra": "ignore"}
 
     format_name: ClassVar[str] = "blockchain_test_engine_x"
@@ -824,7 +837,8 @@ class BlockchainEngineSyncFixture(BlockchainEngineFixture):
 
     format_name: ClassVar[str] = "blockchain_test_sync"
     description: ClassVar[str] = (
-        "Tests that generate a blockchain test fixture for Engine API testing with client sync."
+        "Tests that generate a blockchain test fixture for Engine API "
+        "testing with client sync."
     )
     sync_payload: FixtureEngineNewPayload | None = None
 

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -84,7 +84,8 @@ class TestInfo:
                 str(test_module_relative_dir).replace(os.sep, "__")
             )
         test_name, test_parameter_string = self.get_name_and_parameters()
-        flat_path = f"{str(test_module_relative_dir).replace(os.sep, '__')}__{test_name}"
+        dir_str = str(test_module_relative_dir).replace(os.sep, "__")
+        flat_path = f"{dir_str}__{test_name}"
         if level == "test_function":
             return Path(base_dump_dir) / flat_path
         elif level == "test_parameter":

--- a/packages/testing/src/execution_testing/fixtures/common.py
+++ b/packages/testing/src/execution_testing/fixtures/common.py
@@ -52,7 +52,7 @@ class FixtureAuthorizationTuple(
     """Authorization tuple for fixture transactions."""
 
     # Allow extra fields: FixtureAuthorizationTuple is constructed from
-    # AuthorizationTuple via model_dump(), which includes fields not in this model.
+    # AuthorizationTuple via model_dump(), which has extra fields.
     model_config = CamelModel.model_config | {"extra": "ignore"}
 
     v: ZeroPaddedHexNumber = Field(

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -178,7 +178,7 @@ class ModelDumpCache:
     model_dump_mode: Literal["json", "python"]
     """Mode of the model dump when `model_dump` is called."""
     model_dump_type: Literal["string", "dict"]
-    """Whether `model_dump_json` or `model_dump` was used to generate the data."""
+    """Whether `model_dump_json` or `model_dump` was used to generate data."""
     data: Any
 
 
@@ -197,7 +197,7 @@ class GroupPreAlloc(Alloc):
     _model_dump_cache: ModelDumpCache | None = PrivateAttr(None)
 
     def state_root(self) -> Hash:
-        """On pre-alloc groups, which are normally very big, we always cache."""
+        """On pre-alloc groups, which are normally very big, always cache."""
         if self._cached_state_root is not None:
             return self._cached_state_root
         return super().state_root()
@@ -230,7 +230,7 @@ class GroupPreAlloc(Alloc):
         return data
 
     def model_dump_json(self, **kwargs: Any) -> str:
-        """Model dump the pre-allocation group in JSON string format, with caching."""
+        """Model dump the pre-allocation group in JSON string, with caching."""
         if (
             self._model_dump_cache is not None
             and self._model_dump_cache.model_dump_mode == "json"

--- a/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
@@ -87,8 +87,8 @@ fixture_header_ones = FixtureHeader(
                 "gasLimit": "0x5208",
                 "gasPrice": "0x0a",
                 "v": "0x26",
-                "r": "0xcc61d852649c34cc0b71803115f38036ace257d2914f087bf885e6806a664fbd",
-                "s": "0x2020cb35f5d7731ab540d62614503a7f2344301a86342f67daf011c1341551ff",
+                "r": "0xcc61d852649c34cc0b71803115f38036ace257d2914f087bf885e6806a664fbd",  # noqa: E501
+                "s": "0x2020cb35f5d7731ab540d62614503a7f2344301a86342f67daf011c1341551ff",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_0_default_values",
@@ -108,8 +108,8 @@ fixture_header_ones = FixtureHeader(
                 "gasLimit": "0x5208",
                 "gasPrice": "0x0a",
                 "v": "0x25",
-                "r": "0x1cfe2cbb0c3577f74d9ae192a7f1ee2d670fe806a040f427af9cb768be3d07ce",
-                "s": "0x0cbe2d029f52dbf93ade486625bed0603945d2c7358b31de99fe8786c00f13da",
+                "r": "0x1cfe2cbb0c3577f74d9ae192a7f1ee2d670fe806a040f427af9cb768be3d07ce",  # noqa: E501
+                "s": "0x0cbe2d029f52dbf93ade486625bed0603945d2c7358b31de99fe8786c00f13da",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_0_contract_creation",
@@ -130,8 +130,8 @@ fixture_header_ones = FixtureHeader(
                 "gasPrice": "0x0a",
                 "accessList": [],
                 "v": "0x01",
-                "r": "0x58b4ddaa529492d32b6bc8327eb8ee0bc8b535c3bfc0f4f1db3d7c16b51d1851",
-                "s": "0x5ef19167661b14d06dfc785bf62693e6f9e5a44e7c11e0320efed27b27294970",
+                "r": "0x58b4ddaa529492d32b6bc8327eb8ee0bc8b535c3bfc0f4f1db3d7c16b51d1851",  # noqa: E501
+                "s": "0x5ef19167661b14d06dfc785bf62693e6f9e5a44e7c11e0320efed27b27294970",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_1_default_values",
@@ -155,8 +155,8 @@ fixture_header_ones = FixtureHeader(
                 "maxFeePerGas": "0x07",
                 "accessList": [],
                 "v": "0x00",
-                "r": "0x33fc39081d01f8e7f0ce5426d4a00a7b07c2edea064d24a8cac8e4b1f0c08298",
-                "s": "0x4635e1c45238697db38e37070d4fce27fb5684f9dec4046466ea42a9834bad0a",
+                "r": "0x33fc39081d01f8e7f0ce5426d4a00a7b07c2edea064d24a8cac8e4b1f0c08298",  # noqa: E501
+                "s": "0x4635e1c45238697db38e37070d4fce27fb5684f9dec4046466ea42a9834bad0a",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_2_default_values",
@@ -185,8 +185,8 @@ fixture_header_ones = FixtureHeader(
                 "accessList": [],
                 "blobVersionedHashes": [],
                 "v": "0x01",
-                "r": "0x8978475a00bf155bf5687dfda89c2df55ef6c341cdfd689aeaa6c519569a530a",
-                "s": "0x66fc34935cdd191441a12a2e7b1f224cb40b928afb9bc89c8ddb2b78c19342cc",
+                "r": "0x8978475a00bf155bf5687dfda89c2df55ef6c341cdfd689aeaa6c519569a530a",  # noqa: E501
+                "s": "0x66fc34935cdd191441a12a2e7b1f224cb40b928afb9bc89c8ddb2b78c19342cc",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_3_default_values",
@@ -224,15 +224,15 @@ fixture_header_ones = FixtureHeader(
                         "address": Address(2).hex(),
                         "nonce": "0x03",
                         "v": "0x00",
-                        "r": "0xda29c3bd0304ae475b06d1a11344e0b6d75590f2c23138c9507f4b5bedde3c79",
-                        "s": "0x3e1fb143ae0460373d567cf901645757b321e42c423a53b2d46ed13c9ef0a9ab",
+                        "r": "0xda29c3bd0304ae475b06d1a11344e0b6d75590f2c23138c9507f4b5bedde3c79",  # noqa: E501
+                        "s": "0x3e1fb143ae0460373d567cf901645757b321e42c423a53b2d46ed13c9ef0a9ab",  # noqa: E501
                         "signer": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                         "yParity": "0x00",
                     }
                 ],
                 "v": "0x01",
-                "r": "0xe7da7f244c95cea73ac6316971139ac0eb8fad455d9a25e1c134d7a157c38ff9",
-                "s": "0x1939185d2e2a2b3375183e42b5755d695efbd72e186cf9a3e6958a3fb84cc709",
+                "r": "0xe7da7f244c95cea73ac6316971139ac0eb8fad455d9a25e1c134d7a157c38ff9",  # noqa: E501
+                "s": "0x1939185d2e2a2b3375183e42b5755d695efbd72e186cf9a3e6958a3fb84cc709",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_type_4",
@@ -262,7 +262,7 @@ fixture_header_ones = FixtureHeader(
                 "to": "0x0000000000000000000000000000000000001234",
                 "accessList": [
                     {
-                        "address": "0x0000000000000000000000000000000000001234",
+                        "address": "0x0000000000000000000000000000000000001234",  # noqa: E501
                         "storageKeys": [
                             "0x0000000000000000000000000000000000000000000000000000000000000000",
                             "0x0000000000000000000000000000000000000000000000000000000000000001",
@@ -280,8 +280,8 @@ fixture_header_ones = FixtureHeader(
                     "0x0000000000000000000000000000000000000000000000000000000000000001",
                 ],
                 "v": "0x00",
-                "r": "0x418bb557c43262375f80556cb09dac5e67396acf0eaaf2c2540523d1ce54b280",
-                "s": "0x4fa36090ea68a1138043d943ced123c0b0807d82ff3342a6977cbc09230e927c",
+                "r": "0x418bb557c43262375f80556cb09dac5e67396acf0eaaf2c2540523d1ce54b280",  # noqa: E501
+                "s": "0x4fa36090ea68a1138043d943ced123c0b0807d82ff3342a6977cbc09230e927c",  # noqa: E501
                 "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             },
             id="fixture_transaction_3",
@@ -321,7 +321,7 @@ fixture_header_ones = FixtureHeader(
                 "extraData": Bytes([12]).hex(),
                 "mixHash": Hash(13).hex(),
                 "nonce": HeaderNonce(14).hex(),
-                "hash": "0x1dc087517148c2d6a1dd1ea5de107bc5f728414f9d210ed18286d305abe6ba5e",
+                "hash": "0x1dc087517148c2d6a1dd1ea5de107bc5f728414f9d210ed18286d305abe6ba5e",  # noqa: E501
             },
             id="fixture_header_1",
         ),
@@ -368,7 +368,7 @@ fixture_header_ones = FixtureHeader(
                 "withdrawalsRoot": Hash(16).hex(),
                 "blobGasUsed": ZeroPaddedHexNumber(17).hex(),
                 "excessBlobGas": ZeroPaddedHexNumber(18).hex(),
-                "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",
+                "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",  # noqa: E501
             },
             id="fixture_header_2",
         ),
@@ -423,7 +423,7 @@ fixture_header_ones = FixtureHeader(
                     "withdrawalsRoot": Hash(16).hex(),
                     "blobGasUsed": ZeroPaddedHexNumber(17).hex(),
                     "excessBlobGas": ZeroPaddedHexNumber(18).hex(),
-                    "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",
+                    "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",  # noqa: E501
                 },
                 "blocknumber": "8",
                 "uncleHeaders": [],
@@ -438,8 +438,8 @@ fixture_header_ones = FixtureHeader(
                         "gasLimit": "0x5208",
                         "gasPrice": "0x0a",
                         "v": "0x26",
-                        "r": "0xcc61d852649c34cc0b71803115f38036ace257d2914f087bf885e6806a664fbd",
-                        "s": "0x2020cb35f5d7731ab540d62614503a7f2344301a86342f67daf011c1341551ff",
+                        "r": "0xcc61d852649c34cc0b71803115f38036ace257d2914f087bf885e6806a664fbd",  # noqa: E501
+                        "s": "0x2020cb35f5d7731ab540d62614503a7f2344301a86342f67daf011c1341551ff",  # noqa: E501
                         "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                     }
                 ],
@@ -497,7 +497,7 @@ fixture_header_ones = FixtureHeader(
                     "withdrawalsRoot": Hash(16).hex(),
                     "blobGasUsed": ZeroPaddedHexNumber(17).hex(),
                     "excessBlobGas": ZeroPaddedHexNumber(18).hex(),
-                    "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",
+                    "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",  # noqa: E501
                 },
                 "blocknumber": "8",
                 "uncleHeaders": [],
@@ -512,8 +512,8 @@ fixture_header_ones = FixtureHeader(
                         "gasLimit": "0x5208",
                         "gasPrice": "0x0a",
                         "v": "0x25",
-                        "r": "0x1cfe2cbb0c3577f74d9ae192a7f1ee2d670fe806a040f427af9cb768be3d07ce",
-                        "s": "0x0cbe2d029f52dbf93ade486625bed0603945d2c7358b31de99fe8786c00f13da",
+                        "r": "0x1cfe2cbb0c3577f74d9ae192a7f1ee2d670fe806a040f427af9cb768be3d07ce",  # noqa: E501
+                        "s": "0x0cbe2d029f52dbf93ade486625bed0603945d2c7358b31de99fe8786c00f13da",  # noqa: E501
                         "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                     }
                 ],
@@ -540,7 +540,7 @@ fixture_header_ones = FixtureHeader(
             ),
             {
                 "rlp": "0x00",
-                "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW",
+                "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW",  # noqa: E501
             },
             id="invalid_fixture_block_2",
         ),
@@ -554,7 +554,7 @@ fixture_header_ones = FixtureHeader(
             ),
             {
                 "rlp": "0x00",
-                "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW",
+                "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW",  # noqa: E501
             },
             id="invalid_fixture_block_3",
         ),
@@ -635,7 +635,7 @@ fixture_header_ones = FixtureHeader(
                 "baseFeePerGas": hex(15),
                 "blobGasUsed": hex(17),
                 "excessBlobGas": hex(18),
-                "blockHash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",
+                "blockHash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",  # noqa: E501
                 "transactions": [
                     Transaction(
                         to=0x1234,
@@ -1008,9 +1008,7 @@ class TestPydanticModelConversion:
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
         if not can_be_deserialized:
-            pytest.skip(
-                reason="The model instance in this case can not be deserialized"
-            )
+            pytest.skip(reason="Model instance cannot be deserialized")
         model_type = type(model_instance)
         assert model_type(**json_repr) == model_instance
 
@@ -1412,7 +1410,5 @@ class TestPydanticAdaptersConversion:
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
         if not can_be_deserialized:
-            pytest.skip(
-                reason="The model instance in this case can not be deserialized"
-            )
+            pytest.skip(reason="Model instance cannot be deserialized")
         assert adapter.validate_python(json_repr) == type_instance

--- a/packages/testing/src/execution_testing/fixtures/tests/test_state.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_state.py
@@ -43,7 +43,7 @@ from ..state import FixtureForkPost
                 "hash": Hash(0).hex(),
                 "logs": Hash(1).hex(),
                 "txbytes": Bytes(b"\x02").hex(),
-                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED",
+                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED",  # noqa: E501
                 "indexes": {"data": 0, "gas": 0, "value": 0},
                 "state": {},
             },
@@ -64,7 +64,7 @@ from ..state import FixtureForkPost
                 "hash": Hash(0).hex(),
                 "logs": Hash(1).hex(),
                 "txbytes": Bytes(b"\x02").hex(),
-                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED",
+                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED",  # noqa: E501
                 "indexes": {"data": 0, "gas": 0, "value": 0},
                 "state": {},
             },
@@ -86,7 +86,7 @@ from ..state import FixtureForkPost
                 "hash": Hash(0).hex(),
                 "logs": Hash(1).hex(),
                 "txbytes": Bytes(b"\x02").hex(),
-                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED|"
+                "expectException": "TransactionException.INITCODE_SIZE_EXCEEDED|"  # noqa: E501
                 "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS",
                 "indexes": {"data": 0, "gas": 0, "value": 0},
                 "state": {},
@@ -116,8 +116,6 @@ class TestPydanticModelConversion:
     ) -> None:
         """Test that to_json returns the expected JSON for the given object."""
         if not can_be_deserialized:
-            pytest.skip(
-                reason="The model instance in this case can not be deserialized"
-            )
+            pytest.skip(reason="Model instance cannot be deserialized")
         model_type = type(model_instance)
         assert model_type(**json) == model_instance


### PR DESCRIPTION
## 🗒️ Description

This PR fixes some remaining issues with `static` check after merging #2046.

## 🔗 Related Issues or PRs

#2046 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.TRgXiakp41Y87qWeCT40RgHaDs%3Fpid%3DApi&f=1&ipt=36892248a1c555de7bf83c19fc4d7ffb9cb598b85f17cedf938e106a3e03eb1c&ipo=images)
