### PR TITLE
feat(specs): Introduce comprehensive state tracking objects

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -54,13 +54,6 @@ from .requests import (
 )
 from .state import (
     State,
-    TransientStorage,
-    account_exists_and_is_empty,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    modify_state,
-    set_account_balance,
     state_root,
 )
 from .state_tracker import (
@@ -74,6 +67,19 @@ from .state_tracker import (
     track_balance_change,
     track_nonce_change,
     track_selfdestruct,
+)
+from .state_tracking import (
+    BlockStateTracking,
+    TxStateTracking,
+    account_exists_and_is_empty,
+    bump_index,
+    destroy_account,
+    get_account,
+    incorporate_tx_state_into_parent,
+    increment_nonce,
+    modify_state,
+    set_account_balance,
+    write_block_state_changes,
 )
 from .transactions import (
     AccessListTransaction,
@@ -239,6 +245,14 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     block_env = vm.BlockEnvironment(
         chain_id=chain.chain_id,
         state=chain.state,
+        state_tracking=BlockStateTracking(
+            parent=chain.state,
+            current_index=Uint(0),
+            account_reads=set(),
+            storage_reads=set(),
+            account_writes={},
+            storage_writes={},
+        ),
         block_gas_limit=block.header.gas_limit,
         block_hashes=get_last_256_block_hashes(chain),
         coinbase=block.header.coinbase,
@@ -256,6 +270,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         transactions=block.transactions,
         withdrawals=block.withdrawals,
     )
+    write_block_state_changes(block_env.state_tracking)
     block_state_root = state_root(block_env.state)
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
@@ -488,7 +503,7 @@ def check_transaction(
         raise BlobGasLimitExceededError("blob gas limit exceeded")
 
     sender_address = recover_sender(block_env.chain_id, tx)
-    sender_account = get_account(block_env.state, sender_address)
+    sender_account = get_account(block_env.state_tracking, sender_address)
 
     if isinstance(
         tx, (FeeMarketTransaction, BlobTransaction, SetCodeTransaction)
@@ -644,12 +659,19 @@ def process_system_transaction(
         gas=SYSTEM_TRANSACTION_GAS,
         access_list_addresses=set(),
         access_list_storage_keys=set(),
-        transient_storage=TransientStorage(),
         blob_versioned_hashes=(),
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
         state_changes=system_tx_state_changes,
+        state_tracking=TxStateTracking(
+            parent=block_env.state_tracking,
+            account_reads=set(),
+            storage_reads=set(),
+            account_writes={},
+            storage_writes={},
+            created_accounts=set(),
+        ),
     )
 
     # Create call frame as child of tx frame
@@ -675,6 +697,15 @@ def process_system_transaction(
         parent_evm=None,
         is_create=False,
         state_changes=call_frame,
+        state_tracking=TxStateTracking(
+            parent=block_env.state_tracking,
+            account_reads=set(),
+            storage_reads=set(),
+            account_writes={},
+            storage_writes={},
+            created_accounts=set(),
+        ),
+        transient_storage={},
     )
 
     system_tx_output = process_message_call(system_tx_message)
@@ -682,6 +713,8 @@ def process_system_transaction(
     # Commit system transaction changes to block frame
     # System transactions always succeed (or block is invalid)
     commit_transaction_frame(tx_env.state_changes)
+
+    incorporate_tx_state_into_parent(system_tx_output.state_tracking)
 
     return system_tx_output
 
@@ -710,7 +743,9 @@ def process_checked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_contract_code = get_account(block_env.state, target_address).code
+    system_contract_code = get_account(
+        block_env.state_tracking, target_address
+    ).code
 
     if len(system_contract_code) == 0:
         raise InvalidBlock(
@@ -758,7 +793,9 @@ def process_unchecked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_contract_code = get_account(block_env.state, target_address).code
+    system_contract_code = get_account(
+        block_env.state_tracking, target_address
+    ).code
     return process_system_transaction(
         block_env,
         target_address,
@@ -912,6 +949,15 @@ def process_transaction(
         Index of the transaction in the block.
 
     """
+    tx_state_tracking = TxStateTracking(
+        parent=block_env.state_tracking,
+        account_reads=set(),
+        storage_reads=set(),
+        account_writes={},
+        storage_writes={},
+        created_accounts=set(),
+    )
+
     # EIP-7928: Create a transaction-level StateChanges frame
     # The frame will read the current block_access_index from the block frame
     increment_block_access_index(block_env.state_changes)
@@ -919,7 +965,7 @@ def process_transaction(
 
     # Capture coinbase pre-balance for net-zero filtering
     coinbase_pre_balance = get_account(
-        block_env.state, block_env.coinbase
+        tx_state_tracking, block_env.coinbase
     ).balance
     track_address(tx_state_changes, block_env.coinbase)
     capture_pre_balance(
@@ -945,7 +991,9 @@ def process_transaction(
         tx=tx,
     )
 
-    sender_account = get_account(block_env.state, sender)
+    bump_index(block_env.state_tracking)
+
+    sender_account = get_account(tx_state_tracking, sender)
 
     if isinstance(tx, BlobTransaction):
         blob_gas_fee = calculate_data_fee(block_env.excess_blob_gas, tx)
@@ -957,12 +1005,12 @@ def process_transaction(
     gas = tx.gas - intrinsic_gas
 
     # Track sender nonce increment
-    increment_nonce(block_env.state, sender)
-    sender_nonce_after = get_account(block_env.state, sender).nonce
+    increment_nonce(tx_state_tracking, sender)
+    sender_nonce_after = get_account(tx_state_tracking, sender).nonce
     track_nonce_change(tx_state_changes, sender, U64(sender_nonce_after))
 
     # Track sender balance deduction for gas fee
-    sender_balance_before = get_account(block_env.state, sender).balance
+    sender_balance_before = get_account(tx_state_tracking, sender).balance
     track_address(tx_state_changes, sender)
     capture_pre_balance(tx_state_changes, sender, sender_balance_before)
 
@@ -970,7 +1018,7 @@ def process_transaction(
         Uint(sender_account.balance) - effective_gas_fee - blob_gas_fee
     )
     set_account_balance(
-        block_env.state, sender, U256(sender_balance_after_gas_fee)
+        tx_state_tracking, sender, U256(sender_balance_after_gas_fee)
     )
     track_balance_change(
         tx_state_changes,
@@ -1005,12 +1053,12 @@ def process_transaction(
         gas=gas,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
-        transient_storage=TransientStorage(),
         blob_versioned_hashes=blob_versioned_hashes,
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
         state_changes=tx_state_changes,
+        state_tracking=tx_state_tracking,
     )
 
     message = prepare_message(
@@ -1020,6 +1068,8 @@ def process_transaction(
     )
 
     tx_output = process_message_call(message)
+
+    tx_state_tracking = tx_output.state_tracking
 
     # For EIP-7623 we first calculate the execution_gas_used, which includes
     # the execution gas refund.
@@ -1044,9 +1094,9 @@ def process_transaction(
 
     # refund gas
     sender_balance_after_refund = get_account(
-        block_env.state, sender
+        tx_state_tracking, sender
     ).balance + U256(gas_refund_amount)
-    set_account_balance(block_env.state, sender, sender_balance_after_refund)
+    set_account_balance(tx_state_tracking, sender, sender_balance_after_refund)
     track_balance_change(
         tx_env.state_changes,
         sender,
@@ -1054,11 +1104,13 @@ def process_transaction(
     )
 
     coinbase_balance_after_mining_fee = get_account(
-        block_env.state, block_env.coinbase
+        tx_state_tracking, block_env.coinbase
     ).balance + U256(transaction_fee)
 
     set_account_balance(
-        block_env.state, block_env.coinbase, coinbase_balance_after_mining_fee
+        tx_state_tracking,
+        block_env.coinbase,
+        coinbase_balance_after_mining_fee,
     )
     track_balance_change(
         tx_env.state_changes,
@@ -1067,9 +1119,9 @@ def process_transaction(
     )
 
     if coinbase_balance_after_mining_fee == 0 and account_exists_and_is_empty(
-        block_env.state, block_env.coinbase
+        tx_state_tracking, block_env.coinbase
     ):
-        destroy_account(block_env.state, block_env.coinbase)
+        destroy_account(tx_state_tracking, block_env.coinbase)
 
     block_output.block_gas_used += tx_gas_used_after_refund
     block_output.blob_gas_used += tx_blob_gas_used
@@ -1090,12 +1142,14 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
     for address in tx_output.accounts_to_delete:
-        destroy_account(block_env.state, address)
+        destroy_account(tx_state_tracking, address)
         track_selfdestruct(tx_env.state_changes, address)
 
     # EIP-7928: Commit transaction frame (includes net-zero filtering).
     # Must happen AFTER destroy_account so filtering sees correct state.
     commit_transaction_frame(tx_env.state_changes)
+
+    incorporate_tx_state_into_parent(tx_state_tracking)
 
 
 def process_withdrawals(
@@ -1109,7 +1163,7 @@ def process_withdrawals(
     # Capture pre-state for withdrawal balance filtering
     withdrawal_addresses = {wd.address for wd in withdrawals}
     for address in withdrawal_addresses:
-        pre_balance = get_account(block_env.state, address).balance
+        pre_balance = get_account(block_env.state_tracking, address).balance
         track_address(block_env.state_changes, address)
         capture_pre_balance(block_env.state_changes, address, pre_balance)
 
@@ -1123,17 +1177,22 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        modify_state(block_env.state, wd.address, increase_recipient_balance)
+        if wd.amount > U256(0):
+            modify_state(
+                block_env.state_tracking,
+                wd.address,
+                increase_recipient_balance,
+            )
 
-        new_balance = get_account(block_env.state, wd.address).balance
+        new_balance = get_account(block_env.state_tracking, wd.address).balance
         track_balance_change(
             block_env.state_changes,
             wd.address,
             new_balance,
         )
 
-        if account_exists_and_is_empty(block_env.state, wd.address):
-            destroy_account(block_env.state, wd.address)
+        # if account_exists_and_is_empty(block_env.state_tracking, wd.address):
+        #    destroy_account(block_env.state, wd.address)
 
     # EIP-7928: Filter net-zero balance changes for withdrawals
     filter_net_zero_frame_changes(block_env.state_changes)

--- a/src/ethereum/forks/amsterdam/state.py
+++ b/src/ethereum/forks/amsterdam/state.py
@@ -24,7 +24,7 @@ from ethereum_types.frozen import modify
 from ethereum_types.numeric import U256, Uint
 
 from .fork_types import EMPTY_ACCOUNT, Account, Address, Root
-from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
+from .trie import EMPTY_TRIE_ROOT, Trie, root, trie_get, trie_set
 
 if TYPE_CHECKING:
     from .vm import BlockEnvironment  # noqa: F401
@@ -51,19 +51,6 @@ class State:
     created_accounts: Set[Address] = field(default_factory=set)
 
 
-@dataclass
-class TransientStorage:
-    """
-    Contains all information that is preserved between message calls
-    within a transaction.
-    """
-
-    _tries: Dict[Address, Trie[Bytes32, U256]] = field(default_factory=dict)
-    _snapshots: List[Dict[Address, Trie[Bytes32, U256]]] = field(
-        default_factory=list
-    )
-
-
 def close_state(state: State) -> None:
     """
     Free resources held by the state. Used by optimized implementations to
@@ -73,77 +60,6 @@ def close_state(state: State) -> None:
     del state._storage_tries
     del state._snapshots
     del state.created_accounts
-
-
-def begin_transaction(
-    state: State, transient_storage: TransientStorage
-) -> None:
-    """
-    Start a state transaction.
-
-    Transactions are entirely implicit and can be nested. It is not possible to
-    calculate the state root during a transaction.
-
-    Parameters
-    ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
-
-    """
-    state._snapshots.append(
-        (
-            copy_trie(state._main_trie),
-            {k: copy_trie(t) for (k, t) in state._storage_tries.items()},
-        )
-    )
-    transient_storage._snapshots.append(
-        {k: copy_trie(t) for (k, t) in transient_storage._tries.items()}
-    )
-
-
-def commit_transaction(
-    state: State, transient_storage: TransientStorage
-) -> None:
-    """
-    Commit a state transaction.
-
-    Parameters
-    ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
-
-    """
-    state._snapshots.pop()
-    if not state._snapshots:
-        state.created_accounts.clear()
-
-    transient_storage._snapshots.pop()
-
-
-def rollback_transaction(
-    state: State, transient_storage: TransientStorage
-) -> None:
-    """
-    Rollback a state transaction, resetting the state to the point when the
-    corresponding `begin_transaction()` call was made.
-
-    Parameters
-    ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
-
-    """
-    state._main_trie, state._storage_tries = state._snapshots.pop()
-    if not state._snapshots:
-        state.created_accounts.clear()
-
-    transient_storage._tries = transient_storage._snapshots.pop()
 
 
 def get_account(state: State, address: Address) -> Account:
@@ -662,66 +578,3 @@ def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     assert isinstance(original_value, U256)
 
     return original_value
-
-
-def get_transient_storage(
-    transient_storage: TransientStorage, address: Address, key: Bytes32
-) -> U256:
-    """
-    Get a value at a storage key on an account from transient storage.
-    Returns `U256(0)` if the storage key has not been set previously.
-
-    Parameters
-    ----------
-    transient_storage: `TransientStorage`
-        The transient storage
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to lookup.
-
-    Returns
-    -------
-    value : `U256`
-        Value at the key.
-
-    """
-    trie = transient_storage._tries.get(address)
-    if trie is None:
-        return U256(0)
-
-    value = trie_get(trie, key)
-
-    assert isinstance(value, U256)
-    return value
-
-
-def set_transient_storage(
-    transient_storage: TransientStorage,
-    address: Address,
-    key: Bytes32,
-    value: U256,
-) -> None:
-    """
-    Set a value at a storage key on an account. Setting to `U256(0)` deletes
-    the key.
-
-    Parameters
-    ----------
-    transient_storage: `TransientStorage`
-        The transient storage
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to set.
-    value : `U256`
-        Value to set at the key.
-
-    """
-    trie = transient_storage._tries.get(address)
-    if trie is None:
-        trie = Trie(secured=True, default=U256(0))
-        transient_storage._tries[address] = trie
-    trie_set(trie, key, value)
-    if trie._data == {}:
-        del transient_storage._tries[address]

--- a/src/ethereum/forks/amsterdam/state_tracking.py
+++ b/src/ethereum/forks/amsterdam/state_tracking.py
@@ -1,0 +1,520 @@
+"""
+State Tracker.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from ethereum_types.bytes import Bytes, Bytes32
+from ethereum_types.frozen import modify
+from ethereum_types.numeric import U256, Uint
+
+from . import state as state_
+from .fork_types import EMPTY_ACCOUNT, Account, Address
+from .state import State
+
+BlockAccessIndex = Uint
+
+
+@dataclass
+class BlockStateTracking:
+    """
+    Tracking of state changes at the block level.
+    """
+
+    parent: State
+    current_index: BlockAccessIndex
+
+    account_reads: Set[Address]
+    storage_reads: Set[Tuple[Address, Bytes32]]
+
+    account_writes: Dict[
+        Address, List[Tuple[BlockAccessIndex, Optional[Account]]]
+    ]
+    storage_writes: Dict[
+        Address, Dict[Bytes32, List[Tuple[BlockAccessIndex, U256]]]
+    ]
+
+
+@dataclass
+class TxStateTracking:
+    """
+    Tracking of state changes within a transaction.
+    """
+
+    parent: BlockStateTracking
+
+    account_reads: Set[Address]
+    storage_reads: Set[Tuple[Address, Bytes32]]
+
+    account_writes: Dict[Address, Optional[Account]]
+    storage_writes: Dict[Address, Dict[Bytes32, U256]]
+
+    created_accounts: Set[Address]
+
+
+# get_account_optional
+# set_account
+# get_storage
+# set_storage
+# mark_account_created
+# destroy_storage
+
+
+def get_account_optional(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> Optional[Account]:
+    """FIXME."""
+    if isinstance(state, TxStateTracking):
+        if address in state.account_writes:
+            return state.account_writes[address]
+        else:
+            return get_account_optional(state.parent, address)
+    elif isinstance(state, BlockStateTracking):
+        if address in state.account_writes:
+            return state.account_writes[address][-1][1]
+        else:
+            return state_.get_account_optional(state.parent, address)
+
+
+def set_account(
+    state: TxStateTracking | BlockStateTracking,
+    address: Address,
+    account: Optional[Account],
+) -> None:
+    """FIXME."""
+    if isinstance(state, TxStateTracking):
+        state.account_writes[address] = account
+    elif isinstance(state, BlockStateTracking):
+        writes = state.account_writes.get(address, [])
+        if writes == [] or writes[-1][0] < state.current_index:
+            writes.append((state.current_index, account))
+        else:
+            writes[-1] = (state.current_index, account)
+        state.account_writes[address] = writes
+
+
+def get_storage(
+    state: TxStateTracking | BlockStateTracking, address: Address, key: Bytes32
+) -> U256:
+    """FIXME."""
+    if isinstance(state, TxStateTracking):
+        if key in state.storage_writes.get(address, {}):
+            return state.storage_writes[address][key]
+        else:
+            return get_storage(state.parent, address, key)
+    elif isinstance(state, BlockStateTracking):
+        writes = state.storage_writes.get(address, {}).get(key, [])
+        if writes == []:
+            return state_.get_storage(state.parent, address, key)
+        else:
+            return writes[-1][1]
+
+
+def set_storage(
+    state: TxStateTracking | BlockStateTracking,
+    address: Address,
+    key: Bytes32,
+    value: U256,
+) -> None:
+    """FIXME."""
+    if isinstance(state, TxStateTracking):
+        if address not in state.storage_writes:
+            state.storage_writes[address] = {}
+        state.storage_writes[address][key] = value
+    elif isinstance(state, BlockStateTracking):
+        writes = state.storage_writes.get(address, {}).get(key, [])
+        if writes == [] or writes[-1][0] < state.current_index:
+            writes.append((state.current_index, value))
+        else:
+            writes[-1] = (state.current_index, value)
+        if address not in state.storage_writes:
+            state.storage_writes[address] = {}
+        state.storage_writes[address][key] = writes
+
+
+def destroy_storage(state: TxStateTracking, address: Address) -> None:
+    """FIXME."""
+    if address in state.storage_writes:
+        del state.storage_writes[address]
+
+
+def bump_index(state: BlockStateTracking) -> None:
+    """FIXME."""
+    state.current_index += Uint(1)
+
+
+def mark_account_created(state: TxStateTracking, address: Address) -> None:
+    """FIXME."""
+    state.created_accounts.add(address)
+
+
+def incorporate_tx_state_into_parent(tx_state: TxStateTracking) -> None:
+    """
+    After a transaction has finished, write the final state changes to the
+    parent.
+    """
+    parent = tx_state.parent
+    parent.account_reads |= tx_state.account_reads
+    parent.storage_reads |= tx_state.storage_reads
+    for address, account in tx_state.account_writes.items():
+        set_account(parent, address, account)
+    for address, items in tx_state.storage_writes.items():
+        for key, value in items.items():
+            set_storage(parent, address, key, value)
+
+
+def write_block_state_changes(block_state: BlockStateTracking) -> None:
+    """
+    At the end of the block. Write the final state changes to the state object.
+
+    This is a temporary arrangement, until a future refactor abolishes the
+    state.
+    """
+    parent = block_state.parent
+    for address, writes in block_state.account_writes.items():
+        state_.set_account(parent, address, writes[-1][1])
+    for address, items in block_state.storage_writes.items():
+        for key, writes_ in items.items():
+            state_.set_storage(parent, address, key, writes_[-1][1])
+
+
+def copy_tx_state_tracking(tx_state: TxStateTracking) -> TxStateTracking:
+    """
+    Copy a `TxStateTracking`.
+    """
+    new_storage_writes = {}
+    for key, value in tx_state.storage_writes.items():
+        new_storage_writes[key] = value.copy()
+    return TxStateTracking(
+        parent=tx_state.parent,
+        account_reads=tx_state.account_reads.copy(),
+        storage_reads=tx_state.storage_reads.copy(),
+        account_writes=tx_state.account_writes.copy(),
+        storage_writes=new_storage_writes,
+        created_accounts=tx_state.created_accounts.copy(),
+    )
+
+
+####
+
+
+def get_account(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> Account:
+    """
+    Get the `Account` object at an address. Returns `EMPTY_ACCOUNT` if there
+    is no account at the address.
+
+    Use `get_account_optional()` if you care about the difference between a
+    non-existent account and `EMPTY_ACCOUNT`.
+
+    Parameters
+    ----------
+    state: `TxStateTracking | BlockStateTracking`
+        The state
+    address : `Address`
+        Address to lookup.
+
+    Returns
+    -------
+    account : `Account`
+        Account at address.
+
+    """
+    account = get_account_optional(state, address)
+    if isinstance(account, Account):
+        return account
+    else:
+        return EMPTY_ACCOUNT
+
+
+def destroy_account(state: TxStateTracking, address: Address) -> None:
+    """
+    Completely remove the account at `address` and all of its storage.
+
+    This function is made available exclusively for the `SELFDESTRUCT`
+    opcode. It is expected that `SELFDESTRUCT` will be disabled in a future
+    hardfork and this function will be removed.
+
+    Parameters
+    ----------
+    state: `TxStateTracking | BlockStateTracking`
+        The state
+    address : `Address`
+        Address of account to destroy.
+
+    """
+    destroy_storage(state, address)
+    set_account(state, address, None)
+
+
+def account_exists(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> bool:
+    """
+    Checks if an account exists in the state trie.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    account_exists : `bool`
+        True if account exists in the state trie, False otherwise
+
+    """
+    return get_account_optional(state, address) is not None
+
+
+def account_has_code_or_nonce(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> bool:
+    """
+    Checks if an account has non zero nonce or non empty code.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    has_code_or_nonce : `bool`
+        True if the account has non zero nonce or non empty code,
+        False otherwise.
+
+    """
+    account = get_account(state, address)
+    return account.nonce != Uint(0) or account.code != b""
+
+
+def account_exists_and_is_empty(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> bool:
+    """
+    Checks if an account exists and has zero nonce, empty code and zero
+    balance.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    exists_and_is_empty : `bool`
+        True if an account exists and has zero nonce, empty code and zero
+        balance, False otherwise.
+
+    """
+    account = get_account_optional(state, address)
+    return (
+        account is not None
+        and account.nonce == Uint(0)
+        and account.code == b""
+        and account.balance == 0
+    )
+
+
+def is_account_alive(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> bool:
+    """
+    Check whether an account is both in the state and non-empty.
+
+    Parameters
+    ----------
+    state:
+        The state
+    address:
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : `bool`
+        True if the account is alive.
+
+    """
+    account = get_account_optional(state, address)
+    return account is not None and account != EMPTY_ACCOUNT
+
+
+def modify_state(
+    state: TxStateTracking | BlockStateTracking,
+    address: Address,
+    f: Callable[[Account], None],
+) -> None:
+    """
+    Modify an `Account` in the `State`. If, after modification, the account
+    exists and has zero nonce, empty code, and zero balance, it is destroyed.
+    """
+    new_account = modify(get_account(state, address), f)
+
+    account_exists_and_is_empty = (
+        new_account is not None
+        and new_account.nonce == Uint(0)
+        and new_account.code == b""
+        and new_account.balance == 0
+    )
+
+    if account_exists_and_is_empty:
+        set_account(state, address, None)
+    else:
+        set_account(state, address, new_account)
+
+
+def move_ether(
+    state: TxStateTracking | BlockStateTracking,
+    sender_address: Address,
+    recipient_address: Address,
+    amount: U256,
+) -> None:
+    """
+    Move funds between accounts.
+    """
+
+    def reduce_sender_balance(sender: Account) -> None:
+        if sender.balance < amount:
+            raise AssertionError
+        sender.balance -= amount
+
+    def increase_recipient_balance(recipient: Account) -> None:
+        recipient.balance += amount
+
+    modify_state(state, sender_address, reduce_sender_balance)
+    modify_state(state, recipient_address, increase_recipient_balance)
+
+
+def set_account_balance(
+    state: TxStateTracking | BlockStateTracking, address: Address, amount: U256
+) -> None:
+    """
+    Sets the balance of an account.
+
+    Parameters
+    ----------
+    state:
+        The current state.
+
+    address:
+        Address of the account whose nonce needs to be incremented.
+
+    amount:
+        The amount that needs to set in balance.
+
+    """
+
+    def set_balance(account: Account) -> None:
+        account.balance = amount
+
+    modify_state(state, address, set_balance)
+
+
+def increment_nonce(
+    state: TxStateTracking | BlockStateTracking, address: Address
+) -> None:
+    """
+    Increments the nonce of an account.
+
+    Parameters
+    ----------
+    state:
+        The current state.
+
+    address:
+        Address of the account whose nonce needs to be incremented.
+
+    """
+
+    def increase_nonce(sender: Account) -> None:
+        sender.nonce += Uint(1)
+
+    modify_state(state, address, increase_nonce)
+
+
+def set_code(
+    state: TxStateTracking | BlockStateTracking, address: Address, code: Bytes
+) -> None:
+    """
+    Sets Account code.
+
+    Parameters
+    ----------
+    state:
+        The current state.
+
+    address:
+        Address of the account whose code needs to be update.
+
+    code:
+        The bytecode that needs to be set.
+
+    """
+
+    def write_code(sender: Account) -> None:
+        sender.code = code
+
+    modify_state(state, address, write_code)
+
+
+def set_authority_code(
+    state: TxStateTracking | BlockStateTracking, address: Address, code: Bytes
+) -> None:
+    """
+    Sets authority account code for EIP-7702 delegation.
+
+    This function is used specifically for setting authority code within
+    EIP-7702 Set Code Transactions.
+
+    Parameters
+    ----------
+    state:
+        The current state.
+
+    address:
+        Address of the authority account whose code needs to be set.
+
+    code:
+        The delegation designation bytecode to set.
+
+    """
+
+    def write_code(sender: Account) -> None:
+        sender.code = code
+
+    modify_state(state, address, write_code)
+
+
+def get_storage_original(
+    state: TxStateTracking, address: Address, key: Bytes32
+) -> U256:
+    """
+    Get the original value in a storage slot i.e. the value before the current
+    transaction began. This function reads the value from the snapshots taken
+    before executing the transaction.
+
+    Parameters
+    ----------
+    state:
+        The current state.
+    address:
+        Address of the account to read the value from.
+    key:
+        Key of the storage slot.
+
+    """
+    # In the transaction where an account is created, its preexisting storage
+    # is ignored.
+    if address in state.created_accounts:
+        return U256(0)
+
+    return get_storage(state.parent, address, key)

--- a/src/ethereum/forks/amsterdam/utils/message.py
+++ b/src/ethereum/forks/amsterdam/utils/message.py
@@ -16,8 +16,8 @@ from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import Uint
 
 from ..fork_types import Address
-from ..state import get_account
 from ..state_tracker import create_child_frame
+from ..state_tracking import get_account
 from ..transactions import Transaction
 from ..vm import BlockEnvironment, Message, TransactionEnvironment
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
@@ -55,7 +55,7 @@ def prepare_message(
     if isinstance(tx.to, Bytes0):
         current_target = compute_contract_address(
             tx_env.origin,
-            get_account(block_env.state, tx_env.origin).nonce - Uint(1),
+            get_account(tx_env.state_tracking, tx_env.origin).nonce - Uint(1),
         )
         msg_data = Bytes(b"")
         code = tx.data
@@ -63,7 +63,7 @@ def prepare_message(
     elif isinstance(tx.to, Address):
         current_target = tx.to
         msg_data = tx.data
-        code = get_account(block_env.state, tx.to).code
+        code = get_account(tx_env.state_tracking, tx.to).code
         code_address = tx.to
     else:
         raise AssertionError("Target must be address or empty bytes")
@@ -93,4 +93,6 @@ def prepare_message(
         parent_evm=None,
         is_create=isinstance(tx.to, Bytes0),
         state_changes=call_frame,
+        state_tracking=tx_env.state_tracking,
+        transient_storage={},
     )

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -13,7 +13,7 @@ The abstract computer which runs the code stored in an
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
 from ethereum_types.numeric import U64, U256, Uint
@@ -24,8 +24,12 @@ from ethereum.exceptions import EthereumException
 from ..block_access_lists.rlp_types import BlockAccessList
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Address, Authorization, VersionedHash
-from ..state import State, TransientStorage
+from ..state import State
 from ..state_tracker import StateChanges, merge_on_failure, merge_on_success
+from ..state_tracking import (
+    BlockStateTracking,
+    TxStateTracking,
+)
 from ..transactions import LegacyTransaction
 from ..trie import Trie
 
@@ -40,6 +44,7 @@ class BlockEnvironment:
 
     chain_id: U64
     state: State
+    state_tracking: BlockStateTracking
     block_gas_limit: Uint
     block_hashes: List[Hash32]
     coinbase: Address
@@ -108,12 +113,13 @@ class TransactionEnvironment:
     gas: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
-    transient_storage: TransientStorage
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
     state_changes: "StateChanges" = field(default_factory=StateChanges)
+    # FIXME
+    state_tracking: TxStateTracking = field(default=None)  # type: ignore
 
 
 @dataclass
@@ -141,6 +147,11 @@ class Message:
     parent_evm: Optional["Evm"]
     is_create: bool
     state_changes: "StateChanges" = field(default_factory=StateChanges)
+    # FIXME
+    state_tracking: TxStateTracking = field(default=None)  # type: ignore
+    transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
+        default_factory=dict
+    )
 
 
 @dataclass
@@ -164,6 +175,8 @@ class Evm:
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
     state_changes: StateChanges
+    state_tracking: TxStateTracking
+    transient_storage: Dict[Tuple[Address, Bytes32], U256]
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -184,6 +197,8 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.accounts_to_delete.update(child_evm.accounts_to_delete)
     evm.accessed_addresses.update(child_evm.accessed_addresses)
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
+    evm.state_tracking = child_evm.state_tracking
+    evm.transient_storage = child_evm.transient_storage
 
     merge_on_success(child_evm.state_changes)
 
@@ -201,5 +216,7 @@ def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
 
     """
     evm.gas_left += child_evm.gas_left
+    evm.state_tracking.account_reads |= child_evm.state_tracking.account_reads
+    evm.state_tracking.storage_reads |= child_evm.state_tracking.storage_reads
 
     merge_on_failure(child_evm.state_changes)

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -12,17 +12,17 @@ from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock, InvalidSignatureError
 
 from ..fork_types import Address, Authorization
-from ..state import (
-    account_exists,
-    get_account,
-    increment_nonce,
-    set_authority_code,
-)
 from ..state_tracker import (
     capture_pre_code,
     track_address,
     track_code_change,
     track_nonce_change,
+)
+from ..state_tracking import (
+    account_exists,
+    get_account,
+    increment_nonce,
+    set_authority_code,
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import GAS_COLD_ACCOUNT_ACCESS, GAS_WARM_ACCESS
@@ -143,8 +143,7 @@ def calculate_delegation_cost(
         The delegation address and access gas cost.
 
     """
-    state = evm.message.block_env.state
-
+    state = evm.state_tracking
     code = get_account(state, address).code
     track_address(evm.state_changes, address)
 
@@ -176,7 +175,7 @@ def set_delegation(message: Message) -> U256:
         Refund from authority which already exists in state.
 
     """
-    state = message.block_env.state
+    state = message.state_tracking
     refund_counter = U256(0)
     for auth in message.tx_env.authorizations:
         if auth.chain_id not in (message.block_env.chain_id, U256(0)):

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -19,8 +19,8 @@ from ethereum.utils.numeric import ceil32
 
 # track_address_access removed - now using state_changes.track_address()
 from ...fork_types import EMPTY_ACCOUNT
-from ...state import get_account
 from ...state_tracker import track_address
+from ...state_tracking import get_account
 from ...utils.address import to_address_masked
 from ...vm.memory import buffer_read, memory_write
 from .. import Evm
@@ -87,8 +87,7 @@ def balance(evm: Evm) -> None:
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
-    state = evm.message.block_env.state
-    balance = get_account(state, address).balance
+    balance = get_account(evm.state_tracking, address).balance
     track_address(evm.state_changes, address)
 
     push(evm.stack, balance)
@@ -356,8 +355,7 @@ def extcodesize(evm: Evm) -> None:
     charge_gas(evm, access_gas_cost)
 
     # OPERATION
-    state = evm.message.block_env.state
-    code = get_account(state, address).code
+    code = get_account(evm.state_tracking, address).code
     track_address(evm.state_changes, address)
 
     codesize = U256(len(code))
@@ -403,8 +401,7 @@ def extcodecopy(evm: Evm) -> None:
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
-    state = evm.message.block_env.state
-    code = get_account(state, address).code
+    code = get_account(evm.state_tracking, address).code
     track_address(evm.state_changes, address)
 
     value = buffer_read(code, code_start_index, size)
@@ -496,8 +493,7 @@ def extcodehash(evm: Evm) -> None:
     charge_gas(evm, access_gas_cost)
 
     # OPERATION
-    state = evm.message.block_env.state
-    account = get_account(state, address)
+    account = get_account(evm.state_tracking, address)
     track_address(evm.state_changes, address)
 
     if account == EMPTY_ACCOUNT:
@@ -531,7 +527,7 @@ def self_balance(evm: Evm) -> None:
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(
-        evm.message.block_env.state, evm.message.current_target
+        evm.state_tracking, evm.message.current_target
     ).balance
 
     push(evm.stack, balance)

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -11,19 +11,17 @@ Introduction
 Implementations of the EVM storage related instructions.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import U256, Uint
 
-from ...state import (
-    get_storage,
-    get_storage_original,
-    get_transient_storage,
-    set_storage,
-    set_transient_storage,
-)
 from ...state_tracker import (
     capture_pre_storage,
     track_storage_read,
     track_storage_write,
+)
+from ...state_tracking import (
+    get_storage,
+    get_storage_original,
+    set_storage,
 )
 from .. import Evm
 from ..exceptions import WriteInStaticContext
@@ -62,9 +60,7 @@ def sload(evm: Evm) -> None:
         charge_gas(evm, GAS_COLD_SLOAD)
 
     # OPERATION
-    value = get_storage(
-        evm.message.block_env.state, evm.message.current_target, key
-    )
+    value = get_storage(evm.state_tracking, evm.message.current_target, key)
     track_storage_read(
         evm.state_changes,
         evm.message.current_target,
@@ -97,7 +93,7 @@ def sstore(evm: Evm) -> None:
     # check we have at least the stipend gas
     check_gas(evm, GAS_CALL_STIPEND + Uint(1))
 
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     original_value = get_storage_original(
         state, evm.message.current_target, key
     )
@@ -181,8 +177,9 @@ def tload(evm: Evm) -> None:
     charge_gas(evm, GAS_WARM_ACCESS)
 
     # OPERATION
-    value = get_transient_storage(
-        evm.message.tx_env.transient_storage, evm.message.current_target, key
+    value = evm.transient_storage.get(
+        (evm.message.current_target, key),
+        U256(0),
     )
     push(evm.stack, value)
 
@@ -209,12 +206,7 @@ def tstore(evm: Evm) -> None:
 
     # GAS
     charge_gas(evm, GAS_WARM_ACCESS)
-    set_transient_storage(
-        evm.message.tx_env.transient_storage,
-        evm.message.current_target,
-        key,
-        new_value,
-    )
+    evm.transient_storage[(evm.message.current_target, key)] = new_value
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -17,21 +17,21 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.utils.numeric import ceil32
 
 from ...fork_types import Address
-from ...state import (
-    account_has_code_or_nonce,
-    account_has_storage,
-    get_account,
-    increment_nonce,
-    is_account_alive,
-    move_ether,
-    set_account_balance,
-)
 from ...state_tracker import (
     capture_pre_balance,
     create_child_frame,
     track_address,
     track_balance_change,
     track_nonce_change,
+)
+from ...state_tracking import (
+    account_has_code_or_nonce,
+    copy_tx_state_tracking,
+    get_account,
+    increment_nonce,
+    is_account_alive,
+    move_ether,
+    set_account_balance,
 )
 from ...utils.address import (
     compute_contract_address,
@@ -95,7 +95,7 @@ def generic_create(
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
 
-    state = evm.message.block_env.state
+    state = evm.state_tracking
 
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -122,7 +122,7 @@ def generic_create(
     track_address(evm.state_changes, contract_address)
     if account_has_code_or_nonce(
         state, contract_address
-    ) or account_has_storage(state, contract_address):
+    ):  # or account_has_storage(state, contract_address):
         increment_nonce(state, evm.message.current_target)
         nonce_after = get_account(state, evm.message.current_target).nonce
         track_nonce_change(
@@ -165,6 +165,8 @@ def generic_create(
         parent_evm=evm,
         is_create=True,
         state_changes=child_state_changes,
+        state_tracking=copy_tx_state_tracking(evm.state_tracking),
+        transient_storage=evm.transient_storage.copy(),
     )
     child_evm = process_create_message(child_message)
 
@@ -205,9 +207,7 @@ def create(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     contract_address = compute_contract_address(
         evm.message.current_target,
-        get_account(
-            evm.message.block_env.state, evm.message.current_target
-        ).nonce,
+        get_account(evm.state_tracking, evm.message.current_target).nonce,
     )
 
     generic_create(
@@ -363,6 +363,8 @@ def generic_call(
         parent_evm=evm,
         is_create=False,
         state_changes=child_state_changes,
+        state_tracking=copy_tx_state_tracking(evm.state_tracking),
+        transient_storage=evm.transient_storage.copy(),
     )
 
     child_evm = process_message(child_message)
@@ -375,6 +377,8 @@ def generic_call(
         incorporate_child_on_success(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(1))
+
+    print(evm.state_tracking.storage_writes)
 
     actual_output_size = min(memory_output_size, U256(len(child_evm.output)))
     memory_write(
@@ -430,7 +434,7 @@ def call(evm: Evm) -> None:
     )
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
@@ -537,7 +541,7 @@ def callcode(evm: Evm) -> None:
     )
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -570,7 +574,7 @@ def callcode(evm: Evm) -> None:
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
     sender_balance = get_account(
-        evm.message.block_env.state, evm.message.current_target
+        evm.state_tracking, evm.message.current_target
     ).balance
 
     # EIP-7928: For CALLCODE with value transfer, capture pre-balance
@@ -636,7 +640,7 @@ def selfdestruct(evm: Evm) -> None:
     check_gas(evm, gas_cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
@@ -650,7 +654,7 @@ def selfdestruct(evm: Evm) -> None:
 
     charge_gas(evm, gas_cost)
 
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     originator = evm.message.current_target
     originator_balance = get_account(state, originator).balance
     beneficiary_balance = get_account(state, beneficiary).balance
@@ -733,7 +737,7 @@ def delegatecall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -823,7 +827,7 @@ def staticcall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    state = evm.state_tracking
     if is_cold_access:
         evm.accessed_addresses.add(to)
 

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -31,19 +31,6 @@ from ethereum.trace import (
 
 from ..blocks import Log
 from ..fork_types import Address
-from ..state import (
-    account_has_code_or_nonce,
-    account_has_storage,
-    begin_transaction,
-    commit_transaction,
-    destroy_storage,
-    get_account,
-    increment_nonce,
-    mark_account_created,
-    move_ether,
-    rollback_transaction,
-    set_code,
-)
 from ..state_tracker import (
     capture_pre_balance,
     capture_pre_code,
@@ -53,6 +40,16 @@ from ..state_tracker import (
     track_balance_change,
     track_code_change,
     track_nonce_change,
+)
+from ..state_tracking import (
+    TxStateTracking,
+    account_has_code_or_nonce,
+    copy_tx_state_tracking,
+    get_account,
+    increment_nonce,
+    mark_account_created,
+    move_ether,
+    set_code,
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
@@ -97,6 +94,7 @@ class MessageCallOutput:
     accounts_to_delete: Set[Address]
     error: Optional[EthereumException]
     return_data: Bytes
+    state_tracking: TxStateTracking
 
 
 def process_message_call(message: Message) -> MessageCallOutput:
@@ -115,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
 
     """
-    block_env = message.block_env
+    state_tracking = message.state_tracking
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
-            block_env.state, message.current_target
-        ) or account_has_storage(block_env.state, message.current_target)
+            state_tracking, message.current_target
+        )  # or account_has_storage(block_env.state, message.current_target)
         track_address(message.tx_env.state_changes, message.current_target)
         if is_collision:
             return MessageCallOutput(
@@ -130,6 +128,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
                 set(),
                 AddressCollision(),
                 Bytes(b""),
+                message.state_tracking,
             )
         else:
             evm = process_create_message(message)
@@ -141,7 +140,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         if delegated_address is not None:
             message.disable_precompiles = True
             message.accessed_addresses.add(delegated_address)
-            message.code = get_account(block_env.state, delegated_address).code
+            message.code = get_account(state_tracking, delegated_address).code
             message.code_address = delegated_address
             track_address(message.block_env.state_changes, delegated_address)
 
@@ -150,10 +149,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
     if evm.error:
         logs: Tuple[Log, ...] = ()
         accounts_to_delete = set()
+        state_tracking = message.state_tracking
     else:
         logs = evm.logs
         accounts_to_delete = evm.accounts_to_delete
         refund_counter += U256(evm.refund_counter)
+        state_tracking = evm.state_tracking
 
     tx_end = TransactionEnd(
         int(message.gas) - int(evm.gas_left), evm.output, evm.error
@@ -167,6 +168,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
         accounts_to_delete=accounts_to_delete,
         error=evm.error,
         return_data=evm.output,
+        state_tracking=state_tracking,
     )
 
 
@@ -185,37 +187,10 @@ def process_create_message(message: Message) -> Evm:
         Items containing execution specific objects.
 
     """
-    state = message.block_env.state
-    transient_storage = message.tx_env.transient_storage
-    # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
-
-    # If the address where the account is being created has storage, it is
-    # destroyed. This can only happen in the following highly unlikely
-    # circumstances:
-    # * The address created by a `CREATE` call collides with a subsequent
-    #   `CREATE` or `CREATE2` call.
-    # * The first `CREATE` happened before Spurious Dragon and left empty
-    #   code.
-    destroy_storage(state, message.current_target)
-
-    # In the previously mentioned edge case the preexisting storage is ignored
-    # for gas refund purposes. In order to do this we must track created
-    # accounts. This tracking is also needed to respect the constraints
-    # added to SELFDESTRUCT by EIP-6780.
-    mark_account_created(state, message.current_target)
-
-    increment_nonce(state, message.current_target)
-    nonce_after = get_account(state, message.current_target).nonce
-    track_nonce_change(
-        message.state_changes,
-        message.current_target,
-        U64(nonce_after),
-    )
-
     capture_pre_code(message.tx_env.state_changes, message.current_target, b"")
 
-    evm = process_message(message)
+    evm = process_message(message, create=True)
+    state = evm.state_tracking
     if not evm.error:
         contract_code = evm.output
         contract_code_gas = Uint(len(contract_code)) * GAS_CODE_DEPOSIT
@@ -227,7 +202,6 @@ def process_create_message(message: Message) -> Evm:
             if len(contract_code) > MAX_CODE_SIZE:
                 raise OutOfGasError
         except ExceptionalHalt as error:
-            rollback_transaction(state, transient_storage)
             merge_on_failure(message.state_changes)
             evm.gas_left = Uint(0)
             evm.output = b""
@@ -241,15 +215,13 @@ def process_create_message(message: Message) -> Evm:
                     message.current_target,
                     contract_code,
                 )
-            commit_transaction(state, transient_storage)
             merge_on_success(message.state_changes)
     else:
-        rollback_transaction(state, transient_storage)
         merge_on_failure(message.state_changes)
     return evm
 
 
-def process_message(message: Message) -> Evm:
+def process_message(message: Message, create: bool = False) -> Evm:
     """
     Move ether and execute the relevant code.
 
@@ -257,6 +229,8 @@ def process_message(message: Message) -> Evm:
     ----------
     message :
         Transaction specific items.
+    create : bool
+        Is this a create message?
 
     Returns
     -------
@@ -264,37 +238,9 @@ def process_message(message: Message) -> Evm:
         Items containing execution specific objects
 
     """
-    state = message.block_env.state
-    transient_storage = message.tx_env.transient_storage
+    state = message.state_tracking
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
-
-    code = message.code
-    valid_jump_destinations = get_valid_jump_destinations(code)
-    evm = Evm(
-        pc=Uint(0),
-        stack=[],
-        memory=bytearray(),
-        code=code,
-        gas_left=message.gas,
-        valid_jump_destinations=valid_jump_destinations,
-        logs=(),
-        refund_counter=0,
-        running=True,
-        message=message,
-        output=b"",
-        accounts_to_delete=set(),
-        return_data=b"",
-        error=None,
-        accessed_addresses=message.accessed_addresses,
-        accessed_storage_keys=message.accessed_storage_keys,
-        state_changes=message.state_changes,
-    )
-
-    # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
-
-    track_address(message.state_changes, message.current_target)
 
     if message.should_transfer_value and message.value != 0:
         # Track value transfer
@@ -331,6 +277,58 @@ def process_message(message: Message) -> Evm:
             U256(recipient_new_balance),
         )
 
+    code = message.code
+    valid_jump_destinations = get_valid_jump_destinations(code)
+    evm = Evm(
+        pc=Uint(0),
+        stack=[],
+        memory=bytearray(),
+        code=code,
+        gas_left=message.gas,
+        valid_jump_destinations=valid_jump_destinations,
+        logs=(),
+        refund_counter=0,
+        running=True,
+        message=message,
+        output=b"",
+        accounts_to_delete=set(),
+        return_data=b"",
+        error=None,
+        accessed_addresses=message.accessed_addresses,
+        accessed_storage_keys=message.accessed_storage_keys,
+        state_changes=message.state_changes,
+        state_tracking=copy_tx_state_tracking(message.state_tracking),
+        transient_storage=message.transient_storage,
+    )
+
+    if create:
+        # If the address where the account is being created has storage, it is
+        # destroyed. This can only happen in the following highly unlikely
+        # circumstances:
+        # * The address created by a `CREATE` call collides with a subsequent
+        #   `CREATE` or `CREATE2` call.
+        # * The first `CREATE` happened before Spurious Dragon and left empty
+        #   code.
+        # destroy_storage(state, message.current_target)
+
+        # In the previously mentioned edge case the preexisting storage is
+        # ignored for gas refund purposes. In order to do this we must track
+        # created accounts. This tracking is also needed to respect the
+        # constraints added to SELFDESTRUCT by EIP-6780.
+        mark_account_created(evm.state_tracking, message.current_target)
+
+        increment_nonce(evm.state_tracking, message.current_target)
+        nonce_after = get_account(
+            evm.state_tracking, message.current_target
+        ).nonce
+        track_nonce_change(
+            message.state_changes,
+            message.current_target,
+            U64(nonce_after),
+        )
+
+    track_address(message.state_changes, message.current_target)
+
     try:
         if evm.message.code_address in PRE_COMPILED_CONTRACTS:
             if not message.disable_precompiles:
@@ -360,11 +358,9 @@ def process_message(message: Message) -> Evm:
         evm.error = error
 
     if evm.error:
-        rollback_transaction(state, transient_storage)
         if not message.is_create:
             merge_on_failure(evm.state_changes)
     else:
-        commit_transaction(state, transient_storage)
         if not message.is_create:
             merge_on_success(evm.state_changes)
     return evm

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -312,6 +312,17 @@ class T8N(Load):
         if self.fork.has_block_access_list_hash:
             kw_arguments["state_changes"] = StateChanges()
 
+        kw_arguments["state_tracking"] = self.fork._module(
+            "state_tracking"
+        ).BlockStateTracking(
+            parent=self.alloc.state,
+            current_index=Uint(0),
+            account_reads=set(),
+            storage_reads=set(),
+            account_writes={},
+            storage_writes={},
+        )
+
         return block_environment(**kw_arguments)
 
     def backup_state(self) -> None:
@@ -371,6 +382,10 @@ class T8N(Load):
                 self.txs.rejected_txs[0] = f"Failed transaction: {e!r}"
                 self.restore_state()
                 self.logger.warning(f"Transaction {0} failed: {str(e)}")
+
+        self.fork._module("state_tracking").write_block_state_changes(
+            block_env.state_tracking
+        )
 
         self.result.update(self, block_env, block_output)
         self.result.rejected = self.txs.rejected_txs
@@ -440,6 +455,10 @@ class T8N(Load):
             block_output.block_access_list = self.fork.build_block_access_list(
                 block_env.state_changes
             )
+
+        self.fork._module("state_tracking").write_block_state_changes(
+            block_env.state_tracking
+        )
 
     def run_blockchain_test(self) -> None:
         """


### PR DESCRIPTION
## 🗒️ Description
This PR adds two new types for tracking state:

* `TxStateTracking`: Tracks reads and writes that happened during a transaction.
* `BlockStateTracking`: Tracks reads and writes that happened during a block.

`BlockStateTracking` should be convertible into a BAL. Most of the functions of the `State` object have superseded, it is still used to:

1. Answer queries about the pre-state.
2. Calculate the state root.
3. Communicate state changes back to the caller.

A future PR should be replace it with a suitable interface to do those things.

**Note:** This PR is an early draft. All pre-Amsterdam forks are broken (need back-porting) and code cleanup is required. EIP-7610 is unimplemented.

## Next steps

* Rebase EIP-7928 on this branch and port to use state tracking objects.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/jwgz7bpaoweg1.jpeg)
