### PR TITLE
feat(tests): turn on EIP-7934 tests with BALs

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -23,6 +23,5 @@ benchmark_fast:
 
 bal:
   evm-type: develop
-  # TODO: Turn on block rlp limit tests after making filling them more flexible.
-  fill-params: --fork=Amsterdam -k "not eip7934" --fill-static-tests
+  fill-params: --fork=Amsterdam --fill-static-tests
   feature_only: true


### PR DESCRIPTION
## 🗒️ Description

#2022 fixed EIP-7934 tests to account for new header fields but we did not turn these on for `bal` feature releases. This small change turns on all tests for the next `bal` pre-release, including EIP-7934 tests which can now fill for Amsterdam.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="976" height="772" alt="Screenshot 2026-01-21 at 16 56 56" src="https://github.com/user-attachments/assets/da04a679-5930-4262-a8a1-df7fd73da442" />
