### PR TITLE
chore(docs): bump docs fork to amsterdam

### DIFF
--- a/packages/testing/src/execution_testing/config/docs.py
+++ b/packages/testing/src/execution_testing/config/docs.py
@@ -11,10 +11,10 @@ from pydantic import BaseModel
 class DocsConfig(BaseModel):
     """A class for accessing documentation-related configurations."""
 
-    TARGET_FORK: str = "Osaka"
+    TARGET_FORK: str = "Amsterdam"
     """The target fork for the documentation."""
 
-    GENERATE_UNTIL_FORK: str = "Osaka"
+    GENERATE_UNTIL_FORK: str = "Amsterdam"
     """The fork until which documentation should be generated."""
 
     DOCS_BASE_URL: str = "https://eest.ethereum.org"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fixes the mkdocs build error from https://github.com/ethereum/execution-specs/pull/2062

<img width="787" height="325" alt="Screenshot 2026-01-22 at 16 59 43" src="https://github.com/user-attachments/assets/506241f3-40fd-46e3-a380-7e3685040227" />

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/007.png)
