### PR TITLE
feat(test): mark more `slow` tests as such

### DIFF
--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -26,6 +26,7 @@ REFERENCE_SPEC_GIT_PATH = "EIPS/eip-198.md"
 REFERENCE_SPEC_VERSION = "5c8f066acb210c704ef80c1033a941aa5374aac5"
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Byzantium")
 @pytest.mark.parametrize(
     ["mod_exp_input", "output"],

--- a/tests/byzantium/eip214_staticcall/test_staticcall.py
+++ b/tests/byzantium/eip214_staticcall/test_staticcall.py
@@ -331,6 +331,7 @@ def test_staticcall_call_to_precompile(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.with_all_precompiles
 @pytest.mark.parametrize(
     "call_value", [0, 2], ids=["zero_value", "nonzero_value"]
@@ -474,6 +475,7 @@ def test_staticcall_nested_call_to_precompile(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.with_all_precompiles
 @pytest.mark.parametrize(
     "call_value", [0, 2], ids=["zero_value", "nonzero_value"]

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -385,6 +385,7 @@ def block(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     SpecHelpers.all_valid_blob_combinations,
@@ -587,6 +588,7 @@ def test_invalid_normal_gas(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     SpecHelpers.invalid_blob_combinations,
@@ -674,6 +676,7 @@ def test_insufficient_balance_blob_tx(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     lambda fork: [
@@ -723,6 +726,7 @@ def test_sufficient_balance_blob_tx(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     lambda fork: [
@@ -791,6 +795,7 @@ def test_sufficient_balance_blob_tx_pre_fund_tx(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     lambda fork: [
@@ -871,6 +876,7 @@ def test_blob_gas_subtraction_tx(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "blobs_per_tx",
     SpecHelpers.all_valid_blob_combinations,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -301,6 +301,7 @@ def post(  # noqa: D103
     }
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "parent_blobs",
     lambda fork: range(0, fork.max_blobs_per_block() + 1),
@@ -626,6 +627,7 @@ def test_invalid_static_excess_blob_gas(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "header_excess_blobs_delta",
     lambda fork: range(1, fork.max_blobs_per_block()),
@@ -716,6 +718,7 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     "parent_blobs,header_excess_blobs_delta",
     lambda fork: itertools.product(

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -475,6 +475,7 @@ def test_fork_transition_excess_blob_gas_at_blob_genesis(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.valid_for_bpo_forks
 @pytest.mark.valid_at_transition_to("Prague", subsequent_forks=True)
 @pytest.mark.parametrize_by_fork(

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -492,6 +492,7 @@ def test_external_vectors(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "call_gas,y,result",
     [

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
@@ -187,6 +187,7 @@ def post(
     }
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "call_type",
     [Op.CALL, Op.DELEGATECALL, Op.CALLCODE, Op.STATICCALL],

--- a/tests/frontier/create/test_create_one_byte.py
+++ b/tests/frontier/create/test_create_one_byte.py
@@ -20,6 +20,7 @@ from execution_testing import (
 from execution_testing.forks import London
 
 
+@pytest.mark.slow
 @pytest.mark.ported_from(
     [
         "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stCreateTest/CREATE_FirstByte_loopFiller.yml",

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -149,6 +149,7 @@ def fork_opcodes_increasing_stack(
             yield opcode
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork("opcode", fork_opcodes_increasing_stack)
 @pytest.mark.parametrize("fails", [True, False])
 def test_stack_overflow(
@@ -225,6 +226,7 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
         )
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Berlin")
 @pytest.mark.parametrize_by_fork("opcode", constant_gas_opcodes)
 def test_constant_gas(

--- a/tests/frontier/opcodes/test_blockhash.py
+++ b/tests/frontier/opcodes/test_blockhash.py
@@ -12,6 +12,7 @@ from execution_testing import (
 from execution_testing.forks.helpers import Fork
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.parametrize(
     "setup_blocks_num,setup_blocks_empty",

--- a/tests/frontier/opcodes/test_log.py
+++ b/tests/frontier/opcodes/test_log.py
@@ -15,6 +15,7 @@ REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Berlin")
 @pytest.mark.parametrize(
     "opcode,topics",

--- a/tests/frontier/opcodes/test_push.py
+++ b/tests/frontier/opcodes/test_push.py
@@ -31,6 +31,7 @@ def get_input_for_push_opcode(opcode: Op) -> bytes:
     return ethereum_state_machine[0:input_size]
 
 
+@pytest.mark.slow
 @pytest.mark.ported_from(
     [
         "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/VMTests/vmTests/pushFiller.yml",

--- a/tests/frontier/precompiles/test_precompile_absence.py
+++ b/tests/frontier/precompiles/test_precompile_absence.py
@@ -17,6 +17,7 @@ UPPER_BOUND = 0x101
 RETURNDATASIZE_OFFSET = 0x10000000000000000  # Must be greater than UPPER_BOUND
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "calldata_size",
     [

--- a/tests/istanbul/eip152_blake2/test_blake2.py
+++ b/tests/istanbul/eip152_blake2/test_blake2.py
@@ -438,6 +438,7 @@ def test_blake2b(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Istanbul")
 @pytest.mark.parametrize("call_opcode", [Op.CALL, Op.CALLCODE])
 @pytest.mark.parametrize("gas_limit", [90_000, 110_000, 200_000])
@@ -566,6 +567,7 @@ def tx_gas_limits(fork: Fork) -> List[int]:
     return [max_tx_gas_limit(fork), 90_000, 110_000, 200_000]
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Istanbul")
 @pytest.mark.parametrize("call_opcode", [Op.CALL, Op.CALLCODE])
 @pytest.mark.parametrize_by_fork("gas_limit", tx_gas_limits)

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -392,6 +392,7 @@ def test_tx_gas_limit_cap_full_calldata(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "exceed_tx_gas_limit",
     [
@@ -541,6 +542,7 @@ def test_tx_gas_limit_cap_access_list_with_diff_keys(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "exceed_tx_gas_limit,correct_intrinsic_cost_in_transaction_gas_limit",
     [

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
@@ -17,6 +17,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_7918.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7918.version
 
 
+@pytest.mark.slow
 @pytest.mark.valid_at_transition_to("BPO1")
 @pytest.mark.valid_for_bpo_forks()
 @pytest.mark.parametrize("parent_excess_blobs", [27])

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -547,6 +547,7 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize_by_fork(
     [
         "parent_base_fee_per_gas",

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -413,6 +413,7 @@ def _exact_size_transactions_impl(
     return transactions, final_gas
 
 
+@pytest.mark.slow
 @EIPChecklist.BlockLevelConstraint.Test.Boundary.Under()
 @EIPChecklist.BlockLevelConstraint.Test.Boundary.Exact()
 @EIPChecklist.BlockLevelConstraint.Test.Boundary.Over()
@@ -483,6 +484,7 @@ def test_block_at_rlp_size_limit_boundary(
     )
 
 
+@pytest.mark.slow
 @EIPChecklist.BlockLevelConstraint.Test.Content.TransactionTypes()
 @pytest.mark.with_all_typed_transactions
 @pytest.mark.verify_sync
@@ -525,6 +527,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     )
 
 
+@pytest.mark.slow
 @EIPChecklist.BlockLevelConstraint.Test.Content.Logs()
 @pytest.mark.verify_sync
 @pytest.mark.valid_from("Osaka")
@@ -569,6 +572,7 @@ def test_block_at_rlp_limit_with_logs(
     )
 
 
+@pytest.mark.slow
 @EIPChecklist.BlockLevelConstraint.Test.Content.Withdrawals()
 @pytest.mark.verify_sync
 @pytest.mark.valid_from("Osaka")

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -80,6 +80,7 @@ def clz_parameters() -> list:
     return test_cases
 
 
+@pytest.mark.slow
 @pytest.mark.valid_from("Osaka")
 @pytest.mark.parametrize(
     "test_id,value,expected_clz",

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2mul.py
@@ -156,6 +156,7 @@ def test_valid(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "input_data",
     # Test vectors from the reference spec (from the cryptography team)

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
@@ -35,6 +35,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "input_data,expected_output,vector_gas_value",
     # Test vectors from the reference spec (from the cryptography team)
@@ -200,6 +201,7 @@ def test_valid_multi_inf(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "input_data",
     # Test vectors from the reference spec (from the cryptography team)

--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -914,6 +914,7 @@ pytestmark = pytest.mark.valid_from("Prague")
         ),
     ],
 )
+@pytest.mark.slow
 @pytest.mark.pre_alloc_group(
     "deposit_requests",
     reason="Tests standard deposit request functionality with system contract",

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py
@@ -662,6 +662,7 @@ pytestmark = pytest.mark.valid_from("Prague")
         ),
     ],
 )
+@pytest.mark.slow
 @pytest.mark.pre_alloc_group(
     "withdrawal_requests",
     reason="Tests standard withdrawal request functionality",

--- a/tests/prague/eip7251_consolidations/test_consolidations.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations.py
@@ -677,6 +677,7 @@ pytestmark = pytest.mark.valid_from("Prague")
         ),
     ],
 )
+@pytest.mark.slow
 @pytest.mark.pre_alloc_group(
     "consolidation_requests",
     reason="Tests standard consolidation request functionality",

--- a/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py
@@ -93,6 +93,7 @@ def test_transaction_validity_type_0(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "to",
     [
@@ -172,6 +173,7 @@ def test_transaction_validity_type_1_type_2(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "access_list",
     [
@@ -264,6 +266,7 @@ def test_transaction_validity_type_3(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "access_list",
     [

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -336,6 +336,7 @@ def get_contract_permutations(
         ),
     ],
 )
+@pytest.mark.slow
 @pytest.mark.pre_alloc_group(
     "multi_type_requests",
     reason="Tests combinations of multiple request types",

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -1118,6 +1118,7 @@ def test_account_warming(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     **gas_test_parameter_args(include_pre_authorized=False)
 )

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2836,6 +2836,7 @@ def test_set_code_to_log(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.with_all_call_opcodes
 @pytest.mark.with_all_precompiles
 @EIPChecklist.Precompile.Test.CallContexts.SetCode(eip=[7951, 7883, 7823])

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -428,6 +428,7 @@ def test_pointer_measurements(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.with_all_precompiles
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("sender_delegated", [True, False])
@@ -524,6 +525,7 @@ def test_call_to_precompile_in_pointer_context(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.with_all_precompiles
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("sender_delegated", [True, False])

--- a/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
+++ b/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
@@ -301,6 +301,7 @@ def build_post_state(
 # --- tests --- #
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "is_success", [True, False], ids=["exact_gas", "exact_gas_minus_1"]
 )
@@ -425,6 +426,7 @@ def test_selfdestruct_to_account(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "is_success", [True, False], ids=["exact_gas", "exact_gas_minus_1"]
 )
@@ -561,6 +563,7 @@ def test_selfdestruct_state_access_boundary(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "is_success", [True, False], ids=["exact_gas", "exact_gas_minus_1"]
 )
@@ -682,6 +685,7 @@ def test_selfdestruct_to_precompile(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "is_success", [True, False], ids=["exact_gas", "exact_gas_minus_1"]
 )


### PR DESCRIPTION
## 🗒️ Description
I created [this script](https://gist.github.com/felix314159/c2bfcf57c9874579cf3e444b7c27e8a2) to automate the process of finding:
* tests that are slow but not marked as such
* tests that are not slow but marked as slow

The script was run on our hiveserver using all cores. The script allows you define the threshold of when a test is considered slow, I ran it set to 3 seconds (aggregation of all parametrizations), but in this PR I only mark tests that took 15 seconds or more.

The output of the script that was run can be found [here](https://gist.github.com/felix314159/c2bfcf57c9874579cf3e444b7c27e8a2?permalink_comment_id=5956356#gistcomment-5956356).

Let me know what you think, I would like to reach a point where filling all tests can be done in a reasonable time (and we still occassionally run ALL tests no matter how they are marked).

## 🔗 Related Issues or PRs
Solves #1625 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1349696533922320478/1482020933572235334/IMG_0185.png?ex=69b56f0d&is=69b41d8d&hm=a827f2c53a7278dc813ba81fe700ed1cab48c3100171ed57ca03ce3862ab9dfc&"
  alt="Cute Animal Picture"
  width="320">
