### PR TITLE
feat(spec-tests): Add EIP-7778 tests with multiple refund types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 - ✨ New EIP-7702 test cases added ([#1974](https://github.com/ethereum/execution-specs/pull/1974)).
 - ✨ Add missing benchmark configurations / opcode to benchmark tests for repricing analysis([#2006](https://github.com/ethereum/execution-specs/pull/2006)).
 - ✨ Port STATICCALL to CALL tests with zero and non-zero value transfer from `tests/static`, extending coverage with `pytest.mark.with_all_precompiles` ([#1960](https://github.com/ethereum/execution-specs/pull/1960)).
+- ✨ Add test cases for eip7778 which have multiple refund types in a single tx ([#2074](https://github.com/ethereum/execution-specs/pull/2074)).
 
 ## [v5.4.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v5.4.0) - 2025-12-07
 

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -482,3 +482,49 @@ def test_varying_calldata_costs(
         ],
         post=post,
     )
+
+
+@pytest.mark.parametrize(
+    "refund_tx_reverts",
+    [
+        pytest.param(True, id="refund_tx_reverts"),
+        pytest.param(False, id=""),
+    ],
+)
+@pytest.mark.execute(pytest.mark.skip(reason="Requires specific gas price"))
+@pytest.mark.valid_from("Amsterdam")
+def test_multiple_refund_types_in_one_tx(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    refund_tx_reverts: bool,
+) -> None:
+    """Test gas accounting for all refund types available in the given fork."""
+    refunds_count = 10
+
+    post = Alloc()
+    refund_types = set(fork.refund_types())
+
+    (_, gas_used_pre_refund, call_data_floor_cost, refund_tx) = (
+        build_refund_tx(
+            fork=fork,
+            pre=pre,
+            post=post,
+            refund_types=refund_types,
+            refunds_count=refunds_count,
+            refund_tx_reverts=refund_tx_reverts,
+        )
+    )
+
+    refund_tx_block_gas_used = max(gas_used_pre_refund, call_data_floor_cost)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[refund_tx],
+                expected_gas_used=refund_tx_block_gas_used,
+            )
+        ],
+        post=post,
+    )

--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -4,6 +4,7 @@ Test cases for
 """
 
 from enum import Enum
+from typing import Set, Tuple
 
 import pytest
 from execution_testing import (
@@ -17,7 +18,6 @@ from execution_testing import (
     Environment,
     Fork,
     RefundTypes,
-    Storage,
     Transaction,
     TransactionException,
 )
@@ -26,6 +26,144 @@ from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
 REFERENCE_SPEC_VERSION = "54fba02495a05b57acd3f27473d0493b40a9d920"
+
+
+def build_refund_tx(
+    fork: Fork,
+    pre: Alloc,
+    post: Alloc,
+    refund_types: Set[RefundTypes],
+    refunds_count: int = 1,
+    refund_tx_reverts: bool = False,
+    call_data: bytes = b"",
+    refund_tx_has_extra_gas_limit: bool = False,
+    exceed_block_gas_limit: bool = False,
+) -> Tuple[int, int, int, Transaction]:
+    """Build a transaction that has different refund types from a fork."""
+    # All essential calc functions
+    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    max_refund_quotient = fork.max_refund_quotient()
+    gsc = fork.gas_costs()
+    data_floor_calc = fork.transaction_data_floor_cost_calculator()
+
+    # Initial account pre loading
+    initial_fund = 10**18
+    refund_tx_sender = pre.fund_eoa(initial_fund)
+
+    # Initialize other aspects of pre-alloc
+    code = Bytecode()
+    authorization_list = None
+    refund_counter = 0
+    storage_slots = list(range(HashInt(refunds_count)))
+
+    empty_storage_on_success = False
+    refund_tx_extra_gas = 1 if refund_tx_has_extra_gas_limit else 0
+
+    for refund_type in refund_types:
+        match refund_type:
+            case RefundTypes.STORAGE_CLEAR:
+                for slot in storage_slots:
+                    code += Op.SSTORE(
+                        slot,
+                        Op.PUSH0,
+                        # Gas accounting
+                        original_value=1,
+                        new_value=0,
+                    )
+                empty_storage_on_success = True
+
+            case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
+                code += Op.PUSH0
+                delegated_contract = pre.deploy_contract(code=Bytecode())
+                authorization_list = [
+                    AuthorizationTuple(
+                        address=delegated_contract,
+                        nonce=0,
+                        signer=pre.fund_eoa(amount=1),
+                    )
+                    for _ in range(refunds_count)
+                ]
+                refund_counter += (
+                    gsc.R_AUTHORIZATION_EXISTING_AUTHORITY * refunds_count
+                )
+            case _:
+                raise ValueError(
+                    f"Unknown refund type: {refund_type} (Test needs update)"
+                )
+
+    if refund_tx_reverts:
+        code += Op.REVERT(0, 0)
+
+    contract_address = pre.deploy_contract(
+        code=code,
+        storage=dict.fromkeys(storage_slots, 1),
+    )
+
+    gas_used_pre_refund = intrinsic_cost_calc(
+        calldata=call_data,
+        return_cost_deducted_prior_execution=True,
+        authorization_list_or_count=authorization_list,
+    ) + code.gas_cost(fork)
+
+    # Calculate refund (still applied to user's balance)
+    if not refund_tx_reverts:
+        refund_counter += code.refund(fork)
+
+    effective_refund = min(
+        refund_counter, gas_used_pre_refund // max_refund_quotient
+    )
+    gas_used_post_refund = gas_used_pre_refund - effective_refund
+    call_data_floor_cost = data_floor_calc(data=call_data)
+
+    refund_tx_block_gas_used = max(call_data_floor_cost, gas_used_pre_refund)
+    refund_tx_gas_used = max(call_data_floor_cost, gas_used_post_refund)
+
+    # Build refund transaction
+    refund_tx = Transaction(
+        to=contract_address,
+        data=call_data,
+        gas_limit=refund_tx_block_gas_used + refund_tx_extra_gas,
+        sender=refund_tx_sender,
+        authorization_list=authorization_list,
+        expected_receipt={
+            "gas_used": refund_tx_gas_used,
+        },
+    )
+    refund_tx_gas_price = (
+        refund_tx.gas_price
+        if refund_tx.gas_price
+        else refund_tx.max_fee_per_gas
+    )
+
+    if (
+        refund_tx_reverts
+        or exceed_block_gas_limit
+        or not empty_storage_on_success
+    ):
+        post[contract_address] = Account(
+            storage=dict.fromkeys(storage_slots, 1),
+        )
+    else:
+        post[contract_address] = Account(
+            storage=dict.fromkeys(storage_slots, 0),
+        )
+
+    assert refund_tx_gas_price is not None, (
+        "refund_tx_gas_price should not be None"
+    )
+    expected_balance = initial_fund - (
+        refund_tx_gas_used * refund_tx_gas_price
+    )
+
+    if not exceed_block_gas_limit:
+        post[refund_tx_sender] = Account(balance=expected_balance)
+
+    return (
+        gas_used_post_refund,
+        gas_used_pre_refund,
+        call_data_floor_cost,
+        refund_tx,
+    )
 
 
 @pytest.mark.parametrize(
@@ -46,133 +184,22 @@ def test_simple_gas_accounting(
     refund_tx_reverts: bool,
 ) -> None:
     """Test gas accounting for all refund types available in the given fork."""
-    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    max_refund_quotient = fork.max_refund_quotient()
-
     refunds_count = 10
-    initial_fund = 10**18
-    refund_tx_sender = pre.fund_eoa(initial_fund)
 
-    post = {}
+    post = Alloc()
 
-    match refund_type:
-        case RefundTypes.STORAGE_CLEAR:
-            storage_slots = list(range(refunds_count))
-
-            code = Bytecode()
-            for slot in storage_slots:
-                code += Op.SSTORE(
-                    slot,
-                    Op.PUSH0,
-                    # Gas accounting
-                    original_value=1,
-                    new_value=0,
-                )
-            if refund_tx_reverts:
-                code += Op.REVERT(0, 0)
-
-            contract_address = pre.deploy_contract(
-                code=code,
-                storage=dict.fromkeys(storage_slots, 1),
-            )
-            gas_used_pre_refund = intrinsic_cost_calc() + code.gas_cost(fork)
-
-            # Calculate refund (still applied to user's balance)
-            refund_counter = code.refund(fork)
-            effective_refund = min(
-                refund_counter, gas_used_pre_refund // max_refund_quotient
-            )
-            assert effective_refund > 0, (
-                f"effective_refund ({effective_refund}) must be greater than 0"
-            )
-            gas_used_post_refund = gas_used_pre_refund - effective_refund
-            refund_tx_block_gas_used = gas_used_pre_refund
-            refund_tx_gas_used = gas_used_post_refund
-
-            if refund_tx_reverts:
-                refund_tx_gas_used = refund_tx_block_gas_used
-
-            refund_tx = Transaction(
-                to=contract_address,
-                gas_limit=refund_tx_block_gas_used,
-                sender=refund_tx_sender,
-                expected_receipt={
-                    "gas_used": refund_tx_gas_used,
-                },
-            )
-            refund_tx_gas_price = refund_tx.gas_price
-
-            if refund_tx_reverts:
-                post[contract_address] = Account(
-                    storage=dict.fromkeys(storage_slots, 1),
-                )
-            else:
-                post[contract_address] = Account(
-                    storage=dict.fromkeys(storage_slots, 0),
-                )
-
-        case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
-            if refund_tx_reverts:
-                code = Op.REVERT(0, 0)
-            else:
-                code = Op.STOP
-
-            contract_address = pre.deterministic_deploy_contract(
-                deploy_code=code
-            )
-
-            authorization_list = [
-                AuthorizationTuple(
-                    address=contract_address,
-                    nonce=0,
-                    signer=pre.fund_eoa(amount=1),
-                )
-                for _ in range(refunds_count)
-            ]
-            gas_used_pre_refund = intrinsic_cost_calc(
-                authorization_list_or_count=authorization_list
-            ) + code.gas_cost(fork)
-
-            # Calculate refund (still applied to user's balance)
-            gsc = fork.gas_costs()
-            refund_counter = (
-                gsc.R_AUTHORIZATION_EXISTING_AUTHORITY * refunds_count
-            )
-            effective_refund = min(
-                refund_counter, gas_used_pre_refund // max_refund_quotient
-            )
-            assert effective_refund > 0, (
-                f"effective_refund ({effective_refund}) must be greater than 0"
-            )
-            gas_used_post_refund = gas_used_pre_refund - effective_refund
-
-            refund_tx_block_gas_used = gas_used_pre_refund
-            refund_tx_gas_used = gas_used_post_refund
-
-            refund_tx = Transaction(
-                to=contract_address,
-                gas_limit=refund_tx_block_gas_used,
-                sender=refund_tx_sender,
-                authorization_list=authorization_list,
-                expected_receipt={
-                    "gas_used": refund_tx_gas_used,
-                },
-            )
-            refund_tx_gas_price = refund_tx.max_fee_per_gas
-
-        case _:
-            raise ValueError(
-                f"Unknown refund type: {refund_type} (Test needs update)"
-            )
-
-    assert refund_tx_gas_price is not None, (
-        "refund_tx_gas_price should not be None"
-    )
-    expected_balance = initial_fund - (
-        refund_tx_gas_used * refund_tx_gas_price
+    (_, gas_used_pre_refund, call_data_floor_cost, refund_tx) = (
+        build_refund_tx(
+            fork=fork,
+            pre=pre,
+            post=post,
+            refund_types={refund_type},
+            refunds_count=refunds_count,
+            refund_tx_reverts=refund_tx_reverts,
+        )
     )
 
-    post[refund_tx_sender] = Account(balance=expected_balance)
+    refund_tx_block_gas_used = max(gas_used_pre_refund, call_data_floor_cost)
 
     blockchain_test(
         pre=pre,
@@ -239,138 +266,30 @@ def test_multi_transaction_gas_accounting(
     This tests that clients correctly use pre-refund gas for block accounting.
     """
     intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    max_refund_quotient = fork.max_refund_quotient()
 
-    environment_gas_limit = 0
     refunds_count = 10
-    initial_fund = 10**18
-
-    refund_tx_sender = pre.fund_eoa(initial_fund)
-    refund_tx_extra_gas = 1 if refund_tx_has_extra_gas_limit else 0
-
     stop_bytecode = Op.STOP
     stop_address = pre.deterministic_deploy_contract(deploy_code=stop_bytecode)
 
-    post = {}
-
-    match refund_type:
-        case RefundTypes.STORAGE_CLEAR:
-            # Refund happens due to a storage clearing
-            storage_slots = list(range(refunds_count))
-
-            code = Bytecode()
-            for slot in storage_slots:
-                code += Op.SSTORE(
-                    slot,
-                    Op.PUSH0,
-                    # Gas accounting
-                    original_value=1,
-                    new_value=0,
-                )
-            if refund_tx_reverts:
-                code += Op.REVERT(0, 0)
-
-            contract_address = pre.deploy_contract(
-                code=code,
-                storage=dict.fromkeys(storage_slots, 1),
-            )
-
-            gas_used_pre_refund = intrinsic_cost_calc() + code.gas_cost(fork)
-
-            # Calculate refund (still applied to user's balance)
-            refund_counter = code.refund(fork)
-            effective_refund = min(
-                refund_counter, gas_used_pre_refund // max_refund_quotient
-            )
-            assert effective_refund > 0, (
-                f"effective_refund ({effective_refund}) must be greater than 0"
-            )
-            gas_used_post_refund = gas_used_pre_refund - effective_refund
-
-            refund_tx_block_gas_used = gas_used_pre_refund
-            refund_tx_gas_used = gas_used_post_refund
-
-            if refund_tx_reverts:
-                refund_tx_gas_used = refund_tx_block_gas_used
-
-            refund_tx = Transaction(
-                to=contract_address,
-                gas_limit=gas_used_pre_refund + refund_tx_extra_gas,
-                sender=refund_tx_sender,
-                expected_receipt={
-                    "gas_used": refund_tx_gas_used,
-                },
-            )
-
-            refund_tx_gas_price = refund_tx.gas_price
-
-            if exceed_block_gas_limit or refund_tx_reverts:
-                post[contract_address] = Account(
-                    storage=dict.fromkeys(storage_slots, 1),
-                )
-            else:
-                post[contract_address] = Account(
-                    storage=dict.fromkeys(storage_slots, 0),
-                )
-
-        case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
-            if refund_tx_reverts:
-                code = Op.REVERT(0, 0)
-                contract_address = pre.deterministic_deploy_contract(
-                    deploy_code=code
-                )
-            else:
-                code = stop_bytecode
-                contract_address = stop_address
-            authorization_list = [
-                AuthorizationTuple(
-                    address=contract_address,
-                    nonce=0,
-                    signer=pre.fund_eoa(amount=1),
-                )
-                for _ in range(refunds_count)
-            ]
-            gas_used_pre_refund = intrinsic_cost_calc(
-                authorization_list_or_count=authorization_list
-            ) + code.gas_cost(fork)
-
-            # Calculate refund (still applied to user's balance)
-            gsc = fork.gas_costs()
-            refund_counter = (
-                gsc.R_AUTHORIZATION_EXISTING_AUTHORITY * refunds_count
-            )
-            effective_refund = min(
-                refund_counter, gas_used_pre_refund // max_refund_quotient
-            )
-            assert effective_refund > 0, (
-                f"effective_refund ({effective_refund}) must be greater than 0"
-            )
-            gas_used_post_refund = gas_used_pre_refund - effective_refund
-
-            refund_tx_block_gas_used = gas_used_pre_refund
-            refund_tx_gas_used = gas_used_post_refund
-
-            refund_tx = Transaction(
-                to=contract_address,
-                gas_limit=refund_tx_block_gas_used + refund_tx_extra_gas,
-                sender=refund_tx_sender,
-                authorization_list=authorization_list,
-                expected_receipt={
-                    "gas_used": refund_tx_gas_used,
-                },
-            )
-            refund_tx_gas_price = refund_tx.max_fee_per_gas
-        case _:
-            raise ValueError(
-                f"Unknown refund type: {refund_type} (Test needs update)"
-            )
-
-    assert refund_tx_gas_price is not None, (
-        "refund_tx_gas_price should not be None"
+    post = Alloc()
+    (
+        gas_used_post_refund,
+        gas_used_pre_refund,
+        call_data_floor_cost,
+        refund_tx,
+    ) = build_refund_tx(
+        fork=fork,
+        pre=pre,
+        post=post,
+        refund_types={refund_type},
+        refunds_count=refunds_count,
+        refund_tx_reverts=refund_tx_reverts,
+        call_data=b"",
+        refund_tx_has_extra_gas_limit=refund_tx_has_extra_gas_limit,
+        exceed_block_gas_limit=exceed_block_gas_limit,
     )
-    expected_balance = initial_fund - (
-        refund_tx_gas_used * refund_tx_gas_price
-    )
+    refund_tx_gas_used = max(gas_used_post_refund, call_data_floor_cost)
+    refund_tx_block_gas_used = max(gas_used_pre_refund, call_data_floor_cost)
 
     extra_tx_sender = pre.fund_eoa()
     extra_tx_calldata = b"\xff" if extra_tx_data_floor else b""
@@ -398,7 +317,6 @@ def test_multi_transaction_gas_accounting(
         environment_gas_limit = total_block_gas_used - 1
     else:
         environment_gas_limit = total_block_gas_used
-        post[refund_tx_sender] = Account(balance=expected_balance)
 
     txs = [refund_tx, extra_tx]
 
@@ -470,70 +388,22 @@ def test_varying_calldata_costs(
     2. tx_gas_after_refund < calldata_floor < tx_gas_before_refund
     3. calldata_floor > tx_gas_before_refund
     """
-    fork_gas_costs = fork.gas_costs()
-    intrinsic_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    data_floor_calc = fork.transaction_data_floor_cost_calculator()
-    max_refund_quotient = fork.max_refund_quotient()
+    if refund_type == RefundTypes.STORAGE_CLEAR:
+        if (
+            refund_tx_reverts
+            and calldata_test_type
+            == CallDataTestType.DATA_FLOOR_BETWEEN_TX_GAS_BEFORE_AND_AFTER
+        ):
+            pytest.skip(
+                "calldata_cost cannot be between pre and post refund gas"
+                "since refund is zero when execution reverts"
+            )
 
-    initial_fund = 10**18
-    sender = pre.fund_eoa(initial_fund)
-
-    post = {}
     match refund_type:
         case RefundTypes.STORAGE_CLEAR:
-            if (
-                refund_tx_reverts
-                and calldata_test_type
-                == CallDataTestType.DATA_FLOOR_BETWEEN_TX_GAS_BEFORE_AND_AFTER
-            ):
-                pytest.skip(
-                    "calldata_cost cannot be between pre and post refund gas"
-                    "since refund is zero when execution reverts"
-                )
-
             bytes_to_add_per_iteration = b"00" * 2
-
-            pre_storage: Storage = Storage({HashInt(0): HashInt(1)})
-
-            code = Op.SSTORE(0, 0, original_value=1, new_value=0)
-            execution_cost = code.gas_cost(fork)
-            authorization_list = None
-
-            refund_counter = code.refund(fork)
-            post_storage: Storage = Storage({HashInt(0): HashInt(0)})
-
-            if refund_tx_reverts:
-                code += Op.REVERT(0, 0)
-                post_storage = pre_storage
-                refund_counter = 0
-
-            execution_cost = code.gas_cost(fork)
-            contract_address = pre.deploy_contract(
-                code=code,
-                storage=pre_storage,
-            )
-            post[contract_address] = Account(storage=post_storage)
-
         case RefundTypes.AUTHORIZATION_EXISTING_AUTHORITY:
             bytes_to_add_per_iteration = b"00" * 10
-
-            # Refund is non-zero even if execution reverts
-            refund_counter = fork_gas_costs.R_AUTHORIZATION_EXISTING_AUTHORITY
-
-            if refund_tx_reverts:
-                code = Op.REVERT(0, 0)
-            else:
-                code = Op.STOP
-
-            execution_cost = code.gas_cost(fork)
-            contract_address = pre.deploy_contract(code=code)
-            authorization_list = [
-                AuthorizationTuple(
-                    address=contract_address,
-                    nonce=1,
-                    signer=sender,
-                )
-            ]
         case _:
             raise ValueError(
                 f"Unknown refund type: {refund_type} (Test needs update)"
@@ -549,20 +419,21 @@ def test_varying_calldata_costs(
     # a bit more future proof if the gas calc logic changes
     found_call_data = False
     for _ in range(num_iterations):
-        gas_used_pre_refund = (
-            intrinsic_cost_calc(
-                calldata=data,
-                return_cost_deducted_prior_execution=True,
-                authorization_list_or_count=authorization_list,
-            )
-            + execution_cost
-        )
-        effective_refund = min(
-            refund_counter, gas_used_pre_refund // max_refund_quotient
-        )
-        gas_used_post_refund = gas_used_pre_refund - effective_refund
+        post = Alloc()
 
-        call_data_floor_cost = data_floor_calc(data=data)
+        (
+            gas_used_post_refund,
+            gas_used_pre_refund,
+            call_data_floor_cost,
+            refund_tx,
+        ) = build_refund_tx(
+            fork=fork,
+            pre=pre,
+            post=post,
+            refund_types={refund_type},
+            refund_tx_reverts=refund_tx_reverts,
+            call_data=data,
+        )
 
         if (
             calldata_test_type
@@ -599,28 +470,15 @@ def test_varying_calldata_costs(
             f"Could not find the call_data with {num_iterations} iterations."
         )
 
-    block_gas_used = max(call_data_floor_cost, gas_used_pre_refund)
-    tx_gas_used = max(call_data_floor_cost, gas_used_post_refund)
-
-    tx = Transaction(
-        to=contract_address,
-        gas_limit=fork.transaction_gas_limit_cap(),
-        data=data,
-        sender=sender,
-        gas_price=7,
-        authorization_list=authorization_list,
-        expected_receipt={
-            "gas_used": tx_gas_used,
-        },
-    )
-
-    assert tx.gas_price is not None, "tx.gas_price should not be None"
-    expected_balance = initial_fund - tx_gas_used * tx.gas_price
-
-    post[sender] = Account(balance=expected_balance)
+    refund_tx_block_gas_used = max(call_data_floor_cost, gas_used_pre_refund)
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx], expected_gas_used=block_gas_used)],
+        blocks=[
+            Block(
+                txs=[refund_tx],
+                expected_gas_used=refund_tx_block_gas_used,
+            )
+        ],
         post=post,
     )


### PR DESCRIPTION
## 🗒️ Description
This PR does 2 things

1. Refactor the refund transaction building mechanism into its own helper function so each test doesn't have to build the `refund_tx` from scratch
2. Add a test that has multiple refund types within a single transaction

## 🔗 Related Issues or PRs
#1874 

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.


#### Cute Animal Picture

![Cute Animals - 7 of 12](https://github.com/user-attachments/assets/127e6e96-1d04-4dc0-bcfe-a3a7a7d5d2f3)
