### PR TITLE
chore(ci): only fill native test formats in tox's `pypy3` env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ commands =
 description = Fill the tests using EELS (with Python)
 commands =
     fill \
-        -m "not slow and not zkevm and not benchmark" \
+        -m "not slow and not benchmark" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --skip-index \
         --cov-config=pyproject.toml \
@@ -123,12 +123,12 @@ commands =
         --tb=no \
         --show-capture=no \
         --disable-warnings \
-        -m "not slow and not zkevm and not benchmark" \
+        -m "not slow and not benchmark and not derived_test" \
         -n auto --maxprocesses 7 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \
-        --until BPO4 \
+        --until Amsterdam \
         {posargs} \
         tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \
-        --until Amsterdam \
+        --fork Amsterdam \
         {posargs} \
         tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -128,7 +128,7 @@ commands =
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \
-        --fork Amsterdam \
+        --until Amsterdam \
         {posargs} \
         tests
 


### PR DESCRIPTION
## 🗒️ Description

This PR introduces a workaround for memory issues while running the tox `pypy3` env (with Amsterdam tests) on our CI runners:
1. Bump `--until=BPO4` to `--until=Amsterdam`.
2. Don't `fill` derived tests formats; only fill the native test format: `-m "not derived_test".
    - E.g., the `blockchain_test_engine`, `blockchain_test_from_state_test`, fixture formats get ignored.
3. Clean-up: It additionally removes references to the unused `zkevm` marker.

~~Not filling derived test formats (point 1.) was not enough to enable `--until=Amsterdam`; 2. was necessary as well.~~
**Update:** With the various optimizations this week, pypy3 now fills (with these changes in ~22 mins). I think we can merge this, but we will have to continue to be mindful that we will run into issues again as we add new tests, probably latest in Bogota.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes #2055
- #2055

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img height="512" alt="image" src="https://github.com/user-attachments/assets/5f6798ef-77ff-4780-bcad-72105535dff2" />
