### PR TITLE
feat(ci): update inputs for ci rebase/merge workflows

### DIFF
--- a/.github/actions/merge-eip-branches/action.yaml
+++ b/.github/actions/merge-eip-branches/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: 'Devnet name (e.g., amsterdam/1, bal/2, eip-1234/3). Created branch will be `devnets/$devnet_name`'
     required: true
   eip_numbers:
-    description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
+    description: 'List of EIP numbers (e.g., 1234,2345+3456 for eip-1234 and combined eip-2345+3456)'
     required: true
 
 runs:
@@ -50,8 +50,8 @@ runs:
         for raw in "${RAW_EIPS[@]}"; do
           eip="$(echo "$raw" | xargs)"   # trims leading/trailing whitespace
           if [[ -n "$eip" ]]; then
-            # Optional: ensure it looks numeric
-            if [[ ! "$eip" =~ ^[0-9]+$ ]]; then
+            # Ensure it looks like EIP number(s) - digits optionally joined by +
+            if [[ ! "$eip" =~ ^[0-9]+(\+[0-9]+)*$ ]]; then
               echo "Error: Invalid EIP number ${eip}"
               exit 1
             fi

--- a/.github/actions/rebase-eip-branch/action.yaml
+++ b/.github/actions/rebase-eip-branch/action.yaml
@@ -4,8 +4,9 @@ inputs:
   fork:
     description: 'Fork name (e.g., amsterdam)'
     required: true
+    default: 'amsterdam'
   eip_numbers:
-    description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
+    description: 'List of EIP numbers (e.g., 1234,2345+3456 for eip-1234 and combined eip-2345+3456)'
     required: true
 runs:
   using: "composite"
@@ -37,7 +38,28 @@ runs:
           exit 1
         fi
 
-        IFS=',' read -ra EIPS <<< "$EIP_NUMBERS"
+        # Convert comma-separated list to array
+        IFS=',' read -ra RAW_EIPS <<< "$EIP_NUMBERS"
+
+        # Normalize: trim whitespace, drop empties, validate
+        EIPS=()
+        for raw in "${RAW_EIPS[@]}"; do
+          eip="$(echo "$raw" | xargs)"   # trims leading/trailing whitespace
+          if [[ -n "$eip" ]]; then
+            # Ensure it looks like EIP number(s) - digits optionally joined by +
+            if [[ ! "$eip" =~ ^[0-9]+(\+[0-9]+)*$ ]]; then
+              echo "Error: Invalid EIP number ${eip}"
+              exit 1
+            fi
+            EIPS+=("$eip")
+          fi
+        done
+
+        if [[ ${#EIPS[@]} -eq 0 ]]; then
+          echo "Error: No EIP numbers provided after parsing '${EIP_NUMBERS}'"
+          exit 1
+        fi
+
         for EIP_NUMBER in "${EIPS[@]}"; do
           EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
 
@@ -73,9 +95,12 @@ runs:
         EIP_NUMBERS: ${{ inputs.eip_numbers }}
         REMOTE: origin
       run: |
-        IFS=',' read -ra EIPS <<< "$EIP_NUMBERS"
-        for EIP_NUMBER in "${EIPS[@]}"; do
-          EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
-          echo "Force pushing ${EIP_BRANCH} to ${REMOTE}"
-          git push --force-with-lease "${REMOTE}" "${EIP_BRANCH}"
+        IFS=',' read -ra RAW_EIPS <<< "$EIP_NUMBERS"
+        for raw in "${RAW_EIPS[@]}"; do
+          eip="$(echo "$raw" | xargs)"
+          if [[ -n "$eip" ]]; then
+            EIP_BRANCH="eips/${FORK}/eip-${eip}"
+            echo "Force pushing ${EIP_BRANCH} to ${REMOTE}"
+            git push --force-with-lease "${REMOTE}" "${EIP_BRANCH}"
+          fi
         done

--- a/.github/actions/rebase-eip-branch/action.yaml
+++ b/.github/actions/rebase-eip-branch/action.yaml
@@ -83,10 +83,10 @@ runs:
           fi
 
           echo "Rebase of ${EIP_BRANCH} successful"
-        done
 
-        echo "Running static checks on rebased branch"
-        uvx --with=tox-uv tox -e static
+          echo "Running static checks on ${EIP_BRANCH}"
+          uvx --with=tox-uv tox -e static
+        done
 
     - name: Push rebased branches
       shell: bash

--- a/.github/actions/rebase-eip-branch/action.yaml
+++ b/.github/actions/rebase-eip-branch/action.yaml
@@ -1,11 +1,11 @@
-name: Rebase EIP Branch
-description: Rebases an EIP branch onto a fork branch
+name: Rebase EIP Branches
+description: Rebases EIP branches onto a fork branch
 inputs:
   fork:
     description: 'Fork name (e.g., amsterdam)'
     required: true
-  eip_number:
-    description: 'EIP number'
+  eip_numbers:
+    description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
     required: true
 runs:
   using: "composite"
@@ -16,18 +16,17 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Rebase EIP branch (create if missing)
+    - name: Rebase EIP branches (create if missing)
       shell: bash
       env:
         FORK: ${{ inputs.fork }}
-        EIP_NUMBER: ${{ inputs.eip_number }}
+        EIP_NUMBERS: ${{ inputs.eip_numbers }}
         REMOTE: origin
       run: |
         set -euo pipefail
 
         echo "FORK=$FORK"
-        echo "EIP_NUMBER=$EIP_NUMBER"
-        EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
+        echo "EIP_NUMBERS=$EIP_NUMBERS"
         FORK_BRANCH="forks/${FORK}"
 
         git fetch "${REMOTE}" --prune
@@ -38,37 +37,45 @@ runs:
           exit 1
         fi
 
-        # Create local branch from remote if it exists, else create from fork base
-        if git show-ref --verify --quiet "refs/remotes/${REMOTE}/${EIP_BRANCH}"; then
-          echo "Checking out existing ${EIP_BRANCH} (tracking ${REMOTE})"
-          git checkout -B "${EIP_BRANCH}" "${REMOTE}/${EIP_BRANCH}"
-        else
-          echo "Branch ${EIP_BRANCH} does not exist on ${REMOTE}; creating from ${REMOTE}/${FORK_BRANCH}"
-          git checkout -B "${EIP_BRANCH}" "${REMOTE}/${FORK_BRANCH}"
+        IFS=',' read -ra EIPS <<< "$EIP_NUMBERS"
+        for EIP_NUMBER in "${EIPS[@]}"; do
+          EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
 
-          # First push creates the remote branch (no force needed)
-          git push -u "${REMOTE}" "${EIP_BRANCH}"
-        fi
+          # Create local branch from remote if it exists, else create from fork base
+          if git show-ref --verify --quiet "refs/remotes/${REMOTE}/${EIP_BRANCH}"; then
+            echo "Checking out existing ${EIP_BRANCH} (tracking ${REMOTE})"
+            git checkout -B "${EIP_BRANCH}" "${REMOTE}/${EIP_BRANCH}"
+          else
+            echo "Branch ${EIP_BRANCH} does not exist on ${REMOTE}; creating from ${REMOTE}/${FORK_BRANCH}"
+            git checkout -B "${EIP_BRANCH}" "${REMOTE}/${FORK_BRANCH}"
 
-        echo "Rebasing ${EIP_BRANCH} onto ${REMOTE}/${FORK_BRANCH}"
-        if ! git rebase "${REMOTE}/${FORK_BRANCH}"; then
-          echo "Error: Rebase conflict occurred while rebasing ${EIP_BRANCH} onto ${FORK_BRANCH}"
-          git rebase --abort || true
-          exit 1
-        fi
+            # First push creates the remote branch (no force needed)
+            git push -u "${REMOTE}" "${EIP_BRANCH}"
+          fi
+
+          echo "Rebasing ${EIP_BRANCH} onto ${REMOTE}/${FORK_BRANCH}"
+          if ! git rebase "${REMOTE}/${FORK_BRANCH}"; then
+            echo "Error: Rebase conflict occurred while rebasing ${EIP_BRANCH} onto ${FORK_BRANCH}"
+            git rebase --abort || true
+            exit 1
+          fi
+
+          echo "Rebase of ${EIP_BRANCH} successful"
+        done
 
         echo "Running static checks on rebased branch"
         uvx --with=tox-uv tox -e static
 
-        echo "Rebase successful"
-
-    - name: Push rebased branch
+    - name: Push rebased branches
       shell: bash
       env:
         FORK: ${{ inputs.fork }}
-        EIP_NUMBER: ${{ inputs.eip_number }}
+        EIP_NUMBERS: ${{ inputs.eip_numbers }}
         REMOTE: origin
       run: |
-        EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
-        echo "Force pushing ${EIP_BRANCH} to ${REMOTE}"
-        git push --force-with-lease "${REMOTE}" "${EIP_BRANCH}"
+        IFS=',' read -ra EIPS <<< "$EIP_NUMBERS"
+        for EIP_NUMBER in "${EIPS[@]}"; do
+          EIP_BRANCH="eips/${FORK}/eip-${EIP_NUMBER}"
+          echo "Force pushing ${EIP_BRANCH} to ${REMOTE}"
+          git push --force-with-lease "${REMOTE}" "${EIP_BRANCH}"
+        done

--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -9,7 +9,7 @@ on:
         type: string
         default: 'amsterdam'
       eip_numbers:
-        description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
+        description: 'List of EIP numbers (e.g., 1234,2345+3456 for eip-1234 and combined eip-2345+3456)'
         required: true
         type: string
 

--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -7,13 +7,14 @@ on:
         description: 'Fork name (e.g., amsterdam)'
         required: true
         type: string
-      eip_number:
-        description: 'EIP number'
+        default: 'amsterdam'
+      eip_numbers:
+        description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
         required: true
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.fork }}-${{ github.event.inputs.eip_number }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.fork }}-${{ github.event.inputs.eip_numbers }}
   cancel-in-progress: false
 
 permissions:
@@ -32,8 +33,8 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
 
-      - name: Rebase EIP branch onto fork
+      - name: Rebase EIP branches onto fork
         uses: ./.github/actions/rebase-eip-branch
         with:
           fork: ${{ github.event.inputs.fork }}
-          eip_number: ${{ github.event.inputs.eip_number }}
+          eip_numbers: ${{ github.event.inputs.eip_numbers }}

--- a/.github/workflows/update-devnet-branch.yaml
+++ b/.github/workflows/update-devnet-branch.yaml
@@ -14,7 +14,7 @@ on:
         type: string
         default: 'bal/2'
       eip_numbers:
-        description: 'Comma-separated list of EIP numbers (e.g., 1234,2345,3456)'
+        description: 'List of EIP numbers (e.g., 1234,2345+3456 for eip-1234 and combined eip-2345+3456)'
         required: true
         type: string
         default: '8024,7843,7708,7778'


### PR DESCRIPTION
## 🗒️ Description

- Support multiple EIPs in rebase workflow (comma-separated)
- Support combined EIP branches with `+` in merge and rebase workflows (e.g., `eip-7708+7778`)
- Add `default: 'amsterdam'` to fork input in rebase action
- Add input validation to rebase action (consistent with merge action)
- Fix static checks to run on each rebased branch individually

Combined branches are the result of merge conflicts handled manually.

## Examples
```
# Rebase multiple EIPs
gh workflow run eip-rebase.yaml \
  -f fork=amsterdam \
  -f eip_numbers=7708,7778,7843

# Update devnet with combined EIP branch
gh workflow run update-devnet-branch.yaml \
  -f fork=amsterdam \
  -f devnet_name=bal/2 \
  -f eip_numbers=8024,7843,7708+7778
```
## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).