### PR TITLE
fix(tests): add new Besu exception for BlockException.GAS_USED_OVERFLOW

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -236,6 +236,9 @@ class BesuExceptionMapper(ExceptionMapper):
         TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS: (
             "transaction invalid gasPrice is less than the current BaseFee"
         ),
+        BlockException.GAS_USED_OVERFLOW: (
+            "provided gas insufficient"
+        ),
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             "provided gas insufficient"
         ),


### PR DESCRIPTION
## 🗒️ Description
Add 1 new Besu exception to pass the tests that exceed the EIP-7778 block gas limit

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
