### PR TITLE
feat(src): EIP-7843 execution-api PR #731 implemented

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -300,6 +300,13 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                 )
                 else None
             ),
+            slot_number=(
+                0
+                if self.fork.engine_payload_attribute_slot_number(
+                    block_number=0, timestamp=0
+                )
+                else None
+            ),
         )
         forkchoice_updated_version = (
             self.fork.engine_forkchoice_updated_version()

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -801,6 +801,16 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
+    def engine_payload_attribute_slot_number(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        Return true if the payload attributes include the slot number.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
     def engine_forkchoice_updated_version(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1049,6 +1049,16 @@ class Frontier(BaseFork, solc_name="homestead"):
         return False
 
     @classmethod
+    def engine_payload_attribute_slot_number(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        At genesis, payload attributes do not include the slot number.
+        """
+        del block_number, timestamp
+        return False
+
+    @classmethod
     def engine_forkchoice_updated_version(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
@@ -3404,5 +3414,21 @@ class Amsterdam(BPO2):
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> bool:
         """Slot number in header required from Amsterdam (EIP-7843)."""
+        del block_number, timestamp
+        return True
+
+    @classmethod
+    def engine_forkchoice_updated_version(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> Optional[int]:
+        """From Amsterdam, forkchoice updated calls must use version 4."""
+        del block_number, timestamp
+        return 4
+
+    @classmethod
+    def engine_payload_attribute_slot_number(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """From Amsterdam, payload attributes include the slot number."""
         del block_number, timestamp
         return True

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -157,6 +157,7 @@ class PayloadAttributes(CamelModel):
     parent_beacon_block_root: Hash | None = None
     target_blobs_per_block: HexNumber | None = None
     max_blobs_per_block: HexNumber | None = None
+    slot_number: HexNumber | None = None
 
 
 class BlobsBundle(CamelModel):


### PR DESCRIPTION
## 🗒️ Description
TODO: test against a client

## 🔗 Related Issues or PRs
[execution apis 731](https://github.com/ethereum/execution-apis/pull/731)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
