### PR TITLE
fix(tests): EIP-7883 minor fixes

### DIFF
--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -60,14 +60,18 @@ def total_tx_gas_needed(
         fork.transaction_intrinsic_cost_calculator()
     )
     memory_expansion_gas_calculator = fork.memory_expansion_gas_calculator()
-    sstore_gas = fork.gas_costs().G_STORAGE_SET * (len(modexp_expected) // 32)
+    sstore_gas = (
+        fork.gas_costs().G_STORAGE_SET + fork.gas_costs().G_COLD_SLOAD
+    ) * 5
+    # Ensures that the precompile call is not starved by the 63/64 rule.
+    precompile_gas_with_margin = precompile_gas * 64 // 63
     extra_gas = 100_000
 
     return (
         extra_gas
         + intrinsic_gas_cost_calculator(calldata=bytes(modexp_input))
         + memory_expansion_gas_calculator(new_bytes=len(bytes(modexp_input)))
-        + precompile_gas
+        + precompile_gas_with_margin
         + sstore_gas
     )
 

--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -223,11 +223,11 @@ def precompile_gas(
     Calculate gas cost for the ModExp precompile and verify it matches expected
     gas.
     """
-    spec = Spec if fork < Osaka else Spec7883
+    spec = Spec7883 if fork >= Osaka else Spec
     try:
         calculated_gas = spec.calculate_gas_cost(modexp_input)
         if gas_old is not None and gas_new is not None:
-            expected_gas = gas_old if fork < Osaka else gas_new
+            expected_gas = gas_new if fork >= Osaka else gas_old
             base_len = len(modexp_input.base)
             exp_len = len(modexp_input.exponent)
             mod_len = len(modexp_input.modulus)

--- a/tests/osaka/eip7883_modexp_gas_increase/conftest.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/conftest.py
@@ -60,9 +60,10 @@ def total_tx_gas_needed(
         fork.transaction_intrinsic_cost_calculator()
     )
     memory_expansion_gas_calculator = fork.memory_expansion_gas_calculator()
+    # `gas_measure_contract` does at most 4 SSTOREs to cold slots.
     sstore_gas = (
         fork.gas_costs().G_STORAGE_SET + fork.gas_costs().G_COLD_SLOAD
-    ) * 5
+    ) * 4
     # Ensures that the precompile call is not starved by the 63/64 rule.
     precompile_gas_with_margin = precompile_gas * 64 // 63
     extra_gas = 100_000


### PR DESCRIPTION
## 🗒️ Description

Two unrelated fixes to the EIP-7883 testing:
- fixing the gas formula - I'm not sure why the `(len(modexp_expected) // 32)` factor was there, as the number of SSTOREs never depended on the length. At the same time there were several SSTOREs done throughout the test. Also the precompile gas part of the tx gas must take into account that the 63/64th rule is going to apply
- new gas should apply for forks coming after Osaka, so that forks that might not define its relation to Osaka use old gas

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
