### PR TITLE
fix(tests): fix EIP-7934 tests logic accuracy

### DIFF
--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7251.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7251.py
@@ -1,4 +1,4 @@
-"""Tests for the effects of EIP-7251 beacon roots on EIP-7928."""
+"""Tests for the effects of EIP-7251 consolidation requests on EIP-7928."""
 
 from typing import List
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -364,62 +364,62 @@ def _exact_size_transactions_impl(
             )
 
             if test_size == block_size_limit:
-                # if exact match, use the transaction
                 transactions.append(test_tx)
             else:
-                # search for the best adjustment
+                # Binary search for the calldata size that hits the target.
+                # Block size is monotonically non-decreasing with calldata
+                # length, so binary search converges in ~O(log N) iterations.
                 diff = block_size_limit - test_size
+                search_range = min(abs(diff) + 50, 1000)
+                low = max(0, estimated_calldata - search_range)
+                high = estimated_calldata + search_range
+
                 best_diff = abs(diff)
                 best_tx = test_tx
 
-                search_range = min(abs(diff) + 50, 1000)
+                while low <= high:
+                    mid = (low + high) // 2
+                    mid_calldata = b"\x00" * mid
+                    mid_gas = calculator(calldata=mid_calldata)
 
-                for adjustment in range(-search_range, search_range + 1):
-                    adjusted_size = estimated_calldata + adjustment
-                    if adjusted_size < 0:
+                    if mid_gas > remaining_gas:
+                        high = mid - 1
                         continue
 
-                    adjusted_calldata = b"\x00" * adjusted_size
-                    adjusted_gas = calculator(calldata=adjusted_calldata)
+                    mid_tx = Transaction(
+                        sender=sender,
+                        nonce=nonce,
+                        max_fee_per_gas=10**11,
+                        max_priority_fee_per_gas=10**11,
+                        gas_limit=mid_gas,
+                        data=mid_calldata,
+                    )
 
-                    if adjusted_gas <= remaining_gas:
-                        adjusted_tx = Transaction(
-                            sender=sender,
-                            nonce=nonce,
-                            max_fee_per_gas=10**11,
-                            max_priority_fee_per_gas=10**11,
-                            gas_limit=adjusted_gas,
-                            data=adjusted_calldata,
-                        )
+                    mid_size = get_block_rlp_size(
+                        fork,
+                        transactions + [mid_tx],
+                        withdrawals=withdrawals,
+                    )
 
-                        adjusted_test_size = get_block_rlp_size(
-                            fork,
-                            transactions + [adjusted_tx],
-                            withdrawals=withdrawals,
-                        )
+                    mid_diff = abs(block_size_limit - mid_size)
+                    if mid_diff < best_diff:
+                        best_diff = mid_diff
+                        best_tx = mid_tx
 
-                        if adjusted_test_size == block_size_limit:
-                            # exact match
-                            transactions.append(adjusted_tx)
-                            break
-
-                        adjusted_diff = abs(
-                            block_size_limit - adjusted_test_size
-                        )
-                        if adjusted_diff < best_diff:
-                            best_diff = adjusted_diff
-                            best_tx = adjusted_tx
-                else:
-                    # No exact match found. Due to RLP encoding boundaries,
-                    # certain exact sizes may be unachievable. Accept ±1 byte
-                    # tolerance - the test can compensate via extra_data.
-                    if best_diff <= 1:
-                        transactions.append(best_tx)
+                    if mid_size == block_size_limit:
+                        break
+                    elif mid_size < block_size_limit:
+                        low = mid + 1
                     else:
-                        raise RuntimeError(
-                            "Failed to find a transaction that matches "
-                            f"the target size (best diff: {best_diff} bytes)."
-                        )
+                        high = mid - 1
+
+                if best_diff <= 1:
+                    transactions.append(best_tx)
+                else:
+                    raise RuntimeError(
+                        "Failed to find a transaction that matches "
+                        f"the target size (best diff: {best_diff} bytes)."
+                    )
         else:
             transactions.append(empty_tx)
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -123,12 +123,16 @@ def exact_size_transactions(
     emit_logs: bool = False,
     specific_transaction_to_include: Transaction | None = None,
     withdrawals: List[Withdrawal] | None = None,
-) -> Tuple[List[Transaction], int]:
+) -> Tuple[List[Transaction], int, int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit.
 
     The calculation uses caching to avoid recalculating the same block rlp for
     each fork. Calculate the block and fill with real sender for testing.
+
+    Due to RLP encoding boundaries, certain exact block sizes may be
+    unachievable (±1 byte). The returned extra_data_len compensates for
+    any gap so the final block hits the exact target.
 
     Args:
         sender: The sender account
@@ -140,6 +144,11 @@ def exact_size_transactions(
         specific_transaction_to_include: If provided, this transaction will
             be included
         withdrawals: Optional list of withdrawals to include in the block
+
+    Returns:
+        Tuple of (transactions, gas_used, extra_data_len) where
+        extra_data_len is the number of extra_data bytes needed to hit
+        the exact target block size.
 
     """
     log_contract = None
@@ -169,17 +178,19 @@ def exact_size_transactions(
 
     if not specific_transaction_to_include and not withdrawals:
         # use cached version when possible for performance
-        transactions, gas_used = _exact_size_transactions_cached(
-            block_size_limit,
-            fork,
-            gas_limit,
-            sender,
-            emit_logs_contract=log_contract,
+        transactions, gas_used, extra_data_len = (
+            _exact_size_transactions_cached(
+                block_size_limit,
+                fork,
+                gas_limit,
+                sender,
+                emit_logs_contract=log_contract,
+            )
         )
     else:
         # Direct calculation, no cache, since `Transaction` / `Withdrawal`
         # are not hashable
-        transactions, gas_used = _exact_size_transactions_impl(
+        transactions, gas_used, extra_data_len = _exact_size_transactions_impl(
             block_size_limit,
             fork,
             gas_limit,
@@ -189,7 +200,7 @@ def exact_size_transactions(
             withdrawals=withdrawals,
         )
 
-    return transactions, gas_used
+    return transactions, gas_used, extra_data_len
 
 
 @lru_cache(maxsize=128)
@@ -199,10 +210,16 @@ def _exact_size_transactions_cached(
     gas_limit: int,
     sender: EOA,
     emit_logs_contract: Address | None = None,
-) -> Tuple[List[Transaction], int]:
+) -> Tuple[List[Transaction], int, int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit.
     Abstracted with hashable arguments for caching block calculations.
+
+    Returns:
+        Tuple of (transactions, gas_used, extra_data_len) where
+        extra_data_len is the number of extra_data bytes needed to hit
+        the exact target block size.
+
     """
     return _exact_size_transactions_impl(
         block_size_limit,
@@ -223,7 +240,7 @@ def _exact_size_transactions_impl(
     specific_transaction_to_include: Transaction | None = None,
     emit_logs_contract: Address | None = None,
     withdrawals: List[Withdrawal] | None = None,
-) -> Tuple[List[Transaction], int]:
+) -> Tuple[List[Transaction], int, int]:
     """
     Calculate the exact size of transactions to be included. Shared by both
     cached and non-cached paths.
@@ -353,6 +370,7 @@ def _exact_size_transactions_impl(
                 # search for the best adjustment
                 diff = block_size_limit - test_size
                 best_diff = abs(diff)
+                best_tx = test_tx
 
                 search_range = min(abs(diff) + 50, 1000)
 
@@ -390,11 +408,18 @@ def _exact_size_transactions_impl(
                         )
                         if adjusted_diff < best_diff:
                             best_diff = adjusted_diff
+                            best_tx = adjusted_tx
                 else:
-                    raise RuntimeError(
-                        "Failed to find a transaction that matches "
-                        "the target size."
-                    )
+                    # No exact match found. Due to RLP encoding boundaries,
+                    # certain exact sizes may be unachievable. Accept ±1 byte
+                    # tolerance - the test can compensate via extra_data.
+                    if best_diff <= 1:
+                        transactions.append(best_tx)
+                    else:
+                        raise RuntimeError(
+                            "Failed to find a transaction that matches "
+                            f"the target size (best diff: {best_diff} bytes)."
+                        )
         else:
             transactions.append(empty_tx)
 
@@ -405,12 +430,16 @@ def _exact_size_transactions_impl(
     )
     final_gas = sum(tx.gas_limit for tx in transactions)
 
-    assert final_size == block_size_limit, (
+    # RLP encoding boundaries can make some exactness unachievable (±1 byte).
+    # Compute the extra_data length that compensates for any gap.
+    size_diff = final_size - block_size_limit
+    assert abs(size_diff) <= 1, (
         f"Size mismatch: got {final_size}, "
         f"expected {block_size_limit} "
-        f"({final_size - block_size_limit} bytes diff)"
+        f"({size_diff} bytes diff, exceeds ±1 tolerance)"
     )
-    return transactions, final_gas
+    extra_data_len = len(EXTRA_DATA_AT_LIMIT) - size_diff
+    return transactions, final_gas, extra_data_len
 
 
 @EIPChecklist.BlockLevelConstraint.Test.Boundary.Under()
@@ -446,18 +475,12 @@ def test_block_at_rlp_size_limit_boundary(
     - At the limit, the block is valid
     - At the limit + 1 byte, the block is invalid
     """
-    transactions, gas_used = exact_size_transactions(
+    transactions, gas_used, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
         pre,
         env.gas_limit,
-    )
-    block_rlp_size = get_block_rlp_size(fork, transactions)
-    assert block_rlp_size == block_size_limit, (
-        f"Block RLP size {block_rlp_size} does not exactly match "
-        f"limit {block_size_limit}, difference: "
-        f"{block_rlp_size - block_size_limit} bytes"
     )
 
     block = Block(
@@ -467,12 +490,8 @@ def test_block_at_rlp_size_limit_boundary(
         else None,
     )
 
-    if delta < 0:
-        block.extra_data = Bytes(EXTRA_DATA_AT_LIMIT[: -abs(delta)])
-    elif delta == 0:
-        block.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
-    else:  # delta > 0
-        block.extra_data = Bytes(EXTRA_DATA_AT_LIMIT + b"\x00" * delta)
+    target_extra_data_len = max(extra_data_len + delta, 0)
+    block.extra_data = Bytes(b"\x00" * target_extra_data_len)
 
     block.timestamp = ZeroPaddedHexNumber(HEADER_TIMESTAMP)
     blockchain_test(
@@ -498,7 +517,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     typed_transaction: Transaction,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
-    transactions, gas_used = exact_size_transactions(
+    transactions, gas_used, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -506,15 +525,9 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
         env.gas_limit,
         specific_transaction_to_include=typed_transaction,
     )
-    block_rlp_size = get_block_rlp_size(fork, transactions)
-    assert block_rlp_size == block_size_limit, (
-        f"Block RLP size {block_rlp_size} does not exactly match limit "
-        f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
-        "bytes"
-    )
 
     block = Block(txs=transactions)
-    block.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
+    block.extra_data = Bytes(b"\x00" * extra_data_len)
     block.timestamp = ZeroPaddedHexNumber(HEADER_TIMESTAMP)
 
     blockchain_test(
@@ -541,7 +554,7 @@ def test_block_at_rlp_limit_with_logs(
     Test that a block at the RLP size limit is valid even when transactions
     emit logs.
     """
-    transactions, gas_used = exact_size_transactions(
+    transactions, gas_used, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -550,15 +563,8 @@ def test_block_at_rlp_limit_with_logs(
         emit_logs=True,
     )
 
-    block_rlp_size = get_block_rlp_size(fork, transactions)
-    assert block_rlp_size == block_size_limit, (
-        f"Block RLP size {block_rlp_size} does not exactly match limit "
-        f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
-        "bytes"
-    )
-
     block = Block(txs=transactions)
-    block.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
+    block.extra_data = Bytes(b"\x00" * extra_data_len)
     block.timestamp = ZeroPaddedHexNumber(HEADER_TIMESTAMP)
 
     blockchain_test(
@@ -600,7 +606,7 @@ def test_block_at_rlp_limit_with_withdrawals(
         ),
     ]
 
-    transactions, gas_used = exact_size_transactions(
+    transactions, gas_used, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -609,19 +615,10 @@ def test_block_at_rlp_limit_with_withdrawals(
         withdrawals=withdrawals,
     )
 
-    block_rlp_size = get_block_rlp_size(
-        fork, transactions, withdrawals=withdrawals
-    )
-    assert block_rlp_size == block_size_limit, (
-        f"Block RLP size {block_rlp_size} does not exactly match limit "
-        f"{block_size_limit}, difference: {block_rlp_size - block_size_limit} "
-        "bytes"
-    )
-
     block = Block(
         txs=transactions,
         withdrawals=withdrawals,
-        extra_data=Bytes(EXTRA_DATA_AT_LIMIT),
+        extra_data=Bytes(b"\x00" * extra_data_len),
         timestamp=ZeroPaddedHexNumber(HEADER_TIMESTAMP),
     )
 
@@ -664,39 +661,33 @@ def test_fork_transition_block_rlp_limit(
     sender_before_fork = pre.fund_eoa()
     sender_at_fork = pre.fund_eoa()
 
-    transactions_before, gas_used_before = exact_size_transactions(
-        sender_before_fork,
-        block_size_limit,
-        fork,
-        pre,
-        env.gas_limit,
-    )
-
-    transactions_at_fork, gas_used_at_fork = exact_size_transactions(
-        sender_at_fork,
-        block_size_limit,
-        fork,
-        pre,
-        env.gas_limit,
-    )
-
-    for fork_block_rlp_size in [
-        get_block_rlp_size(fork, transactions_before),
-        get_block_rlp_size(fork, transactions_at_fork),
-    ]:
-        assert fork_block_rlp_size == block_size_limit, (
-            f"Block RLP size {fork_block_rlp_size} does not exactly match "
-            f"limit {block_size_limit}, difference: "
-            f"{fork_block_rlp_size - block_size_limit} bytes"
+    transactions_before, gas_used_before, extra_data_len_before = (
+        exact_size_transactions(
+            sender_before_fork,
+            block_size_limit,
+            fork,
+            pre,
+            env.gas_limit,
         )
+    )
+
+    transactions_at_fork, gas_used_at_fork, extra_data_len_at_fork = (
+        exact_size_transactions(
+            sender_at_fork,
+            block_size_limit,
+            fork,
+            pre,
+            env.gas_limit,
+        )
+    )
 
     # HEADER_TIMESTAMP (123456789) used in calculation takes 4 bytes in RLP
     # encoding. Transition timestamps (14_999 and 15_000) take 2 bytes
     # Re-define `_extradata_at_limit` accounting for this difference
     timestamp_byte_savings = 2
-    _extradata_at_limit = EXTRA_DATA_AT_LIMIT + (
-        b"\x00" * timestamp_byte_savings
-    )
+
+    extra_data_before = extra_data_len_before + timestamp_byte_savings
+    extra_data_at_fork = extra_data_len_at_fork + timestamp_byte_savings
 
     blocks = [
         # before fork, block at limit +1 should be accepted
@@ -704,7 +695,7 @@ def test_fork_transition_block_rlp_limit(
             timestamp=14_999,
             txs=transactions_before,
             # +1 to exceed limit
-            extra_data=Bytes(_extradata_at_limit + b"\x00"),
+            extra_data=Bytes(b"\x00" * (extra_data_before + 1)),
         )
     ]
 
@@ -715,7 +706,7 @@ def test_fork_transition_block_rlp_limit(
                 timestamp=15_000,
                 txs=transactions_at_fork,
                 # +1 to exceed limit, should be rejected
-                extra_data=Bytes(_extradata_at_limit + b"\x00"),
+                extra_data=Bytes(b"\x00" * (extra_data_at_fork + 1)),
                 exception=BlockException.RLP_BLOCK_LIMIT_EXCEEDED,
             )
         )
@@ -725,7 +716,7 @@ def test_fork_transition_block_rlp_limit(
                 timestamp=15_000,
                 txs=transactions_at_fork,
                 # exact limit should be accepted
-                extra_data=Bytes(EXTRA_DATA_AT_LIMIT),
+                extra_data=Bytes(b"\x00" * extra_data_at_fork),
             )
         )
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -359,71 +359,7 @@ def _exact_size_transactions_impl(
                 gas_limit=target_gas,
                 data=target_calldata,
             )
-
-            test_size = get_block_rlp_size(
-                fork,
-                transactions + [test_tx],
-                withdrawals=withdrawals,
-            )
-
-            diff = abs(block_size_limit - test_size)
-
-            if diff <= EXTRA_DATA_TOLERANCE:
-                transactions.append(test_tx)
-            else:
-                # Binary search for calldata size within tolerance.
-                # Block size is monotonically non-decreasing with calldata
-                # length, so binary search converges in ~O(log N) iterations.
-                search_range = min(diff + 50, 1000)
-                low = max(0, estimated_calldata - search_range)
-                high = estimated_calldata + search_range
-
-                best_diff = diff
-                best_tx = test_tx
-
-                while low <= high:
-                    mid = (low + high) // 2
-                    mid_calldata = b"\x00" * mid
-                    mid_gas = calculator(calldata=mid_calldata)
-
-                    if mid_gas > remaining_gas:
-                        high = mid - 1
-                        continue
-
-                    mid_tx = Transaction(
-                        sender=sender,
-                        nonce=nonce,
-                        max_fee_per_gas=10**11,
-                        max_priority_fee_per_gas=10**11,
-                        gas_limit=mid_gas,
-                        data=mid_calldata,
-                    )
-
-                    mid_size = get_block_rlp_size(
-                        fork,
-                        transactions + [mid_tx],
-                        withdrawals=withdrawals,
-                    )
-
-                    mid_diff = abs(block_size_limit - mid_size)
-                    if mid_diff < best_diff:
-                        best_diff = mid_diff
-                        best_tx = mid_tx
-
-                    if mid_diff <= EXTRA_DATA_TOLERANCE:
-                        break
-                    elif mid_size < block_size_limit:
-                        low = mid + 1
-                    else:
-                        high = mid - 1
-
-                if best_diff <= EXTRA_DATA_TOLERANCE:
-                    transactions.append(best_tx)
-                else:
-                    raise RuntimeError(
-                        "Failed to find a transaction that matches "
-                        f"the target size (best diff: {best_diff} bytes)."
-                    )
+            transactions.append(test_tx)
         else:
             transactions.append(empty_tx)
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -126,7 +126,7 @@ def exact_size_transactions(
     emit_logs: bool = False,
     specific_transaction_to_include: Transaction | None = None,
     withdrawals: List[Withdrawal] | None = None,
-) -> Tuple[List[Transaction], int, int]:
+) -> Tuple[List[Transaction], int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit.
 
@@ -149,9 +149,9 @@ def exact_size_transactions(
         withdrawals: Optional list of withdrawals to include in the block
 
     Returns:
-        Tuple of (transactions, gas_used, extra_data_len) where
-        extra_data_len is the number of extra_data bytes needed to hit
-        the exact target block size.
+        Tuple of (transactions, extra_data_len) where extra_data_len is
+        the number of extra_data bytes needed to hit the exact target
+        block size.
 
     """
     log_contract = None
@@ -181,19 +181,17 @@ def exact_size_transactions(
 
     if not specific_transaction_to_include and not withdrawals:
         # use cached version when possible for performance
-        transactions, gas_used, extra_data_len = (
-            _exact_size_transactions_cached(
-                block_size_limit,
-                fork,
-                gas_limit,
-                sender,
-                emit_logs_contract=log_contract,
-            )
+        transactions, extra_data_len = _exact_size_transactions_cached(
+            block_size_limit,
+            fork,
+            gas_limit,
+            sender,
+            emit_logs_contract=log_contract,
         )
     else:
         # Direct calculation, no cache, since `Transaction` / `Withdrawal`
         # are not hashable
-        transactions, gas_used, extra_data_len = _exact_size_transactions_impl(
+        transactions, extra_data_len = _exact_size_transactions_impl(
             block_size_limit,
             fork,
             gas_limit,
@@ -203,7 +201,7 @@ def exact_size_transactions(
             withdrawals=withdrawals,
         )
 
-    return transactions, gas_used, extra_data_len
+    return transactions, extra_data_len
 
 
 @lru_cache(maxsize=128)
@@ -213,15 +211,15 @@ def _exact_size_transactions_cached(
     gas_limit: int,
     sender: EOA,
     emit_logs_contract: Address | None = None,
-) -> Tuple[List[Transaction], int, int]:
+) -> Tuple[List[Transaction], int]:
     """
     Generate transactions that fill a block to exactly the RLP size limit.
     Abstracted with hashable arguments for caching block calculations.
 
     Returns:
-        Tuple of (transactions, gas_used, extra_data_len) where
-        extra_data_len is the number of extra_data bytes needed to hit
-        the exact target block size.
+        Tuple of (transactions, extra_data_len) where extra_data_len is
+        the number of extra_data bytes needed to hit the exact target
+        block size.
 
     """
     return _exact_size_transactions_impl(
@@ -243,7 +241,7 @@ def _exact_size_transactions_impl(
     specific_transaction_to_include: Transaction | None = None,
     emit_logs_contract: Address | None = None,
     withdrawals: List[Withdrawal] | None = None,
-) -> Tuple[List[Transaction], int, int]:
+) -> Tuple[List[Transaction], int]:
     """
     Calculate the exact size of transactions to be included. Shared by both
     cached and non-cached paths.
@@ -368,8 +366,6 @@ def _exact_size_transactions_impl(
         transactions,
         withdrawals=withdrawals,
     )
-    final_gas = sum(tx.gas_limit for tx in transactions)
-
     # Compute the extra_data length that compensates for any size gap.
     size_diff = final_size - block_size_limit
     assert abs(size_diff) <= EXTRA_DATA_TOLERANCE, (
@@ -378,7 +374,7 @@ def _exact_size_transactions_impl(
         f"({size_diff} bytes diff, exceeds ±{EXTRA_DATA_TOLERANCE} tolerance)"
     )
     extra_data_len = len(EXTRA_DATA_AT_LIMIT) - size_diff
-    return transactions, final_gas, extra_data_len
+    return transactions, extra_data_len
 
 
 @EIPChecklist.BlockLevelConstraint.Test.Boundary.Under()
@@ -414,7 +410,7 @@ def test_block_at_rlp_size_limit_boundary(
     - At the limit, the block is valid
     - At the limit + 1 byte, the block is invalid
     """
-    transactions, gas_used, extra_data_len = exact_size_transactions(
+    transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -456,7 +452,7 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     typed_transaction: Transaction,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
-    transactions, gas_used, extra_data_len = exact_size_transactions(
+    transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -493,7 +489,7 @@ def test_block_at_rlp_limit_with_logs(
     Test that a block at the RLP size limit is valid even when transactions
     emit logs.
     """
-    transactions, gas_used, extra_data_len = exact_size_transactions(
+    transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -545,7 +541,7 @@ def test_block_at_rlp_limit_with_withdrawals(
         ),
     ]
 
-    transactions, gas_used, extra_data_len = exact_size_transactions(
+    transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
         fork,
@@ -600,24 +596,20 @@ def test_fork_transition_block_rlp_limit(
     sender_before_fork = pre.fund_eoa()
     sender_at_fork = pre.fund_eoa()
 
-    transactions_before, gas_used_before, extra_data_len_before = (
-        exact_size_transactions(
-            sender_before_fork,
-            block_size_limit,
-            fork,
-            pre,
-            env.gas_limit,
-        )
+    transactions_before, extra_data_len_before = exact_size_transactions(
+        sender_before_fork,
+        block_size_limit,
+        fork,
+        pre,
+        env.gas_limit,
     )
 
-    transactions_at_fork, gas_used_at_fork, extra_data_len_at_fork = (
-        exact_size_transactions(
-            sender_at_fork,
-            block_size_limit,
-            fork,
-            pre,
-            env.gas_limit,
-        )
+    transactions_at_fork, extra_data_len_at_fork = exact_size_transactions(
+        sender_at_fork,
+        block_size_limit,
+        fork,
+        pre,
+        env.gas_limit,
     )
 
     # HEADER_TIMESTAMP (123456789) used in calculation takes 4 bytes in RLP

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -45,7 +45,10 @@ pytestmark = [
 
 
 HEADER_TIMESTAMP = 123456789
-EXTRA_DATA_AT_LIMIT = b"\x00\x00\x00"
+EXTRA_DATA_AT_LIMIT = b"\x00" * 15
+# Max size adjustment extra_data can absorb
+# reserves 1 byte so delta=-1 tests stay valid
+EXTRA_DATA_TOLERANCE = len(EXTRA_DATA_AT_LIMIT) - 1
 BLOCK_GAS_LIMIT = 100_000_000
 
 
@@ -363,18 +366,19 @@ def _exact_size_transactions_impl(
                 withdrawals=withdrawals,
             )
 
-            if test_size == block_size_limit:
+            diff = abs(block_size_limit - test_size)
+
+            if diff <= EXTRA_DATA_TOLERANCE:
                 transactions.append(test_tx)
             else:
-                # Binary search for the calldata size that hits the target.
+                # Binary search for calldata size within tolerance.
                 # Block size is monotonically non-decreasing with calldata
                 # length, so binary search converges in ~O(log N) iterations.
-                diff = block_size_limit - test_size
-                search_range = min(abs(diff) + 50, 1000)
+                search_range = min(diff + 50, 1000)
                 low = max(0, estimated_calldata - search_range)
                 high = estimated_calldata + search_range
 
-                best_diff = abs(diff)
+                best_diff = diff
                 best_tx = test_tx
 
                 while low <= high:
@@ -406,14 +410,14 @@ def _exact_size_transactions_impl(
                         best_diff = mid_diff
                         best_tx = mid_tx
 
-                    if mid_size == block_size_limit:
+                    if mid_diff <= EXTRA_DATA_TOLERANCE:
                         break
                     elif mid_size < block_size_limit:
                         low = mid + 1
                     else:
                         high = mid - 1
 
-                if best_diff <= 1:
+                if best_diff <= EXTRA_DATA_TOLERANCE:
                     transactions.append(best_tx)
                 else:
                     raise RuntimeError(
@@ -430,13 +434,12 @@ def _exact_size_transactions_impl(
     )
     final_gas = sum(tx.gas_limit for tx in transactions)
 
-    # RLP encoding boundaries can make some exactness unachievable (±1 byte).
-    # Compute the extra_data length that compensates for any gap.
+    # Compute the extra_data length that compensates for any size gap.
     size_diff = final_size - block_size_limit
-    assert abs(size_diff) <= 1, (
+    assert abs(size_diff) <= EXTRA_DATA_TOLERANCE, (
         f"Size mismatch: got {final_size}, "
         f"expected {block_size_limit} "
-        f"({size_diff} bytes diff, exceeds ±1 tolerance)"
+        f"({size_diff} bytes diff, exceeds ±{EXTRA_DATA_TOLERANCE} tolerance)"
     )
     extra_data_len = len(EXTRA_DATA_AT_LIMIT) - size_diff
     return transactions, final_gas, extra_data_len
@@ -682,8 +685,8 @@ def test_fork_transition_block_rlp_limit(
     )
 
     # HEADER_TIMESTAMP (123456789) used in calculation takes 4 bytes in RLP
-    # encoding. Transition timestamps (14_999 and 15_000) take 2 bytes
-    # Re-define `_extradata_at_limit` accounting for this difference
+    # encoding. Transition timestamps (14_999 and 15_000) take 2 bytes.
+    # Add the difference to extra_data to keep block at the limit.
     timestamp_byte_savings = 2
 
     extra_data_before = extra_data_len_before + timestamp_byte_savings


### PR DESCRIPTION
## 🗒️ Description

We had some issues filling EIP-7934 tests for Amsterdam after introducing tests for EIP-7843, that we very quickly patched ([here](https://github.com/fselmo/execution-specs/commit/a64c42add7fd4855d3279b6bb2644b47931b9764#diff-5e81bf7f76169cc7ee4c5f8980679196b0c222055826aee1ae7cd3e8868d3f34R48)) so we could get the tests released. This "fix" was more of a bandaid fix that was likely going to leak issues out again eventually. This PR aims to fix this in a more proper way as this is still currently failing one test in `forks/amsterdam` since we haven't introduced this fix here.

- First few commits here Claude added +/- 1byte tolerance which helps us not have to find a perfect match (original problem). Then optimized the search by changing from linear to binary search.
- I then went down a path to play with increasing the starting `extraData` to half of what it can be. `extraData` is a 32-byte field, so if we start somewhere in the middle we can have even better tolerance. It turns out that our calldata estimate for the last tx is good enough where we're always within ~5 bytes of what we need. This actually removes the need for the binary search entirely as we have plenty of tolerance to adjust with block `extraData`.

This PR brings the `fill` time for these tests down significantly to where I don't believe these tests are a burden on `fill` anymore.

---
Bonus:

Fix typo in EIP-7251 BAL tests that was just merged to `forks/amsterdam` and slipped by PR reviews.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="531" height="571" alt="Screenshot 2026-01-26 at 16 14 53" src="https://github.com/user-attachments/assets/db875bec-f6b3-46a7-a50e-d814db980dc5" />
