### PR TITLE
fix(test-benchmark): support `blobhash` benchmark

### DIFF
--- a/tests/benchmark/compute/instruction/test_tx_context.py
+++ b/tests/benchmark/compute/instruction/test_tx_context.py
@@ -7,7 +7,7 @@ Supported Opcodes:
 - BLOBHASH
 """
 
-from typing import Any, Dict
+import math
 
 import pytest
 from execution_testing import (
@@ -41,36 +41,47 @@ def test_call_frame_context_ops(
     )
 
 
-@pytest.mark.repricing(blob_index=0, blobs_present=1)
+@pytest.mark.repricing
 @pytest.mark.parametrize(
-    "blob_index, blobs_present",
+    "blob_present",
     [
-        pytest.param(0, 0, id="no blobs"),
-        pytest.param(0, 1, id="one blob and accessed"),
-        pytest.param(1, 1, id="one blob but access non-existent index"),
-        pytest.param(5, 6, id="six blobs, access latest"),
+        pytest.param(0, id="no_blobs"),
+        pytest.param(1, id="one_blob"),
     ],
 )
 def test_blobhash(
     fork: Fork,
     benchmark_test: BenchmarkTestFiller,
-    blob_index: int,
-    blobs_present: bool,
+    blob_present: int,
+    fixed_opcode_count: int | None,
+    gas_benchmark_value: int,
 ) -> None:
     """Benchmark BLOBHASH instruction."""
-    tx_kwargs: Dict[str, Any] = {}
-    if blobs_present > 0:
-        tx_kwargs["ty"] = TransactionType.BLOB_TRANSACTION
-        tx_kwargs["max_fee_per_blob_gas"] = fork.min_base_fee_per_blob_gas()
-        tx_kwargs["blob_versioned_hashes"] = add_kzg_version(
-            [i.to_bytes() * 32 for i in range(blobs_present)],
-            BlobsSpec.BLOB_COMMITMENT_VERSION_KZG,
-        )
+    tx_kwargs: dict = {}
+    if blob_present:
+        cap = fork.transaction_gas_limit_cap()
+        if fixed_opcode_count is None and cap is not None:
+            # Check if blob tx splits would exceed block blob limit
+            required_splits = math.ceil(gas_benchmark_value / cap)
+            max_blobs = fork.max_blobs_per_block()
+            if required_splits > max_blobs:
+                pytest.skip(
+                    f"Blob tx needs {required_splits} splits but fork allows "
+                    f"{max_blobs} blobs/block"
+                )
+        tx_kwargs = {
+            "ty": TransactionType.BLOB_TRANSACTION,
+            "max_fee_per_blob_gas": fork.min_base_fee_per_blob_gas(),
+            "blob_versioned_hashes": add_kzg_version(
+                [i.to_bytes(32, "big") for i in range(blob_present)],
+                BlobsSpec.BLOB_COMMITMENT_VERSION_KZG,
+            ),
+        }
 
     benchmark_test(
         target_opcode=Op.BLOBHASH,
         code_generator=ExtCallGenerator(
-            attack_block=Op.BLOBHASH(blob_index),
+            attack_block=Op.POP(Op.BLOBHASH(0)),
             tx_kwargs=tx_kwargs,
         ),
     )

--- a/tests/benchmark/compute/instruction/test_tx_context.py
+++ b/tests/benchmark/compute/instruction/test_tx_context.py
@@ -81,7 +81,7 @@ def test_blobhash(
     benchmark_test(
         target_opcode=Op.BLOBHASH,
         code_generator=ExtCallGenerator(
-            attack_block=Op.POP(Op.BLOBHASH(0)),
+            attack_block=Op.BLOBHASH(Op.PUSH0),
             tx_kwargs=tx_kwargs,
         ),
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The original blobhash benchmark is failing in every mode, this PR supports it under `fill` mode with `--gas-benchmark-values` and `--fixed-opcode-count` flag. But it still needs some update to support `execute remote`, since now it does not support blob transactions.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
PR #1695

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![animal-0](https://github.com/user-attachments/assets/01aa07cf-9098-4cc4-965e-aa00563be72f)

