### PR TITLE
refactor(tests): `tx_gas` and `cold_gas` for `gas_test` generator

### DIFF
--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -503,18 +503,12 @@ def gas_test(
         balance=subject_balance,
         address=subject_address,
     )
-    # 2 times GAS, POP, CALL, 6 times PUSH1 - instructions charged for at every
-    # gas run
-    gas_costs = fork.gas_costs()
-    opcode_gas_cost = gas_costs.BASE
-    opcode_pop_cost = gas_costs.BASE
-    opcode_push_cost = gas_costs.VERY_LOW
+
+    # Auxiliary instructions charged for at every gas run
     gas_single_gas_run = (
-        2 * opcode_gas_cost
-        + opcode_pop_cost
-        + gas_costs.WARM_ACCESS
-        + 6 * opcode_push_cost
-    )
+        Op.GAS + Op.CALL(gas=Op.GAS, address_warm=True) + Op.POP
+    ).gas_cost(fork=fork)
+
     address_legacy_harness = pre.deploy_contract(
         code=(
             # warm subject and baseline without executing
@@ -624,13 +618,13 @@ def gas_test(
             LEGACY_CALL_SUCCESS
         )
 
-    sstore_gas = gas_costs.STORAGE_SET + gas_costs.COLD_STORAGE_ACCESS
+    gas_sstore = Op.SSTORE(1, 1).gas_cost(fork=fork)
     if tx_gas is None:
         tx_gas = (
             5 * gas_single_gas_run
             + cold_gas
             + 4 * warm_gas
-            + 5 * sstore_gas
+            + 5 * gas_sstore
             + 500_000
         )
     tx = Transaction(

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -483,9 +483,9 @@ def gas_test(
     if cold_gas is None:
         cold_gas = subject_code.gas_cost(fork)
 
-    if cold_gas <= 0:
+    if cold_gas < 0:
         raise ValueError(
-            f"Target gas allocations (cold_gas) must be > 0, got {cold_gas}"
+            f"Target gas allocations (cold_gas) must be >= 0, got {cold_gas}"
         )
     if warm_gas is None:
         if subject_code_warm is not None:
@@ -624,8 +624,15 @@ def gas_test(
             LEGACY_CALL_SUCCESS
         )
 
+    sstore_gas = gas_costs.STORAGE_SET + gas_costs.COLD_STORAGE_ACCESS
     if tx_gas is None:
-        tx_gas = gas_single_gas_run + cold_gas + 500_000
+        tx_gas = (
+            5 * gas_single_gas_run
+            + cold_gas
+            + 4 * warm_gas
+            + 5 * sstore_gas
+            + 500_000
+        )
     tx = Transaction(
         to=address_legacy_harness, gas_limit=tx_gas, sender=sender
     )

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -223,9 +223,6 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
         # delta used by gas_test. Excluded to keep the test meaningful.
         if fork.is_eip_enabled(8037) and opcode in (Op.CREATE, Op.CREATE2):
             continue
-        if opcode.gas_cost(fork) == 0:
-            # zero constant gas opcodes - untestable
-            continue
         yield pytest.param(
             opcode,
             id=f"{opcode}",
@@ -267,4 +264,5 @@ def test_constant_gas(
         subject_code=opcode,
         subject_code_warm=warm_opcode,
         tear_down_code=prepare_suffix(opcode),
+        out_of_gas_testing=opcode.gas_cost(fork) > 0,
     )


### PR DESCRIPTION
## 🗒️ Description

`gas_test` generator had some gas values hardcoded and wasn't immune to gas repricings. This PR should provide tx_gas based on forks gas_cost values.

Also, it allows to specify `cold_gas=0` to test opcodes like REVERT, and unlocks some standard gas cost tests

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist


- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
