### PR TITLE
nit(testing): Move `valid_opcodes` so merge catches the conflict

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3365,6 +3365,22 @@ class Amsterdam(BPO2):
         )
 
     @classmethod
+    def opcode_gas_map(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
+        """Add SLOTNUM opcode gas cost for Amsterdam (EIP-7843)."""
+        gas_costs = cls.gas_costs(
+            block_number=block_number, timestamp=timestamp
+        )
+        base_map = super(Amsterdam, cls).opcode_gas_map(
+            block_number=block_number, timestamp=timestamp
+        )
+        return {
+            **base_map,
+            Opcodes.SLOTNUM: gas_costs.G_BASE,
+        }
+
+    @classmethod
     def engine_new_payload_version(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
@@ -3390,19 +3406,3 @@ class Amsterdam(BPO2):
         """Slot number in header required from Amsterdam (EIP-7843)."""
         del block_number, timestamp
         return True
-
-    @classmethod
-    def opcode_gas_map(
-        cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> Dict[OpcodeBase, int | Callable[[OpcodeBase], int]]:
-        """Add SLOTNUM opcode gas cost for Amsterdam (EIP-7843)."""
-        gas_costs = cls.gas_costs(
-            block_number=block_number, timestamp=timestamp
-        )
-        base_map = super(Amsterdam, cls).opcode_gas_map(
-            block_number=block_number, timestamp=timestamp
-        )
-        return {
-            **base_map,
-            Opcodes.SLOTNUM: gas_costs.G_BASE,
-        }

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3356,6 +3356,15 @@ class Amsterdam(BPO2):
         return False
 
     @classmethod
+    def valid_opcodes(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> List[Opcodes]:
+        """Add SLOTNUM opcode for Amsterdam (EIP-7843)."""
+        return [Opcodes.SLOTNUM] + super(Amsterdam, cls).valid_opcodes(
+            block_number=block_number, timestamp=timestamp
+        )
+
+    @classmethod
     def engine_new_payload_version(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
@@ -3397,12 +3406,3 @@ class Amsterdam(BPO2):
             **base_map,
             Opcodes.SLOTNUM: gas_costs.G_BASE,
         }
-
-    @classmethod
-    def valid_opcodes(
-        cls, *, block_number: int = 0, timestamp: int = 0
-    ) -> List[Opcodes]:
-        """Add SLOTNUM opcode for Amsterdam (EIP-7843)."""
-        return [Opcodes.SLOTNUM] + super(Amsterdam, cls).valid_opcodes(
-            block_number=block_number, timestamp=timestamp
-        )


### PR DESCRIPTION
## 🗒️ Description
Moves `valid_opcodes` and `opcode_gas_map` to the same place as `eips/amsterdam/eip-8024` so the conflict is caught during merge instead being automatically resolved by adding both versions of both functions to the class.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
