### PR TITLE
fix(fw): Less restrictive TransactionTraces CamelModel

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 ### 🛠️ Framework
 
 - 🐞 Remove `Op.CLZ` from `UndefinedOpcodes` list ([#1970](https://github.com/ethereum/execution-specs/pull/1970)).
+- 🐞 Make `TransactionTraces` `CamelModel` less lestrictive ([#2081](https://github.com/ethereum/execution-specs/pull/2081)).
 
 #### `fill`
 

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -99,6 +99,8 @@ class TraceLine(CamelModel):
 class TransactionTraces(CamelModel):
     """Traces of a single transaction."""
 
+    model_config = CamelModel.model_config | {"extra": "ignore"}
+
     traces: List[TraceLine]
     output: str | None = None
     gas_used: HexNumber | None = None


### PR DESCRIPTION
## 🗒️ Description

Follow-up to #2000 , I still have been getting errors with `--traces` option, when the traces involved an exception. This seems to have fixed it not sure if correct.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
