### PR TITLE
src(fix): framework bug fix for slotnum

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -25,6 +25,7 @@ from execution_testing.base_types import (
     HeaderNonce,
     HexNumber,
     Number,
+    ZeroPaddedHexNumber,
 )
 from execution_testing.client_clis import (
     BlockExceptionWithMessage,
@@ -654,19 +655,32 @@ class BlockchainTest(BaseTest):
         ) > 0:
             blob_gas_used = blob_gas_per_blob * count_blobs(txs)
 
+        # Prepare slot_number for header initialization
+        slot_number_value: ZeroPaddedHexNumber | None = None
+        if self.fork.header_slot_number_required(
+            block_number=int(env.number), timestamp=int(env.timestamp)
+        ):
+            slot_number_value = ZeroPaddedHexNumber(
+                int(env.slot_number) if env.slot_number is not None else 0
+            )
+
         header = FixtureHeader(
             **(
                 transition_tool_output.result.model_dump(
                     exclude_none=True,
                     exclude={"blob_gas_used", "transactions_trie"},
                 )
-                | env.model_dump(exclude_none=True, exclude={"blob_gas_used"})
+                | env.model_dump(
+                    exclude_none=True,
+                    exclude={"blob_gas_used", "slot_number"},
+                )
             ),
             blob_gas_used=blob_gas_used,
             transactions_trie=Transaction.list_root(txs),
             extra_data=block.extra_data
             if block.extra_data is not None
             else b"",
+            slot_number=slot_number_value,
             fork=self.fork,
         )
 


### PR DESCRIPTION
## 🗒️ Description
With this patch on our side and [this patch on geth's side](https://github.com/ethereum/go-ethereum/pull/33723) I was able to successfully run all 7843 tests against geth. also almost all 8024 tests pass (179 out of 184)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
