### PR TITLE
fix(test-fill): stream fixture JSON writes to reduce peak memory

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/collector.py
+++ b/packages/testing/src/execution_testing/fixtures/collector.py
@@ -71,16 +71,15 @@ def merge_partial_fixture_files(output_dir: Path) -> None:
 
         # Write final JSON file
         sorted_keys = sorted(entries.keys())
-        parts = ["{\n"]
         last_idx = len(sorted_keys) - 1
-        for i, key in enumerate(sorted_keys):
-            key_json = json.dumps(key)
-            # Add indentation for nesting inside outer JSON object
-            value_indented = entries[key].replace("\n", "\n    ")
-            parts.append(f"    {key_json}: {value_indented}")
-            parts.append(",\n" if i < last_idx else "\n")
-        parts.append("}")
-        target_path.write_text("".join(parts))
+        with open(target_path, "w") as f:
+            f.write("{\n")
+            for i, key in enumerate(sorted_keys):
+                key_json = json.dumps(key)
+                value_indented = entries[key].replace("\n", "\n    ")
+                f.write(f"    {key_json}: {value_indented}")
+                f.write(",\n" if i < last_idx else "\n")
+            f.write("}")
 
         # Clean up partial files
         for partial in partials:


### PR DESCRIPTION
## 🗒️ Description

- Write merged fixture JSON entries directly to file instead of building the full output string in memory via `"".join(parts)`.
- Attepts to avoid OOM during `merge_partial_fixture_files()` for large fixtures.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Fixes #2123
- #2123

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:dog2: 