### PR TITLE
feat(specs): add max bal item check

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -230,7 +230,7 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "call failed:",
         BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "deposit",
         BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
-            "BlockAccessListGasLimitExceededError"
+            "Block access list exceeds gas limit"
         ),
         TransactionException.LOG_MISMATCH: "LogMismatchError",
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -229,6 +229,9 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_EMPTY: "System contract address",
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: "call failed:",
         BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: "deposit",
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            "BlockAccessListGasLimitExceededError"
+        ),
         TransactionException.LOG_MISMATCH: "LogMismatchError",
     }
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {

--- a/packages/testing/src/execution_testing/exceptions/exceptions/block.py
+++ b/packages/testing/src/execution_testing/exceptions/exceptions/block.py
@@ -186,3 +186,7 @@ class BlockException(ExceptionBase):
     """
     Block BAL is missing an account change that is present in the computed BAL.
     """
+    BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED = auto()
+    """
+    Block access list exceeds the gas limit constraint (EIP-7928).
+    """

--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -361,6 +361,19 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
         """Return true if the header must contain block access list hash."""
         pass
 
+    @classmethod
+    @abstractmethod
+    def empty_block_bal_item_count(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """
+        Return the number of BAL items produced by an empty block.
+
+        Each system contract address counts as 1 item, and each unique
+        storage key it touches (reads or writes) counts as 1 item.
+        """
+        pass
+
     # Gas related abstract methods
 
     @classmethod

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3449,7 +3449,7 @@ class Amsterdam(BPO2):
         in EIP-7928.
         """
         return replace(
-            super(Osaka, cls).gas_costs(
+            super(Amsterdam, cls).gas_costs(
                 block_number=block_number, timestamp=timestamp
             ),
             GAS_BLOCK_ACCESS_LIST_ITEM=2000,

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -200,6 +200,7 @@ class Frontier(BaseFork, solc_name="homestead"):
             GAS_PRECOMPILE_BLS_PAIRING_BASE=0,
             GAS_PRECOMPILE_BLS_PAIRING_PER_PAIR=0,
             GAS_PRECOMPILE_P256VERIFY=0,
+            GAS_BLOCK_ACCESS_LIST_ITEM=0,
         )
 
     @classmethod
@@ -1010,6 +1011,14 @@ class Frontier(BaseFork, solc_name="homestead"):
         """At genesis, header must not contain block access list hash."""
         del block_number, timestamp
         return False
+
+    @classmethod
+    def empty_block_bal_item_count(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Pre-Amsterdam forks have no block access list."""
+        del block_number, timestamp
+        return 0
 
     @classmethod
     def engine_new_payload_version(
@@ -3430,6 +3439,37 @@ class Amsterdam(BPO2):
         """
         del block_number, timestamp
         return True
+
+    @classmethod
+    def gas_costs(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> GasCosts:
+        """
+        On Amsterdam, the cost per block access list item is introduced
+        in EIP-7928.
+        """
+        return replace(
+            super(Osaka, cls).gas_costs(
+                block_number=block_number, timestamp=timestamp
+            ),
+            GAS_BLOCK_ACCESS_LIST_ITEM=2000,
+        )
+
+    @classmethod
+    def empty_block_bal_item_count(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """
+        Return the BAL item count for an empty Amsterdam block.
+
+        Four system contracts produce 15 items:
+          EIP-4788 beacon roots:           1 address + 1 write + 1 read = 3
+          EIP-2935 history storage:        1 address + 1 write          = 2
+          EIP-7002 withdrawal requests:    1 address + 4 reads          = 5
+          EIP-7251 consolidation requests: 1 address + 4 reads          = 5
+        """
+        del block_number, timestamp
+        return 15
 
     @classmethod
     def is_deployed(cls) -> bool:

--- a/packages/testing/src/execution_testing/forks/gas_costs.py
+++ b/packages/testing/src/execution_testing/forks/gas_costs.py
@@ -89,3 +89,5 @@ class GasCosts:
     # Refund constants
     REFUND_STORAGE_CLEAR: int
     REFUND_AUTH_PER_EXISTING_ACCOUNT: int
+
+    GAS_BLOCK_ACCESS_LIST_ITEM: int

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -763,4 +763,7 @@ def validate_block_access_list_gas_limit(
         bal_items += Uint(len(unique_slots))
 
     if bal_items > block_gas_limit // item_cost:
-        raise BlockAccessListGasLimitExceededError
+        raise BlockAccessListGasLimitExceededError(
+            f"Block access list exceeds gas limit, {bal_items} items is "
+            f"exceeds limit of {block_gas_limit // item_cost}."
+        )

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -25,7 +25,6 @@ from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from .exceptions import BlockAccessListGasLimitExceededError
 from .state_tracker import BlockState, TransactionState, get_code
-from .transactions import GAS_TX_ACCESS_LIST_STORAGE_KEY
 
 # TODO: Either remove or generalize these type aliases (#2260).
 
@@ -743,10 +742,9 @@ def validate_block_access_list_gas_limit(
     Validate that the block access list does not exceed the gas limit.
 
     The total number of items (addresses + unique storage keys) must not
-    exceed ``block_gas_limit // ITEM_COST``, where
-    ``ITEM_COST = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST``.
+    exceed ``block_gas_limit // ITEM_COST``, where ``ITEM_COST = 2000``.
     """
-    from .vm.gas import GAS_WARM_ACCESS
+    item_cost = Uint(2000)
 
     bal_items = Uint(0)
     for account in block_access_list:
@@ -763,8 +761,6 @@ def validate_block_access_list_gas_limit(
 
         # Count each unique storage key as one item
         bal_items += Uint(len(unique_slots))
-
-    item_cost = GAS_WARM_ACCESS + GAS_TX_ACCESS_LIST_STORAGE_KEY
 
     if bal_items > block_gas_limit // item_cost:
         raise BlockAccessListGasLimitExceededError

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -25,7 +25,7 @@ from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from .exceptions import BlockAccessListGasLimitExceededError
 from .state_tracker import BlockState, TransactionState, get_code
-from .transactions import TX_ACCESS_LIST_STORAGE_KEY_COST
+from .transactions import GAS_TX_ACCESS_LIST_STORAGE_KEY
 
 # TODO: Either remove or generalize these type aliases (#2260).
 
@@ -743,7 +743,7 @@ def validate_block_access_list_gas_limit(
     ``bal_items <= block_gas_limit // ITEM_COST``
 
     Where ``bal_items = storage_keys + addresses`` and
-    ``ITEM_COST = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST``.
+    ``ITEM_COST = GAS_WARM_ACCESS + GAS_TX_ACCESS_LIST_STORAGE_KEY``.
 
     Parameters
     ----------
@@ -776,7 +776,7 @@ def validate_block_access_list_gas_limit(
         # Count each unique storage key as one item
         bal_items += Uint(len(unique_slots))
 
-    item_cost = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST
+    item_cost = GAS_WARM_ACCESS + GAS_TX_ACCESS_LIST_STORAGE_KEY
 
     if bal_items > block_gas_limit // item_cost:
         raise BlockAccessListGasLimitExceededError

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -23,7 +23,9 @@ from ethereum_types.numeric import U16, U64, U256, Uint
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
+from .exceptions import BlockAccessListGasLimitExceededError
 from .state_tracker import BlockState, TransactionState, get_code
+from .transactions import TX_ACCESS_LIST_STORAGE_KEY_COST
 
 # TODO: Either remove or generalize these type aliases (#2260).
 
@@ -728,3 +730,53 @@ def hash_block_access_list(
     Compute the hash of a Block Access List.
     """
     return keccak256(rlp.encode(block_access_list))
+
+
+def validate_block_access_list_gas_limit(
+    block_access_list: BlockAccessList,
+    block_gas_limit: Uint,
+) -> None:
+    """
+    Validate that the block access list does not exceed the gas limit.
+
+    The constraint is:
+    ``bal_items <= block_gas_limit // ITEM_COST``
+
+    Where ``bal_items = storage_keys + addresses`` and
+    ``ITEM_COST = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST``.
+
+    Parameters
+    ----------
+    block_access_list :
+        The block access list to validate.
+    block_gas_limit :
+        The gas limit of the block.
+
+    Raises
+    ------
+    BlockAccessListGasLimitExceededError :
+        If the block access list exceeds the gas limit constraint.
+
+    """
+    from .vm.gas import GAS_WARM_ACCESS
+
+    count_bal_items = Uint(0)
+    for account in block_access_list:
+        # Count each address as one item
+        count_bal_items += Uint(1)
+
+        # Collect unique storage keys across both
+        # reads and writes
+        unique_slots: Set[U256] = set()
+        for slot_change in account.storage_changes:
+            unique_slots.add(slot_change.slot)
+        for slot in account.storage_reads:
+            unique_slots.add(slot)
+
+        # Count each unique storage key as one item
+        count_bal_items += Uint(len(unique_slots))
+
+    item_cost = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST
+
+    if bal_items > block_gas_limit // item_cost:
+        raise BlockAccessListGasLimitExceededError

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -742,24 +742,9 @@ def validate_block_access_list_gas_limit(
     """
     Validate that the block access list does not exceed the gas limit.
 
-    The constraint is:
-    ``bal_items <= block_gas_limit // ITEM_COST``
-
-    Where ``bal_items = storage_keys + addresses`` and
-    ``ITEM_COST = GAS_WARM_ACCESS + GAS_TX_ACCESS_LIST_STORAGE_KEY``.
-
-    Parameters
-    ----------
-    block_access_list :
-        The block access list to validate.
-    block_gas_limit :
-        The gas limit of the block.
-
-    Raises
-    ------
-    BlockAccessListGasLimitExceededError :
-        If the block access list exceeds the gas limit constraint.
-
+    The total number of items (addresses + unique storage keys) must not
+    exceed ``block_gas_limit // ITEM_COST``, where
+    ``ITEM_COST = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST``.
     """
     from .vm.gas import GAS_WARM_ACCESS
 

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -560,6 +560,9 @@ def _build_from_builder(
        - Storage slots (lexicographically)
        - Transaction indices (numerically) for each change type
 
+    Addresses, storage slots, and block access indices are unique.
+    Storage reads that also appear in storage changes are excluded.
+
     [`BlockAccessList`]: ref:ethereum.forks.amsterdam.block_access_lists.BlockAccessList
     """  # noqa: E501
     block_access_list: BlockAccessList = []

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -742,9 +742,9 @@ def validate_block_access_list_gas_limit(
     Validate that the block access list does not exceed the gas limit.
 
     The total number of items (addresses + unique storage keys) must not
-    exceed ``block_gas_limit // ITEM_COST``, where ``ITEM_COST = 2000``.
+    exceed ``block_gas_limit // GAS_BLOCK_ACCESS_LIST_ITEM``.
     """
-    item_cost = Uint(2000)
+    from .vm.gas import GAS_BLOCK_ACCESS_LIST_ITEM
 
     bal_items = Uint(0)
     for account in block_access_list:
@@ -762,8 +762,9 @@ def validate_block_access_list_gas_limit(
         # Count each unique storage key as one item
         bal_items += Uint(len(unique_slots))
 
-    if bal_items > block_gas_limit // item_cost:
+    if bal_items > block_gas_limit // GAS_BLOCK_ACCESS_LIST_ITEM:
         raise BlockAccessListGasLimitExceededError(
-            f"Block access list exceeds gas limit, {bal_items} items is "
-            f"exceeds limit of {block_gas_limit // item_cost}."
+            f"Block access list exceeds gas limit, {bal_items} items "
+            f"exceeds limit of "
+            f"{block_gas_limit // GAS_BLOCK_ACCESS_LIST_ITEM}."
         )

--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -760,10 +760,10 @@ def validate_block_access_list_gas_limit(
     """
     from .vm.gas import GAS_WARM_ACCESS
 
-    count_bal_items = Uint(0)
+    bal_items = Uint(0)
     for account in block_access_list:
         # Count each address as one item
-        count_bal_items += Uint(1)
+        bal_items += Uint(1)
 
         # Collect unique storage keys across both
         # reads and writes
@@ -774,7 +774,7 @@ def validate_block_access_list_gas_limit(
             unique_slots.add(slot)
 
         # Count each unique storage key as one item
-        count_bal_items += Uint(len(unique_slots))
+        bal_items += Uint(len(unique_slots))
 
     item_cost = GAS_WARM_ACCESS + TX_ACCESS_LIST_STORAGE_KEY_COST
 

--- a/src/ethereum/forks/amsterdam/exceptions.py
+++ b/src/ethereum/forks/amsterdam/exceptions.py
@@ -129,3 +129,13 @@ class TransactionGasLimitExceededError(InvalidTransaction):
     Note that this is _not_ the exception thrown when bytecode execution runs
     out of gas.
     """
+
+
+class BlockAccessListGasLimitExceededError(Exception):
+    """
+    The block access list exceeds the gas limit constraint.
+
+    Introduced in [EIP-7928].
+
+    [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
+    """

--- a/src/ethereum/forks/amsterdam/exceptions.py
+++ b/src/ethereum/forks/amsterdam/exceptions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Final
 
 from ethereum_types.numeric import Uint
 
-from ethereum.exceptions import InvalidTransaction
+from ethereum.exceptions import InvalidBlock, InvalidTransaction
 
 if TYPE_CHECKING:
     from .transactions import Transaction
@@ -131,7 +131,7 @@ class TransactionGasLimitExceededError(InvalidTransaction):
     """
 
 
-class BlockAccessListGasLimitExceededError(Exception):
+class BlockAccessListGasLimitExceededError(InvalidBlock):
     """
     The block access list exceeds the gas limit constraint.
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -35,6 +35,7 @@ from .block_access_lists import (
     BlockAccessListBuilder,
     build_block_access_list,
     hash_block_access_list,
+    validate_block_access_list_gas_limit,
 )
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
@@ -812,6 +813,12 @@ def apply_body(
 
     block_output.block_access_list = build_block_access_list(
         block_env.block_access_list_builder, block_env.state
+    )
+
+    # Validate block access list gas limit constraint (EIP-7928)
+    validate_block_access_list_gas_limit(
+        block_access_list=block_output.block_access_list,
+        block_gas_limit=block_env.block_gas_limit,
     )
 
     return block_output

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -84,6 +84,8 @@ GAS_BLS_G2_ADD = Uint(600)
 GAS_BLS_G2_MUL = Uint(22500)
 GAS_BLS_G2_MAP = Uint(23800)
 
+GAS_BLOCK_ACCESS_LIST_ITEM = Uint(2000)
+
 
 @dataclass
 class ExtendMemory:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -22,6 +22,7 @@ from ethereum.fork_criteria import ByBlockNumber, ByTimestamp, Unscheduled
 from ethereum.forks.amsterdam.block_access_lists import (
     BlockAccessIndex,
     BlockAccessListBuilder,
+    validate_block_access_list_gas_limit,
 )
 from ethereum_spec_tools.forks import Hardfork, TemporaryHardfork
 
@@ -463,6 +464,12 @@ class T8N(Load):
         if self.fork.has_hash_block_access_list:
             block_output.block_access_list = self.fork.build_block_access_list(
                 block_env.block_access_list_builder, block_env.state
+            )
+
+            # Validate block access list gas limit constraint (EIP-7928)
+            validate_block_access_list_gas_limit(
+                block_access_list=block_output.block_access_list,
+                block_gas_limit=block_env.block_gas_limit,
             )
 
     def run_blockchain_test(self) -> None:

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -18,6 +18,7 @@ from execution_testing import (
     Block,
     BlockAccessListExpectation,
     BlockchainTestFiller,
+    BlockException,
     Environment,
     Fork,
     Hash,
@@ -2644,4 +2645,54 @@ def test_bal_lexicographic_address_ordering(
             addr_endian_low: Account(balance=addr_balance),
             addr_endian_high: Account(balance=addr_balance),
         },
+    )
+
+
+@pytest.mark.parametrize(
+    "boundary_offset",
+    [
+        pytest.param(0, id="at_boundary"),
+        pytest.param(
+            -1,
+            marks=pytest.mark.exception_test,
+            id="below_boundary",
+        ),
+    ],
+)
+def test_bal_gas_limit_boundary(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    boundary_offset: int,
+) -> None:
+    """
+    Test the BAL max items gas limit boundary for an empty block.
+
+    The consensus rule requires
+    ``bal_items <= block_gas_limit // GAS_BLOCK_ACCESS_LIST_ITEM``.
+    The boundary gas limit is derived from the fork's system-contract
+    BAL footprint.  At the boundary the check passes; one below it fails.
+    """
+    # EIP-7928
+    # bal_items <= block_gas_limit // ITEM_COST
+    min_gas_limit = (
+        fork.empty_block_bal_item_count()
+        * fork.gas_costs().GAS_BLOCK_ACCESS_LIST_ITEM
+    )
+    gas_limit = min_gas_limit + boundary_offset
+
+    block = Block(
+        txs=[],
+        exception=(
+            BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED
+            if boundary_offset < 0
+            else None
+        ),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[block],
+        post={},
+        genesis_environment=Environment(gas_limit=gas_limit),
     )

--- a/tests/frontier/validation/test_header.py
+++ b/tests/frontier/validation/test_header.py
@@ -1,6 +1,7 @@
 """Test the block header validations applied from Frontier."""
 
 import pytest
+from execution_testing import Fork
 from execution_testing.base_types.base_types import ZeroPaddedHexNumber
 from execution_testing.base_types.composite_types import Alloc
 from execution_testing.exceptions.exceptions import BlockException
@@ -18,7 +19,14 @@ from execution_testing.test_types.block_types import Environment
         pytest.param(0, marks=pytest.mark.exception_test),
         pytest.param(1, marks=pytest.mark.exception_test),
         pytest.param(4999, marks=pytest.mark.exception_test),
-        5000,
+        pytest.param(5000, marks=pytest.mark.valid_until("Osaka")),
+        pytest.param(
+            5000,
+            marks=[
+                pytest.mark.valid_from("Amsterdam"),
+                pytest.mark.exception_test,
+            ],
+        ),
     ],
 )
 def test_gas_limit_below_minimum(
@@ -26,6 +34,7 @@ def test_gas_limit_below_minimum(
     pre: Alloc,
     gas_limit: int,
     env: Environment,
+    fork: Fork,
 ) -> None:
     """
     Tests that a block with a gas limit below the minimum throws an error.
@@ -33,12 +42,12 @@ def test_gas_limit_below_minimum(
     modified_fields = {"gas_limit": gas_limit}
     env.gas_limit = ZeroPaddedHexNumber(5000)
 
-    block = Block(
-        txs=[],
-        rlp_modifier=Header(**modified_fields),
-        exception=BlockException.INVALID_GASLIMIT
-        if gas_limit < 5000
-        else None,
-    )
+    block = Block(txs=[])
+
+    if gas_limit < 5000:
+        block.rlp_modifier = Header(**modified_fields)
+        block.exception = BlockException.INVALID_GASLIMIT
+    elif fork.header_bal_hash_required():
+        block.exception = BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED
 
     blockchain_test(pre=pre, post={}, blocks=[block], genesis_environment=env)

--- a/tests/static/state_tests/stStaticCall/static_InternalCallHittingGasLimitFiller.json
+++ b/tests/static/state_tests/stStaticCall/static_InternalCallHittingGasLimitFiller.json
@@ -3,7 +3,7 @@
         "env" : {
             "currentCoinbase" : "2adf5374fce5edbc8e2a8697c15331677e6ebf0b",
             "currentDifficulty" : "0x020000",
-            "currentGasLimit" : "22000",
+            "currentGasLimit" : "100000",
             "currentNumber" : "1",
             "currentTimestamp" : "1000"
         },

--- a/tests/static/state_tests/stTransactionTest/InternalCallHittingGasLimitFiller.json
+++ b/tests/static/state_tests/stTransactionTest/InternalCallHittingGasLimitFiller.json
@@ -3,7 +3,7 @@
         "env" : {
             "currentCoinbase" : "2adf5374fce5edbc8e2a8697c15331677e6ebf0b",
             "currentDifficulty" : "0x020000",
-            "currentGasLimit" : "22000",
+            "currentGasLimit" : "100000",
             "currentNumber" : "1",
             "currentTimestamp" : "1000"
         },


### PR DESCRIPTION
🗒️ Description

Adds a gas limit constraint validation for EIP-7928 block access lists.

It bounds the block access list size based on available gas after accounting for transaction base costs.

Changes:
- Add BlockAccessListGasLimitExceededError exception
- Add validate_block_access_list_gas_limit() in block_access_lists/builder.py
- Call validation after building the BAL in apply_body()

🔗 Related Issues or PRs

https://github.com/ethereum/EIPs/pull/11223