### PR TITLE
chore(tooling,ci): throttle py3 xdist workers locally, use all cores in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,8 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Run py3 tests
         run: tox -e py3
+        env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
         with:
@@ -152,6 +154,8 @@ jobs:
       - uses: ./.github/actions/build-evmone
       - name: Run py3 tests
         run: tox -e tests_pytest_py3
+        env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: auto
 
   tests_pytest_pypy3:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ dev = [
     { include-group = "doc" },
     { include-group = "mkdocs" },
     "ethereum-execution[optimized]",
+    "psutil>=7.2.2",
 ]
 
 [tool.setuptools.dynamic]

--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,7 @@ description = Fill the tests using EELS (with Python)
 commands =
     fill \
         -m "not slow and not benchmark" \
+        # loadgroup: serialize xdist_group("bigmem") tests onto one worker to limit peak memory
         -n {env:PYTEST_XDIST_AUTO_NUM_WORKERS:6} --dist=loadgroup \
         --skip-index \
         --cov-config=pyproject.toml \
@@ -124,7 +125,9 @@ commands =
         --show-capture=no \
         --disable-warnings \
         -m "not slow and not benchmark and not derived_test" \
-        -n auto --maxprocesses 7 --dist=loadgroup \
+        -n auto --maxprocesses 7 \
+        # loadgroup: serialize xdist_group("bigmem") tests onto one worker to limit peak memory
+        --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
         --log-to "{toxworkdir}/logs" \
         --clean \

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ description = Fill the tests using EELS (with Python)
 commands =
     fill \
         -m "not slow and not benchmark" \
-        -n auto --maxprocesses 10 --dist=loadgroup \
+        -n auto --dist=loadgroup \
         --skip-index \
         --cov-config=pyproject.toml \
         --cov=ethereum \

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ changedir = {toxinidir}/packages/testing
 package = editable
 commands =
     pytest \
-        -n auto --maxprocesses 6 \
+        -n {env:PYTEST_XDIST_AUTO_NUM_WORKERS:6} \
         --basetemp="{temp_dir}/pytest" \
         --ignore=src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py \
         {posargs} \
@@ -92,7 +92,7 @@ description = Fill the tests using EELS (with Python)
 commands =
     fill \
         -m "not slow and not benchmark" \
-        -n auto --dist=loadgroup \
+        -n {env:PYTEST_XDIST_AUTO_NUM_WORKERS:6} --dist=loadgroup \
         --skip-index \
         --cov-config=pyproject.toml \
         --cov=ethereum \

--- a/uv.lock
+++ b/uv.lock
@@ -869,6 +869,7 @@ dev = [
     { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pyflakes" },
     { name = "pyspelling" },
     { name = "pytest" },
@@ -976,6 +977,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=1.0.0,<2" },
     { name = "mypy", specifier = "==1.17.0" },
     { name = "pillow", specifier = ">=10.0.1,<11" },
+    { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyflakes", specifier = ">=3.0" },
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
     { name = "pytest", specifier = ">=8,<9" },
@@ -1953,6 +1955,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

This PR changes the xdist behavior of the `py3` and `tests_pytest_py3` tox environments such that:
- **All physical available cores are used in CI** on self-hosted runners (`-n auto`) instead of being capped via `--maxprocesses`.
- **Only 6 cores are used for local development, by default**; overridable via [`PYTEST_XDIST_AUTO_NUM_WORKERS`](https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus#:~:text=PYTEST_XDIST_AUTO_NUM_WORKERS). This lower default intends to avoid xdist utilizing all cores, which leaves the local workstation unresponsive until the end of the pytest run.

It additionally adds `psutil` to the `dev` dependency group in order to accurately detect the number of physical cores, cf https://pytest-xdist.readthedocs.io/en/stable/distribution.html#running-tests-across-multiple-cpus

### Results

py3 runs:
- 16 workers, but before #2127 (removes 23k tests) and other opts, e.g #2079, #2140:
    ```
    ======== 110675 passed, 1603 skipped, 17 warnings in 1917.08s (0:31:57) ========
    ```
- 16 workers, but after the above optimizations:
    ```
    ======== 87957 passed, 1603 skipped, 17 warnings in 1411.02s (0:23:31) =========
    ```
- 10 workers (before this PR), with the above optimizations:
    ```
    ======== 87957 passed, 1603 skipped, 11 warnings in 1853.90s (0:30:53) =========
    ```

### Approach

Replace `-n auto` (and `-n auto --maxprocesses N`) with:

```
-n {env:PYTEST_XDIST_AUTO_NUM_WORKERS:6}
```

Tox resolves `{env:VAR:default}` at config-parse time from the host shell. CI workflows set the env var to `auto`; locally it falls back to `6`.

| Scenario | Host env | Resolves to |
|---|---|---|
| Local (default) | *unset* | `-n 6` |
| Local (override) | `PYTEST_XDIST_AUTO_NUM_WORKERS=3` | `-n 3` |
| CI | `PYTEST_XDIST_AUTO_NUM_WORKERS=auto` | `-n auto` |

#### Why not `passenv` + `PYTEST_XDIST_AUTO_NUM_WORKERS` directly?

xdist reads `PYTEST_XDIST_AUTO_NUM_WORKERS` from the **child** process environment to resolve `-n auto` to a worker count and requires an integer. Passing `auto` through `passenv` would cause xdist to crash on `int("auto")`. By resolving the env var in tox's own substitution layer, the child process only ever sees `-n <int>` or `-n auto` (with the env var absent), so xdist never encounters a non-integer value.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
#### Cute Animal Picture

:t-rex: 