### PR TITLE
feat(benchmark/tests): Extra sstore benchmark tests

### DIFF
--- a/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
+++ b/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
@@ -3,9 +3,9 @@ Benchmark code generator classes for creating
 optimized bytecode patterns.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from execution_testing.base_types import Address
+from execution_testing.base_types import Address, Storage
 from execution_testing.forks import Fork
 from execution_testing.specs.benchmark import BenchmarkCodeGenerator
 from execution_testing.test_types import Alloc
@@ -17,6 +17,7 @@ class JumpLoopGenerator(BenchmarkCodeGenerator):
     """Generates bytecode that loops execution using JUMP operations."""
 
     contract_balance: int = 0
+    contract_storage: Storage = field(default_factory=Storage)
 
     def deploy_contracts(self, *, pre: Alloc, fork: Fork) -> Address:
         """Deploy the looping contract."""
@@ -31,7 +32,9 @@ class JumpLoopGenerator(BenchmarkCodeGenerator):
             fork=fork,
         )
         self._contract_address = pre.deploy_contract(
-            code=code, balance=self.contract_balance
+            code=code,
+            balance=self.contract_balance,
+            storage=self.contract_storage,
         )
         return self._contract_address
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -10,11 +10,13 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 import json
 import math
 from pathlib import Path
+from typing import Tuple
 
 import pytest
 from execution_testing import (
     AccessList,
     Account,
+    Address,
     Alloc,
     BenchmarkTestFiller,
     Block,
@@ -400,7 +402,13 @@ def test_sstore_erc20_approve(
     )
 
 
-def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
+def sstore_helper_contract(
+    *,
+    sloads_before_sstore: bool,
+    key_warm: bool,
+    original_value: int,
+    new_value: int,
+) -> Tuple[Bytecode, Bytecode, Bytecode]:
     """
     Storage contract for benchmark slot access.
 
@@ -408,68 +416,72 @@ def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
     # - CALLDATA[0..31]: Number of slots to access
     # - CALLDATA[32..63]: Starting slot index
     # - CALLDATA[64..95]: Value to write
+
+    Returns:
+    - setup: Bytecode of the setup of the contract
+    - loop: Bytecode of the loop of the contract
+    - cleanup: Bytecode of the cleanup of the contract
+
     """
     setup = Bytecode()
     loop = Bytecode()
     cleanup = Bytecode()
 
-    start_marker = 10
-    end_marker = 30 + (3 if sloads_before_sstore else 0)
-
     setup += (
-        Op.CALLDATALOAD(0)  # num_slots
-        + Op.CALLDATALOAD(32)  # start_slot
+        Op.ADD(
+            Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)
+        )  # num_slots + start_slot = end_slot
         + Op.CALLDATALOAD(64)  # value
+        + Op.CALLDATALOAD(32)  # start_slot = counter
     )
 
-    setup += Op.PUSH0  # Counter
-    setup += Op.JUMPDEST
-    # [counter, value, start_slot, num_slots]
+    # [counter, value, end_slot]
 
-    # Loop Condition: Counter < Num Slots
-    loop += Op.DUP4
-    loop += Op.DUP2
-    loop += Op.LT
-    loop += Op.ISZERO
-    loop += Op.PUSH1(end_marker)
-    loop += Op.JUMPI
-    # [counter, value, start_slot, num_slots]
+    start_marker = len(setup)
 
+    loop += Op.JUMPDEST
     # Loop Body: Store Value at Start Slot + Counter
-    loop += Op.DUP1
-    loop += Op.DUP4
-    loop += Op.ADD
-    loop += Op.DUP3
-    # [value, start_slot+counter, counter, value, start_slot, num_slots]
-
     if sloads_before_sstore:
-        loop += Op.DUP2
-        loop += Op.SLOAD
+        loop += Op.DUP1  # [counter, counter, value, end_slot]
+        loop += Op.SLOAD(key_warm=key_warm)
         loop += Op.POP
-        loop += Op.SWAP1
-        loop += Op.SSTORE
+        loop += Op.DUP2  # [value, counter, value, end_slot]
+        loop += Op.DUP2  # [counter, value, counter, value, end_slot]
+        loop += Op.SSTORE(
+            key_warm=False,
+            original_value=original_value,
+            new_value=new_value,
+        )
     else:
-        loop += Op.SWAP1
-        loop += Op.SSTORE  # STORAGE[start_slot + counter] = value
-    # [counter, value, start_slot, num_slots]
+        loop += Op.DUP2  # [value, counter, value, end_slot]
+        loop += Op.DUP2  # [counter, value, counter, value, end_slot]
+        loop += Op.SSTORE(  # STORAGE[counter, value] = value
+            key_warm=key_warm,
+            original_value=original_value,
+            new_value=new_value,
+        )
 
     # Loop Post: Increment Counter
     loop += Op.PUSH1(1)
     loop += Op.ADD
+    # [counter + 1, value, end_slot]
+
+    # Loop Condition: Counter < Num Slots
+    loop += Op.DUP3  # [end_slot, counter + 1, value, end_slot]
+    loop += Op.DUP2  # [counter + 1, end_slot, counter + 1, value, end_slot]
+    loop += Op.LT  # [counter + 1 < end_slot, counter + 1, value, end_slot]
+    loop += Op.ISZERO
+    loop += Op.ISZERO
     loop += Op.PUSH1(start_marker)
-    loop += Op.JUMP
-    # [counter + 1, value, start_slot, num_slots]
+    loop += Op.JUMPI
+    # [counter, value, end_slot]
 
     # Cleanup: Stop
-    cleanup += Op.JUMPDEST
     cleanup += Op.STOP
 
-    assert len(setup) - 1 == start_marker
-    assert len(setup) + len(loop) == end_marker
-    return setup + loop + cleanup
+    return setup, loop, cleanup
 
 
-@pytest.mark.parametrize("slot_count", [50, 100])
 @pytest.mark.parametrize("use_access_list", [True, False])
 @pytest.mark.parametrize("sloads_before_sstore", [True, False])
 @pytest.mark.parametrize("num_contracts", [1, 5, 10])
@@ -485,10 +497,10 @@ def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
 )
 def test_sstore_variants(
     benchmark_test: BenchmarkTestFiller,
+    fork: Fork,
     pre: Alloc,
     tx_gas_limit: int,
     gas_benchmark_value: int,
-    slot_count: int,
     use_access_list: bool,
     sloads_before_sstore: bool,
     num_contracts: int,
@@ -505,68 +517,138 @@ def test_sstore_variants(
     - initial_value/write_value: Storage transitions
       (zero_to_zero, zero_to_nonzero, nonzero_to_zero, nonzero_to_nonzero)
     """
-    base_contract = sstore_helper_contract(sloads_before_sstore)
-    padded_contract = base_contract
-
-    slots_per_contract = slot_count // num_contracts
-
-    txs: list[Transaction] = []
-    post = {}
-
-    base_gas_per_contract = min(
-        tx_gas_limit, gas_benchmark_value // num_contracts
+    (
+        base_contract_setup,
+        base_contract_loop,
+        base_contract_cleanup,
+    ) = sstore_helper_contract(
+        sloads_before_sstore=sloads_before_sstore,
+        key_warm=use_access_list,
+        original_value=initial_value,
+        new_value=write_value,
     )
-    gas_remainder = tx_gas_limit % num_contracts
+    base_contract = (
+        base_contract_setup + base_contract_loop + base_contract_cleanup
+    )
 
-    for contract_idx in range(num_contracts):
-        initial_storage = Storage()
+    gas_per_contract = gas_benchmark_value // num_contracts
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
 
-        start_slot = contract_idx * slots_per_contract
-        for i in range(slots_per_contract):
-            initial_storage[start_slot + i] = initial_value
+    def get_calldata(iteration_count: int, start_slot: int) -> bytes:
+        return Hash(iteration_count) + Hash(start_slot) + Hash(write_value)
 
-        contract_addr = pre.deploy_contract(
-            code=padded_contract,
-            storage=initial_storage,
-        )
-
-        calldata = (
-            slots_per_contract.to_bytes(32, "big")
-            + start_slot.to_bytes(32, "big")
-            + write_value.to_bytes(32, "big")
-        )
-
-        access_list = None
+    def get_access_list(
+        iteration_count: int, start_slot: int, contract_addr: Address
+    ) -> list[AccessList] | None:
         if use_access_list:
             storage_keys = [
-                Hash(start_slot + i) for i in range(slots_per_contract)
+                Hash(i)
+                for i in range(start_slot, start_slot + iteration_count)
             ]
-            access_list = [
+            return [
                 AccessList(
                     address=contract_addr,
                     storage_keys=storage_keys,
                 )
             ]
+        return None
 
-        contract_gas_limit = base_gas_per_contract
-        if contract_idx == len(txs) - 1:
-            contract_gas_limit += gas_remainder
-
-        tx = Transaction(
-            to=contract_addr,
-            data=calldata,
-            gas_limit=contract_gas_limit,
-            sender=pre.fund_eoa(),
-            access_list=access_list,
+    def calc_gas_required(
+        iteration_count: int, start_slot: int, contract_addr: Address
+    ) -> int:
+        intrinsic_gas_cost = intrinsic_gas_cost_calc(
+            calldata=get_calldata(iteration_count, start_slot),
+            access_list=get_access_list(
+                iteration_count, start_slot, contract_addr
+            ),
         )
-        txs.append(tx)
+        overhead_gas = (
+            base_contract_setup.gas_cost(fork)
+            + base_contract_cleanup.gas_cost(fork)
+            + intrinsic_gas_cost
+        )
+        iteration_cost = base_contract_loop.gas_cost(fork) * iteration_count
+        return overhead_gas + iteration_cost
+
+    # Calculate how many slots per contract per transaction are required
+    iteration_counts: list[int] = []
+    remaining_gas = gas_per_contract
+    start_slot = 0
+    while remaining_gas > 0:
+        gas_limit = (
+            min(remaining_gas, gas_limit_cap)
+            if gas_limit_cap is not None
+            else remaining_gas
+        )
+        current_iteration_count = 0
+        next_iteration_count = current_iteration_count + 1
+        while True:
+            if (
+                calc_gas_required(next_iteration_count, start_slot, Address(0))
+                > gas_limit
+            ):
+                break
+            current_iteration_count += 1
+            next_iteration_count += 1
+
+        if current_iteration_count > 0:
+            iteration_counts.append(current_iteration_count)
+            start_slot += current_iteration_count
+        else:
+            break
+        remaining_gas -= calc_gas_required(
+            current_iteration_count, start_slot, Address(0)
+        )
+
+    assert len(iteration_counts) > 0, (
+        f"No iteration counts found for {num_contracts} contracts"
+    )
+
+    slots_per_contract = sum(iteration_counts)
+
+    txs: list[Transaction] = []
+    post = {}
+
+    for _ in range(num_contracts):
+        initial_storage = Storage()
+
+        if initial_value != 0:
+            for i in range(slots_per_contract):
+                initial_storage[i] = initial_value
+
+        contract_addr = pre.deploy_contract(
+            code=base_contract,
+            storage=initial_storage,
+        )
+
+        start_slot = 0
+        for iteration_count in iteration_counts:
+            calldata = get_calldata(iteration_count, start_slot)
+            access_list = get_access_list(
+                iteration_count, start_slot, contract_addr
+            )
+            tx_gas_limit = calc_gas_required(
+                iteration_count, start_slot, contract_addr
+            )
+
+            tx = Transaction(
+                to=contract_addr,
+                data=calldata,
+                gas_limit=tx_gas_limit,
+                sender=pre.fund_eoa(),
+                access_list=access_list,
+            )
+            txs.append(tx)
+
+            start_slot += iteration_count
 
         expected_storage = Storage()
         for i in range(slots_per_contract):
-            expected_storage[start_slot + i] = write_value
+            expected_storage[i] = write_value
 
         post[contract_addr] = Account(
-            code=padded_contract,
+            code=base_contract,
             storage=expected_storage,
         )
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -414,8 +414,8 @@ def sstore_helper_contract(
     Storage contract for benchmark slot access.
 
     # Calldata Layout:
-    # - CALLDATA[0..31]: Ending slot
-    # - CALLDATA[32..63]: Starting slot
+    # - CALLDATA[0..31]: Starting slot
+    # - CALLDATA[32..63]: Ending slot
     # - CALLDATA[64..95]: Value to write
 
     Returns:
@@ -470,7 +470,7 @@ def sstore_helper_contract(
     loop += Op.ISZERO
     loop += Op.PUSH1(len(setup))
     loop += Op.JUMPI
-    # [counter, value, end_slot]
+    # [counter + 1, value, end_slot]
 
     # Cleanup: Stop
     cleanup += Op.STOP
@@ -488,7 +488,7 @@ def sstore_helper_contract(
         pytest.param(0, 0xDEADBEEF, id="zero_to_nonzero"),
         pytest.param(0xDEADBEEF, 0, id="nonzero_to_zero"),
         pytest.param(0xDEADBEEF, 0xBEEFBEEF, id="nonzero_to_diff"),
-        pytest.param(0xDEADBEEF, 0xBEEFBEEF, id="nonzero_to_same"),
+        pytest.param(0xDEADBEEF, 0xDEADBEEF, id="nonzero_to_same"),
     ],
 )
 def test_sstore_variants(
@@ -719,7 +719,7 @@ def sload_helper_contract(
     loop += Op.ISZERO
     loop += Op.PUSH1(len(setup))
     loop += Op.JUMPI
-    # [counter, value, end_slot]
+    # [counter + 1, value, end_slot]
 
     # Cleanup: Stop
     cleanup += Op.STOP
@@ -880,12 +880,13 @@ def test_storage_sload_same_key_benchmark(
     """
     contract_storage = Storage()
     if storage_keys_pre_set:
-        contract_storage[0] = 1
+        contract_storage[1] = 1
 
     benchmark_test(
         target_opcode=Op.SLOAD,
         code_generator=JumpLoopGenerator(
-            attack_block=Op.POP(Op.SLOAD(Op.PUSH1[0])),
+            setup=Op.PUSH1(1) if storage_keys_pre_set else Op.PUSH0,
+            attack_block=Op.SLOAD,
             contract_storage=contract_storage,
         ),
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -428,11 +428,9 @@ def sstore_helper_contract(
     cleanup = Bytecode()
 
     setup += (
-        Op.ADD(
-            Op.CALLDATALOAD(0), Op.CALLDATALOAD(32)
-        )  # num_slots + start_slot = end_slot
+        Op.CALLDATALOAD(32)  # end_slot
         + Op.CALLDATALOAD(64)  # value
-        + Op.CALLDATALOAD(32)  # start_slot = counter
+        + Op.CALLDATALOAD(0)  # start_slot = counter
     )
 
     # [counter, value, end_slot]
@@ -536,7 +534,11 @@ def test_sstore_variants(
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
 
     def get_calldata(iteration_count: int, start_slot: int) -> bytes:
-        return Hash(iteration_count) + Hash(start_slot) + Hash(write_value)
+        return (
+            Hash(start_slot)
+            + Hash(start_slot + iteration_count)
+            + Hash(write_value)
+        )
 
     def get_access_list(
         iteration_count: int, start_slot: int, contract_addr: Address

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -24,6 +24,7 @@ from execution_testing import (
     Bytecode,
     Fork,
     Hash,
+    JumpLoopGenerator,
     Op,
     Storage,
     Transaction,
@@ -413,8 +414,8 @@ def sstore_helper_contract(
     Storage contract for benchmark slot access.
 
     # Calldata Layout:
-    # - CALLDATA[0..31]: Number of slots to access
-    # - CALLDATA[32..63]: Starting slot index
+    # - CALLDATA[0..31]: Ending slot
+    # - CALLDATA[32..63]: Starting slot
     # - CALLDATA[64..95]: Value to write
 
     Returns:
@@ -432,10 +433,7 @@ def sstore_helper_contract(
         + Op.CALLDATALOAD(64)  # value
         + Op.CALLDATALOAD(0)  # start_slot = counter
     )
-
     # [counter, value, end_slot]
-
-    start_marker = len(setup)
 
     loop += Op.JUMPDEST
     # Loop Body: Store Value at Start Slot + Counter
@@ -446,7 +444,7 @@ def sstore_helper_contract(
         loop += Op.DUP2  # [value, counter, value, end_slot]
         loop += Op.DUP2  # [counter, value, counter, value, end_slot]
         loop += Op.SSTORE(
-            key_warm=False,
+            key_warm=True,
             original_value=original_value,
             new_value=new_value,
         )
@@ -470,7 +468,7 @@ def sstore_helper_contract(
     loop += Op.LT  # [counter + 1 < end_slot, counter + 1, value, end_slot]
     loop += Op.ISZERO
     loop += Op.ISZERO
-    loop += Op.PUSH1(start_marker)
+    loop += Op.PUSH1(len(setup))
     loop += Op.JUMPI
     # [counter, value, end_slot]
 
@@ -516,18 +514,16 @@ def test_sstore_variants(
       (zero_to_zero, zero_to_nonzero, nonzero_to_zero, nonzero_to_nonzero)
     """
     (
-        base_contract_setup,
-        base_contract_loop,
-        base_contract_cleanup,
+        contract_setup,
+        contract_loop,
+        contract_cleanup,
     ) = sstore_helper_contract(
         sloads_before_sstore=sloads_before_sstore,
         key_warm=use_access_list,
         original_value=initial_value,
         new_value=write_value,
     )
-    base_contract = (
-        base_contract_setup + base_contract_loop + base_contract_cleanup
-    )
+    contract = contract_setup + contract_loop + contract_cleanup
 
     gas_per_contract = gas_benchmark_value // num_contracts
     gas_limit_cap = fork.transaction_gas_limit_cap()
@@ -556,7 +552,7 @@ def test_sstore_variants(
             ]
         return None
 
-    def calc_gas_required(
+    def calc_gas_consumed(
         iteration_count: int, start_slot: int, contract_addr: Address
     ) -> int:
         intrinsic_gas_cost = intrinsic_gas_cost_calc(
@@ -564,14 +560,26 @@ def test_sstore_variants(
             access_list=get_access_list(
                 iteration_count, start_slot, contract_addr
             ),
+            return_cost_deducted_prior_execution=True,
         )
         overhead_gas = (
-            base_contract_setup.gas_cost(fork)
-            + base_contract_cleanup.gas_cost(fork)
+            contract_setup.gas_cost(fork)
+            + contract_cleanup.gas_cost(fork)
             + intrinsic_gas_cost
         )
-        iteration_cost = base_contract_loop.gas_cost(fork) * iteration_count
+        iteration_cost = contract_loop.gas_cost(fork) * iteration_count
         return overhead_gas + iteration_cost
+
+    def calc_gas_required(
+        iteration_count: int, start_slot: int, contract_addr: Address
+    ) -> int:
+        gsc = fork.gas_costs()
+        # SSTORE requires a minimum gas of G_CALL_STIPEND to operate.
+        # TODO: Correct fix is to introduce bytecode.gas_required.
+        return (
+            calc_gas_consumed(iteration_count, start_slot, contract_addr)
+            + gsc.G_CALL_STIPEND
+        )
 
     # Calculate how many slots per contract per transaction are required
     iteration_counts: list[int] = []
@@ -614,6 +622,7 @@ def test_sstore_variants(
     txs: list[Transaction] = []
     post = {}
 
+    gas_used = 0
     for _ in range(num_contracts):
         initial_storage = Storage()
 
@@ -622,7 +631,7 @@ def test_sstore_variants(
                 initial_storage[i] = initial_value
 
         contract_addr = pre.deploy_contract(
-            code=base_contract,
+            code=contract,
             storage=initial_storage,
         )
 
@@ -635,6 +644,14 @@ def test_sstore_variants(
             tx_gas_limit = calc_gas_required(
                 iteration_count, start_slot, contract_addr
             )
+            tx_gas_consumed = calc_gas_consumed(
+                iteration_count, start_slot, contract_addr
+            )
+            max_refund = tx_gas_consumed // 5
+            refund = min(
+                contract_loop.refund(fork) * iteration_count, max_refund
+            )
+            gas_used += tx_gas_consumed - refund
 
             tx = Transaction(
                 to=contract_addr,
@@ -652,128 +669,223 @@ def test_sstore_variants(
             expected_storage[i] = write_value
 
         post[contract_addr] = Account(
-            code=base_contract,
+            code=contract,
             storage=expected_storage,
         )
 
     benchmark_test(
         blocks=[Block(txs=txs)],
         post=post,
-        skip_gas_used_validation=True,
+        expected_benchmark_gas_used=gas_used,
     )
 
 
-def sload_helper_contract() -> Bytecode:
+def sload_helper_contract(
+    *, key_warm: bool
+) -> Tuple[Bytecode, Bytecode, Bytecode]:
     """
     Storage contract for benchmark slot access.
 
     # Calldata Layout:
-    # - CALLDATA[0..31]: incrementer
-    # - CALLDATA[32..63]: Number of slots to access
+    # - CALLDATA[0..31]: Starting slot
+    # - CALLDATA[32..63]: Ending slot
     """
     setup = Bytecode()
     loop = Bytecode()
     cleanup = Bytecode()
 
-    start_marker = 4
-    end_marker = 26
+    setup += Op.CALLDATALOAD(32)  # end_slot
+    setup += Op.CALLDATALOAD(0)  # start slot = counter
+    # [counter, end_slot]
 
-    setup += Op.PUSH0  # counter
-    setup += Op.CALLDATALOAD(32)  # num_slots
-    setup += Op.JUMPDEST
-    # [num_slots, counter]
+    loop += Op.JUMPDEST
+
+    # Loop Body: Load key from storage
+    loop += Op.DUP1
+    loop += Op.SLOAD(key_warm=key_warm)
+    loop += Op.POP
+    # [counter, end_slot]
+
+    # Loop Post: Increment Counter
+    loop += Op.PUSH1(1)
+    loop += Op.ADD
+    # [counter + 1, end_slot]
 
     # Loop Condition: Counter < Num Slots
-    loop += Op.DUP1
+    loop += Op.DUP2  # [end_slot, counter + 1, end_slot]
+    loop += Op.DUP2  # [counter + 1, end_slot, counter + 1, end_slot]
+    loop += Op.LT  # [counter + 1 < end_slot, counter + 1, end_slot]
     loop += Op.ISZERO
-    loop += Op.PUSH1(end_marker)
+    loop += Op.ISZERO
+    loop += Op.PUSH1(len(setup))
     loop += Op.JUMPI
-    # [num_slots, counter]
+    # [counter, value, end_slot]
 
-    # Loop Body: SLOAD value at counter
-    loop += Op.PUSH1(1)
-    loop += Op.SWAP1
-    loop += Op.SUB
-    loop += Op.SWAP1
-    # [counter, num_slots-1]
-
-    loop += Op.DUP1
-    loop += Op.SLOAD
-    loop += Op.POP
-    # [counter, num_slots-1]
-
-    loop += Op.CALLDATALOAD(0)
-    loop += Op.ADD
-    loop += Op.SWAP1
-    # [num_slots-1, incrementer+counter]
-
-    loop += Op.PUSH1(start_marker)
-    loop += Op.JUMP
-    # [num_slots-1, incrementer+counter]
-
-    cleanup += Op.JUMPDEST
+    # Cleanup: Stop
     cleanup += Op.STOP
 
-    assert len(setup) - 1 == start_marker
-    assert len(setup) + len(loop) == end_marker
-    return setup + loop + cleanup
+    return setup, loop, cleanup
 
 
-@pytest.mark.parametrize("num_slots", [1, 10, 50, 100, 200])
 @pytest.mark.parametrize("warm_slots", [False, True])
-@pytest.mark.parametrize("storage_keys_set", [False, True])
-@pytest.mark.parametrize("incrementer", [0, 1])
+@pytest.mark.parametrize("storage_keys_pre_set", [False, True])
 def test_storage_sload_benchmark(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
     warm_slots: bool,
-    storage_keys_set: bool,
-    num_slots: int,
-    incrementer: int,
+    storage_keys_pre_set: bool,
     tx_gas_limit: int,
 ) -> None:
     """
-    Benchmark SSTORE instruction with various configurations.
+    Benchmark SLOAD instruction with various configurations.
 
     Variants:
-    - use_access_list: Warm storage slots via access list
-    - sloads_before_sstore: Number of SLOADs per slot before SSTORE
-    - num_contracts: Number of contract instances (cold storage writes)
-    - initial_value/write_value: Storage transitions
-      (zero_to_zero, zero_to_nonzero, nonzero_to_zero, nonzero_to_nonzero)
+    - warm_slots: Warm storage slots via access list
+    - storage_keys_pre_set: Whether the storage keys are pre-set
     """
-    slots: set[int] = set()
-    if storage_keys_set:
-        slots = {i * incrementer for i in range(num_slots)}
-    initial_storage = Storage.model_validate(dict.fromkeys(slots, 1))
+    contract_setup, contract_loop, contract_cleanup = sload_helper_contract(
+        key_warm=warm_slots
+    )
+    contract = contract_setup + contract_loop + contract_cleanup
 
-    storage_contract = pre.deploy_contract(
-        code=sload_helper_contract(),
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+
+    def get_calldata(iteration_count: int, start_slot: int) -> bytes:
+        return Hash(start_slot) + Hash(start_slot + iteration_count)
+
+    def get_access_list(
+        iteration_count: int, start_slot: int, contract_addr: Address
+    ) -> list[AccessList] | None:
+        if warm_slots:
+            storage_keys = [
+                Hash(i)
+                for i in range(start_slot, start_slot + iteration_count)
+            ]
+            return [
+                AccessList(
+                    address=contract_addr,
+                    storage_keys=storage_keys,
+                )
+            ]
+        return None
+
+    def calc_gas_required(
+        iteration_count: int, start_slot: int, contract_addr: Address
+    ) -> int:
+        intrinsic_gas_cost = intrinsic_gas_cost_calc(
+            calldata=get_calldata(iteration_count, start_slot),
+            access_list=get_access_list(
+                iteration_count, start_slot, contract_addr
+            ),
+            return_cost_deducted_prior_execution=True,
+        )
+        overhead_gas = (
+            contract_setup.gas_cost(fork)
+            + contract_cleanup.gas_cost(fork)
+            + intrinsic_gas_cost
+        )
+        iteration_cost = contract_loop.gas_cost(fork) * iteration_count
+        return overhead_gas + iteration_cost
+
+    # Calculate how many slots per transaction are required
+    iteration_counts: list[int] = []
+    remaining_gas = gas_benchmark_value
+    start_slot = 0
+    while remaining_gas > 0:
+        gas_limit = (
+            min(remaining_gas, gas_limit_cap)
+            if gas_limit_cap is not None
+            else remaining_gas
+        )
+        if calc_gas_required(0, start_slot, Address(0)) > gas_limit:
+            break
+
+        # Binary search the optimal number of iterations given the gas limit
+        low, high = 1, 2
+        while calc_gas_required(high, start_slot, Address(0)) <= gas_limit:
+            high *= 2
+
+        while low < high:
+            mid = (low + high) // 2
+            if calc_gas_required(mid, start_slot, Address(0)) > gas_limit:
+                high = mid
+            else:
+                low = mid + 1
+
+        iteration_count = low - 1
+        iteration_counts.append(iteration_count)
+        start_slot += iteration_count
+        remaining_gas -= calc_gas_required(
+            iteration_count, start_slot, Address(0)
+        )
+
+    assert len(iteration_counts) > 0, "No iteration counts found"
+
+    slot_count = sum(iteration_counts)
+
+    initial_storage = Storage()
+    if storage_keys_pre_set:
+        for i in range(slot_count):
+            initial_storage[i] = 1
+
+    contract_addr = pre.deploy_contract(
+        code=contract,
         storage=initial_storage,
     )
 
-    calldata = incrementer.to_bytes(32, "big") + num_slots.to_bytes(32, "big")
+    start_slot = 0
+    txs: list[Transaction] = []
+    gas_used = 0
+    for iteration_count in iteration_counts:
+        calldata = get_calldata(iteration_count, start_slot)
+        access_list = get_access_list(
+            iteration_count, start_slot, contract_addr
+        )
+        tx_gas_limit = calc_gas_required(
+            iteration_count, start_slot, contract_addr
+        )
+        gas_used += tx_gas_limit
 
-    access_lists: list[AccessList] = []
+        tx = Transaction(
+            to=contract_addr,
+            data=calldata,
+            gas_limit=tx_gas_limit,
+            sender=pre.fund_eoa(),
+            access_list=access_list,
+        )
+        txs.append(tx)
 
-    if warm_slots:
-        access_lists = [
-            AccessList(
-                address=storage_contract,
-                storage_keys=list(slots),
-            ),
-        ]
-
-    tx = Transaction(
-        to=storage_contract,
-        gas_limit=tx_gas_limit,
-        access_list=access_lists,
-        data=calldata,
-        sender=pre.fund_eoa(),
-    )
+        start_slot += iteration_count
 
     benchmark_test(
         pre=pre,
-        blocks=[Block(txs=[tx])],
-        skip_gas_used_validation=True,
+        blocks=[Block(txs=txs)],
+        expected_benchmark_gas_used=gas_used,
+    )
+
+
+@pytest.mark.parametrize("storage_keys_pre_set", [False, True])
+def test_storage_sload_same_key_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    storage_keys_pre_set: bool,
+) -> None:
+    """
+    Benchmark SLOAD instruction when loading the same key over and over.
+
+    Variants:
+    - storage_keys_pre_set: The key is pre-set to a non-zero value.
+    """
+    contract_storage = Storage()
+    if storage_keys_pre_set:
+        contract_storage[0] = 1
+
+    benchmark_test(
+        target_opcode=Op.SLOAD,
+        code_generator=JumpLoopGenerator(
+            attack_block=Op.POP(Op.SLOAD(Op.PUSH1[0])),
+            contract_storage=contract_storage,
+        ),
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -13,13 +13,17 @@ from pathlib import Path
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Alloc,
+    BenchmarkTestFiller,
     Block,
     BlockchainTestFiller,
     Bytecode,
     Fork,
+    Hash,
     Op,
+    Storage,
     Transaction,
     While,
 )
@@ -393,4 +397,296 @@ def test_sstore_erc20_approve(
         pre=pre,
         blocks=[Block(txs=txs)],
         post=post,
+    )
+
+
+def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
+    """
+    Storage contract for benchmark slot access.
+
+    # Calldata Layout:
+    # - CALLDATA[0..31]: Number of slots to access
+    # - CALLDATA[32..63]: Starting slot index
+    # - CALLDATA[64..95]: Value to write
+    """
+    setup = Bytecode()
+    loop = Bytecode()
+    cleanup = Bytecode()
+
+    start_marker = 10
+    end_marker = 30 + (2 if sloads_before_sstore else 0)
+
+    setup += (
+        Op.CALLDATALOAD(0)  # num_slots
+        + Op.CALLDATALOAD(32)  # start_slot
+        + Op.CALLDATALOAD(64)  # value
+    )
+
+    setup += Op.PUSH0  # Counter
+    setup += Op.JUMPDEST
+    # [counter, value, start_slot, num_slots]
+
+    # Loop Condition: Counter < Num Slots
+    loop += Op.DUP4
+    loop += Op.DUP2
+    loop += Op.LT
+    loop += Op.ISZERO
+    loop += Op.PUSH1(end_marker)
+    loop += Op.JUMPI
+    # [counter, value, start_slot, num_slots]
+
+    # Loop Body: Store Value at Start Slot + Counter
+    loop += Op.DUP1
+    loop += Op.DUP4
+    loop += Op.ADD
+    loop += Op.DUP3
+    # [value, start_slot+counter, counter, value, start_slot, num_slots]
+
+    if sloads_before_sstore:
+        loop += Op.DUP2
+        loop += Op.SLOAD
+        loop += Op.POP
+        loop += Op.SSTORE
+    else:
+        loop += Op.SWAP1
+        loop += Op.SSTORE  # STORAGE[start_slot + counter] = value
+    # [counter, value, start_slot, num_slots]
+
+    # Loop Post: Increment Counter
+    loop += Op.PUSH1(1)
+    loop += Op.ADD
+    loop += Op.PUSH1(start_marker)
+    loop += Op.JUMP
+    # [counter + 1, value, start_slot, num_slots]
+
+    # Cleanup: Stop
+    cleanup += Op.JUMPDEST
+    cleanup += Op.STOP
+
+    assert len(setup) - 1 == start_marker
+    assert len(setup) + len(loop) == end_marker
+    return setup + loop + cleanup
+
+
+@pytest.mark.parametrize("slot_count", [50, 100])
+@pytest.mark.parametrize("use_access_list", [True, False])
+@pytest.mark.parametrize("sloads_before_sstore", [True, False])
+@pytest.mark.parametrize("num_contracts", [1, 5, 10])
+@pytest.mark.parametrize(
+    "initial_value,write_value",
+    [
+        pytest.param(0, 0, id="zero_to_zero"),
+        pytest.param(0, 0xDEADBEEF, id="zero_to_nonzero"),
+        pytest.param(0xDEADBEEF, 0, id="nonzero_to_zero"),
+        pytest.param(0xDEADBEEF, 0xBEEFBEEF, id="nonzero_to_diff"),
+        pytest.param(0xDEADBEEF, 0xBEEFBEEF, id="nonzero_to_same"),
+    ],
+)
+def test_sstore_variants(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    tx_gas_limit: int,
+    gas_benchmark_values: int,
+    slot_count: int,
+    use_access_list: bool,
+    sloads_before_sstore: bool,
+    num_contracts: int,
+    initial_value: int,
+    write_value: int,
+) -> None:
+    """
+    Benchmark SSTORE instruction with various configurations.
+
+    Variants:
+    - use_access_list: Warm storage slots via access list
+    - sloads_before_sstore: Number of SLOADs per slot before SSTORE
+    - num_contracts: Number of contract instances (cold storage writes)
+    - initial_value/write_value: Storage transitions
+      (zero_to_zero, zero_to_nonzero, nonzero_to_zero, nonzero_to_nonzero)
+    """
+    base_contract = sstore_helper_contract(sloads_before_sstore)
+    padded_contract = base_contract
+
+    slots_per_contract = slot_count // num_contracts
+
+    txs: list[Transaction] = []
+    post = {}
+
+    base_gas_per_contract = min(
+        tx_gas_limit, gas_benchmark_values // num_contracts
+    )
+    gas_remainder = tx_gas_limit % num_contracts
+
+    for contract_idx in range(num_contracts):
+        initial_storage = Storage()
+
+        start_slot = contract_idx * slots_per_contract
+        for i in range(slots_per_contract):
+            initial_storage[start_slot + i] = initial_value
+
+        contract_addr = pre.deploy_contract(
+            code=padded_contract,
+            storage=initial_storage,
+        )
+
+        calldata = (
+            slots_per_contract.to_bytes(32, "big")
+            + start_slot.to_bytes(32, "big")
+            + write_value.to_bytes(32, "big")
+        )
+
+        access_list = None
+        if use_access_list:
+            storage_keys = [
+                Hash(start_slot + i) for i in range(slots_per_contract)
+            ]
+            access_list = [
+                AccessList(
+                    address=contract_addr,
+                    storage_keys=storage_keys,
+                )
+            ]
+
+        contract_gas_limit = base_gas_per_contract
+        if contract_idx == len(txs) - 1:
+            contract_gas_limit += gas_remainder
+
+        tx = Transaction(
+            to=contract_addr,
+            data=calldata,
+            gas_limit=contract_gas_limit,
+            sender=pre.fund_eoa(),
+            access_list=access_list,
+        )
+        txs.append(tx)
+
+        expected_storage = Storage()
+        for i in range(slots_per_contract):
+            expected_storage[start_slot + i] = write_value
+
+        post[contract_addr] = Account(
+            code=padded_contract,
+            storage=expected_storage,
+        )
+
+    benchmark_test(
+        blocks=[Block(txs=txs)],
+        post=post,
+        skip_gas_used_validation=True,
+    )
+
+
+def sload_helper_contract() -> Bytecode:
+    """
+    Storage contract for benchmark slot access.
+
+    # Calldata Layout:
+    # - CALLDATA[0..31]: incrementer
+    # - CALLDATA[32..63]: Number of slots to access
+    """
+    setup = Bytecode()
+    loop = Bytecode()
+    cleanup = Bytecode()
+
+    start_marker = 4
+    end_marker = 26
+
+    setup += Op.PUSH0  # counter
+    setup += Op.CALLDATALOAD(32)  # num_slots
+    setup += Op.JUMPDEST
+    # [num_slots, counter]
+
+    # Loop Condition: Counter < Num Slots
+    loop += Op.DUP1
+    loop += Op.ISZERO
+    loop += Op.PUSH1(end_marker)
+    loop += Op.JUMPI
+    # [num_slots, counter]
+
+    # Loop Body: SLOAD value at counter
+    loop += Op.PUSH1(1)
+    loop += Op.SWAP1
+    loop += Op.SUB
+    loop += Op.SWAP1
+    # [counter, num_slots-1]
+
+    loop += Op.DUP1
+    loop += Op.SLOAD
+    loop += Op.POP
+    # [counter, num_slots-1]
+
+    loop += Op.CALLDATALOAD(0)
+    loop += Op.ADD
+    loop += Op.SWAP1
+    # [num_slots-1, incrementer+counter]
+
+    loop += Op.PUSH1(start_marker)
+    loop += Op.JUMP
+    # [num_slots-1, incrementer+counter]
+
+    cleanup += Op.JUMPDEST
+    cleanup += Op.STOP
+
+    assert len(setup) - 1 == start_marker
+    assert len(setup) + len(loop) == end_marker
+    return setup + loop + cleanup
+
+
+@pytest.mark.parametrize("num_slots", [1, 10, 50, 100, 200])
+@pytest.mark.parametrize("warm_slots", [False, True])
+@pytest.mark.parametrize("storage_keys_set", [False, True])
+@pytest.mark.parametrize("incrementer", [0, 1])
+def test_storage_sload_benchmark(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    warm_slots: bool,
+    storage_keys_set: bool,
+    num_slots: int,
+    incrementer: int,
+    tx_gas_limit: int,
+) -> None:
+    """
+    Benchmark SSTORE instruction with various configurations.
+
+    Variants:
+    - use_access_list: Warm storage slots via access list
+    - sloads_before_sstore: Number of SLOADs per slot before SSTORE
+    - num_contracts: Number of contract instances (cold storage writes)
+    - initial_value/write_value: Storage transitions
+      (zero_to_zero, zero_to_nonzero, nonzero_to_zero, nonzero_to_nonzero)
+    """
+    slots: set[int] = set()
+    if storage_keys_set:
+        slots = {i * incrementer for i in range(num_slots)}
+    initial_storage = Storage.model_validate(dict.fromkeys(slots, 1))
+
+    storage_contract = pre.deploy_contract(
+        code=sload_helper_contract(),
+        storage=initial_storage,
+    )
+
+    calldata = incrementer.to_bytes(32, "big") + num_slots.to_bytes(32, "big")
+
+    access_lists: list[AccessList] = []
+
+    if warm_slots:
+        access_lists = [
+            AccessList(
+                address=storage_contract,
+                storage_keys=list(slots),
+            ),
+        ]
+
+    tx = Transaction(
+        to=storage_contract,
+        gas_limit=tx_gas_limit,
+        access_list=access_lists,
+        data=calldata,
+        sender=pre.fund_eoa(),
+    )
+
+    benchmark_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        skip_gas_used_validation=True,
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -414,7 +414,7 @@ def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
     cleanup = Bytecode()
 
     start_marker = 10
-    end_marker = 30 + (2 if sloads_before_sstore else 0)
+    end_marker = 30 + (3 if sloads_before_sstore else 0)
 
     setup += (
         Op.CALLDATALOAD(0)  # num_slots
@@ -446,6 +446,7 @@ def sstore_helper_contract(sloads_before_sstore: bool) -> Bytecode:
         loop += Op.DUP2
         loop += Op.SLOAD
         loop += Op.POP
+        loop += Op.SWAP1
         loop += Op.SSTORE
     else:
         loop += Op.SWAP1
@@ -486,7 +487,7 @@ def test_sstore_variants(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     tx_gas_limit: int,
-    gas_benchmark_values: int,
+    gas_benchmark_value: int,
     slot_count: int,
     use_access_list: bool,
     sloads_before_sstore: bool,
@@ -513,7 +514,7 @@ def test_sstore_variants(
     post = {}
 
     base_gas_per_contract = min(
-        tx_gas_limit, gas_benchmark_values // num_contracts
+        tx_gas_limit, gas_benchmark_value // num_contracts
     )
     gas_remainder = tx_gas_limit % num_contracts
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -581,24 +581,26 @@ def test_sstore_variants(
             if gas_limit_cap is not None
             else remaining_gas
         )
-        current_iteration_count = 0
-        next_iteration_count = current_iteration_count + 1
-        while True:
-            if (
-                calc_gas_required(next_iteration_count, start_slot, Address(0))
-                > gas_limit
-            ):
-                break
-            current_iteration_count += 1
-            next_iteration_count += 1
-
-        if current_iteration_count > 0:
-            iteration_counts.append(current_iteration_count)
-            start_slot += current_iteration_count
-        else:
+        if calc_gas_required(0, start_slot, Address(0)) > gas_limit:
             break
+
+        # Binary search the optimal number of iterations given the gas limit
+        low, high = 1, 2
+        while calc_gas_required(high, start_slot, Address(0)) <= gas_limit:
+            high *= 2
+
+        while low < high:
+            mid = (low + high) // 2
+            if calc_gas_required(mid, start_slot, Address(0)) > gas_limit:
+                high = mid
+            else:
+                low = mid + 1
+
+        iteration_count = low - 1
+        iteration_counts.append(iteration_count)
+        start_slot += iteration_count
         remaining_gas -= calc_gas_required(
-            current_iteration_count, start_slot, Address(0)
+            iteration_count, start_slot, Address(0)
         )
 
     assert len(iteration_counts) > 0, (


### PR DESCRIPTION
## 🗒️ Description
Builds on top of changes done by #1774

Main differences:
- Osaka compatible
- Use `gas_benchmark_value` parameter instead of slot numbers
- Splits `test_storage_sload_benchmark` into  two separate test functions instead of using an `incrementer` (Variant 1 uses increasing slot number, variant 2 uses a constant key for SLOAD)
- Uses `bytecode.gas_cost` to calculate the exact gas cost of all bytecode used.


## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
