### PR TITLE
refactor(test-benchmark): add bytecode gas cost calculator

### DIFF
--- a/tests/benchmark/stateful/bloatnet/stubs_bloatnet.json
+++ b/tests/benchmark/stateful/bloatnet/stubs_bloatnet.json
@@ -13,5 +13,11 @@
   "test_mixed_sload_sstore_IMT": "0x13119e34e140097a507b07a5564bde1bc375d9e6",
   "test_sload_empty_erc20_balanceof_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
   "test_sstore_erc20_approve_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
-  "test_mixed_sload_sstore_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17"
+  "test_mixed_sload_sstore_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
+  "bloatnet_factory_0_5kb": "0xDf9da7E8660d38654C8aA267635222c9f5Ac0530",
+  "bloatnet_factory_1kb": "0xA52178573dc859741499946148CA1Fc3822Af600",
+  "bloatnet_factory_2kb": "0x88c159584059308C4B466bafC82c45d52De9951D",
+  "bloatnet_factory_5kb": "0x3f59809dac4b33e251e518acDadf923184151334",
+  "bloatnet_factory_10kb": "0xf90E8a6Ce32A949Ce5F58803BBa07476404cD89F",
+  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef"
 }

--- a/tests/benchmark/stateful/bloatnet/stubs_mainnet.json
+++ b/tests/benchmark/stateful/bloatnet/stubs_mainnet.json
@@ -10,5 +10,11 @@
   "test_mixed_sload_sstore_IMT": "0x13119e34e140097a507b07a5564bde1bc375d9e6",
   "test_sload_empty_erc20_balanceof_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
   "test_sstore_erc20_approve_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
-  "test_mixed_sload_sstore_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17"
+  "test_mixed_sload_sstore_STR": "0x7c4d13a8e743b036f6ba71c5dcadfe4fc9aa7a17",
+  "bloatnet_factory_0_5kb": "0xDf9da7E8660d38654C8aA267635222c9f5Ac0530",
+  "bloatnet_factory_1kb": "0xA52178573dc859741499946148CA1Fc3822Af600",
+  "bloatnet_factory_2kb": "0x88c159584059308C4B466bafC82c45d52De9951D",
+  "bloatnet_factory_5kb": "0x3f59809dac4b33e251e518acDadf923184151334",
+  "bloatnet_factory_10kb": "0xf90E8a6Ce32A949Ce5F58803BBa07476404cD89F",
+  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef"
 }

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -6,17 +6,12 @@ abstract: BloatNet bench cases extracted from https://hackmd.io/9icZeLN7R0Sk5mIj
    operations.
 """
 
-import json
-import math
-from pathlib import Path
-
 import pytest
 from execution_testing import (
-    Account,
+    AccessList,
     Alloc,
     BenchmarkTestFiller,
     Block,
-    BlockchainTestFiller,
     Bytecode,
     Conditional,
     Create2PreimageLayout,
@@ -25,6 +20,12 @@ from execution_testing import (
     Op,
     Transaction,
     While,
+)
+
+from tests.benchmark.stateful.helpers import (
+    APPROVE_SELECTOR,
+    BALANCEOF_SELECTOR,
+    MIXED_TOKENS,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -61,7 +62,6 @@ REFERENCE_SPEC_VERSION = "1.0"
     [True, False],
     ids=["balance_extcodesize", "extcodesize_balance"],
 )
-@pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodesize(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -70,16 +70,7 @@ def test_bloatnet_balance_extcodesize(
     tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
-    """
-    BloatNet test using BALANCE + EXTCODESIZE with "on-the-fly" CREATE2
-    address generation.
-
-    This test:
-    1. Assumes contracts are already deployed via the factory (salt 0 to N-1)
-    2. Generates CREATE2 addresses dynamically during execution
-    3. Calls BALANCE and EXTCODESIZE (order controlled by balance_first param)
-    4. Maximizes cache eviction by accessing many contracts
-    """
+    """Benchmark BALANACE and EXTCODESIZE combination on bloatnet."""
     # Stub Account
     factory_address = pre.deploy_contract(
         code=Bytecode(),  # Required parameter, but will be ignored for stubs
@@ -130,12 +121,12 @@ def test_bloatnet_balance_extcodesize(
             + benchmark_ops
             + create2_preimage.increment_salt_op()
         ),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
+        condition=Op.PUSH1(1)  # [1, num_contract]
+        + Op.SWAP1  # [num_contract, 1]
+        + Op.SUB  # [num_contract-1]
+        + Op.DUP1  # [num_contract-1, num_contract-1]
+        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
+        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
     )
 
     # Contract Deployment
@@ -145,7 +136,9 @@ def test_bloatnet_balance_extcodesize(
     # Gas Accounting
     setup_cost = setup.gas_cost(fork)
     loop_cost = loop.gas_cost(fork)
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 64
+    )
 
     # Attack Loop
     gas_remaining = gas_benchmark_value
@@ -190,7 +183,6 @@ def test_bloatnet_balance_extcodesize(
     [True, False],
     ids=["balance_extcodecopy", "extcodecopy_balance"],
 )
-@pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodecopy(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -199,16 +191,7 @@ def test_bloatnet_balance_extcodecopy(
     tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
-    """
-    BloatNet test using BALANCE + EXTCODECOPY with on-the-fly CREATE2
-    address generation.
-
-    This test forces actual bytecode reads from disk by:
-    1. Assumes contracts are already deployed via the factory
-    2. Generating CREATE2 addresses dynamically during execution
-    3. Using BALANCE and EXTCODECOPY (order controlled by balance_first param)
-    4. Reading 1 byte from the END of the bytecode to force full contract load
-    """
+    """Benchmark BALANACE and EXTCODECOPY combination on bloatnet."""
     # Stub Account
     factory_address = pre.deploy_contract(
         code=Bytecode(),  # Required parameter, but will be ignored for stubs
@@ -247,13 +230,13 @@ def test_bloatnet_balance_extcodecopy(
     max_contract_size = fork.max_code_size()
 
     balance_op = Op.POP(Op.BALANCE)
-    extcodecopy_op = (
-        Op.PUSH1(1)
-        + Op.PUSH2(max_contract_size - 1)
-        + Op.ADD(Op.MLOAD(32), 96)
-        + Op.DUP4
-        + Op.EXTCODECOPY
-        + Op.POP
+    extcodecopy_op = Op.POP(
+        Op.EXTCODECOPY(
+            address=Op.DUP4,
+            destOffset=Op.ADD(Op.MLOAD(32), 96),
+            offset=max_contract_size - 1,
+            size=1,
+        )
     )
     benchmark_ops = (
         (balance_op + extcodecopy_op)
@@ -268,12 +251,12 @@ def test_bloatnet_balance_extcodecopy(
             + benchmark_ops
             + create2_preimage.increment_salt_op()
         ),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
+        condition=Op.PUSH1(1)  # [1, num_contract]
+        + Op.SWAP1  # [num_contract, 1]
+        + Op.SUB  # [num_contract-1]
+        + Op.DUP1  # [num_contract-1, num_contract-1]
+        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
+        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
     )
 
     # Contract Deployment
@@ -283,7 +266,9 @@ def test_bloatnet_balance_extcodecopy(
     # Gas Accounting
     setup_cost = setup.gas_cost(fork)
     loop_cost = loop.gas_cost(fork)
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 64
+    )
 
     # Attack Loop
     gas_remaining = gas_benchmark_value
@@ -328,7 +313,6 @@ def test_bloatnet_balance_extcodecopy(
     [True, False],
     ids=["balance_extcodehash", "extcodehash_balance"],
 )
-@pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodehash(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -337,16 +321,7 @@ def test_bloatnet_balance_extcodehash(
     tx_gas_limit: int,
     balance_first: bool,
 ) -> None:
-    """
-    BloatNet test using BALANCE + EXTCODEHASH with on-the-fly CREATE2
-    address generation.
-
-    This test:
-    1. Assumes contracts are already deployed via the factory
-    2. Generates CREATE2 addresses dynamically during execution
-    3. Calls BALANCE and EXTCODEHASH (order controlled by balance_first param)
-    4. Forces client to compute code hash for 24KB bytecode
-    """
+    """Benchmark BALANACE and EXTCODEHASH combination on bloatnet."""
     # Stub Account
     factory_address = pre.deploy_contract(
         code=Bytecode(),  # Required parameter, but will be ignored for stubs
@@ -397,12 +372,12 @@ def test_bloatnet_balance_extcodehash(
             + benchmark_ops
             + create2_preimage.increment_salt_op()
         ),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
+        condition=Op.PUSH1(1)  # [1, num_contract]
+        + Op.SWAP1  # [num_contract, 1]
+        + Op.SUB  # [num_contract-1]
+        + Op.DUP1  # [num_contract-1, num_contract-1]
+        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
+        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
     )
 
     # Contract Deployment
@@ -412,7 +387,9 @@ def test_bloatnet_balance_extcodehash(
     # Gas Accounting
     setup_cost = setup.gas_cost(fork)
     loop_cost = loop.gas_cost(fork)
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 64
+    )
 
     # Attack Loop
     gas_remaining = gas_benchmark_value
@@ -452,24 +429,6 @@ def test_bloatnet_balance_extcodehash(
     )
 
 
-# ERC20 function selectors
-BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
-APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
-
-# Load token names from stubs.json for test parametrization
-_STUBS_FILE = Path(__file__).parent / "stubs_bloatnet.json"
-with open(_STUBS_FILE) as f:
-    _STUBS = json.load(f)
-
-# Extract unique token names for mixed sload/sstore tests
-MIXED_TOKENS = [
-    k.replace("test_mixed_sload_sstore_", "")
-    for k in _STUBS.keys()
-    if k.startswith("test_mixed_sload_sstore_")
-]
-
-
-@pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("token_name", MIXED_TOKENS)
 @pytest.mark.parametrize(
     "sload_percent,sstore_percent",
@@ -482,7 +441,7 @@ MIXED_TOKENS = [
     ],
 )
 def test_mixed_sload_sstore(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -491,215 +450,214 @@ def test_mixed_sload_sstore(
     sload_percent: int,
     sstore_percent: int,
 ) -> None:
-    """
-    BloatNet mixed SLOAD/SSTORE benchmark with configurable operation ratios.
-
-    This test:
-    1. Uses a single ERC20 contract specified by token_name parameter
-    2. Allocates full gas budget to that contract
-    3. Divides gas into SLOAD and SSTORE portions by percentage
-    4. Executes balanceOf (SLOAD) and approve (SSTORE) calls per the ratio
-    5. Stresses clients with combined read/write operations on large contracts
-    """
-    stub_name = f"test_mixed_sload_sstore_{token_name}"
-    gas_costs = fork.gas_costs()
-
-    # Calculate gas costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Fixed overhead for SLOAD loop
-    sload_loop_overhead = (
-        # Attack contract loop overhead
-        gas_costs.G_VERY_LOW * 2  # MLOAD counter (3*2)
-        + gas_costs.G_VERY_LOW * 2  # MSTORE selector (3*2)
-        + gas_costs.G_VERY_LOW * 3  # MLOAD + MSTORE address (3*3)
-        + gas_costs.G_BASE  # POP (2)
-        + gas_costs.G_BASE * 3  # SUB + MLOAD + MSTORE counter decrement
-        + gas_costs.G_BASE * 2  # ISZERO * 2 for loop condition (2*2)
-        + gas_costs.G_MID  # JUMPI (8)
-    )
-
-    # ERC20 balanceOf internal gas
-    sload_erc20_internal = (
-        gas_costs.G_VERY_LOW  # PUSH4 selector (3)
-        + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
-        + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
-        + gas_costs.G_VERY_LOW * 2  # CALLDATALOAD arg (3*2)
-        + gas_costs.G_KECCAK_256  # keccak256 static (30)
-        + gas_costs.G_KECCAK_256_WORD * 2  # keccak256 dynamic 64 bytes
-        + gas_costs.G_COLD_SLOAD  # Cold SLOAD - always cold
-        + gas_costs.G_VERY_LOW * 3  # MSTORE result + RETURN setup (3*3)
-    )
-
-    # Fixed overhead for SSTORE loop
-    sstore_loop_overhead = (
-        # Attack contract loop body operations
-        gas_costs.G_VERY_LOW  # MSTORE selector at memory[32] (3)
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_VERY_LOW  # MSTORE spender at memory[64] (3)
-        + gas_costs.G_BASE  # POP call result (2)
-        # Counter decrement
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_VERY_LOW  # PUSH1 1 (3)
-        + gas_costs.G_VERY_LOW  # SUB (3)
-        + gas_costs.G_VERY_LOW  # MSTORE counter back (3)
-        # While loop condition check
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI back to loop start (8)
-    )
-
-    # ERC20 approve internal gas
-    # Cold SSTORE: 22100 = 20000 base + 2100 cold access
-    sstore_erc20_internal = (
-        gas_costs.G_VERY_LOW  # PUSH4 selector (3)
-        + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
-        + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
-        + gas_costs.G_VERY_LOW  # CALLDATALOAD spender (3)
-        + gas_costs.G_VERY_LOW  # CALLDATALOAD amount (3)
-        + gas_costs.G_KECCAK_256  # keccak256 static (30)
-        + gas_costs.G_KECCAK_256_WORD * 2  # keccak256 dynamic 64 bytes
-        + gas_costs.G_COLD_SLOAD  # Cold SLOAD for allowance check (2100)
-        + gas_costs.G_STORAGE_SET  # SSTORE base cost (20000)
-        + gas_costs.G_COLD_SLOAD  # Additional cold storage access (2100)
-        + gas_costs.G_VERY_LOW  # PUSH1 1 for return value (3)
-        + gas_costs.G_VERY_LOW  # MSTORE return value (3)
-        + gas_costs.G_VERY_LOW  # PUSH1 32 for return size (3)
-        + gas_costs.G_VERY_LOW  # PUSH1 0 for return offset (3)
-    )
-
-    # Account for cold/warm transitions in CALL costs
-    # First SLOAD call is COLD (2600), rest are WARM (100)
-    sload_warm_cost = (
-        sload_loop_overhead
-        + gas_costs.G_WARM_ACCOUNT_ACCESS
-        + sload_erc20_internal
-    )
-    cold_warm_diff = (
-        gas_costs.G_COLD_ACCOUNT_ACCESS - gas_costs.G_WARM_ACCOUNT_ACCESS
-    )
-
-    # First SSTORE call is COLD (2600), rest are WARM (100)
-    sstore_warm_cost = (
-        sstore_loop_overhead
-        + gas_costs.G_WARM_ACCOUNT_ACCESS
-        + sstore_erc20_internal
-    )
-
-    # Deploy ERC20 contract using stub
+    """Benchmark mixed SLOAD/SSTORE on bloatnet."""
+    # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
-        stub=stub_name,
+        stub=f"test_mixed_sload_sstore_{token_name}",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
-
-    # Calculate total available gas and split by percentage
-    total_available_gas = gas_benchmark_value - (intrinsic_gas * num_txs)
-    sload_gas = (total_available_gas * sload_percent) // 100
-    sstore_gas = (total_available_gas * sstore_percent) // 100
-
-    # Calculate total calls for each operation type
-    total_sload_calls = int((sload_gas - cold_warm_diff) // sload_warm_cost)
-    total_sstore_calls = int((sstore_gas - cold_warm_diff) // sstore_warm_cost)
-
-    # Distribute calls across transactions
-    sload_calls_per_tx = total_sload_calls // num_txs
-    sstore_calls_per_tx = total_sstore_calls // num_txs
-
-    # Log test requirements
-    print(
-        f"Token: {token_name}, "
-        f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas "
-        f"({sload_percent}% SLOAD, {sstore_percent}% SSTORE). "
-        f"{total_sload_calls} balanceOf, {total_sstore_calls} approve "
-        f"across {num_txs} tx(s)."
+    # Contract Construction
+    # MEM[0] = function selector
+    # MEM[32] = address/slot offset (incremented each iteration)
+    # MEM[64] = spender/amount for approve (copied from MEM[32])
+    setup = (
+        Op.MSTORE(
+            0,
+            BALANCEOF_SELECTOR,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.MSTORE(
+            32,
+            Op.CALLDATALOAD(64),  # Slot Offset
+            # gas accounting
+            old_memory_size=32,
+            new_memory_size=64,
+        )
+        + Op.CALLDATALOAD(0)  # [num_sload_calls]
     )
 
-    # Build transactions
+    sload_loop = While(
+        body=Op.POP(
+            Op.CALL(
+                address=erc20_address,
+                value=0,
+                args_offset=28,
+                args_size=36,
+                ret_offset=0,
+                ret_size=0,
+                # gas accounting
+                address_warm=True,
+            )
+        )
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        condition=Op.PUSH1(1)  # [1, num_sload]
+        + Op.SWAP1  # [num_sload, 1]
+        + Op.SUB  # [num_sload-1]
+        + Op.DUP1  # [num_sload-1, num_sload-1]
+        + Op.ISZERO  # [num_sload-1==0, num_sload-1]
+        + Op.ISZERO,  # [num_sload-1!=0, num_sload-1]
+    )
+
+    transition = (
+        Op.POP  # remove 0 counter from sload loop
+        + Op.MSTORE(0, APPROVE_SELECTOR)
+        + Op.CALLDATALOAD(32)  # [num_sstore_calls]
+    )
+
+    sstore_loop = While(
+        body=(
+            Op.MSTORE(64, Op.MLOAD(32))
+            + Op.POP(
+                Op.CALL(
+                    address=erc20_address,
+                    value=0,
+                    args_offset=28,
+                    args_size=68,
+                    ret_offset=0,
+                    ret_size=0,
+                    # gas accounting
+                    address_warm=True,
+                )
+            )
+            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
+        ),
+        condition=Op.PUSH1(1)  # [1, num_sstore]
+        + Op.SWAP1  # [num_sstore, 1]
+        + Op.SUB  # [num_sstore-1]
+        + Op.DUP1  # [num_sstore-1, num_sstore-1]
+        + Op.ISZERO  # [num_sstore-1==0, num_sstore-1]
+        + Op.ISZERO,  # [num_sstore-1!=0, num_sstore-1]
+    )
+
+    # Contract Deployment
+    code = setup + sload_loop + transition + sstore_loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    sload_loop_cost = sload_loop.gas_cost(fork)
+    transition_cost = transition.gas_cost(fork)
+    sstore_loop_cost = sstore_loop.gas_cost(fork)
+
+    access_list = [AccessList(address=erc20_address, storage_keys=[])]
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        access_list=access_list,
+        calldata=b"\xff" * 96,
+    )
+
+    # ERC20 balanceOf bytecode structure:
+    sload_dispatch = (
+        # Selector dispatch
+        Op.PUSH4(BALANCEOF_SELECTOR)
+        + Op.EQ
+        + Op.JUMPI
+        # Function body
+        + Op.JUMPDEST
+        + Op.CALLDATALOAD(4)
+        + Op.MSTORE(0)
+        + Op.MSTORE(32, 0)
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+            old_memory_size=0,
+            new_memory_size=64,
+        )
+        + Op.SLOAD
+        # Return value
+        + Op.MSTORE(0)
+        + Op.RETURN(0, 32)
+    )
+
+    sload_dispatch_cost = sload_dispatch.gas_cost(fork)
+
+    # ERC20 approve bytecode structure:
+    sstore_dispatch = (
+        # Selector dispatch
+        Op.PUSH4(APPROVE_SELECTOR)
+        + Op.EQ
+        + Op.JUMPI
+        # Function body
+        + Op.JUMPDEST
+        + Op.CALLDATALOAD(4)
+        + Op.CALLDATALOAD(36)
+        + Op.MSTORE(0, Op.CALLER)
+        + Op.MSTORE(32, 1)
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+            old_memory_size=0,
+            new_memory_size=64,
+        )
+        + Op.MSTORE(32)
+        + Op.MSTORE(0, Op.CALLDATALOAD(4))
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+        )
+        + Op.DUP1
+        + Op.SLOAD.with_metadata(access_warm=False)
+        + Op.POP
+        + Op.SSTORE
+        # Return true
+        + Op.PUSH1(1)
+        + Op.MSTORE(0)
+        + Op.PUSH1(32)
+        + Op.PUSH1(0)
+        + Op.RETURN(0, 32)
+    )
+
+    sstore_dispatch_cost = sstore_dispatch.gas_cost(fork)
+
+    sload_iter_cost = sload_loop_cost + sload_dispatch_cost
+    sstore_iter_cost = sstore_loop_cost + sstore_dispatch_cost
+    fixed_overhead = intrinsic_gas + setup_cost + transition_cost
+
+    # Attack Loop
+    gas_remaining = gas_benchmark_value
     txs = []
-    post = {}
-    sload_remaining = total_sload_calls
-    sstore_remaining = total_sstore_calls
+    slot_offset = 0
 
-    for i in range(num_txs):
-        # Last tx gets remaining calls
-        tx_sload_calls = (
-            sload_calls_per_tx if i < num_txs - 1 else sload_remaining
-        )
-        tx_sstore_calls = (
-            sstore_calls_per_tx if i < num_txs - 1 else sstore_remaining
-        )
-        sload_remaining -= tx_sload_calls
-        sstore_remaining -= tx_sstore_calls
+    while gas_remaining > fixed_overhead + sload_iter_cost + sstore_iter_cost:
+        gas_available = min(gas_remaining, tx_gas_limit)
 
-        # Build attack code for this transaction
-        attack_code: Bytecode = (
-            Op.JUMPDEST  # Entry point
-            + Op.MSTORE(offset=0, value=BALANCEOF_SELECTOR)
-            # SLOAD operations (balanceOf)
-            + Op.MSTORE(offset=32, value=tx_sload_calls)
-            + While(
-                condition=Op.MLOAD(32) + Op.ISZERO + Op.ISZERO,
-                body=(
-                    Op.CALL(
-                        address=erc20_address,
-                        value=0,
-                        args_offset=28,
-                        args_size=36,
-                        ret_offset=0,
-                        ret_size=0,
-                    )
-                    + Op.POP
-                    + Op.MSTORE(offset=32, value=Op.SUB(Op.MLOAD(32), 1))
-                ),
-            )
-            # SSTORE operations (approve)
-            + Op.MSTORE(offset=0, value=APPROVE_SELECTOR)
-            + Op.MSTORE(offset=32, value=tx_sstore_calls)
-            + While(
-                condition=Op.MLOAD(32) + Op.ISZERO + Op.ISZERO,
-                body=(
-                    Op.MSTORE(offset=64, value=Op.MLOAD(32))
-                    + Op.CALL(
-                        address=erc20_address,
-                        value=0,
-                        args_offset=28,
-                        args_size=68,
-                        ret_offset=0,
-                        ret_size=0,
-                    )
-                    + Op.POP
-                    + Op.MSTORE(offset=32, value=Op.SUB(Op.MLOAD(32), 1))
-                ),
-            )
-        )
+        if gas_available < fixed_overhead + sload_iter_cost + sstore_iter_cost:
+            break
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+        available = gas_available - fixed_overhead
+        sload_gas = (available * sload_percent) // 100
+        sstore_gas = (available * sstore_percent) // 100
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
-        )
+        num_sload = sload_gas // sload_iter_cost
+        num_sstore = sstore_gas // sstore_iter_cost
+
+        if num_sload == 0 or num_sstore == 0:
+            break
+
+        calldata = Hash(num_sload) + Hash(num_sstore) + Hash(slot_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
+                access_list=access_list,
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        slot_offset += num_sload + num_sstore
 
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )

--- a/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_multi_opcode.py
@@ -14,10 +14,14 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
+    BenchmarkTestFiller,
     Block,
     BlockchainTestFiller,
     Bytecode,
+    Conditional,
+    Create2PreimageLayout,
     Fork,
+    Hash,
     Op,
     Transaction,
     While,
@@ -59,7 +63,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 )
 @pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodesize(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -76,57 +80,41 @@ def test_bloatnet_balance_extcodesize(
     3. Calls BALANCE and EXTCODESIZE (order controlled by balance_first param)
     4. Maximizes cache eviction by accessing many contracts
     """
-    gas_costs = fork.gas_costs()
-
-    # Calculate gas costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Cost per contract access with CREATE2 address generation
-    cost_per_contract = (
-        gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
-        + gas_costs.G_BASE  # POP first result (2)
-        + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
-        + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (3)
-        + gas_costs.G_VERY_LOW * 4  # PUSH1 operations (4 * 3)
-        + gas_costs.G_LOW  # MLOAD for salt (3)
-        + gas_costs.G_VERY_LOW  # ADD for increment (3)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
-        + 10  # While loop overhead
-    )
-
-    # Deploy factory using stub contract - NO HARDCODED VALUES
-    # The stub "bloatnet_factory" must be provided via --address-stubs flag
-    # The factory at that address MUST have:
-    # - Slot 0: Number of deployed contracts
-    # - Slot 1: Init code hash for CREATE2 address calculation
+    # Stub Account
     factory_address = pre.deploy_contract(
         code=Bytecode(),  # Required parameter, but will be ignored for stubs
         stub="bloatnet_factory",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
+    # Contract Construction
+    setup = Bytecode()
 
-    # Calculate how many contracts to access based on available gas
-    total_available_gas = (
-        gas_benchmark_value - (intrinsic_gas * num_txs) - 1000
+    setup += Conditional(
+        condition=Op.STATICCALL(
+            gas=Op.GAS,
+            address=factory_address,
+            args_offset=0,
+            args_size=0,
+            ret_offset=96,
+            ret_size=64,
+            # gas accounting
+            address_warm=False,
+            old_memory_size=0,
+            new_memory_size=160,
+        ),
+        if_false=Op.INVALID,
     )
-    total_contracts = int(total_available_gas // cost_per_contract)
-    contracts_per_tx = total_contracts // num_txs
 
-    # Log test requirements - deployed count read from factory storage
-    print(
-        f"Test needs {total_contracts} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas "
-        f"across {num_txs} transaction(s). "
-        f"Factory storage will be checked during execution."
+    create2_preimage = Create2PreimageLayout(
+        factory_address=factory_address,
+        salt=Op.CALLDATALOAD(32),
+        init_code_hash=Op.MLOAD(128),
+        old_memory_size=160,
     )
 
-    # Define operations that differ based on parameter
+    setup += create2_preimage
+    setup += Op.CALLDATALOAD(0)  # [num_contract]
+
     balance_op = Op.POP(Op.BALANCE)
     extcodesize_op = Op.POP(Op.EXTCODESIZE)
     benchmark_ops = (
@@ -135,101 +123,65 @@ def test_bloatnet_balance_extcodesize(
         else (extcodesize_op + balance_op)
     )
 
-    # Build transactions
+    loop = While(
+        body=(
+            create2_preimage.address_op()
+            + Op.DUP1
+            + benchmark_ops
+            + create2_preimage.increment_salt_op()
+        ),
+        condition=Op.PUSH1(1)
+        + Op.SWAP1
+        + Op.SUB
+        + Op.DUP1
+        + Op.ISZERO
+        + Op.ISZERO,
+    )
+
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Attack Loop
+    gas_remaining = gas_benchmark_value
     txs = []
-    post = {}
-    contracts_remaining = total_contracts
     salt_offset = 0
 
-    for i in range(num_txs):
-        # Last tx gets remaining contracts
-        tx_contracts = (
-            contracts_per_tx if i < num_txs - 1 else contracts_remaining
-        )
-        contracts_remaining -= tx_contracts
+    while gas_remaining > intrinsic_gas + setup_cost + loop_cost:
+        gas_available = min(gas_remaining, tx_gas_limit)
 
-        # Build attack contract that reads config from factory
-        attack_code = (
-            # Call getConfig() on factory to get config
-            Op.STATICCALL(
-                gas=Op.GAS,
-                address=factory_address,
-                args_offset=0,
-                args_size=0,
-                ret_offset=96,
-                ret_size=64,
-            )
-            # Check if call succeeded
-            + Op.ISZERO
-            + Op.PUSH2(0x1000)  # Jump to error handler if failed (far jump)
-            + Op.JUMPI
-            # Load results from memory
-            # Memory[96:128] = num_deployed_contracts
-            # Memory[128:160] = init_code_hash
-            + Op.MLOAD(128)  # Load init_code_hash
-            # Setup memory for CREATE2 address generation
-            # Memory layout at 0: 0xFF + factory_addr(20) + salt(32) + hash(32)
-            + Op.MSTORE(
-                0, factory_address
-            )  # Store factory address at memory position 0
-            + Op.MSTORE8(11, 0xFF)  # Store 0xFF prefix at byte 11
-            + Op.MSTORE(32, salt_offset)  # Store starting salt at position 32
-            # Stack now has: [init_code_hash]
-            + Op.PUSH1(64)  # Push memory position
-            + Op.MSTORE  # Store init_code_hash at memory[64]
-            # Push our iteration count onto stack
-            + Op.PUSH4(tx_contracts)
-            # Main attack loop - iterate through contracts for this tx
-            + While(
-                body=(
-                    # Generate CREATE2 addr: keccak256(0xFF+factory+salt+hash)
-                    Op.SHA3(11, 85)  # CREATE2 addr from memory[11:96]
-                    # The address is now on the stack
-                    + Op.DUP1  # Duplicate for second operation
-                    + benchmark_ops  # Execute operations in specified order
-                    # Increment salt for next iteration
-                    + Op.MSTORE(
-                        32, Op.ADD(Op.MLOAD(32), 1)
-                    )  # Increment and store salt
-                ),
-                # Continue while we haven't reached the limit
-                condition=Op.DUP1
-                + Op.PUSH1(1)
-                + Op.SWAP1
-                + Op.SUB
-                + Op.DUP1
-                + Op.ISZERO
-                + Op.ISZERO,
-            )
-            + Op.POP  # Clean up counter
-        )
+        if gas_available < intrinsic_gas + setup_cost:
+            break
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+        num_contract = (
+            gas_available - intrinsic_gas - setup_cost
+        ) // loop_cost
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
-        )
+        if num_contract == 0:
+            break
+
+        calldata = Hash(num_contract) + Hash(salt_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        salt_offset += num_contract
 
-        # Update salt offset for next transaction
-        salt_offset += tx_contracts
-
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )
 
 
@@ -240,7 +192,7 @@ def test_bloatnet_balance_extcodesize(
 )
 @pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodecopy(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -257,67 +209,51 @@ def test_bloatnet_balance_extcodecopy(
     3. Using BALANCE and EXTCODECOPY (order controlled by balance_first param)
     4. Reading 1 byte from the END of the bytecode to force full contract load
     """
-    gas_costs = fork.gas_costs()
-    max_contract_size = fork.max_code_size()
-
-    # Calculate costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Cost per contract with EXTCODECOPY and CREATE2 address generation
-    cost_per_contract = (
-        gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
-        + gas_costs.G_BASE  # POP first result (2)
-        + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access base (100)
-        + gas_costs.G_COPY * 1  # Copy cost for 1 byte (3)
-        + gas_costs.G_BASE * 2  # DUP1 before first op, DUP4 for address (6)
-        + gas_costs.G_VERY_LOW * 8  # PUSH operations (8 * 3 = 24)
-        + gas_costs.G_LOW * 2  # MLOAD for salt twice (6)
-        + gas_costs.G_VERY_LOW * 2  # ADD operations (6)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
-        + gas_costs.G_BASE  # POP after second op (2)
-        + 10  # While loop overhead
-    )
-
-    # Deploy factory using stub contract - NO HARDCODED VALUES
-    # The stub "bloatnet_factory" must be provided via --address-stubs flag
-    # The factory at that address MUST have:
-    # - Slot 0: Number of deployed contracts
-    # - Slot 1: Init code hash for CREATE2 address calculation
+    # Stub Account
     factory_address = pre.deploy_contract(
         code=Bytecode(),  # Required parameter, but will be ignored for stubs
         stub="bloatnet_factory",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
+    # Contract Construction
+    setup = Bytecode()
 
-    # Calculate how many contracts to access
-    total_available_gas = (
-        gas_benchmark_value - (intrinsic_gas * num_txs) - 1000
+    setup += Conditional(
+        condition=Op.STATICCALL(
+            gas=Op.GAS,
+            address=factory_address,
+            args_offset=0,
+            args_size=0,
+            ret_offset=96,
+            ret_size=64,
+            # gas accounting
+            address_warm=False,
+            old_memory_size=0,
+            new_memory_size=160,
+        ),
+        if_false=Op.INVALID,
     )
-    total_contracts = int(total_available_gas // cost_per_contract)
-    contracts_per_tx = total_contracts // num_txs
 
-    # Log test requirements - deployed count read from factory storage
-    print(
-        f"Test needs {total_contracts} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas "
-        f"across {num_txs} transaction(s). "
-        f"Factory storage will be checked during execution."
+    create2_preimage = Create2PreimageLayout(
+        factory_address=factory_address,
+        salt=Op.CALLDATALOAD(32),
+        init_code_hash=Op.MLOAD(128),
+        old_memory_size=160,
     )
 
-    # Define operations that differ based on parameter
+    setup += create2_preimage
+    setup += Op.CALLDATALOAD(0)  # [num_contract]
+
+    max_contract_size = fork.max_code_size()
+
     balance_op = Op.POP(Op.BALANCE)
     extcodecopy_op = (
-        Op.PUSH1(1)  # size (1 byte)
-        + Op.PUSH2(max_contract_size - 1)  # code offset (last byte)
-        + Op.ADD(Op.MLOAD(32), 96)  # unique memory offset
-        + Op.DUP4  # address (duplicated earlier)
+        Op.PUSH1(1)
+        + Op.PUSH2(max_contract_size - 1)
+        + Op.ADD(Op.MLOAD(32), 96)
+        + Op.DUP4
         + Op.EXTCODECOPY
-        + Op.POP  # clean up address
+        + Op.POP
     )
     benchmark_ops = (
         (balance_op + extcodecopy_op)
@@ -325,100 +261,65 @@ def test_bloatnet_balance_extcodecopy(
         else (extcodecopy_op + balance_op)
     )
 
-    # Build transactions
+    loop = While(
+        body=(
+            create2_preimage.address_op()
+            + Op.DUP1
+            + benchmark_ops
+            + create2_preimage.increment_salt_op()
+        ),
+        condition=Op.PUSH1(1)
+        + Op.SWAP1
+        + Op.SUB
+        + Op.DUP1
+        + Op.ISZERO
+        + Op.ISZERO,
+    )
+
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Attack Loop
+    gas_remaining = gas_benchmark_value
     txs = []
-    post = {}
-    contracts_remaining = total_contracts
     salt_offset = 0
 
-    for i in range(num_txs):
-        # Last tx gets remaining contracts
-        tx_contracts = (
-            contracts_per_tx if i < num_txs - 1 else contracts_remaining
-        )
-        contracts_remaining -= tx_contracts
+    while gas_remaining > intrinsic_gas + setup_cost + loop_cost:
+        gas_available = min(gas_remaining, tx_gas_limit)
 
-        # Build attack contract that reads config from factory
-        attack_code = (
-            # Call getConfig() on factory to get config
-            Op.STATICCALL(
-                gas=Op.GAS,
-                address=factory_address,
-                args_offset=0,
-                args_size=0,
-                ret_offset=96,
-                ret_size=64,
-            )
-            # Check if call succeeded
-            + Op.ISZERO
-            + Op.PUSH2(0x1000)  # Jump to error handler if failed (far jump)
-            + Op.JUMPI
-            # Load results from memory
-            # Memory[128:160] = init_code_hash
-            + Op.MLOAD(128)  # Load init_code_hash
-            # Setup memory for CREATE2 address generation
-            # Memory layout at 0: 0xFF + factory_addr(20) + salt(32) + hash(32)
-            + Op.MSTORE(
-                0, factory_address
-            )  # Store factory address at memory position 0
-            + Op.MSTORE8(11, 0xFF)  # Store 0xFF prefix at byte 11
-            + Op.MSTORE(32, salt_offset)  # Store starting salt at position 32
-            # Stack now has: [init_code_hash]
-            + Op.PUSH1(64)  # Push memory position
-            + Op.MSTORE  # Store init_code_hash at memory[64]
-            # Push our iteration count onto stack
-            + Op.PUSH4(tx_contracts)
-            # Main attack loop - iterate through contracts for this tx
-            + While(
-                body=(
-                    # Generate CREATE2 address
-                    Op.SHA3(11, 85)  # CREATE2 addr from memory[11:96]
-                    # The address is now on the stack
-                    + Op.DUP1  # Duplicate for later operations
-                    + benchmark_ops  # Execute operations in specified order
-                    # Increment salt for next iteration
-                    + Op.MSTORE(
-                        32, Op.ADD(Op.MLOAD(32), 1)
-                    )  # Increment and store salt
-                ),
-                # Continue while counter > 0
-                condition=Op.DUP1
-                + Op.PUSH1(1)
-                + Op.SWAP1
-                + Op.SUB
-                + Op.DUP1
-                + Op.ISZERO
-                + Op.ISZERO,
-            )
-            + Op.POP  # Clean up counter
-        )
+        if gas_available < intrinsic_gas + setup_cost:
+            break
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+        num_contract = (
+            gas_available - intrinsic_gas - setup_cost
+        ) // loop_cost
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
-        )
+        if num_contract == 0:
+            break
+
+        calldata = Hash(num_contract) + Hash(salt_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        salt_offset += num_contract
 
-        # Update salt offset for next transaction
-        salt_offset += tx_contracts
-
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )
 
 
@@ -429,7 +330,7 @@ def test_bloatnet_balance_extcodecopy(
 )
 @pytest.mark.valid_from("Prague")
 def test_bloatnet_balance_extcodehash(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -446,53 +347,41 @@ def test_bloatnet_balance_extcodehash(
     3. Calls BALANCE and EXTCODEHASH (order controlled by balance_first param)
     4. Forces client to compute code hash for 24KB bytecode
     """
-    gas_costs = fork.gas_costs()
-
-    # Calculate gas costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Cost per contract access with CREATE2 address generation
-    cost_per_contract = (
-        gas_costs.G_KECCAK_256  # SHA3 static cost for address generation (30)
-        + gas_costs.G_KECCAK_256_WORD
-        * 3  # SHA3 dynamic cost (85 bytes = 3 words * 6)
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # Cold access (2600)
-        + gas_costs.G_BASE  # POP first result (2)
-        + gas_costs.G_WARM_ACCOUNT_ACCESS  # Warm access (100)
-        + gas_costs.G_BASE  # POP second result (2)
-        + gas_costs.G_BASE  # DUP1 before first op (3)
-        + gas_costs.G_VERY_LOW * 4  # PUSH1 operations (4 * 3)
-        + gas_costs.G_LOW  # MLOAD for salt (3)
-        + gas_costs.G_VERY_LOW  # ADD for increment (3)
-        + gas_costs.G_LOW  # MSTORE salt back (3)
-        + 10  # While loop overhead
-    )
-
-    # Deploy factory using stub contract
+    # Stub Account
     factory_address = pre.deploy_contract(
-        code=Bytecode(),
+        code=Bytecode(),  # Required parameter, but will be ignored for stubs
         stub="bloatnet_factory",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
+    # Contract Construction
+    setup = Bytecode()
 
-    # Calculate how many contracts to access based on available gas
-    total_available_gas = (
-        gas_benchmark_value - (intrinsic_gas * num_txs) - 1000
+    setup += Conditional(
+        condition=Op.STATICCALL(
+            gas=Op.GAS,
+            address=factory_address,
+            args_offset=0,
+            args_size=0,
+            ret_offset=96,
+            ret_size=64,
+            # gas accounting
+            address_warm=False,
+            old_memory_size=0,
+            new_memory_size=160,
+        ),
+        if_false=Op.INVALID,
     )
-    total_contracts = int(total_available_gas // cost_per_contract)
-    contracts_per_tx = total_contracts // num_txs
 
-    # Log test requirements
-    print(
-        f"Test needs {total_contracts} contracts for "
-        f"{gas_benchmark_value / 1_000_000:.1f}M gas "
-        f"across {num_txs} transaction(s). "
-        f"Factory storage will be checked during execution."
+    create2_preimage = Create2PreimageLayout(
+        factory_address=factory_address,
+        salt=Op.CALLDATALOAD(32),
+        init_code_hash=Op.MLOAD(128),
+        old_memory_size=160,
     )
 
-    # Define operations that differ based on parameter
+    setup += create2_preimage
+    setup += Op.CALLDATALOAD(0)  # [num_contract]
+
     balance_op = Op.POP(Op.BALANCE)
     extcodehash_op = Op.POP(Op.EXTCODEHASH)
     benchmark_ops = (
@@ -501,91 +390,65 @@ def test_bloatnet_balance_extcodehash(
         else (extcodehash_op + balance_op)
     )
 
-    # Build transactions
+    loop = While(
+        body=(
+            create2_preimage.address_op()
+            + Op.DUP1
+            + benchmark_ops
+            + create2_preimage.increment_salt_op()
+        ),
+        condition=Op.PUSH1(1)
+        + Op.SWAP1
+        + Op.SUB
+        + Op.DUP1
+        + Op.ISZERO
+        + Op.ISZERO,
+    )
+
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Attack Loop
+    gas_remaining = gas_benchmark_value
     txs = []
-    post = {}
-    contracts_remaining = total_contracts
     salt_offset = 0
 
-    for i in range(num_txs):
-        # Last tx gets remaining contracts
-        tx_contracts = (
-            contracts_per_tx if i < num_txs - 1 else contracts_remaining
-        )
-        contracts_remaining -= tx_contracts
+    while gas_remaining > intrinsic_gas + setup_cost + loop_cost:
+        gas_available = min(gas_remaining, tx_gas_limit)
 
-        # Build attack contract that reads config from factory
-        attack_code = (
-            # Call getConfig() on factory to get config
-            Op.STATICCALL(
-                gas=Op.GAS,
-                address=factory_address,
-                args_offset=0,
-                args_size=0,
-                ret_offset=96,
-                ret_size=64,
-            )
-            # Check if call succeeded
-            + Op.ISZERO
-            + Op.PUSH2(0x1000)  # Jump to error handler if failed
-            + Op.JUMPI
-            # Load results from memory
-            + Op.MLOAD(128)  # Load init_code_hash
-            # Setup memory for CREATE2 address generation
-            + Op.MSTORE(0, factory_address)
-            + Op.MSTORE8(11, 0xFF)
-            + Op.MSTORE(32, salt_offset)  # Starting salt for this tx
-            + Op.PUSH1(64)
-            + Op.MSTORE  # Store init_code_hash
-            # Push our iteration count onto stack
-            + Op.PUSH4(tx_contracts)
-            # Main attack loop
-            + While(
-                body=(
-                    # Generate CREATE2 address
-                    Op.SHA3(11, 85)
-                    + Op.DUP1  # Duplicate for second operation
-                    + benchmark_ops  # Execute operations in specified order
-                    # Increment salt
-                    + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
-                ),
-                condition=Op.DUP1
-                + Op.PUSH1(1)
-                + Op.SWAP1
-                + Op.SUB
-                + Op.DUP1
-                + Op.ISZERO
-                + Op.ISZERO,
-            )
-            + Op.POP  # Clean up counter
-        )
+        if gas_available < intrinsic_gas + setup_cost:
+            break
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+        num_contract = (
+            gas_available - intrinsic_gas - setup_cost
+        ) // loop_cost
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
-        )
+        if num_contract == 0:
+            break
+
+        calldata = Hash(num_contract) + Hash(salt_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        salt_offset += num_contract
 
-        # Update salt offset for next transaction
-        salt_offset += tx_contracts
-
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -7,17 +7,13 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
    to benchmark specific state-handling bottlenecks.
 """
 
-import json
-import math
 from functools import partial
-from pathlib import Path
 from typing import Callable, List
 
 import pytest
 from execution_testing import (
     EOA,
     AccessList,
-    Account,
     Address,
     Alloc,
     AuthorizationTuple,
@@ -35,30 +31,15 @@ from execution_testing import (
     While,
 )
 
+from tests.benchmark.stateful.helpers import (
+    APPROVE_SELECTOR,
+    BALANCEOF_SELECTOR,
+    SLOAD_TOKENS,
+    SSTORE_TOKENS,
+)
+
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
 REFERENCE_SPEC_VERSION = "1.0"
-
-# ERC20 function selectors
-BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
-APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
-ALLOWANCE_SELECTOR = 0xDD62ED3E  # allowance(address,address)
-
-# Load token names from stubs.json for test parametrization
-_STUBS_FILE = Path(__file__).parent / "stubs_bloatnet.json"
-with open(_STUBS_FILE) as f:
-    _STUBS = json.load(f)
-
-# Extract unique token names for each test type
-SLOAD_TOKENS = [
-    k.replace("test_sload_empty_erc20_balanceof_", "")
-    for k in _STUBS.keys()
-    if k.startswith("test_sload_empty_erc20_balanceof_")
-]
-SSTORE_TOKENS = [
-    k.replace("test_sstore_erc20_approve_", "")
-    for k in _STUBS.keys()
-    if k.startswith("test_sstore_erc20_approve_")
-]
 
 
 # SLOAD BENCHMARK ARCHITECTURE:
@@ -106,7 +87,6 @@ SSTORE_TOKENS = [
 #   - Simulates real-world contract state accumulation over time
 
 
-@pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 def test_sload_empty_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
@@ -116,18 +96,7 @@ def test_sload_empty_erc20_balanceof(
     tx_gas_limit: int,
     token_name: str,
 ) -> None:
-    """
-    BloatNet SLOAD benchmark using ERC20 balanceOf queries on random
-    addresses.
-
-    This test:
-    1. Uses a single ERC20 contract specified by token_name parameter
-    2. Allocates full gas budget to that contract
-    3. Queries balanceOf() incrementally starting by 0 and increasing by 1
-       (thus forcing SLOADs to non-existing addresses)
-    4. Splits into multiple transactions if gas_benchmark_value > tx_gas_limit
-       (EIP-7825 compliance)
-    """
+    """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
     # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
@@ -151,7 +120,7 @@ def test_sload_empty_erc20_balanceof(
             old_memory_size=32,
             new_memory_size=64,
         )
-        + Op.CALLDATALOAD(0)  # [num_contract]
+        + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
     loop = While(
@@ -168,12 +137,12 @@ def test_sload_empty_erc20_balanceof(
             )
         )
         + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
-        condition=Op.PUSH1(1)  # [1, num_contract]
-        + Op.SWAP1  # [num_contract, 1]
-        + Op.SUB  # [num_contract-1]
-        + Op.DUP1  # [num_contract-1, num_contract-1]
-        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
-        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
+        condition=Op.PUSH1(1)  # [1, num_calls]
+        + Op.SWAP1  # [num_calls, 1]
+        + Op.SUB  # [num_calls-1]
+        + Op.DUP1  # [num_calls-1, num_calls-1]
+        + Op.ISZERO  # [num_calls-1==0, num_calls-1]
+        + Op.ISZERO,  # [num_calls-1!=0, num_calls-1]
     )
 
     # Contract Deployment
@@ -185,9 +154,11 @@ def test_sload_empty_erc20_balanceof(
     loop_cost = loop.gas_cost(fork)
 
     access_list = [AccessList(address=erc20_address, storage_keys=[])]
-    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
-    intrinsic_gas_with_access_list = intrinsic_gas_calculator(
-        access_list=access_list
+    intrinsic_gas_with_access_list = (
+        fork.transaction_intrinsic_cost_calculator()(
+            access_list=access_list,
+            calldata=b"\xff" * 64,
+        )
     )
 
     # ERC20 balanceOf bytecode structure:
@@ -220,7 +191,7 @@ def test_sload_empty_erc20_balanceof(
     # Transaction Loops
     txs = []
     gas_remaining = gas_benchmark_value
-    address_offset = 0
+    slot_offset = 0
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
@@ -228,14 +199,14 @@ def test_sload_empty_erc20_balanceof(
         if gas_available < intrinsic_gas_with_access_list + setup_cost:
             break
 
-        num_contract = (gas_available - intrinsic_gas_with_access_list) // (
-            function_dispatch_cost + loop_cost
-        )
+        num_calls = (
+            gas_available - intrinsic_gas_with_access_list - setup_cost
+        ) // (function_dispatch_cost + loop_cost)
 
-        if num_contract == 0:
+        if num_calls == 0:
             break
 
-        calldata = Hash(num_contract) + Hash(address_offset)
+        calldata = Hash(num_calls) + Hash(slot_offset)
 
         txs.append(
             Transaction(
@@ -248,7 +219,7 @@ def test_sload_empty_erc20_balanceof(
         )
 
         gas_remaining -= gas_available
-        address_offset += num_contract
+        slot_offset += num_calls
 
     benchmark_test(
         pre=pre,
@@ -256,7 +227,6 @@ def test_sload_empty_erc20_balanceof(
     )
 
 
-@pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
 def test_sstore_erc20_approve(
     benchmark_test: BenchmarkTestFiller,
@@ -266,17 +236,7 @@ def test_sstore_erc20_approve(
     tx_gas_limit: int,
     token_name: str,
 ) -> None:
-    """
-    BloatNet SSTORE benchmark using ERC20 approve to write to storage.
-
-    This test:
-    1. Uses a single ERC20 contract specified by token_name parameter
-    2. Allocates full gas budget to that contract
-    3. Calls approve(spender, amount) incrementally (counter as spender)
-    4. Forces SSTOREs to allowance mapping storage slots
-    5. Splits into multiple transactions if gas_benchmark_value > tx_gas_limit
-       (EIP-7825 compliance)
-    """
+    """Benchmark SSTORE using ERC20 approve on bloatnet."""
     # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
@@ -286,9 +246,21 @@ def test_sstore_erc20_approve(
     # MEM[0] = function selector
     # MEM[32] = starting address offset
     setup = (
-        Op.MSTORE(0, APPROVE_SELECTOR)
-        + Op.MSTORE(32, Op.CALLDATALOAD(32))  # Address Offset
-        + Op.CALLDATALOAD(0)  # [num_contract]
+        Op.MSTORE(
+            0,
+            APPROVE_SELECTOR,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.MSTORE(
+            32,
+            Op.CALLDATALOAD(32),  # Address Offset
+            # gas accounting
+            old_memory_size=32,
+            new_memory_size=64,
+        )
+        + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
     loop = While(
@@ -302,28 +274,33 @@ def test_sstore_erc20_approve(
                     args_size=68,
                     ret_offset=0,
                     ret_size=0,
+                    # gas accounting
+                    address_warm=True,
                 )
             )
             + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
         ),
-        condition=Op.PUSH1(1)  # [1, num_contract]
-        + Op.SWAP1  # [num_contract, 1]
-        + Op.SUB  # [num_contract-1]
-        + Op.DUP1  # [num_contract-1, num_contract-1]
-        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
-        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
+        condition=Op.PUSH1(1)  # [1, num_calls]
+        + Op.SWAP1  # [num_calls, 1]
+        + Op.SUB  # [num_calls-1]
+        + Op.DUP1  # [num_calls-1, num_calls-1]
+        + Op.ISZERO  # [num_calls-1==0, num_calls-1]
+        + Op.ISZERO,  # [num_calls-1!=0, num_calls-1]
     )
 
     # Contract Deployment
     code = setup + loop
     attack_contract_address = pre.deploy_contract(code=code)
 
-    # Calculate gas costs
+    # Gas Accounting
     setup_cost = setup.gas_cost(fork)
     loop_cost = loop.gas_cost(fork)
     access_list = [AccessList(address=erc20_address, storage_keys=[])]
     intrinsic_gas_with_access_list = (
-        fork.transaction_intrinsic_cost_calculator()(access_list=access_list)
+        fork.transaction_intrinsic_cost_calculator()(
+            access_list=access_list,
+            calldata=b"\xff" * 64,
+        )
     )
 
     function_dispatch = (
@@ -370,7 +347,7 @@ def test_sstore_erc20_approve(
     # Transaction Loops
     txs = []
     gas_remaining = gas_benchmark_value
-    address_offset = 0
+    slot_offset = 0
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
@@ -378,14 +355,14 @@ def test_sstore_erc20_approve(
         if gas_available < intrinsic_gas_with_access_list + setup_cost:
             break
 
-        num_contract = (gas_available - intrinsic_gas_with_access_list) // (
-            function_dispatch_cost + loop_cost
-        )
+        num_calls = (
+            gas_available - intrinsic_gas_with_access_list - setup_cost
+        ) // (function_dispatch_cost + loop_cost)
 
-        if num_contract == 0:
+        if num_calls == 0:
             break
 
-        calldata = Hash(num_contract) + Hash(address_offset)
+        calldata = Hash(num_calls) + Hash(slot_offset)
 
         txs.append(
             Transaction(
@@ -398,12 +375,11 @@ def test_sstore_erc20_approve(
         )
 
         gas_remaining -= gas_available
-        address_offset += num_contract
+        slot_offset += num_calls
 
     benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )
 
 
@@ -798,6 +774,7 @@ def test_sstore_variants(
     blocks.append(Block(txs=exec_txs))
 
     benchmark_test(
+        pre=pre,
         blocks=blocks,
         expected_benchmark_gas_used=expected_gas_used,
     )
@@ -933,6 +910,7 @@ def test_storage_sload_benchmark(
     blocks.append(Block(txs=exec_txs))
 
     benchmark_test(
+        pre=pre,
         blocks=blocks,
         expected_benchmark_gas_used=expected_gas_used,
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -23,7 +23,6 @@ from execution_testing import (
     AuthorizationTuple,
     BenchmarkTestFiller,
     Block,
-    BlockchainTestFiller,
     Bytecode,
     Fork,
     Hash,
@@ -110,7 +109,7 @@ SSTORE_TOKENS = [
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 def test_sload_empty_erc20_balanceof(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -129,131 +128,138 @@ def test_sload_empty_erc20_balanceof(
     4. Splits into multiple transactions if gas_benchmark_value > tx_gas_limit
        (EIP-7825 compliance)
     """
-    stub_name = f"test_sload_empty_erc20_balanceof_{token_name}"
-    gas_costs = fork.gas_costs()
-
-    # Calculate gas costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Fixed overhead per iteration (loop mechanics, independent of warm/cold)
-    loop_overhead = (
-        # Attack contract loop overhead
-        gas_costs.G_VERY_LOW * 2  # MLOAD counter (3*2)
-        + gas_costs.G_VERY_LOW * 2  # MSTORE selector (3*2)
-        + gas_costs.G_VERY_LOW * 3  # MLOAD + MSTORE address (3*3)
-        + gas_costs.G_BASE  # POP (2)
-        + gas_costs.G_BASE * 3  # SUB + MLOAD + MSTORE counter decrement
-        + gas_costs.G_BASE * 2  # ISZERO * 2 for loop condition (2*2)
-        + gas_costs.G_MID  # JUMPI (8)
-    )
-
-    # ERC20 internal gas (same for all calls)
-    erc20_internal_gas = (
-        gas_costs.G_VERY_LOW  # PUSH4 selector (3)
-        + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
-        + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
-        + gas_costs.G_VERY_LOW * 2  # CALLDATALOAD arg (3*2)
-        + gas_costs.G_KECCAK_256  # keccak256 static (30)
-        + gas_costs.G_KECCAK_256_WORD * 2  # keccak256 dynamic 64 bytes
-        + gas_costs.G_COLD_SLOAD  # Cold SLOAD - always cold
-        + gas_costs.G_VERY_LOW * 3  # MSTORE result + RETURN setup (3*3)
-        # RETURN costs 0 gas
-    )
-
-    # First call is COLD (2600), subsequent are WARM (100)
-    warm_call_cost = (
-        loop_overhead + gas_costs.G_WARM_ACCOUNT_ACCESS + erc20_internal_gas
-    )
-    cold_warm_diff = (
-        gas_costs.G_COLD_ACCOUNT_ACCESS - gas_costs.G_WARM_ACCOUNT_ACCESS
-    )
-
-    # Deploy ERC20 contract using stub
-    # In execute mode: stub points to already-deployed contract on chain
-    # In fill mode: empty bytecode is deployed as placeholder
+    # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
-        stub=stub_name,
+        stub=f"test_sload_empty_erc20_balanceof_{token_name}",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
-
-    # Calculate total calls based on full gas budget
-    total_available_gas = gas_benchmark_value - (intrinsic_gas * num_txs)
-    total_calls = int((total_available_gas - cold_warm_diff) // warm_call_cost)
-    calls_per_tx = total_calls // num_txs
-
-    # Log test requirements
-    print(
-        f"Token: {token_name}, "
-        f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas, "
-        f"{total_calls} balanceOf calls across {num_txs} transaction(s)."
+    # MEM[0] = function selector
+    # MEM[32] = starting address offset
+    setup = (
+        Op.MSTORE(
+            0,
+            BALANCEOF_SELECTOR,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.MSTORE(
+            32,
+            Op.CALLDATALOAD(32),  # Address Offset
+            # gas accounting
+            old_memory_size=32,
+            new_memory_size=64,
+        )
+        + Op.CALLDATALOAD(0)  # [num_contract]
     )
 
-    # Build transactions
-    txs = []
-    post = {}
-    calls_remaining = total_calls
-
-    for i in range(num_txs):
-        # Last tx gets remaining calls
-        tx_calls = calls_per_tx if i < num_txs - 1 else calls_remaining
-        calls_remaining -= tx_calls
-
-        # Build attack code for this transaction
-        attack_code: Bytecode = (
-            Op.JUMPDEST  # Entry point
-            + Op.MSTORE(offset=0, value=BALANCEOF_SELECTOR)
-            + Op.MSTORE(offset=32, value=tx_calls)
-            + While(
-                condition=Op.MLOAD(32) + Op.ISZERO + Op.ISZERO,
-                body=(
-                    Op.CALL(
-                        address=erc20_address,
-                        value=0,
-                        args_offset=28,
-                        args_size=36,
-                        ret_offset=0,
-                        ret_size=0,
-                    )
-                    + Op.POP
-                    + Op.MSTORE(offset=32, value=Op.SUB(Op.MLOAD(32), 1))
-                ),
+    loop = While(
+        body=Op.POP(
+            Op.CALL(
+                address=erc20_address,
+                value=0,
+                args_offset=28,
+                args_size=36,
+                ret_offset=0,
+                ret_size=0,
+                # gas accounting
+                address_warm=True,
             )
         )
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        condition=Op.PUSH1(1)  # [1, num_contract]
+        + Op.SWAP1  # [num_contract, 1]
+        + Op.SUB  # [num_contract-1]
+        + Op.DUP1  # [num_contract-1, num_contract-1]
+        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
+        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
+    )
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+
+    access_list = [AccessList(address=erc20_address, storage_keys=[])]
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas_with_access_list = intrinsic_gas_calculator(
+        access_list=access_list
+    )
+
+    # ERC20 balanceOf bytecode structure:
+    function_dispatch = (
+        # Selector dispatch
+        Op.PUSH4(BALANCEOF_SELECTOR)
+        + Op.EQ
+        + Op.JUMPI
+        # Function body
+        + Op.JUMPDEST
+        + Op.CALLDATALOAD(4)
+        + Op.MSTORE(0)
+        + Op.MSTORE(32, 0)
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+            old_memory_size=0,
+            new_memory_size=64,
         )
+        + Op.SLOAD
+        # Return value
+        + Op.MSTORE(0)
+        + Op.RETURN(0, 32)
+    )
+
+    function_dispatch_cost = function_dispatch.gas_cost(fork)
+
+    # Transaction Loops
+    txs = []
+    gas_remaining = gas_benchmark_value
+    address_offset = 0
+
+    while gas_remaining > intrinsic_gas_with_access_list:
+        gas_available = min(gas_remaining, tx_gas_limit)
+
+        if gas_available < intrinsic_gas_with_access_list + setup_cost:
+            break
+
+        num_contract = (gas_available - intrinsic_gas_with_access_list) // (
+            function_dispatch_cost + loop_cost
+        )
+
+        if num_contract == 0:
+            break
+
+        calldata = Hash(num_contract) + Hash(address_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
+                access_list=access_list,
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        address_offset += num_contract
 
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
-        post=post,
     )
 
 
 @pytest.mark.valid_from("Prague")
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
 def test_sstore_erc20_approve(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     gas_benchmark_value: int,
@@ -271,137 +277,130 @@ def test_sstore_erc20_approve(
     5. Splits into multiple transactions if gas_benchmark_value > tx_gas_limit
        (EIP-7825 compliance)
     """
-    stub_name = f"test_sstore_erc20_approve_{token_name}"
-    gas_costs = fork.gas_costs()
-
-    # Calculate gas costs
-    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(calldata=b"")
-
-    # Fixed overhead per iteration (loop mechanics, independent of warm/cold)
-    loop_overhead = (
-        # Attack contract loop body operations
-        gas_costs.G_VERY_LOW  # MSTORE selector at memory[32] (3)
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_VERY_LOW  # MSTORE spender at memory[64] (3)
-        + gas_costs.G_BASE  # POP call result (2)
-        # Counter decrement: MSTORE(0, SUB(MLOAD(0), 1))
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_VERY_LOW  # PUSH1 1 (3)
-        + gas_costs.G_VERY_LOW  # SUB (3)
-        + gas_costs.G_VERY_LOW  # MSTORE counter back (3)
-        # While loop condition check
-        + gas_costs.G_LOW  # MLOAD counter (5)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_BASE  # ISZERO (2)
-        + gas_costs.G_MID  # JUMPI back to loop start (8)
-    )
-
-    # ERC20 internal gas (same for all calls)
-    # Note: SSTORE cost is 22100 for cold slot, zero-to-non-zero
-    # (20000 base + 2100 cold access)
-    erc20_internal_gas = (
-        gas_costs.G_VERY_LOW  # PUSH4 selector (3)
-        + gas_costs.G_BASE  # EQ selector match (2)
-        + gas_costs.G_MID  # JUMPI to function (8)
-        + gas_costs.G_JUMPDEST  # JUMPDEST at function start (1)
-        + gas_costs.G_VERY_LOW  # CALLDATALOAD spender (3)
-        + gas_costs.G_VERY_LOW  # CALLDATALOAD amount (3)
-        + gas_costs.G_KECCAK_256  # keccak256 static (30)
-        + gas_costs.G_KECCAK_256_WORD * 2  # keccak256 dynamic 64 bytes
-        + gas_costs.G_COLD_SLOAD  # Cold SLOAD for allowance check (2100)
-        + gas_costs.G_STORAGE_SET  # SSTORE base cost (20000)
-        + gas_costs.G_COLD_SLOAD  # Additional cold storage access (2100)
-        + gas_costs.G_VERY_LOW  # PUSH1 1 for return value (3)
-        + gas_costs.G_VERY_LOW  # MSTORE return value (3)
-        + gas_costs.G_VERY_LOW  # PUSH1 32 for return size (3)
-        + gas_costs.G_VERY_LOW  # PUSH1 0 for return offset (3)
-        # RETURN costs 0 gas
-    )
-
-    # First call is COLD (2600), subsequent are WARM (100)
-    warm_call_cost = (
-        loop_overhead + gas_costs.G_WARM_ACCOUNT_ACCESS + erc20_internal_gas
-    )
-    cold_warm_diff = (
-        gas_costs.G_COLD_ACCOUNT_ACCESS - gas_costs.G_WARM_ACCOUNT_ACCESS
-    )
-
-    # Deploy ERC20 contract using stub
+    # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
-        stub=stub_name,
+        stub=f"test_sstore_erc20_approve_{token_name}",
     )
 
-    # Calculate number of transactions needed (EIP-7825 compliance)
-    num_txs = max(1, math.ceil(gas_benchmark_value / tx_gas_limit))
-
-    # Calculate total calls based on full gas budget
-    total_available_gas = gas_benchmark_value - (intrinsic_gas * num_txs)
-    total_calls = int((total_available_gas - cold_warm_diff) // warm_call_cost)
-    calls_per_tx = total_calls // num_txs
-
-    # Log test requirements
-    print(
-        f"Token: {token_name}, "
-        f"Total gas budget: {gas_benchmark_value / 1_000_000:.1f}M gas, "
-        f"{total_calls} approve calls across {num_txs} transaction(s)."
+    # MEM[0] = function selector
+    # MEM[32] = starting address offset
+    setup = (
+        Op.MSTORE(0, APPROVE_SELECTOR)
+        + Op.MSTORE(32, Op.CALLDATALOAD(32))  # Address Offset
+        + Op.CALLDATALOAD(0)  # [num_contract]
     )
 
-    # Build transactions
-    txs = []
-    post = {}
-    calls_remaining = total_calls
-
-    for i in range(num_txs):
-        # Last tx gets remaining calls
-        tx_calls = calls_per_tx if i < num_txs - 1 else calls_remaining
-        calls_remaining -= tx_calls
-
-        # Build attack code for this transaction
-        attack_code: Bytecode = (
-            Op.JUMPDEST  # Entry point
-            + Op.MSTORE(offset=0, value=APPROVE_SELECTOR)
-            + Op.MSTORE(offset=32, value=tx_calls)
-            + While(
-                condition=Op.MLOAD(32) + Op.ISZERO + Op.ISZERO,
-                body=(
-                    # Store spender at memory[64] (counter as spender/amount)
-                    Op.MSTORE(offset=64, value=Op.MLOAD(32))
-                    # Call approve(spender, amount) on ERC20 contract
-                    + Op.CALL(
-                        address=erc20_address,
-                        value=0,
-                        args_offset=28,
-                        args_size=68,
-                        ret_offset=0,
-                        ret_size=0,
-                    )
-                    + Op.POP
-                    + Op.MSTORE(offset=32, value=Op.SUB(Op.MLOAD(32), 1))
-                ),
+    loop = While(
+        body=(
+            Op.MSTORE(64, Op.MLOAD(32))
+            + Op.POP(
+                Op.CALL(
+                    address=erc20_address,
+                    value=0,
+                    args_offset=28,
+                    args_size=68,
+                    ret_offset=0,
+                    ret_size=0,
+                )
             )
+            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
+        ),
+        condition=Op.PUSH1(1)  # [1, num_contract]
+        + Op.SWAP1  # [num_contract, 1]
+        + Op.SUB  # [num_contract-1]
+        + Op.DUP1  # [num_contract-1, num_contract-1]
+        + Op.ISZERO  # [num_contract-1==0, num_contract-1]
+        + Op.ISZERO,  # [num_contract-1!=0, num_contract-1]
+    )
+
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Calculate gas costs
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+    access_list = [AccessList(address=erc20_address, storage_keys=[])]
+    intrinsic_gas_with_access_list = (
+        fork.transaction_intrinsic_cost_calculator()(access_list=access_list)
+    )
+
+    function_dispatch = (
+        # Selector dispatch
+        Op.PUSH4(APPROVE_SELECTOR)
+        + Op.EQ
+        + Op.JUMPI
+        # Function body
+        + Op.JUMPDEST
+        + Op.CALLDATALOAD(4)
+        + Op.CALLDATALOAD(36)
+        + Op.MSTORE(0, Op.CALLER)
+        + Op.MSTORE(32, 1)
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+            old_memory_size=0,
+            new_memory_size=64,
+        )
+        + Op.MSTORE(32)
+        + Op.MSTORE(0, Op.CALLDATALOAD(4))
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+        )
+        + Op.DUP1
+        + Op.SLOAD.with_metadata(access_warm=False)
+        + Op.POP
+        + Op.SSTORE
+        # Return true
+        + Op.PUSH1(1)
+        + Op.MSTORE(0)
+        + Op.PUSH1(32)
+        + Op.PUSH1(0)
+        + Op.RETURN(0, 32)
+    )
+
+    function_dispatch_cost = function_dispatch.gas_cost(fork)
+
+    # Transaction Loops
+    txs = []
+    gas_remaining = gas_benchmark_value
+    address_offset = 0
+
+    while gas_remaining > intrinsic_gas_with_access_list:
+        gas_available = min(gas_remaining, tx_gas_limit)
+
+        if gas_available < intrinsic_gas_with_access_list + setup_cost:
+            break
+
+        num_contract = (gas_available - intrinsic_gas_with_access_list) // (
+            function_dispatch_cost + loop_cost
         )
 
-        # Deploy attack contract for this tx
-        attack_address = pre.deploy_contract(code=attack_code)
+        if num_contract == 0:
+            break
 
-        # Calculate gas for this transaction
-        this_tx_gas = min(
-            tx_gas_limit, gas_benchmark_value - (i * tx_gas_limit)
-        )
+        calldata = Hash(num_contract) + Hash(address_offset)
 
         txs.append(
             Transaction(
-                to=attack_address,
-                gas_limit=this_tx_gas,
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
                 sender=pre.fund_eoa(),
+                access_list=access_list,
             )
         )
 
-        # Add to post-state
-        post[attack_address] = Account(storage={})
+        gas_remaining -= gas_available
+        address_offset += num_contract
 
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         blocks=[Block(txs=txs)],
         post=post,

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,0 +1,31 @@
+"""Shared constants and helpers for stateful benchmark tests."""
+
+import json
+from pathlib import Path
+
+# ERC20 function selectors
+BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
+APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
+ALLOWANCE_SELECTOR = 0xDD62ED3E  # allowance(address,address)
+
+# Load token names from stubs_bloatnet.json for test parametrization
+_STUBS_FILE = Path(__file__).parent / "bloatnet" / "stubs_bloatnet.json"
+with open(_STUBS_FILE) as f:
+    _STUBS = json.load(f)
+
+# Extract unique token names for each test type
+SLOAD_TOKENS = [
+    k.replace("test_sload_empty_erc20_balanceof_", "")
+    for k in _STUBS.keys()
+    if k.startswith("test_sload_empty_erc20_balanceof_")
+]
+SSTORE_TOKENS = [
+    k.replace("test_sstore_erc20_approve_", "")
+    for k in _STUBS.keys()
+    if k.startswith("test_sstore_erc20_approve_")
+]
+MIXED_TOKENS = [
+    k.replace("test_mixed_sload_sstore_", "")
+    for k in _STUBS.keys()
+    if k.startswith("test_mixed_sload_sstore_")
+]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Refactor stateful benchmark using bytecode gas cost calculator.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Partially fixes https://github.com/ethereum/execution-specs/issues/2049.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
