### PR TITLE
fix(test): Update refspec for EIP-7778 to match latest revision

### DIFF
--- a/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
+++ b/tests/amsterdam/eip7778_block_gas_accounting_without_refunds/test_gas_accounting.py
@@ -25,7 +25,7 @@ from execution_testing.base_types import HashInt
 from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7778.md"
-REFERENCE_SPEC_VERSION = "54fba02495a05b57acd3f27473d0493b40a9d920"
+REFERENCE_SPEC_VERSION = "ce17d00b8341032a946301944124c4a6013032d6"
 
 
 def build_refund_tx(


### PR DESCRIPTION
## 🗒️ Description

We recently updated the specs to match the updates to the EIP (reverts changes to receipts, etc). We should update the refspect now that those changes have been merged to the EIP [here](https://github.com/ethereum/EIPs/pull/11191).

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.kJLlU60CP5hW7H8oLE8pMgHaHa%3Fpid%3DApi&f=1&ipt=68e3016b8719aa1529f9a8bf35971a371220229a9ca145558d700a0495345f22&ipo=images)
