### PR TITLE
fix(tests): update nethermind exceptions

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -320,10 +320,10 @@ class NethermindExceptionMapper(ExceptionMapper):
             "max initcode size exceeded"
         ),
         TransactionException.NONCE_MISMATCH_TOO_LOW: (
-            "wrong transaction nonce"
+            "transaction nonce is too low"
         ),
         TransactionException.NONCE_MISMATCH_TOO_HIGH: (
-            "wrong transaction nonce"
+            "transaction nonce is too high"
         ),
         TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS: (
             "InsufficientMaxFeePerBlobGas: Not enough to cover blob gas fee"
@@ -338,7 +338,7 @@ class NethermindExceptionMapper(ExceptionMapper):
             "InvalidTxType: Transaction type in Custom is not supported"
         ),
         TransactionException.TYPE_3_TX_ZERO_BLOBS: (
-            "blob transaction missing blob hashes"
+            "blob transaction must have at least 1 blob"
         ),
         TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH: (
             "InvalidBlobVersionedHashVersion: Blob version not supported"


### PR DESCRIPTION
## 🗒️ Description

Update 3 messages mappings for Nethermind 

## 🔗 Related Issues or PRs

Fixes https://hive.ethpandaops.io/#/test/generic/1769644413-d08b28c9d2589f54ce19ac03b6f52708 runs

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
