### PR TITLE
refactor(spec): refactor `execute_code` into `process_message`

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -45,7 +45,6 @@ from ..state import (
     set_code,
 )
 from ..state_tracker import (
-    StateChanges,
     capture_pre_balance,
     capture_pre_code,
     merge_on_failure,
@@ -270,6 +269,28 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
+    code = message.code
+    valid_jump_destinations = get_valid_jump_destinations(code)
+    evm = Evm(
+        pc=Uint(0),
+        stack=[],
+        memory=bytearray(),
+        code=code,
+        gas_left=message.gas,
+        valid_jump_destinations=valid_jump_destinations,
+        logs=(),
+        refund_counter=0,
+        running=True,
+        message=message,
+        output=b"",
+        accounts_to_delete=set(),
+        return_data=b"",
+        error=None,
+        accessed_addresses=message.accessed_addresses,
+        accessed_storage_keys=message.accessed_storage_keys,
+        state_changes=message.state_changes,
+    )
+
     # take snapshot of state before processing the message
     begin_transaction(state, transient_storage)
 
@@ -310,57 +331,6 @@ def process_message(message: Message) -> Evm:
             U256(recipient_new_balance),
         )
 
-    evm = execute_code(message, message.state_changes)
-    if evm.error:
-        rollback_transaction(state, transient_storage)
-        if not message.is_create:
-            merge_on_failure(evm.state_changes)
-    else:
-        commit_transaction(state, transient_storage)
-        if not message.is_create:
-            merge_on_success(evm.state_changes)
-    return evm
-
-
-def execute_code(message: Message, state_changes: StateChanges) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-    state_changes :
-        The state changes frame to use for tracking.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
-    code = message.code
-    valid_jump_destinations = get_valid_jump_destinations(code)
-
-    evm = Evm(
-        pc=Uint(0),
-        stack=[],
-        memory=bytearray(),
-        code=code,
-        gas_left=message.gas,
-        valid_jump_destinations=valid_jump_destinations,
-        logs=(),
-        refund_counter=0,
-        running=True,
-        message=message,
-        output=b"",
-        accounts_to_delete=set(),
-        return_data=b"",
-        error=None,
-        accessed_addresses=message.accessed_addresses,
-        accessed_storage_keys=message.accessed_storage_keys,
-        state_changes=state_changes,
-    )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             if not message.disable_precompiles:
@@ -374,11 +344,11 @@ def execute_code(message: Message, state_changes: StateChanges) -> Evm:
                 except ValueError as e:
                     raise InvalidOpcode(evm.code[evm.pc]) from e
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -388,4 +358,13 @@ def execute_code(message: Message, state_changes: StateChanges) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        rollback_transaction(state, transient_storage)
+        if not message.is_create:
+            merge_on_failure(evm.state_changes)
+    else:
+        commit_transaction(state, transient_storage)
+        if not message.is_create:
+            merge_on_success(evm.state_changes)
     return evm

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -363,18 +363,16 @@ def execute_code(message: Message, state_changes: StateChanges) -> Evm:
     )
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            if message.disable_precompiles:
-                return evm
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
-            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
-            return evm
-
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+            if not message.disable_precompiles:
+                evm_trace(evm, PrecompileStart(evm.message.code_address))
+                PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
+                evm_trace(evm, PrecompileEnd())
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
             evm_trace(evm, OpStart(op))
             op_implementation[op](evm)

--- a/src/ethereum/forks/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/arrow_glacier/vm/interpreter.py
@@ -225,44 +225,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -282,24 +246,34 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -309,4 +283,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/berlin/vm/interpreter.py
+++ b/src/ethereum/forks/berlin/vm/interpreter.py
@@ -221,44 +221,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -278,24 +242,34 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -305,4 +279,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/byzantium/vm/interpreter.py
+++ b/src/ethereum/forks/byzantium/vm/interpreter.py
@@ -214,44 +214,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -269,24 +233,34 @@ def execute_code(message: Message) -> Evm:
         return_data=b"",
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -296,4 +270,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/cancun/vm/interpreter.py
+++ b/src/ethereum/forks/cancun/vm/interpreter.py
@@ -218,42 +218,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state, transient_storage)
-    else:
-        commit_transaction(state, transient_storage)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -272,24 +238,32 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state, transient_storage)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -299,4 +273,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state, transient_storage)
+    else:
+        commit_transaction(state, transient_storage)
     return evm

--- a/src/ethereum/forks/constantinople/vm/interpreter.py
+++ b/src/ethereum/forks/constantinople/vm/interpreter.py
@@ -215,44 +215,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -270,24 +234,34 @@ def execute_code(message: Message) -> Evm:
         return_data=b"",
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -297,4 +271,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/frontier/vm/interpreter.py
+++ b/src/ethereum/forks/frontier/vm/interpreter.py
@@ -193,44 +193,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -246,27 +210,44 @@ def execute_code(message: Message) -> Evm:
         accounts_to_delete=set(),
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/gray_glacier/vm/interpreter.py
@@ -217,7 +217,7 @@ def process_message(message: Message) -> Evm:
 
     Returns
     -------
-    evm: :py:class:`~ethereum.forks.gray_glacier.vm.Evm`
+    evm: :py:class:`~ethereum.forks.arrow_glacier.vm.Evm`
         Items containing execution specific objects
 
     """
@@ -225,44 +225,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -282,24 +246,34 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -309,4 +283,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/istanbul/vm/interpreter.py
+++ b/src/ethereum/forks/istanbul/vm/interpreter.py
@@ -221,44 +221,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -276,24 +240,34 @@ def execute_code(message: Message) -> Evm:
         return_data=b"",
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -303,4 +277,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/london/vm/interpreter.py
+++ b/src/ethereum/forks/london/vm/interpreter.py
@@ -225,44 +225,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -282,24 +246,35 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -309,4 +284,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/muir_glacier/vm/interpreter.py
@@ -221,44 +221,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -276,24 +240,34 @@ def execute_code(message: Message) -> Evm:
         return_data=b"",
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -303,4 +277,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/paris/vm/interpreter.py
+++ b/src/ethereum/forks/paris/vm/interpreter.py
@@ -214,42 +214,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -268,24 +234,32 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -295,4 +269,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -267,7 +267,6 @@ def process_message(message: Message) -> Evm:
             state, message.caller, message.current_target, message.value
         )
 
-    # Execute message code and handle errors
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             if not message.disable_precompiles:

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -234,46 +234,12 @@ def process_message(message: Message) -> Evm:
 
     """
     state = message.block_env.state
-    transient_storage = message.tx_env.transient_storage
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state, transient_storage)
-    else:
-        commit_transaction(state, transient_storage)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
+    transient_storage = message.tx_env.transient_storage
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -292,26 +258,34 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state, transient_storage)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
+    # Execute message code and handle errors
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
-            if message.disable_precompiles:
-                return evm
-            evm_trace(evm, PrecompileStart(evm.message.code_address))
-            PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
-            evm_trace(evm, PrecompileEnd())
-            return evm
+            if not message.disable_precompiles:
+                evm_trace(evm, PrecompileStart(evm.message.code_address))
+                PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
+                evm_trace(evm, PrecompileEnd())
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -321,4 +295,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state, transient_storage)
+    else:
+        commit_transaction(state, transient_storage)
     return evm

--- a/src/ethereum/forks/shanghai/vm/interpreter.py
+++ b/src/ethereum/forks/shanghai/vm/interpreter.py
@@ -215,42 +215,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -269,24 +235,32 @@ def execute_code(message: Message) -> Evm:
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
@@ -296,4 +270,11 @@ def execute_code(message: Message) -> Evm:
     except Revert as error:
         evm_trace(evm, OpException(error))
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm

--- a/src/ethereum/forks/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/forks/spurious_dragon/vm/interpreter.py
@@ -212,44 +212,8 @@ def process_message(message: Message) -> Evm:
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
-    # take snapshot of state before processing the message
-    begin_transaction(state)
-
-    touch_account(state, message.current_target)
-
-    if message.should_transfer_value and message.value != 0:
-        move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-    evm = execute_code(message)
-    if evm.error:
-        # revert state to the last saved checkpoint
-        # since the message call resulted in an error
-        rollback_transaction(state)
-    else:
-        commit_transaction(state)
-    return evm
-
-
-def execute_code(message: Message) -> Evm:
-    """
-    Executes bytecode present in the `message`.
-
-    Parameters
-    ----------
-    message :
-        Transaction specific items.
-
-    Returns
-    -------
-    evm: `ethereum.vm.EVM`
-        Items containing execution specific objects
-
-    """
     code = message.code
     valid_jump_destinations = get_valid_jump_destinations(code)
-
     evm = Evm(
         pc=Uint(0),
         stack=[],
@@ -266,27 +230,44 @@ def execute_code(message: Message) -> Evm:
         touched_accounts=set(),
         error=None,
     )
+
+    # take snapshot of state before processing the message
+    begin_transaction(state)
+
+    touch_account(state, message.current_target)
+
+    if message.should_transfer_value and message.value != 0:
+        move_ether(
+            state, message.caller, message.current_target, message.value
+        )
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             evm_trace(evm, PrecompileStart(evm.message.code_address))
             PRE_COMPILED_CONTRACTS[evm.message.code_address](evm)
             evm_trace(evm, PrecompileEnd())
-            return evm
+        else:
+            while evm.running and evm.pc < ulen(evm.code):
+                try:
+                    op = Ops(evm.code[evm.pc])
+                except ValueError as e:
+                    raise InvalidOpcode(evm.code[evm.pc]) from e
 
-        while evm.running and evm.pc < ulen(evm.code):
-            try:
-                op = Ops(evm.code[evm.pc])
-            except ValueError as e:
-                raise InvalidOpcode(evm.code[evm.pc]) from e
+                evm_trace(evm, OpStart(op))
+                op_implementation[op](evm)
+                evm_trace(evm, OpEnd())
 
-            evm_trace(evm, OpStart(op))
-            op_implementation[op](evm)
-            evm_trace(evm, OpEnd())
-
-        evm_trace(evm, EvmStop(Ops.STOP))
+            evm_trace(evm, EvmStop(Ops.STOP))
 
     except ExceptionalHalt as error:
         evm_trace(evm, OpException(error))
         evm.gas_left = Uint(0)
         evm.error = error
+
+    if evm.error:
+        # revert state to the last saved checkpoint
+        # since the message call resulted in an error
+        rollback_transaction(state)
+    else:
+        commit_transaction(state)
     return evm


### PR DESCRIPTION
## 🗒️ Description

#2023 backported some changes but it would be good to get them into the development fork and bubble them back up through a rebase into the eips branches. This brings the changes merging `execute_code` logic with `process_message` into the development fork to be rebased back into the `eips/amsterdam/...` branches.

- Cherry-picked original commit
- Added support to all forks in subsequent commit

Based on original comment https://github.com/ethereum/execution-specs/pull/2023#discussion_r2694541641

## 🔗 Related Issues or PRs

#2023, commit 749581369d8998f1ab6beece8d3c85fd8e410a6d

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.explicit.bing.net%2Fth%2Fid%2FOIP.S7dX21NpuddElPGnuKBr-gHaEo%3Fpid%3DApi&f=1&ipt=5fbe1d0c4c40b839b2ac7cf68c85818795638cdcbc880f1c7f68321d666968b0&ipo=images)
