### PR TITLE
feat(spec,test): EIP-7708 spec updates for self as target

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -684,11 +684,12 @@ def selfdestruct(evm: Evm) -> None:
         beneficiary_new_balance,
     )
 
-    # EIP-7708: Emit appropriate log based on beneficiary
-    if beneficiary == originator:
-        # Self-destruct to self burns the balance
+    # EIP-7708: Emit appropriate log based on whether ETH is burned
+    # or transferred to a different account
+    if originator in state.created_accounts and beneficiary == originator:
+        # Self-destruct to self in same tx burns the balance
         emit_selfdestruct_log(evm, originator, originator_balance)
-    else:
+    elif beneficiary != originator:
         # Transfer to different beneficiary
         emit_transfer_log(evm, originator, beneficiary, originator_balance)
 

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -314,9 +314,11 @@ def process_message(message: Message) -> Evm:
         move_ether(
             state, message.caller, message.current_target, message.value
         )
-        emit_transfer_log(
-            evm, message.caller, message.current_target, message.value
-        )
+        # EIP-7708: Only emit transfer log to a different account
+        if message.caller != message.current_target:
+            emit_transfer_log(
+                evm, message.caller, message.current_target, message.value
+            )
 
         sender_new_balance = get_account(state, message.caller).balance
         recipient_new_balance = get_account(

--- a/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/spec.py
@@ -14,7 +14,7 @@ class ReferenceSpec:
 
 
 ref_spec_7708 = ReferenceSpec(
-    "EIPS/eip-7708.md", "a7c5b2ff5697d5a0be5ea804a89d98a7fd0dce60"
+    "EIPS/eip-7708.md", "172188d7b090ed1afb876140f45e19ac00cba4bb"
 )
 
 

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
@@ -14,6 +14,7 @@ from execution_testing import (
     Op,
     Transaction,
     TransactionReceipt,
+    compute_create_address,
 )
 
 from .spec import ref_spec_7708, selfdestruct_log, transfer_log
@@ -22,68 +23,116 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_7708.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7708.version
 
 
+@pytest.mark.parametrize(
+    "same_tx,to_self",
+    [
+        pytest.param(True, True, id="same_tx_to_self"),
+        pytest.param(False, True, id="pre_existing_to_self"),
+        pytest.param(False, False, id="pre_existing_to_other"),
+    ],
+)
 @pytest.mark.valid_at_transition_to("Amsterdam")
 def test_selfdestruct_log_at_fork_transition(
-    blockchain_test: BlockchainTestFiller, pre: Alloc
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    same_tx: bool,
+    to_self: bool,
 ) -> None:
     """
-    Test ETH selfdestruct log behavior at fork transition.
+    Test selfdestruct log emission across the Amsterdam fork transition.
 
-    Before Amsterdam: ETH selfdestructs do NOT emit logs.
-    At/after Amsterdam: ETH selfdestructs emit Selfdestruct logs.
+    same_tx_to_self: Factory CREATEs and selfdestructs to self in one tx.
+    At/after Amsterdam emits a CREATE transfer log + Selfdestruct log.
+
+    pre_existing_to_self: Pre-existing contract selfdestructs to self.
+    No logs at any fork — SELFDESTRUCT to same account emits nothing.
+
+    pre_existing_to_other: Pre-existing contract selfdestructs to a different
+    account. At/after Amsterdam emits a Transfer log.
     """
     sender = pre.fund_eoa()
-    contract1 = pre.deploy_contract(Op.SELFDESTRUCT(Op.ADDRESS), balance=1)
-    contract2 = pre.deploy_contract(Op.SELFDESTRUCT(Op.ADDRESS), balance=2)
-    contract3 = pre.deploy_contract(Op.SELFDESTRUCT(Op.ADDRESS), balance=3)
+    contract_balance = 1000
+
+    if same_tx:
+        initcode = Op.SELFDESTRUCT(Op.ADDRESS)
+        initcode_bytes = bytes(initcode)
+        initcode_len = len(initcode_bytes)
+
+        factory_code = Op.MSTORE(
+            0, Op.PUSH32(initcode_bytes.rjust(32, b"\x00"))
+        ) + Op.CREATE(
+            value=contract_balance, offset=32 - initcode_len, size=initcode_len
+        )
+
+        factory = pre.deploy_contract(
+            factory_code, balance=contract_balance * 3
+        )
+        created = [
+            compute_create_address(address=factory, nonce=n)
+            for n in range(1, 4)
+        ]
+        targets = [factory] * 3
+
+        expected_logs = [
+            [],
+            [
+                transfer_log(factory, created[1], contract_balance),
+                selfdestruct_log(created[1], contract_balance),
+            ],
+            [
+                transfer_log(factory, created[2], contract_balance),
+                selfdestruct_log(created[2], contract_balance),
+            ],
+        ]
+        post: dict = {
+            sender: Account(nonce=3),
+            created[0]: Account.NONEXISTENT,
+            created[1]: Account.NONEXISTENT,
+            created[2]: Account.NONEXISTENT,
+        }
+    elif to_self:
+        targets = [
+            pre.deploy_contract(
+                Op.SELFDESTRUCT(Op.ADDRESS), balance=contract_balance
+            )
+            for _ in range(3)
+        ]
+        expected_logs = [[], [], []]
+        post = {sender: Account(nonce=3)}
+    else:
+        beneficiary = pre.empty_account()
+        targets = [
+            pre.deploy_contract(
+                Op.SELFDESTRUCT(beneficiary), balance=contract_balance
+            )
+            for _ in range(3)
+        ]
+        expected_logs = [
+            [],
+            [transfer_log(targets[1], beneficiary, contract_balance)],
+            [transfer_log(targets[2], beneficiary, contract_balance)],
+        ]
+        post = {
+            sender: Account(nonce=3),
+            beneficiary: Account(balance=contract_balance * 3),
+        }
 
     blocks = [
         Block(
-            timestamp=14_999,
+            timestamp=ts,
             txs=[
                 Transaction(
-                    to=contract1,
+                    to=targets[i],
                     sender=sender,
-                    gas_limit=100_000,
-                    expected_receipt=TransactionReceipt(logs=[]),
+                    gas_limit=200_000,
+                    expected_receipt=TransactionReceipt(logs=expected_logs[i]),
                 )
             ],
-        ),
-        Block(
-            timestamp=15_000,
-            txs=[
-                Transaction(
-                    to=contract2,
-                    sender=sender,
-                    gas_limit=100_000,
-                    expected_receipt=TransactionReceipt(
-                        logs=[selfdestruct_log(contract2, 2)]
-                    ),
-                )
-            ],
-        ),
-        Block(
-            timestamp=15_001,
-            txs=[
-                Transaction(
-                    to=contract3,
-                    sender=sender,
-                    gas_limit=100_000,
-                    expected_receipt=TransactionReceipt(
-                        logs=[selfdestruct_log(contract3, 3)]
-                    ),
-                )
-            ],
-        ),
+        )
+        for i, ts in enumerate([14_999, 15_000, 15_001])
     ]
 
-    blockchain_test(
-        pre=pre,
-        blocks=blocks,
-        post={
-            sender: Account(nonce=3),
-        },
-    )
+    blockchain_test(pre=pre, blocks=blocks, post=post)
 
 
 @pytest.mark.valid_at_transition_to("Amsterdam")

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -3,21 +3,27 @@ Tests for EIP-7708 Selfdestruct logs.
 
 Tests for the Selfdestruct(address,uint256) log emitted when:
 - SELFDESTRUCT to self with nonzero balance
-- Account closure after SELFDESTRUCT
+- Account created and destroyed in the same transaction
 """
 
 import pytest
 from execution_testing import (
     EOA,
+    Account,
     Alloc,
     Environment,
+    Initcode,
     Op,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
+    compute_create_address,
+)
+from execution_testing import (
+    Macros as Om,
 )
 
-from .spec import ref_spec_7708, selfdestruct_log
+from .spec import ref_spec_7708, selfdestruct_log, transfer_log
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7708.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7708.version
@@ -25,17 +31,18 @@ REFERENCE_SPEC_VERSION = ref_spec_7708.version
 pytestmark = pytest.mark.valid_from("Amsterdam")
 
 
-def test_selfdestruct_to_self_emits_log(
+def test_selfdestruct_to_self_pre_existing_no_log(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
 ) -> None:
     """
-    Test that selfdestruct-to-self emits a Selfdestruct log.
+    Test that selfdestruct-to-self emits NO log for pre-existing contracts.
 
-    Since the contract selfdestructs to itself, there is no transfer.
-    Instead, a Selfdestruct log is emitted with the contract's balance.
+    Per EIP-7708, SELFDESTRUCT to the same account does not emit a Transfer
+    log. The Selfdestruct log is only emitted when the account is created
+    and destroyed in the same transaction (actual ETH burn).
     """
     contract_balance = 2000
 
@@ -47,9 +54,184 @@ def test_selfdestruct_to_self_emits_log(
         to=contract,
         value=0,
         gas_limit=100_000,
+        expected_receipt=TransactionReceipt(logs=[]),
+    )
+
+    # Contract keeps its balance (not destroyed since not created in same tx)
+    state_test(
+        env=env,
+        pre=pre,
+        post={contract: Account(balance=contract_balance)},
+        tx=tx,
+    )
+
+
+def test_selfdestruct_to_self_same_tx_emits_log(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+) -> None:
+    """
+    Test that selfdestruct-to-self emits a Selfdestruct log when created in
+    same tx.
+
+    A contract created via CREATE that immediately selfdestructs to itself
+    in initcode is both created and destroyed in the same transaction.
+    Expected logs:
+    - CREATE transfer: factory -> created_address
+    - Selfdestruct: created_address burns its balance
+    """
+    contract_balance = 2000
+
+    initcode = Op.SELFDESTRUCT(Op.ADDRESS)
+    initcode_bytes = bytes(initcode)
+    initcode_len = len(initcode_bytes)
+
+    factory_code = Op.MSTORE(
+        0, Op.PUSH32(initcode_bytes.rjust(32, b"\x00"))
+    ) + Op.CREATE(
+        value=contract_balance, offset=32 - initcode_len, size=initcode_len
+    )
+
+    factory = pre.deploy_contract(factory_code, balance=contract_balance)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    tx = Transaction(
+        sender=sender,
+        to=factory,
+        value=0,
+        gas_limit=200_000,
         expected_receipt=TransactionReceipt(
-            logs=[selfdestruct_log(contract, contract_balance)]
+            logs=[
+                # CREATE transfers value to new contract
+                transfer_log(factory, created_address, contract_balance),
+                # Selfdestruct-to-self burns the balance
+                selfdestruct_log(created_address, contract_balance),
+            ]
         ),
     )
 
     state_test(env=env, pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "to_self",
+    [
+        pytest.param(True, id="to_self"),
+        pytest.param(False, id="to_other"),
+    ],
+)
+def test_selfdestruct_same_tx_zero_balance_no_log(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+    to_self: bool,
+) -> None:
+    """
+    Test that same-tx selfdestruct with zero balance emits no logs.
+
+    Both emit_selfdestruct_log and emit_transfer_log skip zero amounts.
+    A contract created with zero value that immediately selfdestructs in
+    initcode should produce no logs regardless of beneficiary.
+    """
+    beneficiary = pre.deploy_contract(Op.STOP)
+
+    if to_self:
+        initcode = Op.SELFDESTRUCT(Op.ADDRESS)
+    else:
+        initcode = Op.SELFDESTRUCT(beneficiary)
+
+    initcode_bytes = bytes(initcode)
+    initcode_len = len(initcode_bytes)
+
+    factory_code = Op.MSTORE(
+        0, Op.PUSH32(initcode_bytes.rjust(32, b"\x00"))
+    ) + Op.CREATE(value=0, offset=32 - initcode_len, size=initcode_len)
+
+    factory = pre.deploy_contract(factory_code)
+
+    tx = Transaction(
+        sender=sender,
+        to=factory,
+        value=0,
+        gas_limit=200_000,
+        expected_receipt=TransactionReceipt(logs=[]),
+    )
+
+    state_test(env=env, pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "to_self",
+    [
+        pytest.param(True, id="to_self"),
+        pytest.param(False, id="to_other"),
+    ],
+)
+def test_selfdestruct_same_tx_via_call(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+    to_self: bool,
+) -> None:
+    """
+    Test selfdestruct log for contract created via CREATE then called.
+
+    All existing same-tx tests use initcode selfdestruct. This tests the
+    create-then-call path: factory CREATEs a contract with deployed runtime
+    code, then CALLs it to trigger SELFDESTRUCT. Contract is still in
+    created_accounts.
+
+    Expected logs:
+    - to_self: transfer_log(factory, created, 2000) +
+               selfdestruct_log(created, 2000)
+    - to_other: transfer_log(factory, created, 2000) +
+                transfer_log(created, beneficiary, 2000)
+    """
+    contract_balance = 2000
+    beneficiary = pre.deploy_contract(Op.STOP)
+
+    if to_self:
+        runtime_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    else:
+        runtime_code = Op.SELFDESTRUCT(beneficiary)
+
+    initcode = Initcode(deploy_code=runtime_code)
+    initcode_len = len(initcode)
+
+    factory_code = (
+        Om.MSTORE(initcode, 0)
+        + Op.SSTORE(
+            0, Op.CREATE(value=contract_balance, offset=0, size=initcode_len)
+        )
+        + Op.CALL(gas=100_000, address=Op.SLOAD(0), value=0)
+    )
+
+    factory = pre.deploy_contract(factory_code, balance=contract_balance)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    if to_self:
+        expected_logs = [
+            transfer_log(factory, created_address, contract_balance),
+            selfdestruct_log(created_address, contract_balance),
+        ]
+        post = {}
+    else:
+        expected_logs = [
+            transfer_log(factory, created_address, contract_balance),
+            transfer_log(created_address, beneficiary, contract_balance),
+        ]
+        post = {beneficiary: Account(balance=contract_balance)}
+
+    tx = Transaction(
+        sender=sender,
+        to=factory,
+        value=0,
+        gas_limit=300_000,
+        expected_receipt=TransactionReceipt(logs=expected_logs),
+    )
+
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -351,7 +351,9 @@ def test_finalization_selfdestruct_logs(
     # Pre-compute factory address and created contract addresses
     # so we can call them in reverse sorted order to prove finalization
     # logs are sorted by address, not by call order
-    factory_address = Address(0xFACF)
+    factory_address = compute_create_address(
+        address=sender, nonce=sender.nonce
+    )
     x1 = compute_create_address(address=factory_address, nonce=1)
     x2 = compute_create_address(address=factory_address, nonce=2)
     x3 = compute_create_address(address=factory_address, nonce=3)
@@ -406,9 +408,8 @@ def test_finalization_selfdestruct_logs(
         + Op.CALL(gas=100_000, address=p3, args_offset=0, args_size=32)
     )
 
-    factory = pre.deploy_contract(
-        factory_code, balance=6000, address=factory_address
-    )
+    factory_balance = 1000 + 2000 + 3000
+    pre.fund_address(factory_address, factory_balance)
 
     # Amounts based on reverse call order:
     # p1→reverse[0], p2→reverse[1], p3→reverse[2]
@@ -447,7 +448,7 @@ def test_finalization_selfdestruct_logs(
                 transfer_log(x3, beneficiary, 3000),
             ]
         )
-        beneficiary_balance = 6000
+        beneficiary_balance = factory_balance
 
     if not eth_transferred:
         # Reverted CALLs emit no logs, no ETH transferred, no finalization logs
@@ -486,8 +487,9 @@ def test_finalization_selfdestruct_logs(
 
     tx = Transaction(
         sender=sender,
-        to=factory,
+        to=None,
         value=0,
+        data=factory_code,
         gas_limit=1_000_000,
         expected_receipt=TransactionReceipt(
             logs=execution_logs + finalization_logs

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -208,8 +208,13 @@ def test_selfdestruct_same_tx_via_call(
     """
     Test selfdestruct via CREATE-then-CALL (not initcode selfdestruct).
 
-    Factory CREATEs contract with runtime code, then CALLs to trigger
-    SELFDESTRUCT. Contract is still in created_accounts.
+    Factory CREATEs contract with runtime code, then CALLs the contract that
+    was just created to trigger SELFDESTRUCT (depending on
+    `transfer_during_create`, the value of the contract is transferred during
+    the CREATE or CALL opcodes). Contract is still in created_accounts.
+
+    Depending on `call_twice`, the contract can be called twice during the
+    same call frame where it was created.
     """
     contract_balance = 2000
     beneficiary = pre.deploy_contract(Op.STOP)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -180,12 +180,30 @@ def test_selfdestruct_to_different_address_same_tx(
         pytest.param(False, id="to_other"),
     ],
 )
+@pytest.mark.parametrize(
+    "call_twice,second_call_value",
+    [
+        pytest.param(True, 1, id="call_twice_with_value"),
+        pytest.param(True, 0, id="call_twice"),
+        pytest.param(False, 0, id="call_once"),
+    ],
+)
+@pytest.mark.parametrize(
+    "transfer_during_create",
+    [
+        pytest.param(True, id="transfer_during_create"),
+        pytest.param(False, id="transfer_during_call"),
+    ],
+)
 def test_selfdestruct_same_tx_via_call(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
     to_self: bool,
+    call_twice: bool,
+    second_call_value: int,
+    transfer_during_create: bool,
 ) -> None:
     """
     Test selfdestruct via CREATE-then-CALL (not initcode selfdestruct).
@@ -204,15 +222,28 @@ def test_selfdestruct_same_tx_via_call(
     initcode = Initcode(deploy_code=runtime_code)
     initcode_len = len(initcode)
 
+    if transfer_during_create:
+        create_value = contract_balance
+        first_call_value = 0
+    else:
+        create_value = 0
+        first_call_value = contract_balance
+
     factory_code = (
         Om.MSTORE(initcode, 0)
         + Op.TSTORE(
-            0, Op.CREATE(value=contract_balance, offset=0, size=initcode_len)
+            0, Op.CREATE(value=create_value, offset=0, size=initcode_len)
         )
-        + Op.CALL(gas=100_000, address=Op.TLOAD(0), value=0)
+        + Op.CALL(gas=100_000, address=Op.TLOAD(0), value=first_call_value)
     )
+    if call_twice:
+        factory_code += Op.CALL(
+            gas=100_000, address=Op.TLOAD(0), value=second_call_value
+        )
 
-    factory = pre.deploy_contract(factory_code, balance=contract_balance)
+    factory = pre.deploy_contract(
+        factory_code, balance=contract_balance + second_call_value
+    )
     created_address = compute_create_address(address=factory, nonce=1)
 
     if to_self:
@@ -220,13 +251,25 @@ def test_selfdestruct_same_tx_via_call(
             transfer_log(factory, created_address, contract_balance),
             selfdestruct_log(created_address, contract_balance),
         ]
+        if call_twice and second_call_value > 0:
+            expected_logs += [
+                transfer_log(factory, created_address, second_call_value),
+                selfdestruct_log(created_address, second_call_value),
+            ]
         post = {}
     else:
         expected_logs = [
             transfer_log(factory, created_address, contract_balance),
             transfer_log(created_address, beneficiary, contract_balance),
         ]
-        post = {beneficiary: Account(balance=contract_balance)}
+        if call_twice and second_call_value > 0:
+            expected_logs += [
+                transfer_log(factory, created_address, second_call_value),
+                transfer_log(created_address, beneficiary, second_call_value),
+            ]
+        post = {
+            beneficiary: Account(balance=contract_balance + second_call_value)
+        }
 
     tx = Transaction(
         sender=sender,

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -10,10 +10,13 @@ import pytest
 from execution_testing import (
     EOA,
     Account,
+    Address,
     Alloc,
+    Bytecode,
     Environment,
     Initcode,
     Op,
+    Opcodes,
     StateTestFiller,
     Transaction,
     TransactionReceipt,
@@ -287,63 +290,199 @@ def test_selfdestruct_same_tx_via_call(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "payer_code,eth_transferred",
+    [
+        pytest.param(
+            Op.SELFDESTRUCT(Op.CALLDATALOAD(0)),
+            True,
+            id="via_selfdestruct",
+        ),
+        pytest.param(
+            Op.CALL(
+                gas=50_000,
+                address=Op.CALLDATALOAD(0),
+                value=Op.BALANCE(Op.ADDRESS),
+            ),
+            True,
+            id="via_call",
+        ),
+        pytest.param(
+            Op.CALL(
+                gas=50_000,
+                address=Op.CALLDATALOAD(0),
+                value=Op.BALANCE(Op.ADDRESS),
+            )
+            + Op.REVERT(0, 0),
+            False,
+            id="via_call_revert",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to_self",
+    [
+        pytest.param(False, id="to_beneficiary"),
+        pytest.param(True, id="to_self"),
+    ],
+)
 def test_finalization_selfdestruct_logs(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
+    payer_code: Bytecode,
+    eth_transferred: bool,
+    to_self: bool,
 ) -> None:
     """
     Test Selfdestruct logs at finalization for post-selfdestruct balance.
 
-    Contracts A and B selfdestruct, then receive ETH via C1/C2's selfdestruct.
-    At finalization, A and B emit Selfdestruct logs for their remaining balance
-    in lexicographical address order.
+    X contracts (x1, x2, x3) selfdestruct, then receive ETH via payer contracts
+    (p1, p2, p3). At finalization, X contracts emit SELFDESTRUCT logs for their
+    in lexicographical address order (only if they received ETH).
+
+    When to_self=True, X contracts SELFDESTRUCT to themselves (burning ETH
+    with LOG2). When to_self=False, X contracts SELFDESTRUCT to a beneficiary
+    (Transfer LOG3).
     """
     beneficiary = pre.deploy_contract(Op.STOP)
 
-    runtime = Op.SELFDESTRUCT(beneficiary)
+    # Pre-compute factory address and created contract addresses
+    # so we can call them in reverse sorted order to prove finalization
+    # logs are sorted by address, not by call order
+    factory_address = Address(0xFACF)
+    x1 = compute_create_address(address=factory_address, nonce=1)
+    x2 = compute_create_address(address=factory_address, nonce=2)
+    x3 = compute_create_address(address=factory_address, nonce=3)
+
+    # sort() + call in REVERSE order to prove finalization
+    # lexicographical sorting
+    sorted_addrs = sorted([x1, x2, x3])
+    reverse_sorted = list(reversed(sorted_addrs))
+
+    # Runtime: selfdestruct on first call, STOP on subsequent calls
+    selfdestruct_target: Address | Opcodes
+    if to_self:
+        selfdestruct_target = Op.ADDRESS
+    else:
+        selfdestruct_target = beneficiary
+    runtime = (
+        Op.TLOAD(0)
+        + Op.ISZERO
+        + Op.PUSH1(8)
+        + Op.JUMPI
+        + Op.STOP
+        + Op.JUMPDEST
+        + Op.TSTORE(0, 1)
+        + Op.SELFDESTRUCT(selfdestruct_target)
+    )
     initcode = Initcode(deploy_code=runtime)
     initcode_len = len(initcode)
 
-    c1_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
-    c2_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
-    c1 = pre.deploy_contract(c1_code, balance=100)
-    c2 = pre.deploy_contract(c2_code, balance=200)
+    # Payer contracts (p1, p2, p3) will send ETH to created contracts
+    p1 = pre.deploy_contract(payer_code, balance=100)
+    p2 = pre.deploy_contract(payer_code, balance=200)
+    p3 = pre.deploy_contract(payer_code, balance=300)
 
+    # Call p1/p2/p3 targeting addresses in REVERSE sorted order
+    # This proves finalization logs are sorted by address, not call order
     factory_code = (
         Om.MSTORE(initcode, 0)
+        # Create x1, x2, x3
         + Op.TSTORE(0, Op.CREATE(value=1000, offset=0, size=initcode_len))
         + Op.TSTORE(1, Op.CREATE(value=2000, offset=0, size=initcode_len))
+        + Op.TSTORE(2, Op.CREATE(value=3000, offset=0, size=initcode_len))
+        # Call x1, x2, x3 to trigger SELFDESTRUCT
         + Op.CALL(gas=100_000, address=Op.TLOAD(0), value=0)
         + Op.CALL(gas=100_000, address=Op.TLOAD(1), value=0)
-        + Op.MSTORE(0, Op.TLOAD(0))
-        + Op.CALL(gas=100_000, address=c1, args_offset=0, args_size=32)
-        + Op.MSTORE(0, Op.TLOAD(1))
-        + Op.CALL(gas=100_000, address=c2, args_offset=0, args_size=32)
+        + Op.CALL(gas=100_000, address=Op.TLOAD(2), value=0)
+        # p1/p2/p3 send ETH in REVERSE sorted address order
+        + Op.MSTORE(0, reverse_sorted[0])
+        + Op.CALL(gas=100_000, address=p1, args_offset=0, args_size=32)
+        + Op.MSTORE(0, reverse_sorted[1])
+        + Op.CALL(gas=100_000, address=p2, args_offset=0, args_size=32)
+        + Op.MSTORE(0, reverse_sorted[2])
+        + Op.CALL(gas=100_000, address=p3, args_offset=0, args_size=32)
     )
 
-    factory = pre.deploy_contract(factory_code, balance=3000)
-    addr_a = compute_create_address(address=factory, nonce=1)
-    addr_b = compute_create_address(address=factory, nonce=2)
+    factory = pre.deploy_contract(
+        factory_code, balance=6000, address=factory_address
+    )
 
-    # Sort addresses for expected finalization log order
-    sorted_addrs = sorted([addr_a, addr_b])
-    amounts = {addr_a: 100, addr_b: 200}
+    # Amounts based on reverse call order:
+    # p1→reverse[0], p2→reverse[1], p3→reverse[2]
+    amounts = {
+        reverse_sorted[0]: 100,
+        reverse_sorted[1]: 200,
+        reverse_sorted[2]: 300,
+    }
 
-    # Execution logs: CREATE A, CREATE B, SD A, SD B, C1->A, C2->B
+    # Execution logs:
+    # 1. CREATE x1, x2, x3 → LOG3 Transfer (factory → created)
+    # 2. CALL x1, x2, x3 → LOG3 or LOG2 depending on `to_self`
+    # 3. p1/p2/p3 send to reverse_sorted order
     execution_logs = [
-        transfer_log(factory, addr_a, 1000),
-        transfer_log(factory, addr_b, 2000),
-        transfer_log(addr_a, beneficiary, 1000),
-        transfer_log(addr_b, beneficiary, 2000),
-        transfer_log(c1, addr_a, 100),
-        transfer_log(c2, addr_b, 200),
+        transfer_log(factory_address, x1, 1000),
+        transfer_log(factory_address, x2, 2000),
+        transfer_log(factory_address, x3, 3000),
     ]
-    # Finalization logs in sorted address order
-    finalization_logs = [
-        selfdestruct_log(addr, amounts[addr]) for addr in sorted_addrs
-    ]
+
+    if to_self:
+        # SELFDESTRUCT to self burns ETH → LOG2 Selfdestruct
+        execution_logs.extend(
+            [
+                selfdestruct_log(x1, 1000),
+                selfdestruct_log(x2, 2000),
+                selfdestruct_log(x3, 3000),
+            ]
+        )
+        beneficiary_balance = 0
+    else:
+        # SELFDESTRUCT to beneficiary → LOG3 Transfer
+        execution_logs.extend(
+            [
+                transfer_log(x1, beneficiary, 1000),
+                transfer_log(x2, beneficiary, 2000),
+                transfer_log(x3, beneficiary, 3000),
+            ]
+        )
+        beneficiary_balance = 6000
+
+    if not eth_transferred:
+        # Reverted CALLs emit no logs, no ETH transferred, no finalization logs
+        finalization_logs = []
+        post = {
+            x1: Account.NONEXISTENT,
+            x2: Account.NONEXISTENT,
+            x3: Account.NONEXISTENT,
+            beneficiary: Account(balance=beneficiary_balance),
+            p1: Account(balance=100),
+            p2: Account(balance=200),
+            p3: Account(balance=300),
+        }
+    else:
+        # p1/p2/p3 send ETH in reverse sorted order
+        execution_logs.extend(
+            [
+                transfer_log(p1, reverse_sorted[0], 100),
+                transfer_log(p2, reverse_sorted[1], 200),
+                transfer_log(p3, reverse_sorted[2], 300),
+            ]
+        )
+        # Finalization logs emitted in SORTED address order (not call order)
+        finalization_logs = [
+            selfdestruct_log(addr, amounts[addr]) for addr in sorted_addrs
+        ]
+        post = {
+            x1: Account.NONEXISTENT,
+            x2: Account.NONEXISTENT,
+            x3: Account.NONEXISTENT,
+            beneficiary: Account(balance=beneficiary_balance),
+            p1: Account(balance=0),
+            p2: Account(balance=0),
+            p3: Account(balance=0),
+        }
 
     tx = Transaction(
         sender=sender,
@@ -354,13 +493,5 @@ def test_finalization_selfdestruct_logs(
             logs=execution_logs + finalization_logs
         ),
     )
-
-    post = {
-        addr_a: Account.NONEXISTENT,
-        addr_b: Account.NONEXISTENT,
-        beneficiary: Account(balance=3000),
-        c1: Account(balance=0),
-        c2: Account(balance=0),
-    }
 
     state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -235,3 +235,86 @@ def test_selfdestruct_same_tx_via_call(
     )
 
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def test_finalization_selfdestruct_logs(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+) -> None:
+    """
+    Test Selfdestruct logs at finalization for post-selfdestruct balance.
+
+    Multiple contracts selfdestruct then receive ETH. At finalization, logs
+    are emitted in lexicographical order of contract addresses.
+    """
+    beneficiary = pre.deploy_contract(Op.STOP)
+
+    runtime = Op.SELFDESTRUCT(beneficiary)
+    initcode = Initcode(deploy_code=runtime)
+    initcode_len = len(initcode)
+
+    # C1 and C2 selfdestruct to addresses in calldata
+    c1_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
+    c2_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
+    c1 = pre.deploy_contract(c1_code, balance=100)
+    c2 = pre.deploy_contract(c2_code, balance=200)
+
+    # Factory: CREATE A, CREATE B, CALL A, CALL B, then CALL C1/C2 to send ETH
+    factory_code = (
+        Om.MSTORE(initcode, 0)
+        # CREATE A (nonce 1) and B (nonce 2)
+        + Op.SSTORE(0, Op.CREATE(value=1000, offset=0, size=initcode_len))
+        + Op.SSTORE(1, Op.CREATE(value=2000, offset=0, size=initcode_len))
+        # CALL A and B to trigger selfdestructs
+        + Op.CALL(gas=100_000, address=Op.SLOAD(0), value=0)
+        + Op.CALL(gas=100_000, address=Op.SLOAD(1), value=0)
+        # CALL C1 with A's address, CALL C2 with B's address
+        + Op.MSTORE(0, Op.SLOAD(0))
+        + Op.CALL(gas=100_000, address=c1, args_offset=0, args_size=32)
+        + Op.MSTORE(0, Op.SLOAD(1))
+        + Op.CALL(gas=100_000, address=c2, args_offset=0, args_size=32)
+    )
+
+    factory = pre.deploy_contract(factory_code, balance=3000)
+    addr_a = compute_create_address(address=factory, nonce=1)
+    addr_b = compute_create_address(address=factory, nonce=2)
+
+    # Sort addresses for expected finalization log order
+    sorted_addrs = sorted([addr_a, addr_b])
+    amounts = {addr_a: 100, addr_b: 200}
+
+    # Execution logs: CREATE A, CREATE B, SD A, SD B, C1->A, C2->B
+    execution_logs = [
+        transfer_log(factory, addr_a, 1000),
+        transfer_log(factory, addr_b, 2000),
+        transfer_log(addr_a, beneficiary, 1000),
+        transfer_log(addr_b, beneficiary, 2000),
+        transfer_log(c1, addr_a, 100),
+        transfer_log(c2, addr_b, 200),
+    ]
+    # Finalization logs in sorted address order
+    finalization_logs = [
+        selfdestruct_log(addr, amounts[addr]) for addr in sorted_addrs
+    ]
+
+    tx = Transaction(
+        sender=sender,
+        to=factory,
+        value=0,
+        gas_limit=1_000_000,
+        expected_receipt=TransactionReceipt(
+            logs=execution_logs + finalization_logs
+        ),
+    )
+
+    post = {
+        addr_a: Account.NONEXISTENT,
+        addr_b: Account.NONEXISTENT,
+        beneficiary: Account(balance=3000),
+        c1: Account(balance=0),
+        c2: Account(balance=0),
+    }
+
+    state_test(env=env, pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_selfdestruct_logs.py
@@ -40,9 +40,7 @@ def test_selfdestruct_to_self_pre_existing_no_log(
     """
     Test that selfdestruct-to-self emits NO log for pre-existing contracts.
 
-    Per EIP-7708, SELFDESTRUCT to the same account does not emit a Transfer
-    log. The Selfdestruct log is only emitted when the account is created
-    and destroyed in the same transaction (actual ETH burn).
+    Selfdestruct log only emitted when created and destroyed in same tx.
     """
     contract_balance = 2000
 
@@ -66,24 +64,26 @@ def test_selfdestruct_to_self_pre_existing_no_log(
     )
 
 
-def test_selfdestruct_to_self_same_tx_emits_log(
+@pytest.mark.parametrize(
+    "contract_balance",
+    [
+        pytest.param(2000, id="with_balance"),
+        pytest.param(0, id="zero_balance"),
+    ],
+)
+def test_selfdestruct_to_self_same_tx(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
+    contract_balance: int,
 ) -> None:
     """
-    Test that selfdestruct-to-self emits a Selfdestruct log when created in
-    same tx.
+    Test selfdestruct-to-self for same-tx created contracts.
 
-    A contract created via CREATE that immediately selfdestructs to itself
-    in initcode is both created and destroyed in the same transaction.
-    Expected logs:
-    - CREATE transfer: factory -> created_address
-    - Selfdestruct: created_address burns its balance
+    - With balance, SELFDESTRUCT log emitted (burns ETH).
+    - No balance, no logs expected.
     """
-    contract_balance = 2000
-
     initcode = Op.SELFDESTRUCT(Op.ADDRESS)
     initcode_bytes = bytes(initcode)
     initcode_len = len(initcode_bytes)
@@ -91,76 +91,86 @@ def test_selfdestruct_to_self_same_tx_emits_log(
     factory_code = Op.MSTORE(
         0, Op.PUSH32(initcode_bytes.rjust(32, b"\x00"))
     ) + Op.CREATE(
-        value=contract_balance, offset=32 - initcode_len, size=initcode_len
+        value=Op.CALLVALUE, offset=32 - initcode_len, size=initcode_len
     )
 
-    factory = pre.deploy_contract(factory_code, balance=contract_balance)
+    factory = pre.deploy_contract(factory_code)
     created_address = compute_create_address(address=factory, nonce=1)
+
+    if contract_balance > 0:
+        expected_logs = [
+            transfer_log(sender, factory, contract_balance),
+            transfer_log(factory, created_address, contract_balance),
+            selfdestruct_log(created_address, contract_balance),
+        ]
+    else:
+        expected_logs = []
 
     tx = Transaction(
         sender=sender,
         to=factory,
-        value=0,
+        value=contract_balance,
         gas_limit=200_000,
-        expected_receipt=TransactionReceipt(
-            logs=[
-                # CREATE transfers value to new contract
-                transfer_log(factory, created_address, contract_balance),
-                # Selfdestruct-to-self burns the balance
-                selfdestruct_log(created_address, contract_balance),
-            ]
-        ),
+        expected_receipt=TransactionReceipt(logs=expected_logs),
     )
 
     state_test(env=env, pre=pre, post={}, tx=tx)
 
 
 @pytest.mark.parametrize(
-    "to_self",
+    "contract_balance",
     [
-        pytest.param(True, id="to_self"),
-        pytest.param(False, id="to_other"),
+        pytest.param(2000, id="with_balance"),
+        pytest.param(0, id="zero_balance"),
     ],
 )
-def test_selfdestruct_same_tx_zero_balance_no_log(
+def test_selfdestruct_to_different_address_same_tx(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
-    to_self: bool,
+    contract_balance: int,
 ) -> None:
     """
-    Test that same-tx selfdestruct with zero balance emits no logs.
+    Test same-tx selfdestruct to different address.
 
-    Both emit_selfdestruct_log and emit_transfer_log skip zero amounts.
-    A contract created with zero value that immediately selfdestructs in
-    initcode should produce no logs regardless of beneficiary.
+    With balance: Transfer log emitted. Zero balance: no logs.
     """
     beneficiary = pre.deploy_contract(Op.STOP)
 
-    if to_self:
-        initcode = Op.SELFDESTRUCT(Op.ADDRESS)
-    else:
-        initcode = Op.SELFDESTRUCT(beneficiary)
-
+    initcode = Op.SELFDESTRUCT(beneficiary)
     initcode_bytes = bytes(initcode)
     initcode_len = len(initcode_bytes)
 
     factory_code = Op.MSTORE(
         0, Op.PUSH32(initcode_bytes.rjust(32, b"\x00"))
-    ) + Op.CREATE(value=0, offset=32 - initcode_len, size=initcode_len)
+    ) + Op.CREATE(
+        value=Op.CALLVALUE, offset=32 - initcode_len, size=initcode_len
+    )
 
     factory = pre.deploy_contract(factory_code)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    if contract_balance > 0:
+        expected_logs = [
+            transfer_log(sender, factory, contract_balance),
+            transfer_log(factory, created_address, contract_balance),
+            transfer_log(created_address, beneficiary, contract_balance),
+        ]
+        post = {beneficiary: Account(balance=contract_balance)}
+    else:
+        expected_logs = []
+        post = {}
 
     tx = Transaction(
         sender=sender,
         to=factory,
-        value=0,
+        value=contract_balance,
         gas_limit=200_000,
-        expected_receipt=TransactionReceipt(logs=[]),
+        expected_receipt=TransactionReceipt(logs=expected_logs),
     )
 
-    state_test(env=env, pre=pre, post={}, tx=tx)
+    state_test(env=env, pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.parametrize(
@@ -178,18 +188,10 @@ def test_selfdestruct_same_tx_via_call(
     to_self: bool,
 ) -> None:
     """
-    Test selfdestruct log for contract created via CREATE then called.
+    Test selfdestruct via CREATE-then-CALL (not initcode selfdestruct).
 
-    All existing same-tx tests use initcode selfdestruct. This tests the
-    create-then-call path: factory CREATEs a contract with deployed runtime
-    code, then CALLs it to trigger SELFDESTRUCT. Contract is still in
-    created_accounts.
-
-    Expected logs:
-    - to_self: transfer_log(factory, created, 2000) +
-               selfdestruct_log(created, 2000)
-    - to_other: transfer_log(factory, created, 2000) +
-                transfer_log(created, beneficiary, 2000)
+    Factory CREATEs contract with runtime code, then CALLs to trigger
+    SELFDESTRUCT. Contract is still in created_accounts.
     """
     contract_balance = 2000
     beneficiary = pre.deploy_contract(Op.STOP)
@@ -204,10 +206,10 @@ def test_selfdestruct_same_tx_via_call(
 
     factory_code = (
         Om.MSTORE(initcode, 0)
-        + Op.SSTORE(
+        + Op.TSTORE(
             0, Op.CREATE(value=contract_balance, offset=0, size=initcode_len)
         )
-        + Op.CALL(gas=100_000, address=Op.SLOAD(0), value=0)
+        + Op.CALL(gas=100_000, address=Op.TLOAD(0), value=0)
     )
 
     factory = pre.deploy_contract(factory_code, balance=contract_balance)
@@ -246,8 +248,9 @@ def test_finalization_selfdestruct_logs(
     """
     Test Selfdestruct logs at finalization for post-selfdestruct balance.
 
-    Multiple contracts selfdestruct then receive ETH. At finalization, logs
-    are emitted in lexicographical order of contract addresses.
+    Contracts A and B selfdestruct, then receive ETH via C1/C2's selfdestruct.
+    At finalization, A and B emit Selfdestruct logs for their remaining balance
+    in lexicographical address order.
     """
     beneficiary = pre.deploy_contract(Op.STOP)
 
@@ -255,25 +258,20 @@ def test_finalization_selfdestruct_logs(
     initcode = Initcode(deploy_code=runtime)
     initcode_len = len(initcode)
 
-    # C1 and C2 selfdestruct to addresses in calldata
     c1_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
     c2_code = Op.SELFDESTRUCT(Op.CALLDATALOAD(0))
     c1 = pre.deploy_contract(c1_code, balance=100)
     c2 = pre.deploy_contract(c2_code, balance=200)
 
-    # Factory: CREATE A, CREATE B, CALL A, CALL B, then CALL C1/C2 to send ETH
     factory_code = (
         Om.MSTORE(initcode, 0)
-        # CREATE A (nonce 1) and B (nonce 2)
-        + Op.SSTORE(0, Op.CREATE(value=1000, offset=0, size=initcode_len))
-        + Op.SSTORE(1, Op.CREATE(value=2000, offset=0, size=initcode_len))
-        # CALL A and B to trigger selfdestructs
-        + Op.CALL(gas=100_000, address=Op.SLOAD(0), value=0)
-        + Op.CALL(gas=100_000, address=Op.SLOAD(1), value=0)
-        # CALL C1 with A's address, CALL C2 with B's address
-        + Op.MSTORE(0, Op.SLOAD(0))
+        + Op.TSTORE(0, Op.CREATE(value=1000, offset=0, size=initcode_len))
+        + Op.TSTORE(1, Op.CREATE(value=2000, offset=0, size=initcode_len))
+        + Op.CALL(gas=100_000, address=Op.TLOAD(0), value=0)
+        + Op.CALL(gas=100_000, address=Op.TLOAD(1), value=0)
+        + Op.MSTORE(0, Op.TLOAD(0))
         + Op.CALL(gas=100_000, address=c1, args_offset=0, args_size=32)
-        + Op.MSTORE(0, Op.SLOAD(1))
+        + Op.MSTORE(0, Op.TLOAD(1))
         + Op.CALL(gas=100_000, address=c2, args_offset=0, args_size=32)
     )
 

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -27,9 +27,6 @@ from execution_testing import (
     compute_create2_address,
     compute_create_address,
 )
-from execution_testing import (
-    Macros as Om,
-)
 
 from .spec import Spec, ref_spec_7708, transfer_log
 
@@ -1256,8 +1253,8 @@ def test_selfdestruct_to_self_cross_tx_no_log(
     Selfdestruct-to-self in Tx2 emits no log per EIP-7708: no Selfdestruct
     log (not same-tx) and no Transfer log (not a different account).
 
-    Tx1: Factory CREATEs contract with runtime code SELFDESTRUCT(ADDRESS),
-         value=2000. Logs: [transfer_log(factory, created, 2000)]
+    Tx1: Contract creation tx (to=None) deploying SELFDESTRUCT(ADDRESS),
+         value=2000. Logs: [transfer_log(sender, created, 2000)]
     Tx2: Call created contract directly, value=0. Logs: []
     Post: contract keeps balance (not deleted, not in created_accounts in Tx2)
     """
@@ -1266,29 +1263,25 @@ def test_selfdestruct_to_self_cross_tx_no_log(
 
     runtime_code = Op.SELFDESTRUCT(Op.ADDRESS)
     initcode = Initcode(deploy_code=runtime_code)
-    initcode_len = len(initcode)
 
-    factory_code = Om.MSTORE(initcode, 0) + Op.CREATE(
-        value=contract_balance, offset=0, size=initcode_len
-    )
-
-    factory = pre.deploy_contract(factory_code, balance=contract_balance)
-    created_address = compute_create_address(address=factory, nonce=1)
+    # Calculate the address that will be created by the first tx
+    created_address = compute_create_address(address=sender, nonce=0)
 
     blocks = [
         Block(
             txs=[
-                # Tx1: Create the contract via factory
+                # Tx1: Create the contract directly via contract creation tx
                 Transaction(
-                    to=factory,
+                    to=None,
                     sender=sender,
                     nonce=0,
-                    value=0,
+                    value=contract_balance,
+                    data=bytes(initcode),
                     gas_limit=300_000,
                     expected_receipt=TransactionReceipt(
                         logs=[
                             transfer_log(
-                                factory, created_address, contract_balance
+                                sender, created_address, contract_balance
                             ),
                         ]
                     ),

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -795,14 +795,37 @@ def test_zero_value_operations_no_log(
     state_test(env=env, pre=pre, post={}, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "call_opcode",
+    [
+        pytest.param(Op.CALL, id="call"),
+        pytest.param(Op.CALLCODE, id="callcode"),
+    ],
+)
 def test_call_to_self_no_log(
     state_test: StateTestFiller,
     env: Environment,
     pre: Alloc,
     sender: EOA,
+    call_opcode: Op,
 ) -> None:
-    """Test that CALL with value to self emits no transfer log."""
-    contract_code = Op.CALL(gas=100_000, address=Op.ADDRESS, value=1)
+    """
+    Test that CALL/CALLCODE with value to self emits no transfer log.
+
+    Uses CALLDATASIZE to detect recursion: external call has no calldata,
+    recursive call passes 1 byte of calldata to signal stop.
+    """
+    # CALLDATASIZE > 0 means recursive call, jump to end
+    # Byte offsets: CALLDATASIZE(1) + PUSH1(2) + JUMPI(1) = 4
+    # CALL with args_size=1: ~16 bytes, JUMPDEST at offset 20
+    contract_code = (
+        Op.CALLDATASIZE
+        + Op.PUSH1(20)
+        + Op.JUMPI
+        + call_opcode(gas=100_000, address=Op.ADDRESS, value=1, args_size=1)
+        + Op.JUMPDEST
+        + Op.STOP
+    )
     contract = pre.deploy_contract(contract_code, balance=1)
 
     tx = Transaction(

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -18,6 +18,7 @@ from execution_testing import (
     Bytecode,
     Bytes,
     Environment,
+    Initcode,
     Op,
     StateTestFiller,
     Transaction,
@@ -25,6 +26,9 @@ from execution_testing import (
     TransactionReceipt,
     compute_create2_address,
     compute_create_address,
+)
+from execution_testing import (
+    Macros as Om,
 )
 
 from .spec import Spec, ref_spec_7708, transfer_log
@@ -85,6 +89,24 @@ def test_transfer_to_delegated_account_emits_log(
 
     post = {recipient: Account(balance=1)}
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+def test_transfer_to_self_no_log(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+) -> None:
+    """Test that a transaction sending value to self emits no transfer log."""
+    tx = Transaction(
+        sender=sender,
+        to=sender,
+        value=1,
+        gas_limit=21_000,
+        expected_receipt=TransactionReceipt(logs=[]),
+    )
+
+    state_test(env=env, pre=pre, post={}, tx=tx)
 
 
 def test_zero_value_transfer_no_log(
@@ -179,9 +201,9 @@ def test_call_opcodes_transfer_log_behavior(
         expected_logs.append(transfer_log(contract, callee, 1))
         post = {callee: Account(balance=1)}
     elif call_opcode == Op.CALLCODE:
-        # CALLCODE transfers value but stays in caller's context
-        # This is a self-transfer (contract -> contract)
-        expected_logs.append(transfer_log(contract, contract, 1))
+        # CALLCODE transfers value but stays in caller's context.
+        # This is a self-transfer (contract -> contract), so no transfer
+        # log per EIP-7708 ("CALL to a different account").
         post = {}
     else:
         # DELEGATECALL and STATICCALL: no value transfer, no additional log
@@ -776,6 +798,27 @@ def test_zero_value_operations_no_log(
     state_test(env=env, pre=pre, post={}, tx=tx)
 
 
+def test_call_to_self_no_log(
+    state_test: StateTestFiller,
+    env: Environment,
+    pre: Alloc,
+    sender: EOA,
+) -> None:
+    """Test that CALL with value to self emits no transfer log."""
+    contract_code = Op.CALL(gas=100_000, address=Op.ADDRESS, value=1)
+    contract = pre.deploy_contract(contract_code, balance=1)
+
+    tx = Transaction(
+        sender=sender,
+        to=contract,
+        value=0,
+        gas_limit=200_000,
+        expected_receipt=TransactionReceipt(logs=[]),
+    )
+
+    state_test(env=env, pre=pre, post={}, tx=tx)
+
+
 @pytest.mark.parametrize(
     "recipient_code,call_gas,call_value,recipient_balance,contract_balance",
     [
@@ -1199,6 +1242,77 @@ def test_selfdestruct_then_transfer_same_block(
         post={
             beneficiary: Account(balance=600),
             contract: Account(balance=0),
+        },
+    )
+
+
+def test_selfdestruct_to_self_cross_tx_no_log(
+    blockchain_test: BlockchainTestFiller, pre: Alloc
+) -> None:
+    """
+    Test that selfdestruct-to-self in a cross-tx context emits no log.
+
+    A contract created in Tx1 is not in created_accounts during Tx2.
+    Selfdestruct-to-self in Tx2 emits no log per EIP-7708: no Selfdestruct
+    log (not same-tx) and no Transfer log (not a different account).
+
+    Tx1: Factory CREATEs contract with runtime code SELFDESTRUCT(ADDRESS),
+         value=2000. Logs: [transfer_log(factory, created, 2000)]
+    Tx2: Call created contract directly, value=0. Logs: []
+    Post: contract keeps balance (not deleted, not in created_accounts in Tx2)
+    """
+    contract_balance = 2000
+    sender = pre.fund_eoa()
+
+    runtime_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    initcode = Initcode(deploy_code=runtime_code)
+    initcode_len = len(initcode)
+
+    factory_code = Om.MSTORE(initcode, 0) + Op.CREATE(
+        value=contract_balance, offset=0, size=initcode_len
+    )
+
+    factory = pre.deploy_contract(factory_code, balance=contract_balance)
+    created_address = compute_create_address(address=factory, nonce=1)
+
+    blocks = [
+        Block(
+            txs=[
+                # Tx1: Create the contract via factory
+                Transaction(
+                    to=factory,
+                    sender=sender,
+                    nonce=0,
+                    value=0,
+                    gas_limit=300_000,
+                    expected_receipt=TransactionReceipt(
+                        logs=[
+                            transfer_log(
+                                factory, created_address, contract_balance
+                            ),
+                        ]
+                    ),
+                ),
+                # Tx2: Call the created contract directly (cross-tx)
+                Transaction(
+                    to=created_address,
+                    sender=sender,
+                    nonce=1,
+                    value=0,
+                    gas_limit=100_000,
+                    expected_receipt=TransactionReceipt(logs=[]),
+                ),
+            ],
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={
+            # Contract keeps balance: not deleted since not in
+            # created_accounts during Tx2
+            created_address: Account(balance=contract_balance),
         },
     )
 


### PR DESCRIPTION
## 🗒️ Description

### SELFDESTRUCT

- Tracking the discussion [here](https://discord.com/channels/595666850260713488/688075293562503241/1465722727481475174) that selfdestruct logs may only be emitted if created and destroyed in same tx ([EIP-6780](https://eips.ethereum.org/EIPS/eip-6780))
    - EIP update: https://github.com/ethereum/EIPs/pull/11190

### CALL and Transactions

- Exclude logs for transfer of value to self:
  - CALL EIP update: https://github.com/ethereum/EIPs/pull/11187
  - Transaction EIP update: https://github.com/ethereum/EIPs/pull/11188

Also added some more test cases for coverage emitting transfer logs when not in the same tx, self destruct logs when in same tx, combo of transfer and selfdestruct logs across fork transition, update tests to reflect above changes

closes #2088 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="673" height="896" alt="Screenshot 2026-01-28 at 11 06 45" src="https://github.com/user-attachments/assets/c47d9601-0ce3-4738-ac78-592e315b7ae0" />

