### PR TITLE
refactor(test-benchmark): update benchmark fork to Osaka

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -11,11 +11,6 @@ benchmark:
   evm-type: benchmark
   fill-params: --no-html --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 -m benchmark ./tests/benchmark
 
-benchmark_develop:
-  evm-type: benchmark
-  fill-params: --no-html --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 -m "benchmark" ./tests/benchmark
-  feature_only: true
-
 benchmark_fast:
   evm-type: benchmark
   fill-params: --no-html --fork=Osaka --gas-benchmark-values 100 -m "benchmark" ./tests/benchmark

--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -9,7 +9,7 @@ develop:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --no-html --fork=Prague --gas-benchmark-values 1,5,10,30,60,100,150 -m benchmark ./tests/benchmark
+  fill-params: --no-html --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 -m benchmark ./tests/benchmark
 
 benchmark_develop:
   evm-type: benchmark
@@ -18,7 +18,7 @@ benchmark_develop:
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --no-html --fork=Prague --gas-benchmark-values 100 -m "benchmark" ./tests/benchmark
+  fill-params: --no-html --fork=Osaka --gas-benchmark-values 100 -m "benchmark" ./tests/benchmark
   feature_only: true
 
 bal:

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -178,7 +178,7 @@ def create_benchmark_executor(
                 key_warm=False,
                 original_value=original,
                 current_value=original,
-                new_value=original + 1,
+                new_value=2**256 - 1,
             )
 
     # [index, num]
@@ -498,14 +498,15 @@ def test_storage_access_warm(
     """Benchmark warm storage slot accesses."""
     blocks = []
 
-    if storage_action == StorageAction.WRITE_SAME_VALUE:
-        execution_code_body = Op.SSTORE(0, Op.DUP1)
-    elif storage_action == StorageAction.WRITE_NEW_VALUE:
-        execution_code_body = Op.SSTORE(0, Op.GAS)
-    elif storage_action == StorageAction.READ:
-        execution_code_body = Op.POP(Op.SLOAD(0))
-    else:
-        execution_code_body = Bytecode()
+    match storage_action:
+        case StorageAction.WRITE_SAME_VALUE:
+            execution_code_body = Op.SSTORE(0, Op.DUP1)
+        case StorageAction.WRITE_NEW_VALUE:
+            execution_code_body = Op.SSTORE(0, Op.GAS)
+        case StorageAction.READ:
+            execution_code_body = Op.POP(Op.SLOAD(0))
+        case _:
+            raise ValueError("Unspecified storage action")
 
     execution_code = Op.SLOAD(0) + While(body=execution_code_body)
     execution_code_address = pre.deploy_contract(code=execution_code)
@@ -571,14 +572,15 @@ def test_storage_access_warm_benchmark(
     Each iteration accesses a different storage slot (incrementing key)
     to ensure warm access costs are measured.
     """
-    if storage_action == StorageAction.WRITE_SAME_VALUE:
-        attack_block = Op.SSTORE(Op.PUSH0, Op.PUSH0)
-    elif storage_action == StorageAction.WRITE_NEW_VALUE:
-        attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)
-    elif storage_action == StorageAction.READ:
-        attack_block = Op.SLOAD(Op.PUSH0)
-    else:
-        attack_block = Bytecode()
+    match storage_action:
+        case StorageAction.WRITE_SAME_VALUE:
+            attack_block = Op.SSTORE(Op.PUSH0, Op.PUSH0)
+        case StorageAction.WRITE_NEW_VALUE:
+            attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)
+        case StorageAction.READ:
+            attack_block = Op.SLOAD(Op.PUSH0)
+        case _:
+            raise ValueError("Unspecified storage action")
 
     benchmark_test(
         target_opcode=Op.SLOAD

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -13,12 +13,13 @@ import math
 import pytest
 from execution_testing import (
     Alloc,
+    AuthorizationTuple,
     BenchmarkTestFiller,
     Block,
     Bytecode,
-    Environment,
     ExtCallGenerator,
     Fork,
+    Hash,
     JumpLoopGenerator,
     Op,
     TestPhaseManager,
@@ -75,12 +76,7 @@ def test_tstore(
     init_key = 42
     setup = Op.PUSH1(init_key)
 
-    # If fixed_value is False, we use GAS as a cheap way of always
-    # storing a different value than the previous one.
     attack_block = Op.TSTORE(Op.DUP2, Op.GAS if not fixed_value else Op.DUP1)
-
-    # If fixed_key is False, we mutate the key on every iteration of the
-    # big loop.
     cleanup = Op.POP + Op.GAS if not fixed_key else Bytecode()
 
     benchmark_test(
@@ -91,13 +87,134 @@ def test_tstore(
     )
 
 
+def create_storage_initializer(fork: Fork) -> tuple[Bytecode, int, int]:
+    """
+    Create a contract that initializes storage slots from calldata parameters.
+
+    - CALLDATA[0..32] start slot (index)
+    - CALLDATA[32..64] slot count (num)
+
+    storage[i] = i for i in [index, index + num).
+
+    Returns: (bytecode, loop_cost, overhead)
+    """
+    prefix = (
+        Op.CALLDATALOAD(0)  # [index]
+        + Op.DUP1  # [index, index]
+        + Op.CALLDATALOAD(32)  # [index, index, num]
+        + Op.ADD  # [index, index + num]
+    )
+
+    loop = (
+        Op.JUMPDEST
+        + Op.PUSH1(1)  # [index, index + num, 1]
+        + Op.SWAP1  # [index, 1, index + num]
+        + Op.SUB  # [index, index + num - 1]
+        + Op.SSTORE(
+            Op.DUP1,
+            Op.DUP1,
+            key_warm=False,
+            original_value=0,
+            current_value=0,
+            new_value=1,
+        )
+        + Op.JUMPI(len(prefix), Op.GT(Op.DUP2, Op.DUP2))
+    )
+
+    return prefix + loop, loop.gas_cost(fork), prefix.gas_cost(fork)
+
+
+def create_benchmark_executor(
+    storage_action: StorageAction,
+    absent_slots: bool,
+    tx_result: TransactionResult,
+    fork: Fork,
+) -> tuple[Bytecode, int, int]:
+    """
+    Create a contract that executes benchmark operations.
+
+    - CALLDATA[0..32] start slot (index)
+    - CALLDATA[32..64] slot count (num)
+
+    Returns: (bytecode, loop_cost, overhead)
+    """
+    prefix = (
+        Op.CALLDATALOAD(0)  # [index]
+        + Op.CALLDATALOAD(32)  # [index, num]
+    )
+
+    slot_calculation = (
+        Op.DUP2  # [index, num, index]
+        + Op.DUP2  # [index, num, index, num]
+        + Op.ADD  # [index, num, index + num]
+        + Op.PUSH1(1)  # [index, num, index + num, 1]
+        + Op.SWAP1  # [index, num, 1, index + num]
+        + Op.SUB  # [index, num, index + num - 1]
+    )
+
+    original = 0 if absent_slots else 1
+
+    # [index, num, index + num - 1]
+    match storage_action:
+        case StorageAction.READ:
+            operation = Op.POP(Op.SLOAD.with_metadata(key_warm=False))
+        case StorageAction.WRITE_SAME_VALUE:
+            new_value = 1 if absent_slots else original
+            operation = (
+                Op.SSTORE(
+                    Op.DUP1,
+                    Op.DUP1,
+                    key_warm=False,
+                    original_value=original,
+                    current_value=original,
+                    new_value=new_value,
+                )
+                + Op.POP
+            )
+        case StorageAction.WRITE_NEW_VALUE:
+            operation = Op.SSTORE(
+                Op.SWAP1,
+                Op.NOT(0),
+                key_warm=False,
+                original_value=original,
+                current_value=original,
+                new_value=original + 1,
+            )
+
+    # [index, num]
+    loop_condition = (
+        Op.PUSH1(1)  # [index, num, 1]
+        + Op.SWAP1  # [index, 1, num]
+        + Op.SUB  # [index, num - 1]
+        + Op.DUP1  # [index, num - 1, num - 1]
+        + Op.ISZERO  # [index, num - 1 == 0]
+        + Op.ISZERO  # [index, num - 1 != 0]
+    )
+
+    match tx_result:
+        case TransactionResult.REVERT:
+            suffix = Op.REVERT(0, 0)
+        case TransactionResult.OUT_OF_GAS:
+            suffix = Bytecode()
+        case _:
+            suffix = Op.STOP
+
+    loop = (
+        Op.JUMPDEST
+        + slot_calculation
+        + operation
+        + Op.JUMPI(len(prefix), loop_condition)
+    )
+    code = prefix + loop + suffix
+
+    return code, loop.gas_cost(fork), (prefix + suffix).gas_cost(fork)
+
+
 @pytest.mark.parametrize(
     "storage_action,tx_result",
     [
         pytest.param(
-            StorageAction.READ,
-            TransactionResult.SUCCESS,
-            id="SSLOAD",
+            StorageAction.READ, TransactionResult.SUCCESS, id="SSLOAD"
         ),
         pytest.param(
             StorageAction.WRITE_SAME_VALUE,
@@ -131,161 +248,201 @@ def test_tstore(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "absent_slots",
-    [
-        True,
-        False,
-    ],
-)
+@pytest.mark.parametrize("absent_slots", [True, False])
 def test_storage_access_cold(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     storage_action: StorageAction,
     absent_slots: bool,
-    env: Environment,
     gas_benchmark_value: int,
+    tx_gas_limit: int,
     tx_result: TransactionResult,
 ) -> None:
     """
-    Benchmark cold storage slot accesses.
+    Benchmark cold storage slot accesses using EIP-7702 delegation.
+
+    The authority EOA delegates to:
+    - StorageInitializer: storage[i] = i for each slot (absent_slots=False)
+    - BenchmarkExecutor: performs the benchmark operation (SLOAD/SSTORE)
     """
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
     gas_costs = fork.gas_costs()
-    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
 
-    loop_cost = gas_costs.G_COLD_SLOAD  # All accesses are always cold
-    if storage_action == StorageAction.WRITE_NEW_VALUE:
-        if not absent_slots:
-            loop_cost += gas_costs.G_STORAGE_RESET
-        else:
-            loop_cost += gas_costs.G_STORAGE_SET
-    elif storage_action == StorageAction.WRITE_SAME_VALUE:
-        if absent_slots:
-            loop_cost += gas_costs.G_STORAGE_SET
-        else:
-            loop_cost += gas_costs.G_WARM_SLOAD
-    elif storage_action == StorageAction.READ:
-        loop_cost += 0  # Only G_COLD_SLOAD is charged
-
-    # Contract code
-    execution_code_body = Bytecode()
-    if storage_action == StorageAction.WRITE_SAME_VALUE:
-        # All the storage slots in the contract are initialized to their index.
-        # That is, storage slot `i` is initialized to `i`.
-        execution_code_body = Op.SSTORE(Op.DUP1, Op.DUP1)
-        loop_cost += gas_costs.G_VERY_LOW * 2
-    elif storage_action == StorageAction.WRITE_NEW_VALUE:
-        # The new value 2^256-1 is guaranteed to be different from the initial
-        # value.
-        execution_code_body = Op.SSTORE(Op.DUP2, Op.NOT(0))
-        loop_cost += gas_costs.G_VERY_LOW * 3
-    elif storage_action == StorageAction.READ:
-        execution_code_body = Op.POP(Op.SLOAD(Op.DUP1))
-        loop_cost += gas_costs.G_VERY_LOW + gas_costs.G_BASE
-
-    # Add costs jump-logic costs
-    loop_cost += (
-        gas_costs.G_JUMPDEST  # Prefix Jumpdest
-        + gas_costs.G_VERY_LOW * 7  # ISZEROs, PUSHs, SWAPs, SUB, DUP
-        + gas_costs.G_HIGH  # JUMPI
+    executor_code, exec_loop_cost, exec_overhead = create_benchmark_executor(
+        storage_action, absent_slots, tx_result, fork
+    )
+    initializer_code, init_loop_cost, init_overhead = (
+        create_storage_initializer(fork)
     )
 
-    prefix_cost = (
-        gas_costs.G_VERY_LOW  # Target slots push
-    )
+    authority = pre.fund_eoa(amount=0)
+    initializer_addr = pre.deploy_contract(code=initializer_code)
+    executor_addr = pre.deploy_contract(code=executor_code)
 
-    suffix_cost = 0
-    if tx_result == TransactionResult.REVERT:
-        suffix_cost = (
-            gas_costs.G_VERY_LOW * 2  # Revert PUSHs
-        )
+    delegation_intrinsic = intrinsic_calc(authorization_list_or_count=1)
+    max_intrinsic = intrinsic_calc(calldata=bytes([0xFF] * 64))
 
-    num_target_slots = (
-        gas_benchmark_value
-        - intrinsic_gas_cost_calc()
-        - prefix_cost
-        - suffix_cost
-    ) // loop_cost
-    if tx_result == TransactionResult.OUT_OF_GAS:
-        # Add an extra slot to make it run out-of-gas
-        num_target_slots += 1
+    # Number of slots that can be processed in the execution phase
+    num_target_slots = 0
+    current_slot = 1
+    gas_remaining = gas_benchmark_value - delegation_intrinsic
+    while gas_remaining > 0:
+        tx_gas = min(tx_gas_limit, gas_remaining)
+        if tx_gas < max_intrinsic + exec_overhead + exec_loop_cost:
+            break
 
-    code_prefix = Op.PUSH4(num_target_slots) + Op.JUMPDEST
-    code_loop = execution_code_body + Op.JUMPI(
-        len(code_prefix) - 1,
-        Op.PUSH1(1) + Op.SWAP1 + Op.SUB + Op.DUP1 + Op.ISZERO + Op.ISZERO,
-    )
-    execution_code = code_prefix + code_loop
+        slots = (tx_gas - max_intrinsic - exec_overhead) // exec_loop_cost
 
-    if tx_result == TransactionResult.REVERT:
-        execution_code += Op.REVERT(0, 0)
-    else:
-        execution_code += Op.STOP
+        calldata = bytes(Hash(current_slot)) + bytes(Hash(slots))
+        execution_intrinsic = intrinsic_calc(calldata=calldata)
 
-    execution_code_address = pre.deploy_contract(code=execution_code)
+        slots = (
+            tx_gas - execution_intrinsic - exec_overhead
+        ) // exec_loop_cost
 
-    total_gas_used = (
-        num_target_slots * loop_cost
-        + intrinsic_gas_cost_calc()
-        + prefix_cost
-        + suffix_cost
-    )
+        num_target_slots += slots
+        current_slot += slots
+        gas_remaining -= tx_gas
 
-    # Contract creation
-    slots_init = Bytecode()
+    blocks = []
+    authority_nonce = 0
+
+    # Setup phase: initialize storage slots (only if absent_slots=False)
     if not absent_slots:
-        slots_init = Op.PUSH4(num_target_slots) + While(
-            body=Op.SSTORE(Op.DUP1, Op.DUP1),
-            condition=Op.PUSH1(1)
-            + Op.SWAP1
-            + Op.SUB
-            + Op.DUP1
-            + Op.ISZERO
-            + Op.ISZERO,
+        setup_txs = []
+
+        with TestPhaseManager.setup():
+            delegation_sender = pre.fund_eoa()
+            delegation_tx = Transaction(
+                to=delegation_sender,
+                gas_limit=tx_gas_limit,
+                sender=delegation_sender,
+                authorization_list=[
+                    AuthorizationTuple(
+                        address=initializer_addr,
+                        nonce=authority_nonce,
+                        signer=authority,
+                    ),
+                ],
+            )
+            authority_nonce += 1
+
+            setup_txs.append(delegation_tx)
+
+            current_slot = 1
+            remaining_slots = num_target_slots
+
+            while remaining_slots > 0:
+                if (
+                    tx_gas_limit
+                    < max_intrinsic + init_overhead + init_loop_cost
+                ):
+                    break
+
+                slots = (
+                    tx_gas_limit - max_intrinsic - init_overhead
+                ) // init_loop_cost
+                slots = min(slots, remaining_slots)
+
+                calldata = bytes(Hash(current_slot)) + bytes(Hash(slots))
+                execution_intrinsic = intrinsic_calc(calldata=calldata)
+
+                slots = (
+                    tx_gas_limit - execution_intrinsic - init_overhead
+                ) // init_loop_cost
+                slots = min(slots, remaining_slots)
+
+                setup_txs.append(
+                    Transaction(
+                        to=authority,
+                        gas_limit=tx_gas_limit,
+                        data=Hash(current_slot) + Hash(slots),
+                        sender=pre.fund_eoa(),
+                    )
+                )
+                current_slot += slots
+                remaining_slots -= slots
+
+            blocks.append(Block(txs=setup_txs))
+
+    # Execution phase: run benchmark
+    # For absent_slots=False, authority has storage, triggering refund
+    expected_gas_used = delegation_intrinsic
+    exec_txs = []
+
+    if not absent_slots:
+        expected_gas_used -= min(
+            gas_costs.R_AUTHORIZATION_EXISTING_AUTHORITY,
+            delegation_intrinsic // 5,
         )
 
-    # To create the contract, we apply the slots_init code to initialize the
-    # storage slots (int the case of absent_slots=False) and then copy the
-    # execution code to the contract.
-    creation_code = (
-        slots_init
-        + Op.EXTCODECOPY(
-            address=execution_code_address,
-            dest_offset=0,
-            offset=0,
-            size=Op.EXTCODESIZE(execution_code_address),
-        )
-        + Op.RETURN(0, Op.MSIZE)
-    )
-    sender_addr = pre.fund_eoa()
     with TestPhaseManager.setup():
-        setup_tx = Transaction(
-            to=None,
-            gas_limit=env.gas_limit,
-            data=creation_code,
-            sender=sender_addr,
+        delegation_sender = pre.fund_eoa()
+        delegation_tx = Transaction(
+            to=delegation_sender,
+            gas_limit=tx_gas_limit,
+            sender=delegation_sender,
+            authorization_list=[
+                AuthorizationTuple(
+                    address=executor_addr,
+                    nonce=authority_nonce,
+                    signer=authority,
+                ),
+            ],
         )
 
-    blocks = [Block(txs=[setup_tx])]
-
-    contract_address = compute_create_address(address=sender_addr, nonce=0)
+    exec_txs.append(delegation_tx)
+    current_slot = 1
+    gas_remaining = gas_benchmark_value - delegation_intrinsic
 
     with TestPhaseManager.execution():
-        op_tx = Transaction(
-            to=contract_address,
-            gas_limit=gas_benchmark_value,
-            sender=pre.fund_eoa(),
-        )
-    blocks.append(Block(txs=[op_tx]))
+        while gas_remaining > 0:
+            tx_gas = min(tx_gas_limit, gas_remaining)
+
+            if tx_gas < max_intrinsic + exec_overhead + exec_loop_cost:
+                break
+
+            slots = (tx_gas - max_intrinsic - exec_overhead) // exec_loop_cost
+
+            calldata = bytes(Hash(current_slot)) + bytes(Hash(slots))
+            execution_intrinsic = intrinsic_calc(calldata=calldata)
+            slots = (
+                tx_gas - execution_intrinsic - exec_overhead
+            ) // exec_loop_cost
+
+            if tx_result == TransactionResult.OUT_OF_GAS:
+                slots = slots * 2
+
+            exec_txs.append(
+                Transaction(
+                    to=authority,
+                    gas_limit=tx_gas,
+                    data=Hash(current_slot) + Hash(slots),
+                    sender=pre.fund_eoa(),
+                )
+            )
+
+            if tx_result == TransactionResult.OUT_OF_GAS:
+                expected_gas_used += tx_gas
+            else:
+                expected_gas_used += (
+                    intrinsic_calc(
+                        calldata=calldata,
+                        return_cost_deducted_prior_execution=True,
+                    )
+                    + slots * exec_loop_cost
+                    + exec_overhead
+                )
+                current_slot += slots
+
+            gas_remaining -= tx_gas
+
+    blocks.append(Block(txs=exec_txs))
 
     benchmark_test(
         blocks=blocks,
-        expected_benchmark_gas_used=(
-            total_gas_used
-            if tx_result != TransactionResult.OUT_OF_GAS
-            else gas_benchmark_value
-        ),
+        expected_benchmark_gas_used=expected_gas_used,
     )
 
 
@@ -319,9 +476,7 @@ def test_storage_access_cold_benchmark(
         target_opcode=Op.SLOAD
         if storage_action == StorageAction.READ
         else Op.SSTORE,
-        code_generator=ExtCallGenerator(
-            attack_block=attack_block,
-        ),
+        code_generator=ExtCallGenerator(attack_block=attack_block),
     )
 
 
@@ -340,25 +495,19 @@ def test_storage_access_warm(
     gas_benchmark_value: int,
     tx_gas_limit: int,
 ) -> None:
-    """
-    Benchmark warm storage slot accesses.
-    """
+    """Benchmark warm storage slot accesses."""
     blocks = []
 
-    # The warm access is done in storage slot 0.
-
-    # Contract code
-    execution_code_body = Bytecode()
     if storage_action == StorageAction.WRITE_SAME_VALUE:
         execution_code_body = Op.SSTORE(0, Op.DUP1)
     elif storage_action == StorageAction.WRITE_NEW_VALUE:
         execution_code_body = Op.SSTORE(0, Op.GAS)
     elif storage_action == StorageAction.READ:
         execution_code_body = Op.POP(Op.SLOAD(0))
+    else:
+        execution_code_body = Bytecode()
 
-    execution_code = Op.SLOAD(0) + While(
-        body=execution_code_body,
-    )
+    execution_code = Op.SLOAD(0) + While(body=execution_code_body)
     execution_code_address = pre.deploy_contract(code=execution_code)
 
     creation_code = (
@@ -391,12 +540,13 @@ def test_storage_access_warm(
             gas_limit = min(
                 tx_gas_limit, gas_benchmark_value - i * tx_gas_limit
             )
-            op_tx = Transaction(
-                to=contract_address,
-                gas_limit=gas_limit,
-                sender=pre.fund_eoa(),
+            txs.append(
+                Transaction(
+                    to=contract_address,
+                    gas_limit=gas_limit,
+                    sender=pre.fund_eoa(),
+                )
             )
-            txs.append(op_tx)
         blocks.append(Block(txs=txs))
 
     benchmark_test(blocks=blocks)
@@ -421,19 +571,18 @@ def test_storage_access_warm_benchmark(
     Each iteration accesses a different storage slot (incrementing key)
     to ensure warm access costs are measured.
     """
-    attack_block = Bytecode()
     if storage_action == StorageAction.WRITE_SAME_VALUE:
         attack_block = Op.SSTORE(Op.PUSH0, Op.PUSH0)
     elif storage_action == StorageAction.WRITE_NEW_VALUE:
         attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)
     elif storage_action == StorageAction.READ:
         attack_block = Op.SLOAD(Op.PUSH0)
+    else:
+        attack_block = Bytecode()
 
     benchmark_test(
         target_opcode=Op.SLOAD
         if storage_action == StorageAction.READ
         else Op.SSTORE,
-        code_generator=ExtCallGenerator(
-            attack_block=attack_block,
-        ),
+        code_generator=ExtCallGenerator(attack_block=attack_block),
     )

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -190,15 +190,15 @@ def test_block_full_of_ether_transfers(
 
 
 @pytest.fixture
-def total_cost_floor_per_token() -> int:
-    """Total cost floor per token."""
-    return 10
+def total_cost_floor_per_token(fork: Fork) -> int:
+    """Total cost floor per token (EIP-7623)."""
+    return fork.gas_costs().G_TX_DATA_FLOOR_TOKEN_COST
 
 
 @pytest.fixture
-def total_cost_standard_per_token() -> int:
-    """Total cost floor per token."""
-    return 4
+def total_cost_standard_per_token(fork: Fork) -> int:
+    """Standard cost per token (EIP-7623)."""
+    return fork.gas_costs().G_TX_DATA_STANDARD_TOKEN_COST
 
 
 def calldata_generator(
@@ -251,13 +251,37 @@ def test_block_full_data(
     tx_gas_limit: int,
     fork: Fork,
 ) -> None:
-    """Test a block with empty payload."""
+    """Test a block full of calldata, respecting RLP size limits."""
     iteration_count = math.ceil(gas_benchmark_value / tx_gas_limit)
 
-    gas_remaining = gas_benchmark_value
+    # check for EIP-7934 block RLP size limit and cap gas to stay under it
+    block_rlp_limit = fork.block_rlp_size_limit()
+    effective_gas = gas_benchmark_value
+
+    if block_rlp_limit:
+        # Max calldata bytes at 99% of limit (Osaka: 8,388,608 * 0.99 ≈ 8.3 MB)
+        safe_calldata_bytes = int(block_rlp_limit * 0.99)
+
+        # convert to gas: zero bytes = 10 gas/byte, non-zero = 40 gas/byte
+        gas_per_byte = (
+            total_cost_floor_per_token
+            if zero_byte
+            else total_cost_floor_per_token * 4
+        )
+        # For zero bytes: 8.3MB * 10 = 83M gas just for calldata
+        max_calldata_gas = safe_calldata_bytes * gas_per_byte
+        # Add intrinsic cost per tx (Osaka): 83M + 6 txs * 21k ≈ 83.1M total
+        rlp_limited_gas = max_calldata_gas + iteration_count * intrinsic_cost
+
+        # use the min between benchmark target and the RLP limit
+        effective_gas = min(gas_benchmark_value, rlp_limited_gas)
+
+    gas_remaining = effective_gas
     total_gas_used = 0
     txs = []
     for _ in range(iteration_count):
+        if gas_remaining <= intrinsic_cost:
+            break
         gas_available = min(tx_gas_limit, gas_remaining) - intrinsic_cost
         data = calldata_generator(
             gas_available,

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,7 @@ commands =
         --evm-bin={env:EVM_BIN:evmone-t8n} \
         --gas-benchmark-values 1 \
         --generate-pre-alloc-groups \
-        --fork Prague \
+        --fork Osaka \
         -m "benchmark and not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Update workflow from Prague to Osaka for benchmark

Refactor `test_storage_access_cold` benchmark.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
