### PR TITLE
chore(tests): use representative blob combos in high blob count forks

### DIFF
--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -1,9 +1,10 @@
 """Defines EIP-4844 specification constants and functions."""
 
 import itertools
+import math
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import List, Optional, Tuple
+from typing import List, Optional, Set, Tuple
 
 from execution_testing import Fork, Transaction
 
@@ -87,6 +88,134 @@ class SpecHelpers:
     """
 
     BYTES_PER_FIELD_ELEMENT = 32
+    _EXHAUSTIVE_MAX_BLOBS_PER_BLOCK = 9  # Osaka max; exhaustive is tractable up to here
+
+    @classmethod
+    def get_representative_blob_combinations(
+        cls,
+        blob_count: int,
+        max_blobs_per_tx: int,
+    ) -> List[Tuple[int, ...]]:
+        """
+        Get a bounded set of representative blob-per-tx partitions for a given
+        blob count, instead of exhaustively enumerating all valid partitions.
+        """
+        n = blob_count
+        if n < 1:
+            return []
+        m = max_blobs_per_tx
+        seen: Set[Tuple[int, ...]] = set()
+        result: List[Tuple[int, ...]] = []
+
+        def add(combo: Tuple[int, ...]) -> None:
+            if combo not in seen:
+                seen.add(combo)
+                result.append(combo)
+
+        # 1. Single tx (if it fits)
+        # e.g. n=5, m=6 → (5,)
+        if n <= m:
+            add((n,))
+
+        # 2. All singles
+        # e.g. n=10 → (1,1,1,1,1,1,1,1,1,1)
+        if n > 1:
+            add((1,) * n)
+
+        # 3. Greedy pack: fill max-sized txs first
+        # e.g. n=10, m=6 → (6,4)
+        if n > m:
+            q, r = divmod(n, m)
+            greedy = (m,) * q + ((r,) if r else ())
+            add(greedy)
+
+            # 4. Reversed greedy
+            # e.g. n=10, m=6 → (4,6)
+            rev = tuple(reversed(greedy))
+            add(rev)
+
+        # 5. One big tx + singles for the rest (and reversed)
+        # e.g. n=10, m=6 → (6,1,1,1,1) and (1,1,1,1,6)
+        if n > 1:
+            big = min(n - 1, m)
+            rest = n - big
+            combo = (big,) + (1,) * rest
+            add(combo)
+            add(tuple(reversed(combo)))
+
+        # 6. Balanced split into two txs (and reversed)
+        # e.g. n=10, m=6 → (5,5); n=9, m=6 → (5,4) and (4,5)
+        if n > 1:
+            half_hi = math.ceil(n / 2)
+            half_lo = n - half_hi
+            if half_hi <= m and half_lo >= 1:
+                add((half_hi, half_lo))
+                if half_hi != half_lo:
+                    add((half_lo, half_hi))
+
+        # 7. Uniform non-max: all txs same size, 1 < k < m
+        # e.g. n=12, m=6 → (4,4,4); n=15, m=6 → (5,5,5)
+        if n > 1:
+            for k in range(m - 1, 1, -1):
+                if n % k == 0 and n // k > 1:
+                    add((k,) * (n // k))
+                    break
+
+        return result
+
+    @classmethod
+    def get_representative_invalid_blob_combinations(
+        cls,
+        fork: Fork,
+    ) -> List[Tuple[int, ...]]:
+        """
+        Get a bounded set of representative invalid blob-per-tx partitions
+        that exceed the block blob limit by exactly one.
+        """
+        max_blobs_per_block = fork.max_blobs_per_block()
+        max_blobs_per_tx = fork.max_blobs_per_tx()
+        total = max_blobs_per_block + 1
+        m = max_blobs_per_tx
+        seen: Set[Tuple[int, ...]] = set()
+        result: List[Tuple[int, ...]] = []
+
+        def add(combo: Tuple[int, ...]) -> None:
+            if combo not in seen:
+                seen.add(combo)
+                result.append(combo)
+
+        # 1. Single oversized tx — e.g. (16,)
+        add((total,))
+
+        # 2. Greedy pack of total — e.g. total=16, m=6 → (6,6,4)
+        q, r = divmod(total, m)
+        greedy = (m,) * q + ((r,) if r else ())
+        add(greedy)
+
+        # 3. All singles — e.g. (1,)*16
+        add((1,) * total)
+
+        # 4. One full tx + overflow — e.g. total=16, m=6 → (6,10)
+        overflow = total - m
+        if overflow >= 1:
+            add((m, overflow))
+
+        # 5. One blob + full block — e.g. (1,21)
+        # Per-tx-oversized elements must be last: the test sends all txs from one
+        # sender with sequential nonces, so a rejected non-last tx creates a nonce
+        # gap that causes subsequent txs to fail with NONCE_MISMATCH, not the
+        # expected blob error.
+        add((1, max_blobs_per_block))
+
+        # 6. Balanced all-valid: near-equal tx sizes, all within per-tx limit
+        # e.g. total=16, m=6 → (6,5,5)
+        num_txs = math.ceil(total / m)
+        base, extra = divmod(total, num_txs)
+        balanced = (base + 1,) * extra + (base,) * (num_txs - extra)
+        if all(b <= m for b in balanced):
+            add(balanced)
+
+        return result
 
     @classmethod
     def get_min_excess_blob_gas_for_blob_gas_price(
@@ -173,10 +302,16 @@ class SpecHelpers:
         """
         max_blobs_per_block = fork.max_blobs_per_block()
         max_blobs_per_tx = fork.max_blobs_per_tx()
+        exhaustive = max_blobs_per_block <= cls._EXHAUSTIVE_MAX_BLOBS_PER_BLOCK
 
         combinations: List[Tuple[int, ...]] = []
         for i in range(1, max_blobs_per_block + 1):
-            combinations += cls.get_blob_combinations(i, max_blobs_per_tx)
+            if exhaustive:
+                combinations += cls.get_blob_combinations(i, max_blobs_per_tx)
+            else:
+                combinations += cls.get_representative_blob_combinations(
+                    i, max_blobs_per_tx
+                )
         return combinations
 
     @classmethod
@@ -187,9 +322,13 @@ class SpecHelpers:
         """
         max_blobs_per_block = fork.max_blobs_per_block()
         max_blobs_per_tx = fork.max_blobs_per_tx()
-        invalid_combinations = cls.get_blob_combinations(
-            max_blobs_per_block + 1,
-            max_blobs_per_tx,
-        )
-        invalid_combinations.append((max_blobs_per_block + 1,))
-        return invalid_combinations
+
+        if max_blobs_per_block <= cls._EXHAUSTIVE_MAX_BLOBS_PER_BLOCK:
+            invalid_combinations = cls.get_blob_combinations(
+                max_blobs_per_block + 1,
+                max_blobs_per_tx,
+            )
+            invalid_combinations.append((max_blobs_per_block + 1,))
+            return invalid_combinations
+        else:
+            return cls.get_representative_invalid_blob_combinations(fork)

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -88,7 +88,9 @@ class SpecHelpers:
     """
 
     BYTES_PER_FIELD_ELEMENT = 32
-    _EXHAUSTIVE_MAX_BLOBS_PER_BLOCK = 9  # Osaka max; exhaustive is tractable up to here
+    _EXHAUSTIVE_MAX_BLOBS_PER_BLOCK = (
+        9  # Osaka max; exhaustive is tractable up to here
+    )
 
     @classmethod
     def get_representative_blob_combinations(
@@ -201,10 +203,10 @@ class SpecHelpers:
             add((m, overflow))
 
         # 5. One blob + full block — e.g. (1,21)
-        # Per-tx-oversized elements must be last: the test sends all txs from one
-        # sender with sequential nonces, so a rejected non-last tx creates a nonce
-        # gap that causes subsequent txs to fail with NONCE_MISMATCH, not the
-        # expected blob error.
+        # Per-tx-oversized elements must be last: the test sends all txs from
+        # one sender with sequential nonces, so a rejected non-last tx creates
+        # a nonce gap that causes subsequent txs to fail with NONCE_MISMATCH,
+        # not the expected blob error.
         add((1, max_blobs_per_block))
 
         # 6. Balanced all-valid: near-equal tx sizes, all within per-tx limit

--- a/tests/cancun/eip4844_blobs/spec.py
+++ b/tests/cancun/eip4844_blobs/spec.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import List, Optional, Set, Tuple
 
-from execution_testing import Fork, Transaction
+import pytest
+from execution_testing import Fork, ParameterSet, Transaction
 
 
 @dataclass(frozen=True)
@@ -297,7 +298,7 @@ class SpecHelpers:
         return combinations
 
     @classmethod
-    def all_valid_blob_combinations(cls, fork: Fork) -> List[Tuple[int, ...]]:
+    def all_valid_blob_combinations(cls, fork: Fork) -> List[ParameterSet]:
         """
         Return all valid blob tx combinations for a given block, assuming the
         given MAX_BLOBS_PER_BLOCK, whilst respecting MAX_BLOBS_PER_TX.
@@ -314,10 +315,16 @@ class SpecHelpers:
                 combinations += cls.get_representative_blob_combinations(
                     i, max_blobs_per_tx
                 )
-        return combinations
+        return [
+            pytest.param(
+                combination,
+                id=f"blobs_per_tx_{repr(combination).replace(' ', '')}",
+            )
+            for combination in combinations
+        ]
 
     @classmethod
-    def invalid_blob_combinations(cls, fork: Fork) -> List[Tuple[int, ...]]:
+    def invalid_blob_combinations(cls, fork: Fork) -> List[ParameterSet]:
         """
         Return invalid blob tx combinations for a given block that use up to
         MAX_BLOBS_PER_BLOCK+1 blobs.
@@ -325,12 +332,21 @@ class SpecHelpers:
         max_blobs_per_block = fork.max_blobs_per_block()
         max_blobs_per_tx = fork.max_blobs_per_tx()
 
+        invalid_combinations: List[Tuple[int, ...]] = []
         if max_blobs_per_block <= cls._EXHAUSTIVE_MAX_BLOBS_PER_BLOCK:
-            invalid_combinations = cls.get_blob_combinations(
+            invalid_combinations += cls.get_blob_combinations(
                 max_blobs_per_block + 1,
                 max_blobs_per_tx,
             )
             invalid_combinations.append((max_blobs_per_block + 1,))
-            return invalid_combinations
         else:
-            return cls.get_representative_invalid_blob_combinations(fork)
+            invalid_combinations = (
+                cls.get_representative_invalid_blob_combinations(fork)
+            )
+        return [
+            pytest.param(
+                combination,
+                id=f"blobs_per_tx_{repr(combination).replace(' ', '')}",
+            )
+            for combination in invalid_combinations
+        ]


### PR DESCRIPTION
This PR removes some parametrized blob combination test cases from Amsterdam:

- Replace exhaustive blob-per-tx partition enumeration with bounded representative sampling for forks where `max_blobs_per_block > 9`.
- Keep exhaustive enumeration for Cancun, Prague, and Osaka.
- Amsterdam (max_blobs_per_block=21, max_blobs_per_tx=6) drops from 21,816 valid + 1,562 invalid → 648 valid + 12 invalid parametrized tests.

## Motivation

`SpecHelpers.get_blob_combinations()` enumerates every valid integer partition of a blob count into transactions. The count of partitions grows combinatorially with `max_blobs_per_block`. Three parametrized tests (`test_valid_blob_tx_combinations`, `test_insufficient_balance_blob_tx_combinations`, `test_invalid_block_blob_count`) multiply these combinations by fixture format and base fee, producing an intractable number of test cases for high-blob forks.

Collected via `--collect-only -q --until Amsterdam`:

| Fork      | max/block | max/tx | Method         | Valid combos | Valid tests   | Invalid combos | Invalid tests |
| --------- | --------- | ------ | -------------- | ------------ | ------------- | -------------- | ------------- |
| Cancun    | 6         | 6      | exhaustive     | 44 → 44      | 264 → 264     | 28 → 28        | 56 → 56       |
| Prague    | 9         | 9      | exhaustive     | 169 → 169    | 1,014 → 1,014 | 80 → 80        | 160 → 160     |
| Osaka     | 9         | 6      | exhaustive     | 158 → 158    | 948 → 948     | 68 → 68        | 136 → 136     |
| Amsterdam | 21        | 6      | representative | 3,636 → 108  | 21,816 → 648  | 781 → 6        | 1,562 → 12    |

## Approach

A threshold constant `_EXHAUSTIVE_MAX_BLOBS_PER_BLOCK = 9` controls dispatch. Below this threshold, the existing exhaustive `get_blob_combinations()` runs unchanged. Above it, `get_representative_blob_combinations()` generates a bounded set of partitions per blob count, covering distinct structural patterns:

1. **Single tx** `(N,)` - tests the single-tx-fills-block case (only when N ≤ max_per_tx).
2. **All singles** `(1,)*N` - maximum transaction count; every tx carries one blob.
3. **Greedy pack** `(M,)*q + (R,)` - minimum transaction count; fill max-sized txs first.
4. **Reversed greedy** - tests ordering sensitivity (small remainder tx first).
5. **One big + singles** `(min(N-1, M), 1, 1, ...)` and its reverse - asymmetric distribution in both orderings.
6. **Balanced split** `(⌈N/2⌉, ⌊N/2⌋)` and its reverse - two roughly equal txs (only when both halves ≤ max_per_tx).
7. **Uniform non-max** `(k,)*q` - all txs same size where 1 < k < max_per_tx (largest k that evenly divides N).

Deduplication via a `seen` set ensures no redundant entries when rules converge (e.g., for small N, several rules produce the same partition).

Invalid combinations use a parallel `get_representative_invalid_blob_combinations()` generating ~6 partitions for `total = max_blobs_per_block + 1`, including a balanced all-per-tx-valid entry for better coverage of the block-level-only rejection path.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
