### PR TITLE
chore(test-specs): fix fork transition tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1181,6 +1181,24 @@ def add_fork_covariant_parameters(
                 fp for fp in fork_parametrizers if fp.fork >= param_min_fork
             ]
 
+    # Filter out forks where blob params don't change for valid_for_bpo_forks
+    if list(metafunc.definition.iter_markers(name="valid_for_bpo_forks")):
+        filtered_forks = [
+            fp.fork
+            for fp in fork_parametrizers
+            if not blob_params_changed_at_transition(fp.fork)
+        ]
+        if filtered_forks:
+            logger.debug(
+                f"Skipping {metafunc.function.__name__} for forks with "
+                f"unchanged blob params: {[f.name() for f in filtered_forks]}"
+            )
+        fork_parametrizers[:] = [
+            fp
+            for fp in fork_parametrizers
+            if blob_params_changed_at_transition(fp.fork)
+        ]
+
     for covariant_descriptor in fork_covariant_decorators:
         if list(
             metafunc.definition.iter_markers(covariant_descriptor.marker_name)
@@ -1270,6 +1288,47 @@ def parametrize_fork(
     metafunc.parametrize(
         param_names, param_values, scope="function", indirect=indirect
     )
+
+
+def blob_params_changed_at_transition(fork: Fork) -> bool:
+    """
+    Check if BPO-relevant blob parameters change at a fork transition.
+
+    For transition forks, compares the 3 blob parameters that BPO forks modify:
+
+    - target_blobs_per_block
+    - max_blobs_per_block
+    - blob_base_fee_update_fraction
+
+    before (timestamp=0) and after (timestamp=15_000) the transition.
+    Returns True if any parameter changed, False otherwise.
+
+    For non-transition forks, returns True (no filtering needed).
+    """
+    # Check if this is a transition fork
+    if not hasattr(fork, "transitions_from") or not hasattr(
+        fork, "transitions_to"
+    ):
+        return True
+
+    # Compare the 3 blob parameters that BPO forks modify
+    # timestamp=0 is before transition, timestamp=15_000 is after
+    bpo_blob_params = [
+        "target_blobs_per_block",
+        "max_blobs_per_block",
+        "blob_base_fee_update_fraction",
+    ]
+
+    for param in bpo_blob_params:
+        method = getattr(fork, param, None)
+        if method is None:
+            continue
+        before = method(timestamp=0)
+        after = method(timestamp=15_000)
+        if before != after:
+            return True
+
+    return False
 
 
 def pytest_collection_modifyitems(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -1294,13 +1294,13 @@ def blob_params_changed_at_transition(fork: Fork) -> bool:
     """
     Check if BPO-relevant blob parameters change at a fork transition.
 
-    For transition forks, compares the 3 blob parameters that BPO forks modify:
+    For transition forks, compares the 3 blob parameters that BPO forks modify
+    between the from_fork and to_fork:
 
     - target_blobs_per_block
     - max_blobs_per_block
     - blob_base_fee_update_fraction
 
-    before (timestamp=0) and after (timestamp=15_000) the transition.
     Returns True if any parameter changed, False otherwise.
 
     For non-transition forks, returns True (no filtering needed).
@@ -1311,8 +1311,10 @@ def blob_params_changed_at_transition(fork: Fork) -> bool:
     ):
         return True
 
+    from_fork = fork.transitions_from()
+    to_fork = fork.transitions_to()
+
     # Compare the 3 blob parameters that BPO forks modify
-    # timestamp=0 is before transition, timestamp=15_000 is after
     bpo_blob_params = [
         "target_blobs_per_block",
         "max_blobs_per_block",
@@ -1320,12 +1322,11 @@ def blob_params_changed_at_transition(fork: Fork) -> bool:
     ]
 
     for param in bpo_blob_params:
-        method = getattr(fork, param, None)
-        if method is None:
+        from_method = getattr(from_fork, param, None)
+        to_method = getattr(to_fork, param, None)
+        if from_method is None or to_method is None:
             continue
-        before = method(timestamp=0)
-        after = method(timestamp=15_000)
-        if before != after:
+        if from_method() != to_method():
             return True
 
     return False

--- a/packages/testing/src/execution_testing/forks/forks/transition.py
+++ b/packages/testing/src/execution_testing/forks/forks/transition.py
@@ -6,6 +6,7 @@ from .forks import (
     BPO2,
     BPO3,
     BPO4,
+    Amsterdam,
     Berlin,
     Cancun,
     London,
@@ -62,6 +63,17 @@ class OsakaToBPO1AtTime15k(Osaka):
 @transition_fork(to_fork=BPO2, at_timestamp=15_000)
 class BPO1ToBPO2AtTime15k(BPO1):
     """BPO1 to BPO2 transition at Timestamp 15k."""
+
+    pass
+
+
+@transition_fork(to_fork=Amsterdam, at_timestamp=15_000)
+class BPO2ToAmsterdamAtTime15k(BPO2):
+    """BPO2 to Amsterdam transition at Timestamp 15k."""
+
+    # TODO: We may need to adjust which BPO Amsterdam inherits from as the
+    #  related Amsterdam specs change over time, and before Amsterdam is
+    #  live on mainnet.
 
     pass
 

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
@@ -283,7 +283,7 @@ def test_modexp_upper_bounds(
         ),
     ],
 )
-@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+@pytest.mark.valid_at_transition_to("Osaka")
 def test_modexp_upper_bounds_fork_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_transition_fork.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_transition_fork.py
@@ -28,7 +28,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7825.version
 @EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedBeforeFork()
 @EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.AcceptedAfterFork()
 @EIPChecklist.ModifiedTransactionValidityConstraint.Test.ForkTransition.RejectedAfterFork()
-@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+@pytest.mark.valid_at_transition_to("Osaka")
 @pytest.mark.parametrize(
     "transaction_at_cap",
     [

--- a/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds_transition.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds_transition.py
@@ -21,7 +21,7 @@ from .spec import Spec, ref_spec_7883
 REFERENCE_SPEC_GIT_PATH = ref_spec_7883.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7883.version
 
-pytestmark = pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+pytestmark = pytest.mark.valid_at_transition_to("Osaka")
 
 
 @pytest.mark.parametrize(

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -558,7 +558,9 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
     ],
     get_fork_scenarios,
 )
-@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+@pytest.mark.valid_at_transition_to(
+    "Osaka", subsequent_forks=True, until="BPO4"
+)
 @pytest.mark.valid_for_bpo_forks()
 def test_reserve_price_at_transition(
     blockchain_test: BlockchainTestFiller,

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -558,9 +558,7 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
     ],
     get_fork_scenarios,
 )
-@pytest.mark.valid_at_transition_to(
-    "Osaka", subsequent_forks=True, until="BPO4"
-)
+@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
 @pytest.mark.valid_for_bpo_forks()
 def test_reserve_price_at_transition(
     blockchain_test: BlockchainTestFiller,

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -284,7 +284,7 @@ def test_clz_push_operation_same_value(
 
 @EIPChecklist.Opcode.Test.ForkTransition.Invalid()
 @EIPChecklist.Opcode.Test.ForkTransition.At()
-@pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
+@pytest.mark.valid_at_transition_to("Osaka")
 def test_clz_fork_transition(
     blockchain_test: BlockchainTestFiller, pre: Alloc
 ) -> None:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Adds transition fork for Amsterdam for transition tests. Required to fill EIP-7708 transition tests.

Sets bpo reserve price transition test to only fill until BPO4 (error otherwise), when filling Amsterdam transition tests with `--fork Amsterdam`:
```bash
ERROR tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py - assert 0 > 0
ERROR tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py - assert 0 > 0
ERROR tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py - assert 0 > 0
ERROR tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py - assert 0 > 0
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/008.png)
