### PR TITLE
feat(test): update EIP-8024 refspec and align on latest changes to EIP

### DIFF
--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
@@ -19,7 +19,7 @@ class ReferenceSpec:
 
 ref_spec_8024 = ReferenceSpec(
     git_path="EIPS/eip-8024.md",
-    version="9842e867b5c75b9624d1e62b4eb532d3b219e70d",
+    version="b54accd182b0e2e040ce2ba1a8a61bff6ca9fa0e",
 )
 
 

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
@@ -588,3 +588,48 @@ def test_vector_exchange_invalid_0x50(
     post = {contract_address: Account(storage={})}
 
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "eip8024_opcode,stack_items",
+    [
+        pytest.param(Op.DUPN, 17, id="dupn"),
+        pytest.param(Op.SWAPN, 18, id="swapn"),
+        pytest.param(Op.EXCHANGE, 30, id="exchange"),
+    ],
+)
+def test_eip_vector_end_of_code(
+    pre: Alloc,
+    state_test: StateTestFiller,
+    eip8024_opcode: Op,
+    stack_items: int,
+) -> None:
+    """
+    Test EIP-8024 opcodes at end of code (no immediate byte).
+
+    When an opcode appears at end of code, code[pc+1] = 0 beyond end of code.
+    - DUPN: decode_single(0) = 17, needs 17 items on stack
+    - SWAPN: decode_single(0) = 17, needs 18 items on stack
+    - EXCHANGE: decode_pair(0) = (1, 29), needs 30 items on stack
+
+    Store a marker before the opcode to verify the transaction succeeded,
+    since adding any opcode after would make that opcode byte the immediate.
+    """
+    sender = pre.fund_eoa()
+    marker_value = 0x42
+
+    code = (
+        # store marker for verification
+        Op.SSTORE(0, marker_value)
+        # push minimum required stack items for the opcode
+        + Op.PUSH0 * stack_items
+        # end-of-code EIP-8024 opcode
+        + eip8024_opcode
+    )
+    contract_address = pre.deploy_contract(code=code)
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    # verify marker was stored (tx succeeded)
+    post = {contract_address: Account(storage={0: marker_value})}
+    state_test(pre=pre, post=post, tx=tx)


### PR DESCRIPTION
## 🗒️ Description

Updates to EIP-8024 since the last refspec hash:

- https://github.com/ethereum/EIPs/pull/11085
- https://github.com/ethereum/EIPs/pull/11095

Add test cases for expected end-of-code behavior

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.qwzb4YP-mLn6WXDL-Q3cTAHaEo%3Fpid%3DApi&f=1&ipt=e74b0446a7d4163a346738c329a28ffbad9cb28dd9fe0097fcf223117379f3cc&ipo=images)
