### PR TITLE
feat(ci): Run static checks on all generated branches

### DIFF
--- a/.github/actions/merge-eip-branches/action.yaml
+++ b/.github/actions/merge-eip-branches/action.yaml
@@ -113,6 +113,9 @@ runs:
           fi
         done
 
+        echo "Running static checks on merged branch"
+        uvx --with=tox-uv tox -e static
+
         echo "All EIP branches merged successfully"
 
     - name: Push devnet branch

--- a/.github/actions/rebase-eip-branch/action.yaml
+++ b/.github/actions/rebase-eip-branch/action.yaml
@@ -57,6 +57,9 @@ runs:
           exit 1
         fi
 
+        echo "Running static checks on rebased branch"
+        uvx --with=tox-uv tox -e static
+
         echo "Rebase successful"
 
     - name: Push rebased branch

--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -29,6 +29,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+
       - name: Rebase EIP branch onto fork
         uses: ./.github/actions/rebase-eip-branch
         with:

--- a/.github/workflows/update-devnet-branch.yaml
+++ b/.github/workflows/update-devnet-branch.yaml
@@ -36,6 +36,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+
       - name: Merge EIP branches into devnet
         uses: ./.github/actions/merge-eip-branches
         with:


### PR DESCRIPTION
## 🗒️ Description
Runs static checks on all workflows that generate branches automatically (Like EIP branch rebase, EIP branch merge).

This will catch merge issues, e.g. `forks.py` is updated by two different EIPs but the methods were added on different lines, so the automatic merge puts both different versions inside of the class automatically, causing an invisible error.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
