### PR TITLE
feat(src): add `getBlobsV3` support and test case for it

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -109,6 +109,8 @@ def base_pre(
     return Alloc(
         {
             seed_key: Account(balance=seed_key_initial_balance),
+            # Pre-deploy the deterministic factory to avoid needing unprotected
+            # transactions (geth rejects unprotected txs by default)
             DETERMINISTIC_FACTORY_ADDRESS: Account(
                 nonce=1, code=DETERMINISTIC_FACTORY_BYTECODE
             ),
@@ -167,6 +169,11 @@ def base_pre_genesis(
         parent_beacon_block_root=env.parent_beacon_block_root,
         requests_hash=Requests()
         if session_fork.header_requests_required(
+            block_number=block_number, timestamp=timestamp
+        )
+        else None,
+        block_access_list_hash=Hash(EmptyTrieRoot)
+        if session_fork.header_bal_hash_required(
             block_number=block_number, timestamp=timestamp
         )
         else None,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -12,6 +12,7 @@ from pytest_metadata.plugin import metadata_key
 from execution_testing.base_types import Address, Number, Wei
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
+from execution_testing.rpc.rpc_types import JSONRPCError
 from execution_testing.test_types import (
     EOA,
     Transaction,
@@ -411,11 +412,17 @@ def worker_key(
 ) -> Generator[EOA, None, None]:
     """Prepare the worker key for the current test."""
     logger.debug(f"Preparing worker key {session_worker_key} for test")
-    session_worker_account = eth_rpc.get_account(
-        session_worker_key, block_number="pending", skip_code=True
-    )
+    try:
+        session_worker_account = eth_rpc.get_account(
+            session_worker_key, block_number="latest", skip_code=True
+        )
+    except JSONRPCError:
+        logger.debug("Latest state not available, falling back to pending")
+        session_worker_account = eth_rpc.get_account(
+            session_worker_key, block_number="pending", skip_code=True
+        )
     rpc_nonce = Number(session_worker_account.nonce)
-    if rpc_nonce != session_worker_key.nonce:
+    if rpc_nonce > session_worker_key.nonce:
         wk_nonce = session_worker_key.nonce
         logger.info(f"Worker key nonce mismatch: {wk_nonce} != {rpc_nonce}")
         logger.info(f"Updating worker key nonce to {rpc_nonce}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1855,6 +1855,9 @@ def pytest_collection_modifyitems(
     These can't be handled in this plugins pytest_generate_tests() as the fork
     parametrization occurs in the forks plugin.
     """
+    # Track specs with no fixture formats for warning message
+    specs_without_fixture_formats: Dict[str, Set[str]] = {}
+
     items_for_removal = []
     for i, item in enumerate(items):
         item.name = item.name.strip().replace(" ", "-")
@@ -1870,6 +1873,15 @@ def pytest_collection_modifyitems(
         spec_type, fixture_format = get_spec_format_for_item(params)
         if isinstance(fixture_format, NotSetType):
             items_for_removal.append(i)
+            # Track this spec type and the test file
+            spec_name = spec_type.__name__
+            if spec_name not in specs_without_fixture_formats:
+                specs_without_fixture_formats[spec_name] = set()
+            # Get the test file path from the item
+            test_file = (
+                str(item.fspath) if hasattr(item, "fspath") else str(item.path)
+            )
+            specs_without_fixture_formats[spec_name].add(test_file)
             continue
         assert issubclass(fixture_format, BaseFixture)
         if not fixture_format.supports_fork(fork):
@@ -1912,6 +1924,39 @@ def pytest_collection_modifyitems(
 
     for i in reversed(items_for_removal):
         items.pop(i)
+
+    # Warn users if tests were removed because they have no fixture formats
+    if specs_without_fixture_formats:
+        reporter = config.pluginmanager.get_plugin("terminalreporter")
+        if reporter and isinstance(reporter, TerminalReporter):
+            reporter.write_line("")
+            reporter.write_sep(
+                "=",
+                "NOTICE: Tests skipped (no fixture formats)",
+                yellow=True,
+                bold=True,
+            )
+            for spec_name, test_files in specs_without_fixture_formats.items():
+                reporter.write_line(
+                    f"  {spec_name} has no supported_fixture_formats "
+                    f"for 'fill' command.",
+                    yellow=True,
+                )
+                for test_file in sorted(test_files):
+                    reporter.write_line(f"    - {test_file}", yellow=True)
+            reporter.write_line("")
+            reporter.write_line(
+                "  These tests are designed for the 'execute' command, "
+                "not 'fill'.",
+                yellow=True,
+            )
+            reporter.write_line(
+                "  Use 'uv run execute hive' or 'uv run execute remote' "
+                "instead.",
+                yellow=True,
+            )
+            reporter.write_sep("=", yellow=True, bold=True)
+            reporter.write_line("")
 
     # Build base_nodeid cache and identify slow groups.
     # If ANY fixture format variant is marked slow, treat ALL variants as slow

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1932,7 +1932,7 @@ def pytest_collection_modifyitems(
             reporter.write_line("")
             reporter.write_sep(
                 "=",
-                "NOTICE: Tests skipped (no fixture formats)",
+                "NOTICE: Tests ignored (as expected; no fixture formats)",
                 yellow=True,
                 bold=True,
             )

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -31,6 +31,81 @@ from .base import BaseExecute, ExecuteResult
 logger = get_logger(__name__)
 
 
+def _validate_blob_and_proof(
+    expected_blob: BlobAndProofV1 | BlobAndProofV2 | None,
+    received_blob: BlobAndProofV1 | BlobAndProofV2 | None,
+    index: int,
+) -> None:
+    """
+    Validate that a received blob and proof match the expected values.
+
+    When expected is None (non-existing blob hash), the received blob must
+    also be None. When expected is not None, the received blob must match.
+    Raise ValueError with a detailed message on mismatch.
+    """
+    if expected_blob is None:
+        if received_blob is None:
+            logger.info(
+                f"Blob at index {index} correctly returned null "
+                "(non-existing blob hash)"
+            )
+            return
+        raise ValueError(
+            f"Blob at index {index} should not exist but "
+            f"client returned: {received_blob}"
+        )
+    if received_blob is None:
+        raise ValueError(f"Received blob at index {index} is empty.")
+    if isinstance(expected_blob, BlobAndProofV1):
+        if not isinstance(received_blob, BlobAndProofV1):
+            raise ValueError(
+                f"Received blob at index {index} is not a BlobAndProofV1."
+            )
+        if expected_blob.blob != received_blob.blob:
+            raise ValueError(f"Blob mismatch at index {index}.")
+        if expected_blob.proof != received_blob.proof:
+            raise ValueError(f"Proof mismatch at index {index}.")
+    elif isinstance(expected_blob, BlobAndProofV2):
+        if not isinstance(received_blob, BlobAndProofV2):
+            raise ValueError(
+                f"Received blob at index {index} is not a BlobAndProofV2."
+            )
+        if expected_blob.blob != received_blob.blob:
+            raise ValueError(f"Blob mismatch at index {index}.")
+        if expected_blob.proofs != received_blob.proofs:
+            error_message = f"Proofs mismatch at index {index}."
+            expected_len = len(expected_blob.proofs)
+            received_len = len(received_blob.proofs)
+            error_message += f"len(expected_blob.proofs) = {expected_len}, "
+            error_message += f"len(received_blob.proofs) = {received_len}\n"
+            if expected_len == received_len:
+                for j, (expected_proof, received_proof) in enumerate(
+                    zip(
+                        expected_blob.proofs,
+                        received_blob.proofs,
+                        strict=False,
+                    )
+                ):
+                    if len(expected_proof) != len(received_proof):
+                        exp_len = len(expected_proof)
+                        rcv_len = len(received_proof)
+                        error_message += f"Proof length mismatch. index = {j},"
+                        error_message += f"expected_proof length = {exp_len}, "
+                        error_message += f"received_proof length = {rcv_len}\n"
+                        continue
+                    if expected_proof != received_proof:
+                        exp_hash = sha256(expected_proof).hexdigest()
+                        rcv_hash = sha256(received_proof).hexdigest()
+                        error_message += f"Proof mismatch. index = {j},"
+                        error_message += f"expected_proof hash = {exp_hash}, "
+                        error_message += f"received_proof hash = {rcv_hash}\n"
+            raise ValueError(error_message)
+    else:
+        raise ValueError(
+            f"Unexpected blob type at index {index}: {type(expected_blob)}"
+        )
+
+
 def versioned_hashes_with_blobs_and_proofs(
     tx: NetworkWrappedTransaction,
 ) -> Dict[Hash, BlobAndProofV1 | BlobAndProofV2]:
@@ -205,24 +280,22 @@ class BlobTransaction(BaseExecute):
                         f"Expected {expected_count} blob responses, "
                         f"got {len(blob_response)}."
                     )
-                # Verify existing blobs are returned and non-existing are null
+                # Build expected list: real blobs then None for non-existing
+                expected_blobs_and_proofs: List[
+                    BlobAndProofV1 | BlobAndProofV2 | None
+                ] = list(versioned_hashes.values()) + [None] * len(
+                    self.nonexisting_blob_hashes
+                )
+                for i, (expected_blob, received_blob) in enumerate(
+                    zip(
+                        expected_blobs_and_proofs,
+                        blob_response.root,
+                        strict=True,
+                    )
+                ):
+                    _validate_blob_and_proof(expected_blob, received_blob, i)
                 existing_count = len(versioned_hashes)
                 nonexisting_count = len(self.nonexisting_blob_hashes)
-                for i, received_blob in enumerate(blob_response.root):
-                    if i < existing_count:
-                        # This should be an existing blob
-                        if received_blob is None:
-                            raise ValueError(
-                                f"Blob at index {i} should exist but client "
-                                "returned null."
-                            )
-                    else:
-                        # This should be a non-existing blob (null)
-                        if received_blob is not None:
-                            raise ValueError(
-                                f"Blob at index {i} should not exist but "
-                                f"client returned: {received_blob}"
-                            )
                 logger.info(
                     f"Test passed: getBlobsV{version} correctly returned "
                     f"partial response with {existing_count} existing blobs "
@@ -245,73 +318,14 @@ class BlobTransaction(BaseExecute):
             f"got {len(blob_response)}."
         )
 
-        for expected_blob, received_blob in zip(
-            local_blobs_and_proofs, blob_response.root, strict=True
+        for i, (expected_blob, received_blob) in enumerate(
+            zip(
+                local_blobs_and_proofs,
+                blob_response.root,
+                strict=True,
+            )
         ):
-            if received_blob is None:
-                raise ValueError("Received blob is empty.")
-            if isinstance(expected_blob, BlobAndProofV1):
-                if not isinstance(received_blob, BlobAndProofV1):
-                    raise ValueError("Received blob is not a BlobAndProofV1.")
-                if expected_blob.blob != received_blob.blob:
-                    raise ValueError("Blob mismatch.")
-                if expected_blob.proof != received_blob.proof:
-                    raise ValueError("Proof mismatch.")
-            elif isinstance(expected_blob, BlobAndProofV2):
-                if not isinstance(received_blob, BlobAndProofV2):
-                    raise ValueError("Received blob is not a BlobAndProofV2.")
-                if expected_blob.blob != received_blob.blob:
-                    raise ValueError("Blob mismatch.")
-                if expected_blob.proofs != received_blob.proofs:
-                    error_message = "Proofs mismatch."
-                    expected_len = len(expected_blob.proofs)
-                    received_len = len(received_blob.proofs)
-                    error_message += (
-                        f"len(expected_blob.proofs) = {expected_len}, "
-                    )
-                    error_message += (
-                        f"len(received_blob.proofs) = {received_len}\n"
-                    )
-                    if len(expected_blob.proofs) == len(received_blob.proofs):
-                        index = 0
-
-                        for expected_proof, received_proof in zip(
-                            expected_blob.proofs,
-                            received_blob.proofs,
-                            strict=False,
-                        ):
-                            if len(expected_proof) != len(received_proof):
-                                error_message += (
-                                    f"Proof length mismatch. index = {index},"
-                                )
-                                exp_len = len(expected_proof)
-                                rcv_len = len(received_proof)
-                                error_message += (
-                                    f"expected_proof length = {exp_len}, "
-                                )
-                                error_message += (
-                                    f"received_proof length = {rcv_len}\n"
-                                )
-                                index += 1
-                                continue
-                            if expected_proof != received_proof:
-                                error_message += (
-                                    f"Proof mismatch. index = {index},"
-                                )
-                                exp_hash = sha256(expected_proof).hexdigest()
-                                rcv_hash = sha256(received_proof).hexdigest()
-                                error_message += (
-                                    f"expected_proof hash = {exp_hash}, "
-                                )
-                                error_message += (
-                                    f"received_proof hash = {rcv_hash}\n"
-                                )
-                            index += 1
-                    raise ValueError(error_message)
-            else:
-                raise ValueError(
-                    f"Unexpected blob type: {type(expected_blob)}"
-                )
+            _validate_blob_and_proof(expected_blob, received_blob, i)
 
         eth_rpc.wait_for_transactions(sent_txs)
         return ExecuteResult(

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -72,6 +72,7 @@ class BlobTransaction(BaseExecute):
 
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
+    get_blobs_version: int | None = None
 
     def get_required_sender_balances(
         self,
@@ -144,12 +145,17 @@ class BlobTransaction(BaseExecute):
                 benchmark_gas_used=None,
             )
 
-        version = fork.engine_get_blobs_version()
-        assert version is not None, (
-            "Engine get blobs version is not supported by the fork."
-        )
+        # Use explicit version if provided, otherwise derive from fork
+        if self.get_blobs_version is not None:
+            version = self.get_blobs_version
+        else:
+            fork_version = fork.engine_get_blobs_version()
+            assert fork_version is not None, (
+                "Engine get blobs version is not supported by the fork."
+            )
+            version = fork_version
 
-        # ensure that clients respond 'null' when they have no access to at
+        # ensure that clients respond correctly when they have no access to at
         # least one blob
         list_versioned_hashes = list(versioned_hashes.keys())
         if self.nonexisting_blob_hashes is not None:
@@ -159,19 +165,68 @@ class BlobTransaction(BaseExecute):
             list_versioned_hashes, version=version
         )
 
-        # if non-existing blob hashes were requested then the response must be
-        # 'null'
+        # if non-existing blob hashes were requested, behavior depends on
+        # engine_getBlobsV* version:
+        # - V1/V2: entire response must be 'null' (all-or-nothing)
+        # - V3+: partial responses allowed (null only for missing blobs)
         if self.nonexisting_blob_hashes is not None:
-            if blob_response is not None:
-                raise ValueError(
-                    "Non-existing blob hashes were requested and the client "
-                    "was expected to respond with 'null', but instead it "
-                    f"replied: {blob_response.root}"
-                )
+            if version <= 2:
+                # V1/V2 behavior: entire response is null if any blob missing
+                if blob_response is not None:
+                    raise ValueError(
+                        "Non-existing blob hashes were requested and the "
+                        f"client (using getBlobsV{version}) was expected to "
+                        "respond with 'null', but instead it replied: "
+                        f"{blob_response.root}"
+                    )
+                else:
+                    logger.info(
+                        f"Test passed: getBlobsV{version} correctly returned "
+                        "'null' (partial responses not allowed in V1/V2)"
+                    )
+                    eth_rpc.wait_for_transactions(sent_txs)
+                    return ExecuteResult(
+                        benchmark_gas_used=None,
+                    )
             else:
+                # V3+ behavior: partial responses with null for missing blobs
+                if blob_response is None:
+                    raise ValueError(
+                        "Non-existing blob hashes were requested and the "
+                        f"client (using getBlobsV{version}) was expected to "
+                        "respond with a partial response containing null "
+                        "entries for missing blobs, but instead it replied "
+                        "with 'null' for the entire response."
+                    )
+                # Verify we got the expected number of responses
+                expected_count = len(list_versioned_hashes)
+                if len(blob_response) != expected_count:
+                    raise ValueError(
+                        f"Expected {expected_count} blob responses, "
+                        f"got {len(blob_response)}."
+                    )
+                # Verify existing blobs are returned and non-existing are null
+                existing_count = len(versioned_hashes)
+                nonexisting_count = len(self.nonexisting_blob_hashes)
+                for i, received_blob in enumerate(blob_response.root):
+                    if i < existing_count:
+                        # This should be an existing blob
+                        if received_blob is None:
+                            raise ValueError(
+                                f"Blob at index {i} should exist but client "
+                                "returned null."
+                            )
+                    else:
+                        # This should be a non-existing blob (null)
+                        if received_blob is not None:
+                            raise ValueError(
+                                f"Blob at index {i} should not exist but "
+                                f"client returned: {received_blob}"
+                            )
                 logger.info(
-                    "Test was passed (partial responses are not allowed and "
-                    "the client correctly returned 'null')"
+                    f"Test passed: getBlobsV{version} correctly returned "
+                    f"partial response with {existing_count} existing blobs "
+                    f"and {nonexisting_count} null entries for missing blobs"
                 )
                 eth_rpc.wait_for_transactions(sent_txs)
                 return ExecuteResult(

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -168,7 +168,7 @@ class BlobTransaction(BaseExecute):
         # if non-existing blob hashes were requested, behavior depends on
         # engine_getBlobsV* version:
         # - V1/V2: entire response must be 'null' (all-or-nothing)
-        # - V3+: partial responses allowed (null only for missing blobs)
+        # - V3: partial responses allowed (null only for missing blobs)
         if self.nonexisting_blob_hashes is not None:
             if version <= 2:
                 # V1/V2 behavior: entire response is null if any blob missing
@@ -188,8 +188,8 @@ class BlobTransaction(BaseExecute):
                     return ExecuteResult(
                         benchmark_gas_used=None,
                     )
-            else:
-                # V3+ behavior: partial responses with null for missing blobs
+            elif version == 3:
+                # V3 behavior: partial responses with null for missing blobs
                 if blob_response is None:
                     raise ValueError(
                         "Non-existing blob hashes were requested and the "
@@ -231,6 +231,11 @@ class BlobTransaction(BaseExecute):
                 eth_rpc.wait_for_transactions(sent_txs)
                 return ExecuteResult(
                     benchmark_gas_used=None,
+                )
+            else:
+                raise NotImplementedError(
+                    "Non-existing blob hash handling is not implemented for "
+                    f"getBlobsV{version}. Supported versions: V1, V2, V3."
                 )
 
         assert blob_response is not None

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -230,8 +230,6 @@ class BlobTransaction(BaseExecute):
             )
             version = fork_version
 
-        # ensure that clients respond correctly when they have no access to at
-        # least one blob
         list_versioned_hashes = list(versioned_hashes.keys())
         if self.nonexisting_blob_hashes is not None:
             list_versioned_hashes.extend(self.nonexisting_blob_hashes)
@@ -240,92 +238,82 @@ class BlobTransaction(BaseExecute):
             list_versioned_hashes, version=version
         )
 
-        # if non-existing blob hashes were requested, behavior depends on
-        # engine_getBlobsV* version:
-        # - V1/V2: entire response must be 'null' (all-or-nothing)
-        # - V3: partial responses allowed (null only for missing blobs)
-        if self.nonexisting_blob_hashes is not None:
-            if version <= 2:
-                # V1/V2 behavior: entire response is null if any blob missing
+        if version <= 2:
+            # V1/V2: all-or-nothing behavior
+            if self.nonexisting_blob_hashes is not None:
+                # Any missing blob must cause the entire response to be null
                 if blob_response is not None:
                     raise ValueError(
                         "Non-existing blob hashes were requested and the "
-                        f"client (using getBlobsV{version}) was expected to "
-                        "respond with 'null', but instead it replied: "
+                        f"client (using getBlobsV{version}) was expected "
+                        "to respond with 'null', but instead it replied: "
                         f"{blob_response.root}"
                     )
-                else:
-                    logger.info(
-                        f"Test passed: getBlobsV{version} correctly returned "
-                        "'null' (partial responses not allowed in V1/V2)"
-                    )
-                    eth_rpc.wait_for_transactions(sent_txs)
-                    return ExecuteResult(
-                        benchmark_gas_used=None,
-                    )
-            elif version == 3:
-                # V3 behavior: partial responses with null for missing blobs
-                if blob_response is None:
-                    raise ValueError(
-                        "Non-existing blob hashes were requested and the "
-                        f"client (using getBlobsV{version}) was expected to "
-                        "respond with a partial response containing null "
-                        "entries for missing blobs, but instead it replied "
-                        "with 'null' for the entire response."
-                    )
-                # Verify we got the expected number of responses
-                expected_count = len(list_versioned_hashes)
-                if len(blob_response) != expected_count:
-                    raise ValueError(
-                        f"Expected {expected_count} blob responses, "
-                        f"got {len(blob_response)}."
-                    )
-                # Build expected list: real blobs then None for non-existing
-                expected_blobs_and_proofs: List[
-                    BlobAndProofV1 | BlobAndProofV2 | None
-                ] = list(versioned_hashes.values()) + [None] * len(
-                    self.nonexisting_blob_hashes
+                logger.info(
+                    f"Test passed: getBlobsV{version} correctly returned "
+                    "'null' (partial responses not allowed in V1/V2)"
+                )
+            else:
+                # All blobs should be present and valid
+                assert blob_response is not None, (
+                    f"getBlobsV{version} returned 'null' but all "
+                    "requested blobs should exist."
+                )
+                local_blobs_and_proofs = list(versioned_hashes.values())
+                assert len(blob_response) == len(local_blobs_and_proofs), (
+                    f"Expected {len(local_blobs_and_proofs)} blobs and "
+                    f"proofs, got {len(blob_response)}."
                 )
                 for i, (expected_blob, received_blob) in enumerate(
                     zip(
-                        expected_blobs_and_proofs,
+                        local_blobs_and_proofs,
                         blob_response.root,
                         strict=True,
                     )
                 ):
                     _validate_blob_and_proof(expected_blob, received_blob, i)
+        elif version == 3:
+            # V3: partial responses (null only for missing blobs)
+            if blob_response is None:
+                raise ValueError(
+                    f"getBlobsV{version} returned 'null' for the entire "
+                    "response, but V3 should always return an array "
+                    "(with null entries for missing blobs)."
+                )
+            expected_blobs_and_proofs: List[
+                BlobAndProofV1 | BlobAndProofV2 | None
+            ] = list(versioned_hashes.values())
+            if self.nonexisting_blob_hashes is not None:
+                expected_blobs_and_proofs += [None] * len(
+                    self.nonexisting_blob_hashes
+                )
+            if len(blob_response) != len(expected_blobs_and_proofs):
+                raise ValueError(
+                    f"Expected {len(expected_blobs_and_proofs)} blob "
+                    f"responses, got {len(blob_response)}."
+                )
+            for i, (expected, received) in enumerate(
+                zip(
+                    expected_blobs_and_proofs,
+                    blob_response.root,
+                    strict=True,
+                )
+            ):
+                _validate_blob_and_proof(expected, received, i)
+            if self.nonexisting_blob_hashes is not None:
                 existing_count = len(versioned_hashes)
                 nonexisting_count = len(self.nonexisting_blob_hashes)
                 logger.info(
                     f"Test passed: getBlobsV{version} correctly returned "
-                    f"partial response with {existing_count} existing blobs "
-                    f"and {nonexisting_count} null entries for missing blobs"
+                    f"partial response with {existing_count} existing "
+                    f"blobs and {nonexisting_count} null entries for "
+                    "missing blobs"
                 )
-                eth_rpc.wait_for_transactions(sent_txs)
-                return ExecuteResult(
-                    benchmark_gas_used=None,
-                )
-            else:
-                raise NotImplementedError(
-                    "Non-existing blob hash handling is not implemented for "
-                    f"getBlobsV{version}. Supported versions: V1, V2, V3."
-                )
-
-        assert blob_response is not None
-        local_blobs_and_proofs = list(versioned_hashes.values())
-        assert len(blob_response) == len(local_blobs_and_proofs), (
-            f"Expected {len(local_blobs_and_proofs)} blobs and proofs, "
-            f"got {len(blob_response)}."
-        )
-
-        for i, (expected_blob, received_blob) in enumerate(
-            zip(
-                local_blobs_and_proofs,
-                blob_response.root,
-                strict=True,
+        else:
+            raise NotImplementedError(
+                f"getBlobsV{version} is not supported. "
+                "Supported versions: V1, V2, V3."
             )
-        ):
-            _validate_blob_and_proof(expected_blob, received_blob, i)
 
         eth_rpc.wait_for_transactions(sent_txs)
         return ExecuteResult(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3485,6 +3485,14 @@ class Amsterdam(BPO2):
         return 5
 
     @classmethod
+    def engine_get_payload_version(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Optional[int]:
+        """From Amsterdam, get payload calls must use version 6."""
+        del block_number, timestamp
+        return 6
+
+    @classmethod
     def engine_execution_payload_block_access_list(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> bool:

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -85,7 +85,14 @@ class SendTransactionExceptionError(Exception):
         if self.tx is not None:
             return f"{base} Transaction={self.tx.model_dump_json()}"
         elif self.tx_rlp is not None:
-            return f"{base} Transaction RLP={self.tx_rlp.hex()}"
+            rlp_hex = self.tx_rlp.hex()
+            # Cap RLP output at 200 characters to avoid overwhelming output
+            max_rlp_length = 200
+            if len(rlp_hex) > max_rlp_length:
+                rlp_display = f"{rlp_hex[:max_rlp_length]}... (truncated)"
+            else:
+                rlp_display = rlp_hex
+            return f"{base} Transaction RLP={rlp_display}"
         return base
 
 

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -36,10 +36,10 @@ class JSONRPCError(Exception):
 
     code: int
     message: str
-    data: str | None
+    data: str | dict | None
 
     def __init__(
-        self, code: int | str, message: str, data: str | None = None
+        self, code: int | str, message: str, data: str | dict | None = None
     ) -> None:
         """Initialize the JSONRPCError."""
         self.code = int(code)
@@ -79,7 +79,7 @@ class JSONRPCErrorObject(BaseModel):
 
     code: int
     message: str
-    data: str | None = None
+    data: str | dict | None = None
 
 
 class JSONRPCResponse(BaseModel):

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -23,6 +23,7 @@ class BlobsTest(BaseTest):
     pre: Alloc
     txs: List[NetworkWrappedTransaction | Transaction]
     nonexisting_blob_hashes: List[Hash] | None = None
+    get_blobs_version: int | None = None
 
     supported_execute_formats: ClassVar[Sequence[LabeledExecuteFormat]] = [
         LabeledExecuteFormat(
@@ -52,6 +53,7 @@ class BlobsTest(BaseTest):
             return BlobTransaction(
                 txs=self.txs,
                 nonexisting_blob_hashes=self.nonexisting_blob_hashes,
+                get_blobs_version=self.get_blobs_version,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -462,3 +462,30 @@ def test_get_blobs_nonexisting_getblobsv3(
         nonexisting_blob_hashes=nonexisting_blob_hashes,
         get_blobs_version=3,
     )
+
+
+# disable real blobs for this test (fixture is autouse so overwrite with empty)
+@pytest.mark.parametrize("txs_blobs", [[]], ids=["no_blobs"])
+@pytest.mark.exception_test
+@pytest.mark.valid_from("Osaka")
+def test_get_blobs_only_nonexisting_getblobsv3(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test that getBlobsV3 returns an array of null entries (one per requested
+    hash) when all requested blobs are non-existing, rather than returning a
+    single null for the entire response.
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    print("Testing getBlobsV3 (only non-existing blobs)")
+    for i, nh in enumerate(nonexisting_blob_hashes):
+        print(f"  non-existing {i}: {nh.hex()}")
+    blobs_test(
+        pre=pre,
+        txs=[],
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+        get_blobs_version=3,
+    )

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -413,14 +413,14 @@ def test_get_blobs_nonexisting_getblobsv2(
     nonexisting_blob_hashes = [
         Hash(sha256(str(i).encode()).digest()) for i in range(5)
     ]
-    logger.info("Testing getBlobsV2 (all-or-nothing behavior)")
+    print("Testing getBlobsV2 (all-or-nothing behavior)")
     for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
         for blob_idx, vh in enumerate(tx_hashes):
-            logger.info(
+            print(
                 f"  tx {tx_idx}, blob {blob_idx}: {Hash(vh).hex()} (existing)"
             )
     for i, nh in enumerate(nonexisting_blob_hashes):
-        logger.info(f"  non-existing {i}: {nh.hex()}")
+        print(f"  non-existing {i}: {nh.hex()}")
     blobs_test(
         pre=pre,
         txs=txs,
@@ -448,14 +448,14 @@ def test_get_blobs_nonexisting_getblobsv3(
     nonexisting_blob_hashes = [
         Hash(sha256(str(i).encode()).digest()) for i in range(5)
     ]
-    logger.info("Testing getBlobsV3 (partial response behavior)")
+    print("Testing getBlobsV3 (partial response behavior)")
     for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
         for blob_idx, vh in enumerate(tx_hashes):
-            logger.info(
+            print(
                 f"  tx {tx_idx}, blob {blob_idx}: {Hash(vh).hex()} (existing)"
             )
     for i, nh in enumerate(nonexisting_blob_hashes):
-        logger.info(f"  non-existing {i}: {nh.hex()}")
+        print(f"  non-existing {i}: {nh.hex()}")
     blobs_test(
         pre=pre,
         txs=txs,

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -404,6 +404,7 @@ def test_get_blobs_nonexisting_getblobsv2(
     blobs_test: BlobsTestFiller,
     pre: Alloc,
     txs: List[NetworkWrappedTransaction | Transaction],
+    txs_versioned_hashes: List[List[bytes]],
 ) -> None:
     """
     Test that ensures clients respond with 'null' when at least one requested
@@ -412,6 +413,14 @@ def test_get_blobs_nonexisting_getblobsv2(
     nonexisting_blob_hashes = [
         Hash(sha256(str(i).encode()).digest()) for i in range(5)
     ]
+    logger.info("Testing getBlobsV2 (all-or-nothing behavior)")
+    for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
+        for blob_idx, vh in enumerate(tx_hashes):
+            logger.info(
+                f"  tx {tx_idx}, blob {blob_idx}: {Hash(vh).hex()} (existing)"
+            )
+    for i, nh in enumerate(nonexisting_blob_hashes):
+        logger.info(f"  non-existing {i}: {nh.hex()}")
     blobs_test(
         pre=pre,
         txs=txs,
@@ -430,6 +439,7 @@ def test_get_blobs_nonexisting_getblobsv3(
     blobs_test: BlobsTestFiller,
     pre: Alloc,
     txs: List[NetworkWrappedTransaction | Transaction],
+    txs_versioned_hashes: List[List[bytes]],
 ) -> None:
     """
     Test that ensures clients respond with partial results when some requested
@@ -438,6 +448,14 @@ def test_get_blobs_nonexisting_getblobsv3(
     nonexisting_blob_hashes = [
         Hash(sha256(str(i).encode()).digest()) for i in range(5)
     ]
+    logger.info("Testing getBlobsV3 (partial response behavior)")
+    for tx_idx, tx_hashes in enumerate(txs_versioned_hashes):
+        for blob_idx, vh in enumerate(tx_hashes):
+            logger.info(
+                f"  tx {tx_idx}, blob {blob_idx}: {Hash(vh).hex()} (existing)"
+            )
+    for i, nh in enumerate(nonexisting_blob_hashes):
+        logger.info(f"  non-existing {i}: {nh.hex()}")
     blobs_test(
         pre=pre,
         txs=txs,

--- a/tests/osaka/eip7594_peerdas/test_get_blobs.py
+++ b/tests/osaka/eip7594_peerdas/test_get_blobs.py
@@ -278,11 +278,18 @@ def generate_valid_blob_tests(
             [
                 [
                     Blob.from_fork(fork, s)
-                    for s in range(target_blobs_per_block // 2)
+                    for s in range(
+                        min(target_blobs_per_block // 2, max_blobs_per_tx)
+                    )
                 ],
                 [
-                    Blob.from_fork(fork, s + target_blobs_per_block // 2)
-                    for s in range(target_blobs_per_block // 2)
+                    Blob.from_fork(
+                        fork,
+                        s + min(target_blobs_per_block // 2, max_blobs_per_tx),
+                    )
+                    for s in range(
+                        min(target_blobs_per_block // 2, max_blobs_per_tx)
+                    )
                 ],
             ],
             id="two_tx_equal_blobs",
@@ -292,15 +299,29 @@ def generate_valid_blob_tests(
             [
                 [
                     Blob.from_fork(fork, s)
-                    for s in range(target_blobs_per_block // 3)
+                    for s in range(
+                        min(target_blobs_per_block // 3, max_blobs_per_tx)
+                    )
                 ],
                 [
-                    Blob.from_fork(fork, s + target_blobs_per_block // 3)
-                    for s in range(target_blobs_per_block // 3)
+                    Blob.from_fork(
+                        fork,
+                        s + min(target_blobs_per_block // 3, max_blobs_per_tx),
+                    )
+                    for s in range(
+                        min(target_blobs_per_block // 3, max_blobs_per_tx)
+                    )
                 ],
                 [
-                    Blob.from_fork(fork, s + 2 * (target_blobs_per_block // 3))
-                    for s in range(target_blobs_per_block // 3)
+                    Blob.from_fork(
+                        fork,
+                        s
+                        + 2
+                        * min(target_blobs_per_block // 3, max_blobs_per_tx),
+                    )
+                    for s in range(
+                        min(target_blobs_per_block // 3, max_blobs_per_tx)
+                    )
                 ],
             ],
             id="three_tx_equal_blobs",
@@ -352,18 +373,74 @@ def test_get_blobs(
 )
 @pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
-def test_get_blobs_nonexisting(
+@pytest.mark.valid_until("Prague")
+def test_get_blobs_nonexisting_getblobsv1(
     blobs_test: BlobsTestFiller,
     pre: Alloc,
     txs: List[NetworkWrappedTransaction | Transaction],
 ) -> None:
     """
     Test that ensures clients respond with 'null' when at least one requested
-    blob is not available.
+    blob is not available (getBlobsV1 behavior: all-or-nothing response).
     """
     nonexisting_blob_hashes = [
         Hash(sha256(str(i).encode()).digest()) for i in range(5)
     ]
     blobs_test(
-        pre=pre, txs=txs, nonexisting_blob_hashes=nonexisting_blob_hashes
+        pre=pre,
+        txs=txs,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+        get_blobs_version=1,
+    )
+
+
+@pytest.mark.parametrize_by_fork(
+    "txs_blobs",
+    generate_valid_blob_tests,
+)
+@pytest.mark.exception_test
+@pytest.mark.valid_from("Osaka")
+def test_get_blobs_nonexisting_getblobsv2(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+) -> None:
+    """
+    Test that ensures clients respond with 'null' when at least one requested
+    blob is not available (getBlobsV2 behavior: all-or-nothing response).
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+        get_blobs_version=2,
+    )
+
+
+@pytest.mark.parametrize_by_fork(
+    "txs_blobs",
+    generate_valid_blob_tests,
+)
+@pytest.mark.exception_test
+@pytest.mark.valid_from("Osaka")
+def test_get_blobs_nonexisting_getblobsv3(
+    blobs_test: BlobsTestFiller,
+    pre: Alloc,
+    txs: List[NetworkWrappedTransaction | Transaction],
+) -> None:
+    """
+    Test that ensures clients respond with partial results when some requested
+    blobs are not available (getBlobsV3 behavior: null only for missing blobs).
+    """
+    nonexisting_blob_hashes = [
+        Hash(sha256(str(i).encode()).digest()) for i in range(5)
+    ]
+    blobs_test(
+        pre=pre,
+        txs=txs,
+        nonexisting_blob_hashes=nonexisting_blob_hashes,
+        get_blobs_version=3,
     )


### PR DESCRIPTION
## 🗒️ Description
1. Fix: deterministic factory is now pre-deployed in the genesis, so u can do `execute hive` again because there is no need to allow unprotecte transactions anymore
2. Another fix that adds BAL support to `execute hive`
3. QoL fix that does not let blobs spam terminal with RLP data in case of failure (upper cap on printed chars)
4. Fixes flaw in blobs test where it tried to put 7 blobs for amsterdam when upper cap is 6
5. Framework improvements for testing different getBlobsVX behaviors, we can now explicitely tests getBlobsV1, V2 and V3
6. Adds warning when user tries to `fill` a blobs test (would just fill 0 without telling why). it is non-obvious that you are supposed to use `execute hive` for blobs tests, the printed warning clearly states that now
7. Improves logic flow of blobs execute function
8. Adds new tests (getblobsv3 behavior, validity of those blobs, and also edgecase for v3 where actually all blobs were indeed non-existing)

---

How to test:

1. Use this `clients.yaml` file for hive:

```
- client: go-ethereum
  nametag: default
  dockerfile: git
  build_args:
    github: ethereum/go-ethereum
    tag: bal-devnet-2
```

2. Ensure you have latest hive master and run:
`go run . --docker.nocache=go-ethereum --docker.buildoutput --docker.output --client=go-ethereum --client-file=clients.yaml --dev --loglevel=5 --sim.loglevel=5`

3. Cherry-pick all of these 5 commits from our SLOTNUM (7843) branch:
* `git cherry-pick 95794929f`
* `git cherry-pick fa411a3d2`
* `git cherry-pick ca529e272`
* `git cherry-pick 61c548aca`
* `git cherry-pick dba41c003`

4. Run:
`uv run execute hive -v -s ./tests/osaka/eip7594_peerdas/test_get_blobs.py --fork=amsterdam`

-> all 24 tests pass

## 🔗 Related Issues or PRs
[engine_getBlobsV3 PR](https://github.com/ethereum/execution-apis/pull/719)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img src="https://cdn.discordapp.com/attachments/1349696533922320478/1467841425986289810/IMG_0162.png?ex=6981d95b&is=698087db&hm=88efcf02d0c88c584a6211a1e776032bf6d77cad18fb28518952478a6c5d9feb" width="30%">
