### PR TITLE
refactor(spec-tool): remove unused fields

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
@@ -49,17 +49,12 @@ class BaseLoad(ABC):
 class Load(BaseLoad):
     """Class for loading json fixtures."""
 
-    _network: str
-    _fork_module: str
     fork: ForkLoad
 
     def __init__(self, network: str, fork_module: str | Hardfork):
-        self._network = network
         if isinstance(fork_module, Hardfork):
             self.fork = ForkLoad(fork_module)
-            self._fork_module = fork_module.short_name
         else:
-            self._fork_module = fork_module
             for fork in Hardfork.discover():
                 if fork.short_name == fork_module:
                     self.fork = ForkLoad(fork)

--- a/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fixture_loader.py
@@ -51,7 +51,7 @@ class Load(BaseLoad):
 
     fork: ForkLoad
 
-    def __init__(self, network: str, fork_module: str | Hardfork):
+    def __init__(self, fork_module: str | Hardfork):
         if isinstance(fork_module, Hardfork):
             self.fork = ForkLoad(fork_module)
         else:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -256,10 +256,7 @@ class T8N(Load):
 
         self.logger = get_stream_logger("T8N")
 
-        super().__init__(
-            self.options.state_fork,
-            fork,
-        )
+        super().__init__(fork)
 
         self.chain_id = parse_hex_or_int(self.options.state_chainid, U64)
         self.alloc = Alloc(self, stdin)

--- a/tests/json_infra/helpers/load_blockchain_tests.py
+++ b/tests/json_infra/helpers/load_blockchain_tests.py
@@ -121,10 +121,7 @@ class BlockchainTestFixture(Fixture, FixtureTestItem):
                 f"{self.test_file}[{self.test_key}] has unrelated exceptions"
             )
 
-        load = Load(
-            self.fork_name,
-            self.eels_fork,
-        )
+        load = Load(self.eels_fork)
 
         genesis_header = load.json_to_header(json_data["genesisBlockHeader"])
         parameters = [

--- a/tests/json_infra/test_ethash.py
+++ b/tests/json_infra/test_ethash.py
@@ -142,7 +142,7 @@ def test_pow_validation_block_headers(
     ).decode()
     block_json_data = json.loads(block_str_data)
 
-    load = Load(json_fork, eels_fork)
+    load = Load(eels_fork)
     header = load.json_to_header(block_json_data)
     fork_module.validate_proof_of_work(header)
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -83,9 +83,6 @@ EELST8N.version
 EELST8N.is_fork_supported
 EELST8N.evaluate
 
-# src/ethereum_spec_tools/loaders/fixture_loader.py
-Load._network
-
 # src/ethereum_spec_tools/loaders/transaction_loader.py
 TransactionLoad.json_to_authorizations
 TransactionLoad.json_to_chain_id

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -16,7 +16,6 @@ from ethereum.utils.hexadecimal import hex_to_bytes256
 from ethereum_optimized.state_db import State
 from ethereum_spec_tools.docc import *
 from ethereum_spec_tools.evm_tools.daemon import _EvmToolHandler
-from ethereum_spec_tools.evm_tools.loaders.fixture_loader import Load
 from ethereum_spec_tools.evm_tools.loaders.transaction_loader import (
     TransactionLoad,
 )


### PR DESCRIPTION
Previously, the Load class stored _network and _fork_module fields that were never read anywhere in the codebase. One of them was even whitelisted in vulture_whitelist.py despite having no real dynamic usage. This made the loader API misleading and introduced unnecessary internal state.