### PR TITLE
feat(test-fill): speed up filling

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -1,27 +1,27 @@
 # Unless filling for special features, all features should fill for previous forks (starting from Frontier) too
 stable:
   evm-type: stable
-  fill-params: --until=Prague --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
+  fill-params: --no-html --until=Prague --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 develop:
   evm-type: develop
-  fill-params: --until=BPO4 --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
+  fill-params: --no-html --until=BPO4 --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Prague --gas-benchmark-values 1,5,10,30,60,100,150 -m benchmark ./tests/benchmark
+  fill-params: --no-html --fork=Prague --gas-benchmark-values 1,5,10,30,60,100,150 -m benchmark ./tests/benchmark
 
 benchmark_develop:
   evm-type: benchmark
-  fill-params: --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 -m "benchmark" ./tests/benchmark
+  fill-params: --no-html --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 -m "benchmark" ./tests/benchmark
   feature_only: true
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --fork=Prague --gas-benchmark-values 100 -m "benchmark" ./tests/benchmark
+  fill-params: --no-html --fork=Prague --gas-benchmark-values 100 -m "benchmark" ./tests/benchmark
   feature_only: true
 
 bal:
   evm-type: develop
-  fill-params: --fork=Amsterdam --fill-static-tests
+  fill-params: --no-html --fork=Amsterdam --fill-static-tests
   feature_only: true

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -4,7 +4,7 @@ stable:
   fill-params: --until=Prague --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 develop:
-  evm-type: develop 
+  evm-type: develop
   fill-params: --until=BPO4 --fill-static-tests --ignore=tests/static/state_tests/stQuadraticComplexityTest
 
 benchmark:

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -257,7 +257,9 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
         return
 
     # Merge all partial indexes (JSONL format: one entry per line)
-    all_entries: List[TestCaseIndexFile] = []
+    # Read as raw dicts — the data was already validated when collected
+    # from live Pydantic fixture objects in add_fixture().
+    all_raw_entries: list[dict] = []
     all_forks: set = set()
     all_formats: set = set()
 
@@ -268,27 +270,27 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
                 if not line:
                     continue
                 entry_data = json.loads(line)
-                # Validate with Pydantic
-                # (deferred from add_fixture for performance)
-                entry = TestCaseIndexFile.model_validate(entry_data)
-                all_entries.append(entry)
-                # Collect forks and formats from validated entries
-                if entry.fork:
-                    all_forks.add(entry.fork.name())
-                if entry.format:
-                    all_formats.add(entry.format.format_name)
+                all_raw_entries.append(entry_data)
+                # Collect forks and formats from raw strings
+                if entry_data.get("fork"):
+                    all_forks.add(entry_data["fork"])
+                if entry_data.get("format"):
+                    all_formats.add(entry_data["format"])
 
-    # Compute root hash from collected fixture hashes
-    root_hash = HashableItem.from_index_entries(all_entries).hash()
+    # Compute root hash from raw dicts (no Pydantic needed)
+    root_hash = HashableItem.from_raw_entries(all_raw_entries).hash()
 
-    # Build final index
-    index = IndexFile(
-        test_cases=all_entries,
-        root_hash=HexNumber(root_hash),
-        created_at=datetime.datetime.now(),
-        test_count=len(all_entries),
-        forks=list(all_forks),
-        fixture_formats=list(all_formats),
+    # Build final index — Pydantic validates the entire structure once
+    # via model_validate(), not 96k individual model_validate() calls.
+    index = IndexFile.model_validate(
+        {
+            "test_cases": all_raw_entries,
+            "root_hash": HexNumber(root_hash),
+            "created_at": datetime.datetime.now(),
+            "test_count": len(all_raw_entries),
+            "forks": list(all_forks),
+            "fixture_formats": list(all_formats),
+        }
     )
 
     # Write final index
@@ -299,7 +301,7 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
     if not quiet_mode:
         rich.print(
             f"[green]Merged {len(partial_files)} partial indexes "
-            f"({len(all_entries)} test cases) into {index_path}[/]"
+            f"({len(all_raw_entries)} test cases) into {index_path}[/]"
         )
 
     # Cleanup partial files

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -226,5 +226,73 @@ def generate_fixtures_index(
         f.write(index.model_dump_json(exclude_none=False, indent=2))
 
 
+def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
+    """
+    Merge partial index files from all workers into final index.json.
+
+    This is called by pytest_sessionfinish on the master process after all
+    workers have finished and written their partial indexes.
+
+    Args:
+        output_dir: The fixture output directory.
+        quiet_mode: If True, don't print status messages.
+
+    """
+    meta_dir = output_dir / ".meta"
+    partial_files = list(meta_dir.glob("partial_index*.json"))
+
+    if not partial_files:
+        # Fallback to old method if no partial indexes exist
+        if not quiet_mode:
+            rich.print(
+                "[yellow]No partial indexes found, "
+                "falling back to full scan[/]"
+            )
+        generate_fixtures_index(
+            output_dir, quiet_mode=quiet_mode, force_flag=True
+        )
+        return
+
+    # Merge all partial indexes
+    all_entries: List[TestCaseIndexFile] = []
+    all_forks: set = set()
+    all_formats: set = set()
+
+    for partial_file in partial_files:
+        partial_data = json.loads(partial_file.read_text())
+        for entry in partial_data["entries"]:
+            all_entries.append(TestCaseIndexFile.model_validate(entry))
+        all_forks.update(partial_data.get("forks", []))
+        all_formats.update(partial_data.get("formats", []))
+
+    # Compute root hash from collected fixture hashes
+    root_hash = HashableItem.from_index_entries(all_entries).hash()
+
+    # Build final index
+    index = IndexFile(
+        test_cases=all_entries,
+        root_hash=HexNumber(root_hash),
+        created_at=datetime.datetime.now(),
+        test_count=len(all_entries),
+        forks=list(all_forks),
+        fixture_formats=list(all_formats),
+    )
+
+    # Write final index
+    index_path = meta_dir / "index.json"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(index.model_dump_json(exclude_none=False, indent=2))
+
+    if not quiet_mode:
+        rich.print(
+            f"[green]Merged {len(partial_files)} partial indexes "
+            f"({len(all_entries)} test cases) into {index_path}[/]"
+        )
+
+    # Cleanup partial files
+    for partial_file in partial_files:
+        partial_file.unlink()
+
+
 if __name__ == "__main__":
     generate_fixtures_index_cli()

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -233,13 +233,16 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
     This is called by pytest_sessionfinish on the master process after all
     workers have finished and written their partial indexes.
 
+    Partial indexes use JSONL format (one JSON object per line) for efficient
+    append-only writes during fill. Entries are validated with Pydantic here.
+
     Args:
         output_dir: The fixture output directory.
         quiet_mode: If True, don't print status messages.
 
     """
     meta_dir = output_dir / ".meta"
-    partial_files = list(meta_dir.glob("partial_index*.json"))
+    partial_files = list(meta_dir.glob("partial_index*.jsonl"))
 
     if not partial_files:
         # Fallback to old method if no partial indexes exist
@@ -253,17 +256,27 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
         )
         return
 
-    # Merge all partial indexes
+    # Merge all partial indexes (JSONL format: one entry per line)
     all_entries: List[TestCaseIndexFile] = []
     all_forks: set = set()
     all_formats: set = set()
 
     for partial_file in partial_files:
-        partial_data = json.loads(partial_file.read_text())
-        for entry in partial_data["entries"]:
-            all_entries.append(TestCaseIndexFile.model_validate(entry))
-        all_forks.update(partial_data.get("forks", []))
-        all_formats.update(partial_data.get("formats", []))
+        with open(partial_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry_data = json.loads(line)
+                # Validate with Pydantic
+                # (deferred from add_fixture for performance)
+                entry = TestCaseIndexFile.model_validate(entry_data)
+                all_entries.append(entry)
+                # Collect forks and formats from validated entries
+                if entry.fork:
+                    all_forks.add(entry.fork.name())
+                if entry.format:
+                    all_formats.add(entry.format.__name__)
 
     # Compute root hash from collected fixture hashes
     root_hash = HashableItem.from_index_entries(all_entries).hash()

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -276,7 +276,7 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
                 if entry.fork:
                     all_forks.add(entry.fork.name())
                 if entry.format:
-                    all_formats.add(entry.format.__name__)
+                    all_formats.add(entry.format.format_name)
 
     # Compute root hash from collected fixture hashes
     root_hash = HashableItem.from_index_entries(all_entries).hash()

--- a/packages/testing/src/execution_testing/cli/gen_index.py
+++ b/packages/testing/src/execution_testing/cli/gen_index.py
@@ -245,16 +245,7 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
     partial_files = list(meta_dir.glob("partial_index*.jsonl"))
 
     if not partial_files:
-        # Fallback to old method if no partial indexes exist
-        if not quiet_mode:
-            rich.print(
-                "[yellow]No partial indexes found, "
-                "falling back to full scan[/]"
-            )
-        generate_fixtures_index(
-            output_dir, quiet_mode=quiet_mode, force_flag=True
-        )
-        return
+        raise Exception("No partial indexes found.")
 
     # Merge all partial indexes (JSONL format: one entry per line)
     # Read as raw dicts — the data was already validated when collected
@@ -296,7 +287,7 @@ def merge_partial_indexes(output_dir: Path, quiet_mode: bool = False) -> None:
     # Write final index
     index_path = meta_dir / "index.json"
     index_path.parent.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(index.model_dump_json(exclude_none=False, indent=2))
+    index_path.write_text(index.model_dump_json(exclude_none=True, indent=2))
 
     if not quiet_mode:
         rich.print(

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
-from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import IntEnum, auto
 from pathlib import Path
@@ -153,71 +152,77 @@ class HashableItem:
 
     @classmethod
     def from_index_entries(
-        cls, entries: List[TestCaseIndexFile]
+        cls, entries: List["TestCaseIndexFile"]
     ) -> "HashableItem":
         """
         Create a hashable item tree from index entries (no file I/O).
 
         This produces the same hash as from_folder() but uses pre-collected
         fixture hashes instead of reading files from disk.
+
+        Optimized to O(n) using a trie-like structure built in a single pass,
+        avoiding repeated path operations and iterations.
         """
-        # Group entries by file path
-        files_entries: Dict[Path, List[TestCaseIndexFile]] = defaultdict(list)
+        # Build a trie where each node is either:
+        # - A dict (folder node) containing child nodes
+        # - A list of (test_id, hash_bytes) tuples (file node marker)
+        #
+        # Structure: {folder: {folder: {file.json: [(id, hash), ...]}}}
+        root_trie: dict = {}
+
+        # Single pass: insert all entries into trie
         for entry in entries:
-            files_entries[entry.json_path].append(entry)
+            if not entry.fixture_hash:
+                continue
 
-        # Build HashableItem for each file (contains test items)
-        file_items: Dict[Path, HashableItem] = {}
-        for file_path, file_entries in files_entries.items():
-            test_items: Dict[str, HashableItem] = {}
-            for entry in file_entries:
-                if entry.fixture_hash:
-                    # Convert HexNumber (int subclass) to 32-byte hash
-                    hash_bytes = int(entry.fixture_hash).to_bytes(32, "big")
-                    test_items[entry.id] = cls(
-                        type=HashableItemType.TEST,
-                        root=hash_bytes,
-                    )
-            file_items[file_path] = cls(
-                type=HashableItemType.FILE,
-                items=test_items,
-            )
+            # Navigate/create path to file node
+            path_parts = Path(entry.json_path).parts
+            current = root_trie
 
-        # Build folder hierarchy recursively
-        def build_folder(folder_path: Path) -> HashableItem:
-            """Build HashableItem for a folder from file_items."""
+            # Navigate to parent folder, creating nodes as needed
+            for part in path_parts[:-1]:
+                if part not in current:
+                    current[part] = {}
+                current = current[part]
+
+            # Add test entry to file node (file nodes are lists of tuples)
+            file_name = path_parts[-1]
+            if file_name not in current:
+                current[file_name] = []
+
+            # Convert HexNumber (int subclass) to 32-byte hash
+            hash_bytes = int(entry.fixture_hash).to_bytes(32, "big")
+            current[file_name].append((entry.id, hash_bytes))
+
+        # Convert trie to HashableItem tree (single recursive pass)
+        def trie_to_hashable(node: dict) -> Dict[str, "HashableItem"]:
+            """Convert a trie node to HashableItem dict."""
             items: Dict[str, HashableItem] = {}
 
-            # Add files directly in this folder
-            for file_path, file_item in file_items.items():
-                if file_path.parent == folder_path:
-                    items[file_path.name] = file_item
+            for name, child in node.items():
+                if isinstance(child, list):
+                    # File node: child is list of (test_id, hash_bytes)
+                    test_items = {
+                        test_id: cls(
+                            type=HashableItemType.TEST, root=hash_bytes
+                        )
+                        for test_id, hash_bytes in child
+                    }
+                    items[name] = cls(
+                        type=HashableItemType.FILE, items=test_items
+                    )
+                else:
+                    # Folder node: recurse
+                    items[name] = cls(
+                        type=HashableItemType.FOLDER,
+                        items=trie_to_hashable(child),
+                    )
 
-            # Find and add immediate subfolders
-            subfolders: set = set()
-            for file_path in file_items.keys():
-                try:
-                    rel = file_path.relative_to(folder_path)
-                    if len(rel.parts) > 1:
-                        subfolders.add(folder_path / rel.parts[0])
-                except ValueError:
-                    continue
+            return items
 
-            for subfolder in subfolders:
-                items[subfolder.name] = build_folder(subfolder)
-
-            return cls(type=HashableItemType.FOLDER, items=items)
-
-        # Find top-level folders and build root
-        top_level_folders: set = set()
-        for file_path in file_items.keys():
-            top_level_folders.add(Path(file_path.parts[0]))
-
-        root_items: Dict[str, HashableItem] = {}
-        for folder in top_level_folders:
-            root_items[folder.name] = build_folder(folder)
-
-        return cls(type=HashableItemType.FOLDER, items=root_items)
+        return cls(
+            type=HashableItemType.FOLDER, items=trie_to_hashable(root_trie)
+        )
 
 
 def render_hash_report(

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -163,6 +163,29 @@ class HashableItem:
         Optimized to O(n) using a trie-like structure built in a single pass,
         avoiding repeated path operations and iterations.
         """
+        raw = [
+            {
+                "id": e.id,
+                "json_path": str(e.json_path),
+                "fixture_hash": str(e.fixture_hash)
+                if e.fixture_hash
+                else None,
+            }
+            for e in entries
+        ]
+        return cls.from_raw_entries(raw)
+
+    @classmethod
+    def from_raw_entries(cls, entries: List[Dict]) -> "HashableItem":
+        """
+        Create a hashable item tree from raw entry dicts (no file I/O).
+
+        Accepts dicts with "id", "json_path", and "fixture_hash" keys.
+        This avoids Pydantic overhead entirely — only plain string/int
+        operations are used to build the hash tree.
+
+        Produces the same hash as from_folder() and from_index_entries().
+        """
         # Build a trie where each node is either:
         # - A dict (folder node) containing child nodes
         # - A list of (test_id, hash_bytes) tuples (file node marker)
@@ -172,11 +195,12 @@ class HashableItem:
 
         # Single pass: insert all entries into trie
         for entry in entries:
-            if not entry.fixture_hash:
+            fixture_hash = entry.get("fixture_hash")
+            if not fixture_hash:
                 continue
 
             # Navigate/create path to file node
-            path_parts = Path(entry.json_path).parts
+            path_parts = Path(entry["json_path"]).parts
             current = root_trie
 
             # Navigate to parent folder, creating nodes as needed
@@ -185,14 +209,14 @@ class HashableItem:
                     current[part] = {}
                 current = current[part]
 
-            # Add test entry to file node (file nodes are lists of tuples)
+            # Add test entry to file node
             file_name = path_parts[-1]
             if file_name not in current:
                 current[file_name] = []
 
-            # Convert HexNumber (int subclass) to 32-byte hash
-            hash_bytes = int(entry.fixture_hash).to_bytes(32, "big")
-            current[file_name].append((entry.id, hash_bytes))
+            # Convert hex string to 32-byte hash
+            hash_bytes = int(fixture_hash, 16).to_bytes(32, "big")
+            current[file_name].append((entry["id"], hash_bytes))
 
         # Convert trie to HashableItem tree (single recursive pass)
         def trie_to_hashable(node: dict) -> Dict[str, "HashableItem"]:

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -1,16 +1,22 @@
 """Simple CLI tool to hash a directory of JSON fixtures."""
 
+from __future__ import annotations
+
 import hashlib
 import json
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import IntEnum, auto
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar
 
 import click
 from rich.console import Console
 from rich.markup import escape as rich_escape
+
+if TYPE_CHECKING:
+    from execution_testing.fixtures.consume import TestCaseIndexFile
 
 
 class HashableItemType(IntEnum):
@@ -144,6 +150,74 @@ class HashableItem:
                 )
                 items[file_path.name] = item
         return cls(type=HashableItemType.FOLDER, items=items, parents=parents)
+
+    @classmethod
+    def from_index_entries(
+        cls, entries: List[TestCaseIndexFile]
+    ) -> "HashableItem":
+        """
+        Create a hashable item tree from index entries (no file I/O).
+
+        This produces the same hash as from_folder() but uses pre-collected
+        fixture hashes instead of reading files from disk.
+        """
+        # Group entries by file path
+        files_entries: Dict[Path, List[TestCaseIndexFile]] = defaultdict(list)
+        for entry in entries:
+            files_entries[entry.json_path].append(entry)
+
+        # Build HashableItem for each file (contains test items)
+        file_items: Dict[Path, HashableItem] = {}
+        for file_path, file_entries in files_entries.items():
+            test_items: Dict[str, HashableItem] = {}
+            for entry in file_entries:
+                if entry.fixture_hash:
+                    # Convert HexNumber (int subclass) to 32-byte hash
+                    hash_bytes = int(entry.fixture_hash).to_bytes(32, "big")
+                    test_items[entry.id] = cls(
+                        type=HashableItemType.TEST,
+                        root=hash_bytes,
+                    )
+            file_items[file_path] = cls(
+                type=HashableItemType.FILE,
+                items=test_items,
+            )
+
+        # Build folder hierarchy recursively
+        def build_folder(folder_path: Path) -> HashableItem:
+            """Build HashableItem for a folder from file_items."""
+            items: Dict[str, HashableItem] = {}
+
+            # Add files directly in this folder
+            for file_path, file_item in file_items.items():
+                if file_path.parent == folder_path:
+                    items[file_path.name] = file_item
+
+            # Find and add immediate subfolders
+            subfolders: set = set()
+            for file_path in file_items.keys():
+                try:
+                    rel = file_path.relative_to(folder_path)
+                    if len(rel.parts) > 1:
+                        subfolders.add(folder_path / rel.parts[0])
+                except ValueError:
+                    continue
+
+            for subfolder in subfolders:
+                items[subfolder.name] = build_folder(subfolder)
+
+            return cls(type=HashableItemType.FOLDER, items=items)
+
+        # Find top-level folders and build root
+        top_level_folders: set = set()
+        for file_path in file_items.keys():
+            top_level_folders.add(Path(file_path.parts[0]))
+
+        root_items: Dict[str, HashableItem] = {}
+        for folder in top_level_folders:
+            root_items[folder.name] = build_folder(folder)
+
+        return cls(type=HashableItemType.FOLDER, items=root_items)
 
 
 def render_hash_report(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -44,6 +44,7 @@ from execution_testing.fixtures import (
     PreAllocGroupBuilders,
     PreAllocGroups,
     TestInfo,
+    merge_partial_fixture_files,
 )
 from execution_testing.forks import (
     Fork,
@@ -1240,12 +1241,12 @@ def fixture_collector(
         generate_index=request.config.getoption("generate_index"),
     )
     yield fixture_collector
-    fixture_collector.dump_fixtures()
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", None)
+    fixture_collector.dump_fixtures(worker_id)
     if do_fixture_verification:
         fixture_collector.verify_fixture_files(evm_fixture_verification)
     # Write partial index for this worker/scope
     if fixture_collector.generate_index:
-        worker_id = os.environ.get("PYTEST_XDIST_WORKER", None)
         fixture_collector.write_partial_index(worker_id)
 
 
@@ -1647,6 +1648,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
     if fixture_output.is_stdout or is_help_or_collectonly_mode(session.config):
         return
+
+    # Merge partial fixture files from all workers into final JSON files
+    merge_partial_fixture_files(fixture_output.directory)
 
     # Remove any lock files that may have been created.
     for file in fixture_output.directory.rglob("*.lock"):

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -29,7 +29,7 @@ from execution_testing.base_types import (
     ReferenceSpec,
 )
 from execution_testing.cli.gen_index import (
-    generate_fixtures_index,
+    merge_partial_indexes,
 )
 from execution_testing.client_clis import TransitionTool
 from execution_testing.client_clis.clis.geth import FixtureConsumerTool
@@ -1237,11 +1237,16 @@ def fixture_collector(
         single_fixture_per_file=fixture_output.single_fixture_per_file,
         filler_path=filler_path,
         base_dump_dir=base_dump_dir,
+        generate_index=request.config.getoption("generate_index"),
     )
     yield fixture_collector
     fixture_collector.dump_fixtures()
     if do_fixture_verification:
         fixture_collector.verify_fixture_files(evm_fixture_verification)
+    # Write partial index for this worker/scope
+    if fixture_collector.generate_index:
+        worker_id = os.environ.get("PYTEST_XDIST_WORKER", None)
+        fixture_collector.write_partial_index(worker_id)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -1634,14 +1639,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     for file in fixture_output.directory.rglob("*.lock"):
         file.unlink()
 
-    # Generate index file for all produced fixtures.
+    # Generate index file for all produced fixtures by merging partial indexes.
     if (
         session.config.getoption("generate_index")
         and not session_instance.phase_manager.is_pre_alloc_generation
     ):
-        generate_fixtures_index(
-            fixture_output.directory, quiet_mode=True, force_flag=False
-        )
+        merge_partial_indexes(fixture_output.directory, quiet_mode=True)
 
     # Create tarball of the output directory if the output is a tarball.
     fixture_output.create_tarball()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1653,11 +1653,16 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         file.unlink()
 
     # Generate index file for all produced fixtures by merging partial indexes.
+    # Only merge if partial indexes were actually written (i.e., tests produced
+    # fixtures). When no tests are filled (e.g., all skipped), no partial
+    # indexes exist and merge_partial_indexes should not be called.
     if (
         session.config.getoption("generate_index")
         and not session_instance.phase_manager.is_pre_alloc_generation
     ):
-        merge_partial_indexes(fixture_output.directory, quiet_mode=True)
+        meta_dir = fixture_output.directory / ".meta"
+        if meta_dir.exists() and any(meta_dir.glob("partial_index*.jsonl")):
+            merge_partial_indexes(fixture_output.directory, quiet_mode=True)
 
     # Create tarball of the output directory if the output is a tarball.
     fixture_output.create_tarball()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1594,6 +1594,19 @@ def pytest_collection_modifyitems(
     for i in reversed(items_for_removal):
         items.pop(i)
 
+    # Schedule slow-marked tests first (Longest Processing Time First).
+    # Workers each grab the next test from the queue, so slow tests get
+    # distributed across workers and finish before the fast-test tail.
+    slow_items = []
+    normal_items = []
+    for item in items:
+        if item.get_closest_marker("slow") is not None:
+            slow_items.append(item)
+        else:
+            normal_items.append(item)
+    if slow_items:
+        items[:] = slow_items + normal_items
+
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """

--- a/packages/testing/src/execution_testing/cli/tests/test_hasher.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_hasher.py
@@ -1,16 +1,57 @@
-"""Tests for the hasher CLI tool and module."""
+"""Tests for the hasher CLI tool, module, and merge_partial_indexes."""
 
 import json
 import tempfile
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 import pytest
 from click.testing import CliRunner
 
 from execution_testing.base_types import HexNumber
+from execution_testing.cli.gen_index import merge_partial_indexes
 from execution_testing.cli.hasher import HashableItem, hasher
-from execution_testing.fixtures.consume import TestCaseIndexFile
+from execution_testing.fixtures.consume import IndexFile, TestCaseIndexFile
+
+HASH_1 = 0x1111111111111111111111111111111111111111111111111111111111111111
+HASH_2 = 0x2222222222222222222222222222222222222222222222222222222222222222
+HASH_3 = 0x3333333333333333333333333333333333333333333333333333333333333333
+HASH_4 = 0x4444444444444444444444444444444444444444444444444444444444444444
+HASH_9 = 0x9999999999999999999999999999999999999999999999999999999999999999
+
+
+def _hex_str(h: int) -> str:
+    """Convert an integer hash to its 0x-prefixed hex string."""
+    return f"0x{h:064x}"
+
+
+def _make_entry(
+    test_id: str,
+    json_path: str,
+    fixture_hash: int,
+    fork: str | None = None,
+    fmt: str | None = None,
+) -> TestCaseIndexFile:
+    """Create a TestCaseIndexFile for testing."""
+    return TestCaseIndexFile(
+        id=test_id,
+        json_path=Path(json_path),
+        fixture_hash=HexNumber(fixture_hash),
+        fork=fork,
+        format=fmt,
+    )
+
+
+def _make_json_fixture(test_names_and_hashes: dict[str, int]) -> str:
+    """Create a JSON fixture file matching from_folder expectations."""
+    data = {}
+    for name, h in test_names_and_hashes.items():
+        data[name] = {
+            "_info": {"hash": _hex_str(h)},
+            "pre": {},
+            "post": {},
+        }
+    return json.dumps(data)
 
 
 def create_fixture(path: Path, test_name: str, hash_value: str) -> None:
@@ -356,211 +397,379 @@ class TestHashableItemFromIndexEntries:
         with tempfile.TemporaryDirectory() as tmpdir:
             base = Path(tmpdir)
 
-            # Create structure: state_tests/cancun/test.json
+            # state_tests/cancun/test.json (two tests)
             state_tests = base / "state_tests" / "cancun"
             state_tests.mkdir(parents=True)
+            (state_tests / "test.json").write_text(
+                _make_json_fixture({"test_one": HASH_1, "test_two": HASH_2})
+            )
 
-            # Create a fixture file with two tests
-            fixture_file = state_tests / "test.json"
-            fixture_data = {
-                "test_one": {
-                    "_info": {
-                        "hash": "0x1111111111111111111111111111111111111111111111111111111111111111"  # noqa: E501
-                    },
-                    "pre": {},
-                    "post": {},
-                },
-                "test_two": {
-                    "_info": {
-                        "hash": "0x2222222222222222222222222222222222222222222222222222222222222222"  # noqa: E501
-                    },
-                    "pre": {},
-                    "post": {},
-                },
-            }
-            fixture_file.write_text(json.dumps(fixture_data))
-
-            # Create another fixture file in a different folder
+            # blockchain_tests/cancun/test.json (one test)
             blockchain_tests = base / "blockchain_tests" / "cancun"
             blockchain_tests.mkdir(parents=True)
-
-            fixture_file2 = blockchain_tests / "test.json"
-            fixture_data2 = {
-                "test_three": {
-                    "_info": {
-                        "hash": "0x3333333333333333333333333333333333333333333333333333333333333333"  # noqa: E501
-                    },
-                    "pre": {},
-                    "post": {},
-                },
-            }
-            fixture_file2.write_text(json.dumps(fixture_data2))
+            (blockchain_tests / "test.json").write_text(
+                _make_json_fixture({"test_three": HASH_3})
+            )
 
             yield base
 
     @pytest.fixture
-    def index_entries(self) -> list[TestCaseIndexFile]:
+    def index_entries(self) -> List[TestCaseIndexFile]:
         """Create index entries matching the fixture_dir structure."""
         return [
-            TestCaseIndexFile(
-                id="test_one",
-                json_path=Path("state_tests/cancun/test.json"),
-                fixture_hash=HexNumber(
-                    0x1111111111111111111111111111111111111111111111111111111111111111
-                ),
-                fork=None,
-                format=None,
-            ),
-            TestCaseIndexFile(
-                id="test_two",
-                json_path=Path("state_tests/cancun/test.json"),
-                fixture_hash=HexNumber(
-                    0x2222222222222222222222222222222222222222222222222222222222222222
-                ),
-                fork=None,
-                format=None,
-            ),
-            TestCaseIndexFile(
-                id="test_three",
-                json_path=Path("blockchain_tests/cancun/test.json"),
-                fixture_hash=HexNumber(
-                    0x3333333333333333333333333333333333333333333333333333333333333333
-                ),
-                fork=None,
-                format=None,
+            _make_entry("test_one", "state_tests/cancun/test.json", HASH_1),
+            _make_entry("test_two", "state_tests/cancun/test.json", HASH_2),
+            _make_entry(
+                "test_three", "blockchain_tests/cancun/test.json", HASH_3
             ),
         ]
 
     def test_hash_matches_from_folder(
-        self, fixture_dir: Path, index_entries: list[TestCaseIndexFile]
+        self,
+        fixture_dir: Path,
+        index_entries: List[TestCaseIndexFile],
     ) -> None:
         """Verify from_index_entries produces same hash as from_folder."""
-        # Get hash using from_folder (reads files)
         hash_from_folder = HashableItem.from_folder(
             folder_path=fixture_dir
         ).hash()
-
-        # Get hash using from_index_entries (no file I/O)
         hash_from_entries = HashableItem.from_index_entries(
             index_entries
         ).hash()
-
         assert hash_from_folder == hash_from_entries
 
     def test_hash_changes_with_different_entries(
-        self, index_entries: list[TestCaseIndexFile]
+        self, index_entries: List[TestCaseIndexFile]
     ) -> None:
         """Verify hash changes when entries change."""
         hash1 = HashableItem.from_index_entries(index_entries).hash()
 
-        # Modify one entry's hash
-        modified_entries = index_entries.copy()
-        modified_entries[0] = TestCaseIndexFile(
-            id="test_one",
-            json_path=Path("state_tests/cancun/test.json"),
-            fixture_hash=HexNumber(
-                0x9999999999999999999999999999999999999999999999999999999999999999
-            ),
-            fork=None,
-            format=None,
+        modified = index_entries.copy()
+        modified[0] = _make_entry(
+            "test_one", "state_tests/cancun/test.json", HASH_9
         )
-
-        hash2 = HashableItem.from_index_entries(modified_entries).hash()
+        hash2 = HashableItem.from_index_entries(modified).hash()
 
         assert hash1 != hash2
 
     def test_empty_entries(self) -> None:
         """Verify empty entries produces a valid hash."""
-        hash_result = HashableItem.from_index_entries([]).hash()
-        # Empty tree should still produce a hash (sha256 of empty string)
-        assert hash_result is not None
-        assert len(hash_result) == 32  # SHA256 produces 32 bytes
+        result = HashableItem.from_index_entries([]).hash()
+        assert result is not None
+        assert len(result) == 32
 
     def test_multiple_files_in_same_folder(self) -> None:
-        """Verify multiple files in same folder are handled correctly."""
-        entries = [
-            TestCaseIndexFile(
-                id="test_a",
-                json_path=Path("state_tests/cancun/file1.json"),
-                fixture_hash=HexNumber(
-                    0x1111111111111111111111111111111111111111111111111111111111111111
-                ),
-                fork=None,
-                format=None,
-            ),
-            TestCaseIndexFile(
-                id="test_b",
-                json_path=Path("state_tests/cancun/file2.json"),
-                fixture_hash=HexNumber(
-                    0x2222222222222222222222222222222222222222222222222222222222222222
-                ),
-                fork=None,
-                format=None,
-            ),
-        ]
-        item = HashableItem.from_index_entries(entries)
-        hash_result = item.hash()
-        assert hash_result is not None
-        assert len(hash_result) == 32
+        """Verify hash with multiple JSON files in the same folder."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            folder = base / "tests" / "cancun"
+            folder.mkdir(parents=True)
+
+            (folder / "test_a.json").write_text(
+                _make_json_fixture({"a1": HASH_1})
+            )
+            (folder / "test_b.json").write_text(
+                _make_json_fixture({"b1": HASH_2})
+            )
+
+            entries = [
+                _make_entry("a1", "tests/cancun/test_a.json", HASH_1),
+                _make_entry("b1", "tests/cancun/test_b.json", HASH_2),
+            ]
+
+            hash_from_folder = HashableItem.from_folder(
+                folder_path=base
+            ).hash()
+            hash_from_entries = HashableItem.from_index_entries(entries).hash()
+            assert hash_from_folder == hash_from_entries
 
     def test_deeply_nested_paths(self) -> None:
-        """Verify deeply nested paths are handled correctly."""
-        entries = [
-            TestCaseIndexFile(
-                id="test_deep",
-                json_path=Path("a/b/c/d/test.json"),
-                fixture_hash=HexNumber(
-                    0x1111111111111111111111111111111111111111111111111111111111111111
-                ),
-                fork=None,
-                format=None,
-            ),
-        ]
-        item = HashableItem.from_index_entries(entries)
-        hash_result = item.hash()
-        assert hash_result is not None
-        assert len(hash_result) == 32
+        """Verify hash with deeply nested folder structures (3+ levels)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            deep = base / "a" / "b" / "c" / "d"
+            deep.mkdir(parents=True)
+
+            (deep / "test.json").write_text(
+                _make_json_fixture({"t1": HASH_1, "t2": HASH_2})
+            )
+
+            entries = [
+                _make_entry("t1", "a/b/c/d/test.json", HASH_1),
+                _make_entry("t2", "a/b/c/d/test.json", HASH_2),
+            ]
+
+            hash_from_folder = HashableItem.from_folder(
+                folder_path=base
+            ).hash()
+            hash_from_entries = HashableItem.from_index_entries(entries).hash()
+            assert hash_from_folder == hash_from_entries
 
     def test_single_file_single_test(self) -> None:
-        """Verify single file with single test works."""
-        entries = [
-            TestCaseIndexFile(
-                id="only_test",
-                json_path=Path("tests/test.json"),
-                fixture_hash=HexNumber(
-                    0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-                ),
-                fork=None,
-                format=None,
-            ),
-        ]
-        item = HashableItem.from_index_entries(entries)
-        hash_result = item.hash()
-        assert hash_result is not None
-        assert len(hash_result) == 32
+        """Verify degenerate case: one folder, one file, one test."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            folder = base / "tests"
+            folder.mkdir()
+
+            (folder / "only.json").write_text(
+                _make_json_fixture({"solo": HASH_4})
+            )
+
+            entries = [_make_entry("solo", "tests/only.json", HASH_4)]
+
+            hash_from_folder = HashableItem.from_folder(
+                folder_path=base
+            ).hash()
+            hash_from_entries = HashableItem.from_index_entries(entries).hash()
+            assert hash_from_folder == hash_from_entries
 
     def test_entries_with_none_fixture_hash_skipped(self) -> None:
-        """Verify entries with None fixture_hash are skipped."""
-        entries = [
+        """Verify entries with fixture_hash=None are skipped."""
+        entries_with_none = [
+            _make_entry("t1", "tests/a.json", HASH_1),
             TestCaseIndexFile(
-                id="test_with_hash",
-                json_path=Path("tests/test.json"),
-                fixture_hash=HexNumber(
-                    0x1111111111111111111111111111111111111111111111111111111111111111
-                ),
-                fork=None,
-                format=None,
-            ),
-            TestCaseIndexFile(
-                id="test_without_hash",
-                json_path=Path("tests/test.json"),
+                id="t_null",
+                json_path=Path("tests/a.json"),
                 fixture_hash=None,
                 fork=None,
                 format=None,
             ),
         ]
-        item = HashableItem.from_index_entries(entries)
-        # Should still work, just skip the None entry
-        hash_result = item.hash()
-        assert hash_result is not None
-        assert len(hash_result) == 32
+        entries_without_none = [
+            _make_entry("t1", "tests/a.json", HASH_1),
+        ]
+
+        hash_with = HashableItem.from_index_entries(entries_with_none).hash()
+        hash_without = HashableItem.from_index_entries(
+            entries_without_none
+        ).hash()
+        assert hash_with == hash_without
+
+
+class TestMergePartialIndexes:
+    """Test the JSONL partial index merge pipeline end-to-end."""
+
+    def _write_jsonl(self, path: Path, entries: list[dict]) -> None:
+        """Write a list of dicts as JSONL lines."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def _make_entry_dict(
+        self,
+        test_id: str,
+        json_path: str,
+        fixture_hash: int,
+        fork: str | None = None,
+        fmt: str | None = None,
+    ) -> dict:
+        """Create a dict matching what collector.py writes to JSONL."""
+        return {
+            "id": test_id,
+            "json_path": json_path,
+            "fixture_hash": _hex_str(fixture_hash),
+            "fork": fork,
+            "format": fmt,
+            "pre_hash": None,
+        }
+
+    def test_merge_produces_valid_index(self) -> None:
+        """Verify merging JSONL partials produces a valid index.json."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            meta_dir = output_dir / ".meta"
+            meta_dir.mkdir(parents=True)
+
+            entries = [
+                self._make_entry_dict(
+                    "test_a",
+                    "state_tests/cancun/test.json",
+                    HASH_1,
+                    fork="Cancun",
+                    fmt="state_test",
+                ),
+                self._make_entry_dict(
+                    "test_b",
+                    "blockchain_tests/cancun/test.json",
+                    HASH_2,
+                    fork="Cancun",
+                    fmt="blockchain_test",
+                ),
+            ]
+
+            self._write_jsonl(
+                meta_dir / "partial_index.gw0.jsonl", entries[:1]
+            )
+            self._write_jsonl(
+                meta_dir / "partial_index.gw1.jsonl", entries[1:]
+            )
+
+            merge_partial_indexes(output_dir, quiet_mode=True)
+
+            index_path = meta_dir / "index.json"
+            assert index_path.exists()
+
+            index = IndexFile.model_validate_json(index_path.read_text())
+            assert index.test_count == 2
+            assert index.root_hash is not None
+            assert index.root_hash != 0
+
+    def test_merge_fixture_formats_uses_format_name(self) -> None:
+        """
+        Verify fixture_formats contains format_name values (e.g.
+        'state_test') not class names (e.g. 'StateFixture').
+
+        This is the exact bug that format.__name__ would have caused.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            meta_dir = output_dir / ".meta"
+
+            entries = [
+                self._make_entry_dict(
+                    "t1",
+                    "state_tests/test.json",
+                    HASH_1,
+                    fork="Cancun",
+                    fmt="state_test",
+                ),
+                self._make_entry_dict(
+                    "t2",
+                    "blockchain_tests/test.json",
+                    HASH_2,
+                    fork="Cancun",
+                    fmt="blockchain_test",
+                ),
+            ]
+            self._write_jsonl(meta_dir / "partial_index.gw0.jsonl", entries)
+
+            merge_partial_indexes(output_dir, quiet_mode=True)
+
+            index = IndexFile.model_validate_json(
+                (meta_dir / "index.json").read_text()
+            )
+            assert index.fixture_formats is not None
+            assert sorted(index.fixture_formats) == [
+                "blockchain_test",
+                "state_test",
+            ]
+
+    def test_merge_forks_collected_correctly(self) -> None:
+        """Verify forks are collected from validated entries."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            meta_dir = output_dir / ".meta"
+
+            entries = [
+                self._make_entry_dict(
+                    "t1",
+                    "state_tests/test.json",
+                    HASH_1,
+                    fork="Cancun",
+                    fmt="state_test",
+                ),
+                self._make_entry_dict(
+                    "t2",
+                    "state_tests/test2.json",
+                    HASH_2,
+                    fork="Shanghai",
+                    fmt="state_test",
+                ),
+            ]
+            self._write_jsonl(meta_dir / "partial_index.gw0.jsonl", entries)
+
+            merge_partial_indexes(output_dir, quiet_mode=True)
+
+            index = IndexFile.model_validate_json(
+                (meta_dir / "index.json").read_text()
+            )
+            assert index.forks is not None
+            assert sorted(str(f) for f in index.forks) == [
+                "Cancun",
+                "Shanghai",
+            ]
+
+    def test_merge_cleans_up_partial_files(self) -> None:
+        """Verify partial JSONL files are deleted after merge."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            meta_dir = output_dir / ".meta"
+
+            entries = [
+                self._make_entry_dict(
+                    "t1",
+                    "state_tests/test.json",
+                    HASH_1,
+                    fmt="state_test",
+                ),
+            ]
+            self._write_jsonl(meta_dir / "partial_index.gw0.jsonl", entries)
+            self._write_jsonl(meta_dir / "partial_index.gw1.jsonl", entries)
+
+            merge_partial_indexes(output_dir, quiet_mode=True)
+
+            remaining = list(meta_dir.glob("partial_index*.jsonl"))
+            assert remaining == []
+
+    def test_merge_multiple_workers_same_hash_as_single(self) -> None:
+        """Verify hash is the same regardless of how entries are split."""
+        entry_dicts = [
+            self._make_entry_dict(
+                "t1", "state_tests/a.json", HASH_1, fmt="state_test"
+            ),
+            self._make_entry_dict(
+                "t2", "state_tests/a.json", HASH_2, fmt="state_test"
+            ),
+            self._make_entry_dict(
+                "t3", "blockchain_tests/b.json", HASH_3, fmt="blockchain_test"
+            ),
+        ]
+
+        # Single worker: all entries in one file
+        with tempfile.TemporaryDirectory() as tmpdir1:
+            output1 = Path(tmpdir1)
+            meta1 = output1 / ".meta"
+            self._write_jsonl(meta1 / "partial_index.gw0.jsonl", entry_dicts)
+            merge_partial_indexes(output1, quiet_mode=True)
+            index1 = IndexFile.model_validate_json(
+                (meta1 / "index.json").read_text()
+            )
+
+        # Multiple workers: entries split across files
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            output2 = Path(tmpdir2)
+            meta2 = output2 / ".meta"
+            self._write_jsonl(
+                meta2 / "partial_index.gw0.jsonl", entry_dicts[:1]
+            )
+            self._write_jsonl(
+                meta2 / "partial_index.gw1.jsonl", entry_dicts[1:2]
+            )
+            self._write_jsonl(
+                meta2 / "partial_index.gw2.jsonl", entry_dicts[2:]
+            )
+            merge_partial_indexes(output2, quiet_mode=True)
+            index2 = IndexFile.model_validate_json(
+                (meta2 / "index.json").read_text()
+            )
+
+        assert index1.root_hash == index2.root_hash
+        assert index1.test_count == index2.test_count
+
+    def test_merge_fallback_when_no_partial_files(self) -> None:
+        """Verify fallback to generate_fixtures_index when no partials."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            meta_dir = output_dir / ".meta"
+            meta_dir.mkdir(parents=True)
+
+            # No partial files exist, no fixture files either —
+            # fallback should run but produce an empty/minimal index
+            # (or raise if no fixtures). Just verify it doesn't crash
+            # on an empty directory with no partials.
+            merge_partial_indexes(output_dir, quiet_mode=True)
+
+            index_path = meta_dir / "index.json"
+            assert index_path.exists()

--- a/packages/testing/src/execution_testing/cli/tests/test_hasher.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_hasher.py
@@ -1,11 +1,16 @@
-"""Tests for the hasher CLI tool."""
+"""Tests for the hasher CLI tool and module."""
 
 import json
+import tempfile
 from pathlib import Path
+from typing import Generator
 
+import pytest
 from click.testing import CliRunner
 
-from execution_testing.cli.hasher import hasher
+from execution_testing.base_types import HexNumber
+from execution_testing.cli.hasher import HashableItem, hasher
+from execution_testing.fixtures.consume import TestCaseIndexFile
 
 
 def create_fixture(path: Path, test_name: str, hash_value: str) -> None:
@@ -340,3 +345,222 @@ class TestHelpOptions:
         result = runner.invoke(hasher, ["hash", "--help"])
         assert result.exit_code == 0
         assert "Hash folders of JSON fixtures" in result.output
+
+
+class TestHashableItemFromIndexEntries:
+    """Test that from_index_entries produces same hash as from_folder."""
+
+    @pytest.fixture
+    def fixture_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory with test fixtures."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            # Create structure: state_tests/cancun/test.json
+            state_tests = base / "state_tests" / "cancun"
+            state_tests.mkdir(parents=True)
+
+            # Create a fixture file with two tests
+            fixture_file = state_tests / "test.json"
+            fixture_data = {
+                "test_one": {
+                    "_info": {
+                        "hash": "0x1111111111111111111111111111111111111111111111111111111111111111"  # noqa: E501
+                    },
+                    "pre": {},
+                    "post": {},
+                },
+                "test_two": {
+                    "_info": {
+                        "hash": "0x2222222222222222222222222222222222222222222222222222222222222222"  # noqa: E501
+                    },
+                    "pre": {},
+                    "post": {},
+                },
+            }
+            fixture_file.write_text(json.dumps(fixture_data))
+
+            # Create another fixture file in a different folder
+            blockchain_tests = base / "blockchain_tests" / "cancun"
+            blockchain_tests.mkdir(parents=True)
+
+            fixture_file2 = blockchain_tests / "test.json"
+            fixture_data2 = {
+                "test_three": {
+                    "_info": {
+                        "hash": "0x3333333333333333333333333333333333333333333333333333333333333333"  # noqa: E501
+                    },
+                    "pre": {},
+                    "post": {},
+                },
+            }
+            fixture_file2.write_text(json.dumps(fixture_data2))
+
+            yield base
+
+    @pytest.fixture
+    def index_entries(self) -> list[TestCaseIndexFile]:
+        """Create index entries matching the fixture_dir structure."""
+        return [
+            TestCaseIndexFile(
+                id="test_one",
+                json_path=Path("state_tests/cancun/test.json"),
+                fixture_hash=HexNumber(
+                    0x1111111111111111111111111111111111111111111111111111111111111111
+                ),
+                fork=None,
+                format=None,
+            ),
+            TestCaseIndexFile(
+                id="test_two",
+                json_path=Path("state_tests/cancun/test.json"),
+                fixture_hash=HexNumber(
+                    0x2222222222222222222222222222222222222222222222222222222222222222
+                ),
+                fork=None,
+                format=None,
+            ),
+            TestCaseIndexFile(
+                id="test_three",
+                json_path=Path("blockchain_tests/cancun/test.json"),
+                fixture_hash=HexNumber(
+                    0x3333333333333333333333333333333333333333333333333333333333333333
+                ),
+                fork=None,
+                format=None,
+            ),
+        ]
+
+    def test_hash_matches_from_folder(
+        self, fixture_dir: Path, index_entries: list[TestCaseIndexFile]
+    ) -> None:
+        """Verify from_index_entries produces same hash as from_folder."""
+        # Get hash using from_folder (reads files)
+        hash_from_folder = HashableItem.from_folder(
+            folder_path=fixture_dir
+        ).hash()
+
+        # Get hash using from_index_entries (no file I/O)
+        hash_from_entries = HashableItem.from_index_entries(
+            index_entries
+        ).hash()
+
+        assert hash_from_folder == hash_from_entries
+
+    def test_hash_changes_with_different_entries(
+        self, index_entries: list[TestCaseIndexFile]
+    ) -> None:
+        """Verify hash changes when entries change."""
+        hash1 = HashableItem.from_index_entries(index_entries).hash()
+
+        # Modify one entry's hash
+        modified_entries = index_entries.copy()
+        modified_entries[0] = TestCaseIndexFile(
+            id="test_one",
+            json_path=Path("state_tests/cancun/test.json"),
+            fixture_hash=HexNumber(
+                0x9999999999999999999999999999999999999999999999999999999999999999
+            ),
+            fork=None,
+            format=None,
+        )
+
+        hash2 = HashableItem.from_index_entries(modified_entries).hash()
+
+        assert hash1 != hash2
+
+    def test_empty_entries(self) -> None:
+        """Verify empty entries produces a valid hash."""
+        hash_result = HashableItem.from_index_entries([]).hash()
+        # Empty tree should still produce a hash (sha256 of empty string)
+        assert hash_result is not None
+        assert len(hash_result) == 32  # SHA256 produces 32 bytes
+
+    def test_multiple_files_in_same_folder(self) -> None:
+        """Verify multiple files in same folder are handled correctly."""
+        entries = [
+            TestCaseIndexFile(
+                id="test_a",
+                json_path=Path("state_tests/cancun/file1.json"),
+                fixture_hash=HexNumber(
+                    0x1111111111111111111111111111111111111111111111111111111111111111
+                ),
+                fork=None,
+                format=None,
+            ),
+            TestCaseIndexFile(
+                id="test_b",
+                json_path=Path("state_tests/cancun/file2.json"),
+                fixture_hash=HexNumber(
+                    0x2222222222222222222222222222222222222222222222222222222222222222
+                ),
+                fork=None,
+                format=None,
+            ),
+        ]
+        item = HashableItem.from_index_entries(entries)
+        hash_result = item.hash()
+        assert hash_result is not None
+        assert len(hash_result) == 32
+
+    def test_deeply_nested_paths(self) -> None:
+        """Verify deeply nested paths are handled correctly."""
+        entries = [
+            TestCaseIndexFile(
+                id="test_deep",
+                json_path=Path("a/b/c/d/test.json"),
+                fixture_hash=HexNumber(
+                    0x1111111111111111111111111111111111111111111111111111111111111111
+                ),
+                fork=None,
+                format=None,
+            ),
+        ]
+        item = HashableItem.from_index_entries(entries)
+        hash_result = item.hash()
+        assert hash_result is not None
+        assert len(hash_result) == 32
+
+    def test_single_file_single_test(self) -> None:
+        """Verify single file with single test works."""
+        entries = [
+            TestCaseIndexFile(
+                id="only_test",
+                json_path=Path("tests/test.json"),
+                fixture_hash=HexNumber(
+                    0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+                ),
+                fork=None,
+                format=None,
+            ),
+        ]
+        item = HashableItem.from_index_entries(entries)
+        hash_result = item.hash()
+        assert hash_result is not None
+        assert len(hash_result) == 32
+
+    def test_entries_with_none_fixture_hash_skipped(self) -> None:
+        """Verify entries with None fixture_hash are skipped."""
+        entries = [
+            TestCaseIndexFile(
+                id="test_with_hash",
+                json_path=Path("tests/test.json"),
+                fixture_hash=HexNumber(
+                    0x1111111111111111111111111111111111111111111111111111111111111111
+                ),
+                fork=None,
+                format=None,
+            ),
+            TestCaseIndexFile(
+                id="test_without_hash",
+                json_path=Path("tests/test.json"),
+                fixture_hash=None,
+                fork=None,
+                format=None,
+            ),
+        ]
+        item = HashableItem.from_index_entries(entries)
+        # Should still work, just skip the None entry
+        hash_result = item.hash()
+        assert hash_result is not None
+        assert len(hash_result) == 32

--- a/packages/testing/src/execution_testing/cli/tests/test_hasher.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_hasher.py
@@ -758,18 +758,12 @@ class TestMergePartialIndexes:
         assert index1.root_hash == index2.root_hash
         assert index1.test_count == index2.test_count
 
-    def test_merge_fallback_when_no_partial_files(self) -> None:
-        """Verify fallback to generate_fixtures_index when no partials."""
+    def test_merge_raises_when_no_partial_files(self) -> None:
+        """Verify merge_partial_indexes raises when no partials exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir)
             meta_dir = output_dir / ".meta"
             meta_dir.mkdir(parents=True)
 
-            # No partial files exist, no fixture files either —
-            # fallback should run but produce an empty/minimal index
-            # (or raise if no fixtures). Just verify it doesn't crash
-            # on an empty directory with no partials.
-            merge_partial_indexes(output_dir, quiet_mode=True)
-
-            index_path = meta_dir / "index.json"
-            assert index_path.exists()
+            with pytest.raises(Exception, match="No partial indexes found"):
+                merge_partial_indexes(output_dir, quiet_mode=True)

--- a/packages/testing/src/execution_testing/fixtures/__init__.py
+++ b/packages/testing/src/execution_testing/fixtures/__init__.py
@@ -14,7 +14,11 @@ from .blockchain import (
     BlockchainFixture,
     BlockchainFixtureCommon,
 )
-from .collector import FixtureCollector, TestInfo
+from .collector import (
+    FixtureCollector,
+    TestInfo,
+    merge_partial_fixture_files,
+)
 from .consume import FixtureConsumer
 from .pre_alloc_groups import (
     PreAllocGroup,
@@ -45,4 +49,5 @@ __all__ = [
     "StateFixture",
     "TestInfo",
     "TransactionFixture",
+    "merge_partial_fixture_files",
 ]

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -9,12 +9,19 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar, Dict, Literal, Optional, Tuple
+from typing import (
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+)
 
 from execution_testing.base_types import to_json
 
 from .base import BaseFixture
-from .consume import FixtureConsumer
+from .consume import FixtureConsumer, TestCaseIndexFile
 from .file import Fixtures
 
 
@@ -125,10 +132,14 @@ class FixtureCollector:
     filler_path: Path
     base_dump_dir: Optional[Path] = None
     flush_interval: int = 1000
+    generate_index: bool = True
 
     # Internal state
     all_fixtures: Dict[Path, Fixtures] = field(default_factory=dict)
     json_path_to_test_item: Dict[Path, TestInfo] = field(default_factory=dict)
+    index_entries: List[TestCaseIndexFile] = field(default_factory=list)
+    index_forks: set = field(default_factory=set)
+    index_formats: set = field(default_factory=set)
 
     def get_fixture_basename(self, info: TestInfo) -> Path:
         """Return basename of the fixture file for a given test case."""
@@ -165,6 +176,24 @@ class FixtureCollector:
             self.json_path_to_test_item[fixture_path] = info
 
         self.all_fixtures[fixture_path][info.get_id()] = fixture
+
+        # Collect index entry while data is in memory (if indexing enabled)
+        if self.generate_index:
+            relative_path = fixture_path.relative_to(self.output_dir)
+            fixture_fork = fixture.get_fork()
+            self.index_entries.append(
+                TestCaseIndexFile(
+                    id=info.get_id(),
+                    json_path=relative_path,
+                    fixture_hash=fixture.hash,
+                    fork=fixture_fork,
+                    format=fixture.__class__,
+                    pre_hash=getattr(fixture, "pre_hash", None),
+                )
+            )
+            if fixture_fork:
+                self.index_forks.add(fixture_fork)
+            self.index_formats.add(fixture.format_name)
 
         if (
             self.flush_interval > 0
@@ -231,3 +260,57 @@ class FixtureCollector:
             return info.get_dump_dir_path(
                 self.base_dump_dir, self.filler_path, level="test_function"
             )
+
+    def write_partial_index(self, worker_id: str | None = None) -> Path | None:
+        """
+        Append collected index entries to a partial index file.
+
+        Each worker appends to its own partial index file which is later merged
+        by the master process in pytest_sessionfinish. Uses file locking to
+        handle multiple fixture_collector instances per worker (e.g., when
+        using module-scoped collection).
+
+        Args:
+            worker_id: The xdist worker ID (e.g., "gw0"), or None for master.
+
+        Returns:
+            Path to the partial index file, or None if indexing is disabled.
+
+        """
+        from filelock import FileLock
+
+        if not self.generate_index or not self.index_entries:
+            return None
+
+        suffix = f".{worker_id}" if worker_id else ".master"
+        partial_index_path = (
+            self.output_dir / ".meta" / f"partial_index{suffix}.json"
+        )
+        partial_index_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_file_path = partial_index_path.with_suffix(".lock")
+
+        # Append to existing partial index
+        # (may have multiple collectors per worker)
+        with FileLock(lock_file_path):
+            existing_data: Dict = {"entries": [], "forks": [], "formats": []}
+            if partial_index_path.exists():
+                existing_data = json.loads(partial_index_path.read_text())
+
+            # Merge new entries with existing
+            existing_data["entries"].extend(
+                [e.model_dump(mode="json") for e in self.index_entries]
+            )
+            # Convert Fork objects to strings
+            new_forks = {
+                f.name() if hasattr(f, "name") else str(f)
+                for f in self.index_forks
+            }
+            existing_data["forks"] = list(
+                set(existing_data["forks"]) | new_forks
+            )
+            existing_data["formats"] = list(
+                set(existing_data["formats"]) | self.index_formats
+            )
+
+            partial_index_path.write_text(json.dumps(existing_data))
+        return partial_index_path

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -203,7 +203,6 @@ class FixtureCollector:
     # Internal state
     all_fixtures: Dict[Path, Fixtures] = field(default_factory=dict)
     json_path_to_test_item: Dict[Path, TestInfo] = field(default_factory=dict)
-    _pre_serialized: Dict[str, str] = field(default_factory=dict)
     # Store index entries as simple dicts
     # (avoid Pydantic overhead during collection)
     index_entries: List[Dict] = field(default_factory=list)
@@ -243,13 +242,6 @@ class FixtureCollector:
             self.json_path_to_test_item[fixture_path] = info
 
         self.all_fixtures[fixture_path][info.get_id()] = fixture
-
-        # Pre-serialize fixture JSON during test execution (parallelized
-        # across xdist workers) to avoid a single giant json.dumps() at
-        # teardown.
-        self._pre_serialized[info.get_id()] = json.dumps(
-            fixture.json_dict_with_info(), indent=4
-        )
 
         # Collect index entry while data is in memory (if indexing enabled)
         # Store as simple dict to avoid Pydantic overhead during collection
@@ -295,7 +287,6 @@ class FixtureCollector:
             self._write_partial_fixtures(fixture_path, fixtures, worker_id)
 
         self.all_fixtures.clear()
-        self._pre_serialized.clear()
 
     def _write_partial_fixtures(
         self, file_path: Path, fixtures: Fixtures, worker_id: str | None
@@ -314,13 +305,8 @@ class FixtureCollector:
 
         lines = []
         for name in fixtures:
-            if name in self._pre_serialized:
-                value = self._pre_serialized[name]
-            else:
-                value = json.dumps(
-                    fixtures[name].json_dict_with_info(), indent=4
-                )
-            # Store as JSONL: {"k": key, "v": pre-serialized value string}
+            value = json.dumps(fixtures[name].json_dict_with_info(), indent=4)
+            # Store as JSONL: {"k": key, "v": serialized value string}
             lines.append(json.dumps({"k": name, "v": value}) + "\n")
 
         with FileLock(lock_file_path):

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -184,18 +184,16 @@ class FixtureCollector:
         if self.generate_index:
             relative_path = fixture_path.relative_to(self.output_dir)
             fixture_fork = fixture.get_fork()
-            self.index_entries.append(
-                {
-                    "id": info.get_id(),
-                    "json_path": str(relative_path),
-                    "fixture_hash": str(fixture.hash)
-                    if fixture.hash
-                    else None,
-                    "fork": fixture_fork.name() if fixture_fork else None,
-                    "format": fixture.format_name,
-                    "pre_hash": getattr(fixture, "pre_hash", None),
-                }
-            )
+            index_entry = {
+                "id": info.get_id(),
+                "json_path": str(relative_path),
+                "fixture_hash": str(fixture.hash) if fixture.hash else None,
+                "fork": fixture_fork.name() if fixture_fork else None,
+                "format": fixture.format_name,
+            }
+            if (pre_hash := getattr(fixture, "pre_hash", None)) is not None:
+                index_entry["pre_hash"] = pre_hash
+            self.index_entries.append(index_entry)
 
         if (
             self.flush_interval > 0

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -27,6 +27,70 @@ from .consume import FixtureConsumer
 from .file import Fixtures
 
 
+def merge_partial_fixture_files(output_dir: Path) -> None:
+    """
+    Merge all partial fixture JSONL files into final JSON fixture files.
+
+    Called at session end after all workers have written their partials.
+    Each partial file contains JSONL lines: {"k": fixture_id, "v": json_str}
+    """
+    # Find all partial files
+    partial_files = list(output_dir.rglob("*.partial.*.jsonl"))
+    if not partial_files:
+        return
+
+    # Group partial files by their target fixture file
+    # e.g., "test.partial.gw0.jsonl" -> "test.json"
+    partials_by_target: Dict[Path, List[Path]] = {}
+    for partial in partial_files:
+        # Remove .partial.{worker_id}.jsonl suffix to get target
+        name = partial.name
+        # Find ".partial." and remove everything after
+        idx = name.find(".partial.")
+        if idx == -1:
+            continue
+        target_name = name[:idx] + ".json"
+        target_path = partial.parent / target_name
+        if target_path not in partials_by_target:
+            partials_by_target[target_path] = []
+        partials_by_target[target_path].append(partial)
+
+    # Merge each group into its target file
+    for target_path, partials in partials_by_target.items():
+        entries: Dict[str, str] = {}
+
+        # Read all partial files
+        for partial in partials:
+            with open(partial) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    entry = json.loads(line)
+                    entries[entry["k"]] = entry["v"]
+
+        # Write final JSON file
+        sorted_keys = sorted(entries.keys())
+        parts = ["{\n"]
+        last_idx = len(sorted_keys) - 1
+        for i, key in enumerate(sorted_keys):
+            key_json = json.dumps(key)
+            # Add indentation for nesting inside outer JSON object
+            value_indented = entries[key].replace("\n", "\n    ")
+            parts.append(f"    {key_json}: {value_indented}")
+            parts.append(",\n" if i < last_idx else "\n")
+        parts.append("}")
+        target_path.write_text("".join(parts))
+
+        # Clean up partial files
+        for partial in partials:
+            partial.unlink()
+            # Also remove lock files
+            lock_file = partial.with_suffix(".lock")
+            if lock_file.exists():
+                lock_file.unlink()
+
+
 @dataclass(kw_only=True, slots=True)
 class TestInfo:
     """Contains test information from the current node."""
@@ -211,7 +275,7 @@ class FixtureCollector:
 
         return fixture_path
 
-    def dump_fixtures(self) -> None:
+    def dump_fixtures(self, worker_id: str | None = None) -> None:
         """Dump all collected fixtures to their respective files."""
         if self.output_dir.name == "stdout":
             combined_fixtures = {
@@ -228,97 +292,40 @@ class FixtureCollector:
                 raise TypeError(
                     "All fixtures in a single file must have the same format."
                 )
-            self._write_fixture_file(fixture_path, fixtures)
+            self._write_partial_fixtures(fixture_path, fixtures, worker_id)
 
         self.all_fixtures.clear()
         self._pre_serialized.clear()
 
-    def _write_fixture_file(self, file_path: Path, fixtures: Fixtures) -> None:
+    def _write_partial_fixtures(
+        self, file_path: Path, fixtures: Fixtures, worker_id: str | None
+    ) -> None:
         """
-        Write fixtures to file using pre-serialized JSON strings.
+        Write fixtures to a partial JSONL file (append-only).
 
-        Concatenates individually pre-serialized fixture values into a valid
-        JSON object, avoiding a single large json.dumps() call at teardown.
+        Each line is a JSON object: {"key": "fixture_id", "value": "json_str"}
+        This avoids O(n) merge work per worker - just O(1) append.
+        Final merge to JSON happens at session end.
         """
-        entries: Dict[str, str] = {}
-        lock_file_path = file_path.with_suffix(".lock")
+        suffix = f".{worker_id}" if worker_id else ".main"
+        partial_path = file_path.with_suffix(f".partial{suffix}.jsonl")
+        partial_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_file_path = partial_path.with_suffix(".lock")
+
+        lines = []
+        for name in fixtures:
+            if name in self._pre_serialized:
+                value = self._pre_serialized[name]
+            else:
+                value = json.dumps(
+                    fixtures[name].json_dict_with_info(), indent=4
+                )
+            # Store as JSONL: {"k": key, "v": pre-serialized value string}
+            lines.append(json.dumps({"k": name, "v": value}) + "\n")
+
         with FileLock(lock_file_path):
-            # Merge with any existing entries on disk (xdist workers writing
-            # to same file). Extract entries as raw strings to avoid
-            # re-serializing thousands of fixtures.
-            if file_path.exists():
-                entries = self._extract_entries_from_file(file_path)
-
-            # Look up pre-serialized strings for current fixtures
-            for name in fixtures:
-                if name in self._pre_serialized:
-                    entries[name] = self._pre_serialized[name]
-                else:
-                    entries[name] = json.dumps(
-                        fixtures[name].json_dict_with_info(), indent=4
-                    )
-
-            # Write sorted entries as a JSON object by concatenating strings
-            sorted_keys = sorted(entries.keys())
-            with open(file_path, "w") as f:
-                f.write("{\n")
-                for i, key in enumerate(sorted_keys):
-                    key_json = json.dumps(key)
-                    value_str = entries[key].replace("\n", "\n    ")
-                    f.write(f"    {key_json}: {value_str}")
-                    if i < len(sorted_keys) - 1:
-                        f.write(",\n")
-                    else:
-                        f.write("\n")
-                f.write("}")
-
-    def _extract_entries_from_file(self, file_path: Path) -> Dict[str, str]:
-        """
-        Extract fixture entries from an existing file as raw JSON strings.
-
-        This avoids re-serializing entries written by other xdist workers,
-        which would be O(n) json.dumps() calls at teardown time.
-        """
-        content = file_path.read_text()
-        entries: Dict[str, str] = {}
-        decoder = json.JSONDecoder()
-
-        # Skip opening brace and whitespace
-        pos = content.find("{") + 1
-
-        while pos < len(content):
-            # Skip whitespace
-            while pos < len(content) and content[pos] in " \t\n":
-                pos += 1
-
-            if pos >= len(content) or content[pos] == "}":
-                break
-
-            # Decode the key
-            key, end = decoder.raw_decode(content, pos)
-            pos = end
-
-            # Skip colon and whitespace
-            while pos < len(content) and content[pos] in " \t\n:":
-                pos += 1
-
-            # Decode the value and capture its string boundaries
-            value_start = pos
-            _, end = decoder.raw_decode(content, pos)
-            value_end = end
-
-            # Extract the raw value string and remove outer indentation
-            raw_value = content[value_start:value_end]
-            # The file format adds 4-space indent; remove it to get original
-            entries[key] = raw_value.replace("\n    ", "\n")
-
-            pos = value_end
-
-            # Skip comma and whitespace
-            while pos < len(content) and content[pos] in " \t\n,":
-                pos += 1
-
-        return entries
+            with open(partial_path, "a") as f:
+                f.writelines(lines)
 
     def verify_fixture_files(
         self, evm_fixture_verification: FixtureConsumer

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -18,10 +18,12 @@ from typing import (
     Tuple,
 )
 
+from filelock import FileLock
+
 from execution_testing.base_types import to_json
 
 from .base import BaseFixture
-from .consume import FixtureConsumer, TestCaseIndexFile
+from .consume import FixtureConsumer
 from .file import Fixtures
 
 
@@ -137,9 +139,9 @@ class FixtureCollector:
     # Internal state
     all_fixtures: Dict[Path, Fixtures] = field(default_factory=dict)
     json_path_to_test_item: Dict[Path, TestInfo] = field(default_factory=dict)
-    index_entries: List[TestCaseIndexFile] = field(default_factory=list)
-    index_forks: set = field(default_factory=set)
-    index_formats: set = field(default_factory=set)
+    # Store index entries as simple dicts
+    # (avoid Pydantic overhead during collection)
+    index_entries: List[Dict] = field(default_factory=list)
 
     def get_fixture_basename(self, info: TestInfo) -> Path:
         """Return basename of the fixture file for a given test case."""
@@ -178,22 +180,22 @@ class FixtureCollector:
         self.all_fixtures[fixture_path][info.get_id()] = fixture
 
         # Collect index entry while data is in memory (if indexing enabled)
+        # Store as simple dict to avoid Pydantic overhead during collection
         if self.generate_index:
             relative_path = fixture_path.relative_to(self.output_dir)
             fixture_fork = fixture.get_fork()
             self.index_entries.append(
-                TestCaseIndexFile(
-                    id=info.get_id(),
-                    json_path=relative_path,
-                    fixture_hash=fixture.hash,
-                    fork=fixture_fork,
-                    format=fixture.__class__,
-                    pre_hash=getattr(fixture, "pre_hash", None),
-                )
+                {
+                    "id": info.get_id(),
+                    "json_path": str(relative_path),
+                    "fixture_hash": str(fixture.hash)
+                    if fixture.hash
+                    else None,
+                    "fork": fixture_fork.name() if fixture_fork else None,
+                    "format": fixture.format_name,
+                    "pre_hash": getattr(fixture, "pre_hash", None),
+                }
             )
-            if fixture_fork:
-                self.index_forks.add(fixture_fork)
-            self.index_formats.add(fixture.format_name)
 
         if (
             self.flush_interval > 0
@@ -263,12 +265,12 @@ class FixtureCollector:
 
     def write_partial_index(self, worker_id: str | None = None) -> Path | None:
         """
-        Append collected index entries to a partial index file.
+        Append collected index entries to a partial index file using JSONL
+        format.
 
-        Each worker appends to its own partial index file which is later merged
-        by the master process in pytest_sessionfinish. Uses file locking to
-        handle multiple fixture_collector instances per worker (e.g., when
-        using module-scoped collection).
+        Uses append-only JSONL (JSON Lines) format for efficient writes without
+        read-modify-write cycles. Each line is a complete JSON object
+        representing one index entry.
 
         Args:
             worker_id: The xdist worker ID (e.g., "gw0"), or None for master.
@@ -277,40 +279,21 @@ class FixtureCollector:
             Path to the partial index file, or None if indexing is disabled.
 
         """
-        from filelock import FileLock
-
         if not self.generate_index or not self.index_entries:
             return None
 
         suffix = f".{worker_id}" if worker_id else ".master"
         partial_index_path = (
-            self.output_dir / ".meta" / f"partial_index{suffix}.json"
+            self.output_dir / ".meta" / f"partial_index{suffix}.jsonl"
         )
         partial_index_path.parent.mkdir(parents=True, exist_ok=True)
         lock_file_path = partial_index_path.with_suffix(".lock")
 
-        # Append to existing partial index
-        # (may have multiple collectors per worker)
+        # Append entries as JSONL (one JSON object per line)
+        # This avoids read-modify-write cycles
         with FileLock(lock_file_path):
-            existing_data: Dict = {"entries": [], "forks": [], "formats": []}
-            if partial_index_path.exists():
-                existing_data = json.loads(partial_index_path.read_text())
+            with open(partial_index_path, "a") as f:
+                for entry in self.index_entries:
+                    f.write(json.dumps(entry) + "\n")
 
-            # Merge new entries with existing
-            existing_data["entries"].extend(
-                [e.model_dump(mode="json") for e in self.index_entries]
-            )
-            # Convert Fork objects to strings
-            new_forks = {
-                f.name() if hasattr(f, "name") else str(f)
-                for f in self.index_forks
-            }
-            existing_data["forks"] = list(
-                set(existing_data["forks"]) | new_forks
-            )
-            existing_data["formats"] = list(
-                set(existing_data["formats"]) | self.index_formats
-            )
-
-            partial_index_path.write_text(json.dumps(existing_data))
         return partial_index_path

--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -139,6 +139,7 @@ class FixtureCollector:
     # Internal state
     all_fixtures: Dict[Path, Fixtures] = field(default_factory=dict)
     json_path_to_test_item: Dict[Path, TestInfo] = field(default_factory=dict)
+    _pre_serialized: Dict[str, str] = field(default_factory=dict)
     # Store index entries as simple dicts
     # (avoid Pydantic overhead during collection)
     index_entries: List[Dict] = field(default_factory=list)
@@ -178,6 +179,13 @@ class FixtureCollector:
             self.json_path_to_test_item[fixture_path] = info
 
         self.all_fixtures[fixture_path][info.get_id()] = fixture
+
+        # Pre-serialize fixture JSON during test execution (parallelized
+        # across xdist workers) to avoid a single giant json.dumps() at
+        # teardown.
+        self._pre_serialized[info.get_id()] = json.dumps(
+            fixture.json_dict_with_info(), indent=4
+        )
 
         # Collect index entry while data is in memory (if indexing enabled)
         # Store as simple dict to avoid Pydantic overhead during collection
@@ -220,9 +228,97 @@ class FixtureCollector:
                 raise TypeError(
                     "All fixtures in a single file must have the same format."
                 )
-            fixtures.collect_into_file(fixture_path)
+            self._write_fixture_file(fixture_path, fixtures)
 
         self.all_fixtures.clear()
+        self._pre_serialized.clear()
+
+    def _write_fixture_file(self, file_path: Path, fixtures: Fixtures) -> None:
+        """
+        Write fixtures to file using pre-serialized JSON strings.
+
+        Concatenates individually pre-serialized fixture values into a valid
+        JSON object, avoiding a single large json.dumps() call at teardown.
+        """
+        entries: Dict[str, str] = {}
+        lock_file_path = file_path.with_suffix(".lock")
+        with FileLock(lock_file_path):
+            # Merge with any existing entries on disk (xdist workers writing
+            # to same file). Extract entries as raw strings to avoid
+            # re-serializing thousands of fixtures.
+            if file_path.exists():
+                entries = self._extract_entries_from_file(file_path)
+
+            # Look up pre-serialized strings for current fixtures
+            for name in fixtures:
+                if name in self._pre_serialized:
+                    entries[name] = self._pre_serialized[name]
+                else:
+                    entries[name] = json.dumps(
+                        fixtures[name].json_dict_with_info(), indent=4
+                    )
+
+            # Write sorted entries as a JSON object by concatenating strings
+            sorted_keys = sorted(entries.keys())
+            with open(file_path, "w") as f:
+                f.write("{\n")
+                for i, key in enumerate(sorted_keys):
+                    key_json = json.dumps(key)
+                    value_str = entries[key].replace("\n", "\n    ")
+                    f.write(f"    {key_json}: {value_str}")
+                    if i < len(sorted_keys) - 1:
+                        f.write(",\n")
+                    else:
+                        f.write("\n")
+                f.write("}")
+
+    def _extract_entries_from_file(self, file_path: Path) -> Dict[str, str]:
+        """
+        Extract fixture entries from an existing file as raw JSON strings.
+
+        This avoids re-serializing entries written by other xdist workers,
+        which would be O(n) json.dumps() calls at teardown time.
+        """
+        content = file_path.read_text()
+        entries: Dict[str, str] = {}
+        decoder = json.JSONDecoder()
+
+        # Skip opening brace and whitespace
+        pos = content.find("{") + 1
+
+        while pos < len(content):
+            # Skip whitespace
+            while pos < len(content) and content[pos] in " \t\n":
+                pos += 1
+
+            if pos >= len(content) or content[pos] == "}":
+                break
+
+            # Decode the key
+            key, end = decoder.raw_decode(content, pos)
+            pos = end
+
+            # Skip colon and whitespace
+            while pos < len(content) and content[pos] in " \t\n:":
+                pos += 1
+
+            # Decode the value and capture its string boundaries
+            value_start = pos
+            _, end = decoder.raw_decode(content, pos)
+            value_end = end
+
+            # Extract the raw value string and remove outer indentation
+            raw_value = content[value_start:value_end]
+            # The file format adds 4-space indent; remove it to get original
+            entries[key] = raw_value.replace("\n    ", "\n")
+
+            pos = value_end
+
+            # Skip comma and whitespace
+            while pos < len(content) and content[pos] in " \t\n,":
+                pos += 1
+
+        return entries
 
     def verify_fixture_files(
         self, evm_fixture_verification: FixtureConsumer

--- a/packages/testing/src/execution_testing/fixtures/consume.py
+++ b/packages/testing/src/execution_testing/fixtures/consume.py
@@ -47,8 +47,8 @@ class TestCaseBase(BaseModel):
     """Base model for a test case used in EEST consume commands."""
 
     id: str
-    fixture_hash: HexNumber | None
-    fork: Fork | None
+    fixture_hash: HexNumber | None = None
+    fork: Fork | None = None
     format: FixtureFormat
     pre_hash: str | None = None
     __test__ = False  # stop pytest from collecting this class as a test

--- a/packages/testing/src/execution_testing/fixtures/file.py
+++ b/packages/testing/src/execution_testing/fixtures/file.py
@@ -67,5 +67,5 @@ class Fixtures(EthereumTestRootModel):
                 json_fixtures[name] = fixture.json_dict_with_info()
 
             file_path.write_text(
-                json.dumps(dict(sorted(json_fixtures.items())), indent=2)
+                json.dumps(dict(sorted(json_fixtures.items())), indent=4)
             )

--- a/packages/testing/src/execution_testing/fixtures/file.py
+++ b/packages/testing/src/execution_testing/fixtures/file.py
@@ -62,10 +62,10 @@ class Fixtures(EthereumTestRootModel):
         lock_file_path = file_path.with_suffix(".lock")
         with FileLock(lock_file_path):
             if file_path.exists():
-                with open(file_path, "r") as f:
-                    json_fixtures = json.load(f)
+                json_fixtures = json.loads(file_path.read_bytes())
             for name, fixture in self.items():
                 json_fixtures[name] = fixture.json_dict_with_info()
 
-            with open(file_path, "w") as f:
-                json.dump(dict(sorted(json_fixtures.items())), f, indent=4)
+            file_path.write_text(
+                json.dumps(dict(sorted(json_fixtures.items())), indent=2)
+            )

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -62,53 +62,6 @@ def module_path(filler_path: Path) -> Path:
     return mod
 
 
-class TestPreSerialization:
-    """Tests for the pre-serialization optimization in FixtureCollector."""
-
-    def test_add_fixture_populates_pre_serialized(
-        self, output_dir: Path, filler_path: Path, module_path: Path
-    ) -> None:
-        """
-        add_fixture() stores a pre-serialized JSON string for each fixture.
-        """
-        collector = FixtureCollector(
-            output_dir=output_dir,
-            fill_static_tests=False,
-            single_fixture_per_file=False,
-            filler_path=filler_path,
-            generate_index=False,
-        )
-        fixture = _make_fixture(1)
-        info = _make_info("tx_test", module_path)
-        collector.add_fixture(info, fixture)
-
-        fixture_id = info.get_id()
-        assert fixture_id in collector._pre_serialized
-        # The pre-serialized string must be valid JSON matching the fixture
-        parsed = json.loads(collector._pre_serialized[fixture_id])
-        assert parsed == fixture.json_dict_with_info()
-
-    def test_dump_fixtures_clears_pre_serialized(
-        self, output_dir: Path, filler_path: Path, module_path: Path
-    ) -> None:
-        """dump_fixtures() clears _pre_serialized alongside all_fixtures."""
-        collector = FixtureCollector(
-            output_dir=output_dir,
-            fill_static_tests=False,
-            single_fixture_per_file=False,
-            filler_path=filler_path,
-            generate_index=False,
-        )
-        fixture = _make_fixture(1)
-        info = _make_info("tx_test", module_path)
-        collector.add_fixture(info, fixture)
-
-        assert len(collector._pre_serialized) == 1
-        collector.dump_fixtures()
-        assert len(collector._pre_serialized) == 0
-        assert len(collector.all_fixtures) == 0
-
-
 class TestPartialFixtureFiles:
     """Tests for partial fixture file writing and merging."""
 

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import pytest
 
-from ..collector import FixtureCollector, TestInfo
+from ..base import BaseFixture
+from ..collector import FixtureCollector, TestInfo, merge_partial_fixture_files
+from ..file import Fixtures
 from ..transaction import FixtureResult, TransactionFixture
 
 
@@ -107,8 +109,8 @@ class TestPreSerialization:
         assert len(collector.all_fixtures) == 0
 
 
-class TestWriteFixtureFile:
-    """Tests for _write_fixture_file output format correctness."""
+class TestPartialFixtureFiles:
+    """Tests for partial fixture file writing and merging."""
 
     def test_single_fixture_matches_json_dumps(
         self, output_dir: Path, filler_path: Path, module_path: Path
@@ -124,7 +126,8 @@ class TestWriteFixtureFile:
         fixture = _make_fixture(1)
         info = _make_info("tx_test", module_path)
         collector.add_fixture(info, fixture)
-        collector.dump_fixtures()
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(output_dir)
 
         # Find the written file
         json_files = list(output_dir.rglob("*.json"))
@@ -157,7 +160,8 @@ class TestWriteFixtureFile:
             collector.add_fixture(info, fixture)
             fixtures_and_infos.append((info, fixture))
 
-        collector.dump_fixtures()
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(output_dir)
 
         json_files = list(output_dir.rglob("*.json"))
         assert len(json_files) == 1
@@ -170,39 +174,56 @@ class TestWriteFixtureFile:
         expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
         assert written == expected
 
-    def test_flush_then_append_matches_json_dumps(
+    def test_multiple_workers_merge_correctly(
         self, output_dir: Path, filler_path: Path, module_path: Path
     ) -> None:
         """
-        When flush_interval triggers a mid-run dump, subsequent fixtures
-        appended to the same file must produce output matching json.dumps.
+        Simulates xdist: worker A and B write partial files, merge at end.
+        Final output should match json.dumps of all fixtures.
         """
-        collector = FixtureCollector(
+        collector1 = FixtureCollector(
             output_dir=output_dir,
             fill_static_tests=False,
             single_fixture_per_file=False,
             filler_path=filler_path,
-            flush_interval=2,
             generate_index=False,
         )
-        all_pairs = []
-        # Add 3 fixtures — the 2nd add triggers a flush, then a 3rd is added
+        # Worker A writes fixtures 0-2
+        pairs_a = []
         for i in range(3):
             fixture = _make_fixture(i)
             info = _make_info(f"tx_test_{i}", module_path)
-            collector.add_fixture(info, fixture)
-            all_pairs.append((info, fixture))
+            collector1.add_fixture(info, fixture)
+            pairs_a.append((info, fixture))
+        collector1.dump_fixtures(worker_id="gw0")
 
-        # Final dump for remaining fixtures
-        collector.dump_fixtures()
+        # Worker B writes fixtures 3-5 (separate partial file)
+        collector2 = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        pairs_b = []
+        for i in range(3, 6):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector2.add_fixture(info, fixture)
+            pairs_b.append((info, fixture))
+        collector2.dump_fixtures(worker_id="gw1")
 
+        # Merge at session end
+        merge_partial_fixture_files(output_dir)
+
+        # Verify final output matches json.dumps of all 6 fixtures
         json_files = list(output_dir.rglob("*.json"))
         assert len(json_files) == 1
         written = json_files[0].read_text()
 
         expected_dict = {
             info.get_id(): fixture.json_dict_with_info()
-            for info, fixture in all_pairs
+            for info, fixture in pairs_a + pairs_b
         }
         expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
         assert written == expected
@@ -223,7 +244,8 @@ class TestWriteFixtureFile:
             info = _make_info(f"tx_test_{i}", module_path)
             collector.add_fixture(info, fixture)
 
-        collector.dump_fixtures()
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(output_dir)
 
         json_files = list(output_dir.rglob("*.json"))
         assert len(json_files) == 1
@@ -248,7 +270,8 @@ class TestWriteFixtureFile:
             info = _make_info(f"tx_test_{i}", module_path)
             collector.add_fixture(info, fixture)
 
-        collector.dump_fixtures()
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(output_dir)
 
         json_files = list(output_dir.rglob("*.json"))
         assert len(json_files) == 1
@@ -257,14 +280,10 @@ class TestWriteFixtureFile:
         keys = list(parsed.keys())
         assert keys == sorted(keys)
 
-
-class TestExtractEntriesFromFile:
-    """Tests for _extract_entries_from_file to avoid re-serialization."""
-
-    def test_extract_preserves_json_format(
+    def test_partial_files_cleaned_up_after_merge(
         self, output_dir: Path, filler_path: Path, module_path: Path
     ) -> None:
-        """Extracted entries produce identical output when re-written."""
+        """Partial JSONL files are deleted after merging."""
         collector = FixtureCollector(
             output_dir=output_dir,
             fill_static_tests=False,
@@ -272,73 +291,192 @@ class TestExtractEntriesFromFile:
             filler_path=filler_path,
             generate_index=False,
         )
-        # Write initial fixtures
-        for i in range(3):
+        fixture = _make_fixture(1)
+        info = _make_info("tx_test", module_path)
+        collector.add_fixture(info, fixture)
+        collector.dump_fixtures(worker_id="gw0")
+
+        # Verify partial file exists before merge
+        partial_files = list(output_dir.rglob("*.partial.*.jsonl"))
+        assert len(partial_files) == 1
+
+        merge_partial_fixture_files(output_dir)
+
+        # Verify partial file is deleted after merge
+        partial_files = list(output_dir.rglob("*.partial.*.jsonl"))
+        assert len(partial_files) == 0
+
+
+class TestLegacyCompatibility:
+    """
+    Tests verifying the new partial file approach produces byte-identical
+    output to the legacy Fixtures.collect_into_file() method.
+    """
+
+    def test_single_fixture_matches_legacy(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Single fixture output matches legacy collect_into_file()."""
+        fixture: BaseFixture = _make_fixture(1)
+        info = _make_info("tx_test", module_path)
+        fixture_id = info.get_id()
+
+        # Legacy approach: use Fixtures.collect_into_file()
+        legacy_dir = output_dir / "legacy"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "test.json"
+        legacy_fixtures = Fixtures(root={fixture_id: fixture})
+        legacy_fixtures.collect_into_file(legacy_file)
+        legacy_output = legacy_file.read_text()
+
+        # New approach: use partial files + merge
+        new_dir = output_dir / "new"
+        new_dir.mkdir()
+        collector = FixtureCollector(
+            output_dir=new_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        collector.add_fixture(info, fixture)
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(new_dir)
+        new_files = list(new_dir.rglob("*.json"))
+        assert len(new_files) == 1
+        new_output = new_files[0].read_text()
+
+        assert new_output == legacy_output
+
+    def test_multiple_fixtures_match_legacy(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Multiple fixtures output matches legacy collect_into_file()."""
+        fixtures_dict: dict[str, BaseFixture] = {}
+        infos = []
+        for i in range(5):
             fixture = _make_fixture(i)
             info = _make_info(f"tx_test_{i}", module_path)
-            collector.add_fixture(info, fixture)
-        collector.dump_fixtures()
+            fixtures_dict[info.get_id()] = fixture
+            infos.append(info)
 
-        json_files = list(output_dir.rglob("*.json"))
+        # Legacy approach
+        legacy_dir = output_dir / "legacy"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "test.json"
+        legacy_fixtures = Fixtures(root=fixtures_dict)
+        legacy_fixtures.collect_into_file(legacy_file)
+        legacy_output = legacy_file.read_text()
 
-        # Extract and verify the entries match what json.dumps would produce
-        extracted = collector._extract_entries_from_file(json_files[0])
-        assert len(extracted) == 3
+        # New approach
+        new_dir = output_dir / "new"
+        new_dir.mkdir()
+        collector = FixtureCollector(
+            output_dir=new_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        for i, info in enumerate(infos):
+            collector.add_fixture(info, list(fixtures_dict.values())[i])
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(new_dir)
+        new_files = list(new_dir.rglob("*.json"))
+        assert len(new_files) == 1
+        new_output = new_files[0].read_text()
 
-        for _, value_str in extracted.items():
-            # Each extracted value should be valid JSON
-            parsed = json.loads(value_str)
-            # And should match json.dumps with indent=4
-            expected = json.dumps(parsed, indent=4)
-            assert value_str == expected
+        assert new_output == legacy_output
 
-    def test_extract_then_write_is_identical(
+    def test_multiple_workers_match_legacy(
         self, output_dir: Path, filler_path: Path, module_path: Path
     ) -> None:
         """
-        Simulates xdist: worker A writes, worker B reads and adds more.
-        Final output should match json.dumps of all fixtures.
+        Multiple workers writing to same logical file matches legacy output.
         """
-        collector1 = FixtureCollector(
-            output_dir=output_dir,
+        fixtures_dict: dict[str, BaseFixture] = {}
+        infos = []
+        for i in range(6):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            fixtures_dict[info.get_id()] = fixture
+            infos.append(info)
+
+        # Legacy approach: all fixtures in one call
+        legacy_dir = output_dir / "legacy"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "test.json"
+        legacy_fixtures = Fixtures(root=fixtures_dict)
+        legacy_fixtures.collect_into_file(legacy_file)
+        legacy_output = legacy_file.read_text()
+
+        # New approach: simulate 3 workers, each with 2 fixtures
+        new_dir = output_dir / "new"
+        new_dir.mkdir()
+        fixture_values = list(fixtures_dict.values())
+        for worker_idx in range(3):
+            collector = FixtureCollector(
+                output_dir=new_dir,
+                fill_static_tests=False,
+                single_fixture_per_file=False,
+                filler_path=filler_path,
+                generate_index=False,
+            )
+            start = worker_idx * 2
+            for i in range(start, start + 2):
+                collector.add_fixture(infos[i], fixture_values[i])
+            collector.dump_fixtures(worker_id=f"gw{worker_idx}")
+
+        merge_partial_fixture_files(new_dir)
+        new_files = list(new_dir.rglob("*.json"))
+        assert len(new_files) == 1
+        new_output = new_files[0].read_text()
+
+        assert new_output == legacy_output
+
+    def test_special_characters_in_keys_match_legacy(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Fixture IDs with special characters produce identical output."""
+        # Create fixtures with complex IDs (typical pytest node IDs)
+        fixtures_dict: dict[str, BaseFixture] = {}
+        infos = []
+        complex_ids = [
+            "param[fork_Paris-state_test]",
+            "param[fork_Shanghai-blockchain_test]",
+            'param[value="quoted"]',
+            "param[path/with/slashes]",
+        ]
+        for i, test_id in enumerate(complex_ids):
+            fixture = _make_fixture(i)
+            info = _make_info(test_id, module_path)
+            fixtures_dict[info.get_id()] = fixture
+            infos.append(info)
+
+        # Legacy approach
+        legacy_dir = output_dir / "legacy"
+        legacy_dir.mkdir()
+        legacy_file = legacy_dir / "test.json"
+        legacy_fixtures = Fixtures(root=fixtures_dict)
+        legacy_fixtures.collect_into_file(legacy_file)
+        legacy_output = legacy_file.read_text()
+
+        # New approach
+        new_dir = output_dir / "new"
+        new_dir.mkdir()
+        collector = FixtureCollector(
+            output_dir=new_dir,
             fill_static_tests=False,
             single_fixture_per_file=False,
             filler_path=filler_path,
             generate_index=False,
         )
-        # Worker A writes fixtures 0-2
-        pairs_a = []
-        for i in range(3):
-            fixture = _make_fixture(i)
-            info = _make_info(f"tx_test_{i}", module_path)
-            collector1.add_fixture(info, fixture)
-            pairs_a.append((info, fixture))
-        collector1.dump_fixtures()
+        for i, info in enumerate(infos):
+            collector.add_fixture(info, list(fixtures_dict.values())[i])
+        collector.dump_fixtures(worker_id="gw0")
+        merge_partial_fixture_files(new_dir)
+        new_files = list(new_dir.rglob("*.json"))
+        assert len(new_files) == 1
+        new_output = new_files[0].read_text()
 
-        # Worker B writes fixtures 3-5 to the same file
-        collector2 = FixtureCollector(
-            output_dir=output_dir,
-            fill_static_tests=False,
-            single_fixture_per_file=False,
-            filler_path=filler_path,
-            generate_index=False,
-        )
-        pairs_b = []
-        for i in range(3, 6):
-            fixture = _make_fixture(i)
-            info = _make_info(f"tx_test_{i}", module_path)
-            collector2.add_fixture(info, fixture)
-            pairs_b.append((info, fixture))
-        collector2.dump_fixtures()
-
-        # Verify final output matches json.dumps of all 6 fixtures
-        json_files = list(output_dir.rglob("*.json"))
-        assert len(json_files) == 1
-        written = json_files[0].read_text()
-
-        expected_dict = {
-            info.get_id(): fixture.json_dict_with_info()
-            for info, fixture in pairs_a + pairs_b
-        }
-        expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
-        assert written == expected
+        assert new_output == legacy_output

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -1,0 +1,344 @@
+"""Test cases for the execution_testing.fixtures.collector module."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ..collector import FixtureCollector, TestInfo
+from ..transaction import FixtureResult, TransactionFixture
+
+
+def _make_fixture(nonce: int = 0) -> TransactionFixture:
+    """Create a minimal TransactionFixture for testing."""
+    fixture = TransactionFixture(
+        transaction=f"0x{nonce:04x}",
+        result={"Paris": FixtureResult(intrinsic_gas=nonce)},
+    )
+    fixture.fill_info(
+        "t8n-test",
+        f"test description {nonce}",
+        fixture_source_url="http://example.com",
+        ref_spec=None,
+        _info_metadata={},
+    )
+    return fixture
+
+
+def _make_info(test_id: str, module_path: Path) -> TestInfo:
+    """Create a TestInfo for testing."""
+    return TestInfo(
+        name=f"test_func[fork_Paris-{test_id}]",
+        id=f"{module_path}::test_func[fork_Paris-{test_id}]",
+        original_name="test_func",
+        module_path=module_path,
+    )
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path) -> Path:
+    """Create output directory for test fixtures."""
+    out = tmp_path / "output"
+    out.mkdir()
+    return out
+
+
+@pytest.fixture
+def filler_path(tmp_path: Path) -> Path:
+    """Create a filler path (tests directory root)."""
+    p = tmp_path / "tests"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def module_path(filler_path: Path) -> Path:
+    """Create a dummy test module path."""
+    mod = filler_path / "cancun" / "test_example.py"
+    mod.parent.mkdir(parents=True, exist_ok=True)
+    mod.touch()
+    return mod
+
+
+class TestPreSerialization:
+    """Tests for the pre-serialization optimization in FixtureCollector."""
+
+    def test_add_fixture_populates_pre_serialized(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        add_fixture() stores a pre-serialized JSON string for each fixture.
+        """
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixture = _make_fixture(1)
+        info = _make_info("tx_test", module_path)
+        collector.add_fixture(info, fixture)
+
+        fixture_id = info.get_id()
+        assert fixture_id in collector._pre_serialized
+        # The pre-serialized string must be valid JSON matching the fixture
+        parsed = json.loads(collector._pre_serialized[fixture_id])
+        assert parsed == fixture.json_dict_with_info()
+
+    def test_dump_fixtures_clears_pre_serialized(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """dump_fixtures() clears _pre_serialized alongside all_fixtures."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixture = _make_fixture(1)
+        info = _make_info("tx_test", module_path)
+        collector.add_fixture(info, fixture)
+
+        assert len(collector._pre_serialized) == 1
+        collector.dump_fixtures()
+        assert len(collector._pre_serialized) == 0
+        assert len(collector.all_fixtures) == 0
+
+
+class TestWriteFixtureFile:
+    """Tests for _write_fixture_file output format correctness."""
+
+    def test_single_fixture_matches_json_dumps(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Output for a single fixture must match json.dumps(..., indent=4)."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixture = _make_fixture(1)
+        info = _make_info("tx_test", module_path)
+        collector.add_fixture(info, fixture)
+        collector.dump_fixtures()
+
+        # Find the written file
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        written = json_files[0].read_text()
+
+        # Build expected output using the original json.dumps approach
+        fixture_id = info.get_id()
+        expected_dict = {fixture_id: fixture.json_dict_with_info()}
+        expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
+        assert written == expected
+
+    def test_multiple_fixtures_match_json_dumps(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        Output for multiple fixtures must match json.dumps(..., indent=4).
+        """
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        fixtures_and_infos = []
+        for i in range(5):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector.add_fixture(info, fixture)
+            fixtures_and_infos.append((info, fixture))
+
+        collector.dump_fixtures()
+
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        written = json_files[0].read_text()
+
+        expected_dict = {
+            info.get_id(): fixture.json_dict_with_info()
+            for info, fixture in fixtures_and_infos
+        }
+        expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
+        assert written == expected
+
+    def test_flush_then_append_matches_json_dumps(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        When flush_interval triggers a mid-run dump, subsequent fixtures
+        appended to the same file must produce output matching json.dumps.
+        """
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            flush_interval=2,
+            generate_index=False,
+        )
+        all_pairs = []
+        # Add 3 fixtures — the 2nd add triggers a flush, then a 3rd is added
+        for i in range(3):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector.add_fixture(info, fixture)
+            all_pairs.append((info, fixture))
+
+        # Final dump for remaining fixtures
+        collector.dump_fixtures()
+
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        written = json_files[0].read_text()
+
+        expected_dict = {
+            info.get_id(): fixture.json_dict_with_info()
+            for info, fixture in all_pairs
+        }
+        expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
+        assert written == expected
+
+    def test_output_is_valid_json(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """The written file must be parseable as valid JSON."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        for i in range(3):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector.add_fixture(info, fixture)
+
+        collector.dump_fixtures()
+
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        parsed = json.loads(json_files[0].read_text())
+        assert isinstance(parsed, dict)
+        assert len(parsed) == 3
+
+    def test_fixtures_sorted_by_key(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Fixture entries in the output file must be sorted by key."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        # Add in reverse order
+        for i in reversed(range(3)):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector.add_fixture(info, fixture)
+
+        collector.dump_fixtures()
+
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        content = json_files[0].read_text()
+        parsed = json.loads(content)
+        keys = list(parsed.keys())
+        assert keys == sorted(keys)
+
+
+class TestExtractEntriesFromFile:
+    """Tests for _extract_entries_from_file to avoid re-serialization."""
+
+    def test_extract_preserves_json_format(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """Extracted entries produce identical output when re-written."""
+        collector = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        # Write initial fixtures
+        for i in range(3):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector.add_fixture(info, fixture)
+        collector.dump_fixtures()
+
+        json_files = list(output_dir.rglob("*.json"))
+
+        # Extract and verify the entries match what json.dumps would produce
+        extracted = collector._extract_entries_from_file(json_files[0])
+        assert len(extracted) == 3
+
+        for _, value_str in extracted.items():
+            # Each extracted value should be valid JSON
+            parsed = json.loads(value_str)
+            # And should match json.dumps with indent=4
+            expected = json.dumps(parsed, indent=4)
+            assert value_str == expected
+
+    def test_extract_then_write_is_identical(
+        self, output_dir: Path, filler_path: Path, module_path: Path
+    ) -> None:
+        """
+        Simulates xdist: worker A writes, worker B reads and adds more.
+        Final output should match json.dumps of all fixtures.
+        """
+        collector1 = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        # Worker A writes fixtures 0-2
+        pairs_a = []
+        for i in range(3):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector1.add_fixture(info, fixture)
+            pairs_a.append((info, fixture))
+        collector1.dump_fixtures()
+
+        # Worker B writes fixtures 3-5 to the same file
+        collector2 = FixtureCollector(
+            output_dir=output_dir,
+            fill_static_tests=False,
+            single_fixture_per_file=False,
+            filler_path=filler_path,
+            generate_index=False,
+        )
+        pairs_b = []
+        for i in range(3, 6):
+            fixture = _make_fixture(i)
+            info = _make_info(f"tx_test_{i}", module_path)
+            collector2.add_fixture(info, fixture)
+            pairs_b.append((info, fixture))
+        collector2.dump_fixtures()
+
+        # Verify final output matches json.dumps of all 6 fixtures
+        json_files = list(output_dir.rglob("*.json"))
+        assert len(json_files) == 1
+        written = json_files[0].read_text()
+
+        expected_dict = {
+            info.get_id(): fixture.json_dict_with_info()
+            for info, fixture in pairs_a + pairs_b
+        }
+        expected = json.dumps(dict(sorted(expected_dict.items())), indent=4)
+        assert written == expected

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -526,6 +526,7 @@ def test_fork_transition_excess_blob_gas_at_blob_genesis(
     ],
 )
 @pytest.mark.parametrize("block_base_fee_per_gas", [7, 16, 23])
+@pytest.mark.slow
 def test_fork_transition_excess_blob_gas_post_blob_genesis(
     blockchain_test: BlockchainTestFiller,
     genesis_environment: Environment,

--- a/tests/frontier/opcodes/test_blockhash.py
+++ b/tests/frontier/opcodes/test_blockhash.py
@@ -22,6 +22,7 @@ from execution_testing.forks.helpers import Fork
         pytest.param(256, True, id="256_empty_blocks"),
     ],
 )
+@pytest.mark.slow()
 def test_genesis_hash_available(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
@@ -21,6 +21,7 @@ REFERENCE_SPEC_VERSION = ref_spec_7918.version
 @pytest.mark.valid_for_bpo_forks()
 @pytest.mark.parametrize("parent_excess_blobs", [27])
 @pytest.mark.parametrize("block_base_fee_per_gas", [17])
+@pytest.mark.slow
 def test_blob_base_fee_with_bpo_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -560,6 +560,7 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
 )
 @pytest.mark.valid_at_transition_to("Osaka", subsequent_forks=True)
 @pytest.mark.valid_for_bpo_forks()
+@pytest.mark.slow()
 def test_reserve_price_at_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip6110_deposits/test_deposits.py
+++ b/tests/prague/eip6110_deposits/test_deposits.py
@@ -914,6 +914,7 @@ pytestmark = pytest.mark.valid_from("Prague")
         ),
     ],
 )
+@pytest.mark.slow()
 @pytest.mark.pre_alloc_group(
     "deposit_requests",
     reason="Tests standard deposit request functionality with system contract",

--- a/tests/static/state_tests/stAttackTest/ContractCreationSpamFiller.json
+++ b/tests/static/state_tests/stAttackTest/ContractCreationSpamFiller.json
@@ -1,5 +1,8 @@
 {
     "ContractCreationSpam" : {
+        "_info" : {
+            "pytest_marks": ["slow"]
+        },
         "env" : {
             "currentCoinbase" : "2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
             "currentDifficulty" : "0x20000",

--- a/tests/static/state_tests/stQuadraticComplexityTest/Return50000_2Filler.json
+++ b/tests/static/state_tests/stQuadraticComplexityTest/Return50000_2Filler.json
@@ -1,5 +1,8 @@
 {
     "Return50000_2" : {
+        "_info" : {
+            "pytest_marks": ["slow"]
+        },
         "env" : {
             "currentCoinbase" : "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "currentDifficulty" : "0x020000",

--- a/tests/static/state_tests/stStaticCall/static_Return50000_2Filler.json
+++ b/tests/static/state_tests/stStaticCall/static_Return50000_2Filler.json
@@ -1,5 +1,8 @@
 {
     "static_Return50000_2" : {
+        "_info" : {
+            "pytest_marks": ["slow"]
+        },
         "env" : {
             "currentCoinbase" : "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "currentDifficulty" : "0x020000",

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,7 @@ commands =
         --log-to "{toxworkdir}/logs" \
         --clean \
         --until Amsterdam \
+        --durations=50 \
         {posargs} \
         tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,7 @@ commands =
     fill \
         -m "not slow and not zkevm and not benchmark" \
         -n auto --maxprocesses 10 --dist=loadgroup \
+        --skip-index \
         --cov-config=pyproject.toml \
         --cov=ethereum \
         --cov-report=term \


### PR DESCRIPTION
## 🗒️ Description

- Build index incrementally on the fly, across runners, and merge at the end. Remove the bottleneck at the end of filling, re-reading all files in a single main thread.
- Defer index model validation until merge, append-only:
    - Claude summary is worth it here:
      ```
      Before: Each write_partial_index() call (which happens per module scope) had to:                                                                                                                                                                                                                                          
        1. Acquire FileLock                                                                                                                                                                                                                                                                                                       
        2. Read the entire existing JSON file                                                                                                                                                                                                                                                                                     
        3. Parse it (json.loads)                                                                                                                                                                                                                                                                                                  
        4. Append new entries to the list                                                                                                                                                                                                                                                                                         
        5. Serialize the entire thing back (json.dumps)                                                                                                                                                                                                                                                                           
        6. Write the whole file                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
        Every write re-reads and re-writes everything written so far. For a worker that processes 500 modules, the 500th write re-serializes all entries from the previous 499.                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
      After: Each call just:                                                                                                                                                                                                                                                                                                    
        1. Acquire FileLock                                                                                                                                                                                                                                                                                                       
        2. Open file in append mode ("a")                                                                                                                                                                                                                                                                                         
        3. Write new lines                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
        No reading, no parsing, no re-serialization of existing data. O(new entries) per write instead of O(all entries so far).```
- Use a trie-building approach for `HashableItem.from_index_entries()` and add tests to ensure same hashes are produced - from O(n^2) to O(n):
  - Every folder in the hierarchy used to scan all files twice. From Claude: `Each entry is now inserted once by walking its path components (bounded depth, typically 3-5 levels). The conversion visits each trie node exactly once. Total: O(n). No redundant scanning, no relative_to(), no ValueError try/except.`
- Use `--no-html` for releases since we don't publish the html in the artifacts, this is not needed (small win)
- Validate at `IndexFile` once, not at every single file (just one validation instead of potentially +100k times)
- Distribute slow-marked tests to workers first so we don't hang at the end of test runs (no bricked slow tail)
- Also build fixtures in parts via workers and merge at the end... this reduces test `teardown` phase significantly (seeing some improvements from ~80s to ~1` in some longer tests). 
- Turns on `--durations=50` for `py3` run so we can see the slowest 50 durations. Anything in the ~200s and above range was marked as a slow test in this PR.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="477" height="429" alt="Screenshot 2026-01-27 at 10 46 09" src="https://github.com/user-attachments/assets/7f2dd341-0106-435e-ab92-6cad85184f0e" />

