### PR TITLE
feat(specs): add EIP-7981

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -33,12 +33,14 @@ Base cost of a transaction in gas units. This is the minimum amount of gas
 required to execute a transaction.
 """
 
-FLOOR_CALLDATA_COST = Uint(10)
+FLOOR_CALLDATA_COST = Uint(15)
 """
-Minimum gas cost per byte of calldata as per [EIP-7623]. Used to calculate
-the minimum gas cost for transactions that include calldata.
+Minimum gas cost per byte of calldata as per [EIP-7623] and [EIP-7976].
+Used to calculate the minimum gas cost for transactions that include
+calldata.
 
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+[EIP-7976]: https://eips.ethereum.org/EIPS/eip-7976
 """
 
 STANDARD_CALLDATA_TOKEN_COST = Uint(4)
@@ -603,10 +605,6 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             zero_bytes += 1
 
     tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
-        tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
-    )
 
     data_cost = tokens_in_calldata * STANDARD_CALLDATA_TOKEN_COST
 
@@ -616,6 +614,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
+    tokens_in_access_list = Uint(0)
     if isinstance(
         tx,
         (
@@ -631,6 +630,30 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
                 ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
             )
 
+        # EIP-7981: Count data tokens in access list
+        al_zero_bytes = 0
+        for access in tx.access_list:
+            for byte in access.account:
+                if byte == 0:
+                    al_zero_bytes += 1
+            for slot in access.slots:
+                for byte in slot:
+                    if byte == 0:
+                        al_zero_bytes += 1
+        al_total_bytes = sum(
+            len(access.account) + len(access.slots) * 32
+            for access in tx.access_list
+        )
+        tokens_in_access_list = Uint(
+            al_zero_bytes + (al_total_bytes - al_zero_bytes) * 4
+        )
+        # EIP-7981: Always charge data cost for access list
+        access_list_cost += tokens_in_access_list * FLOOR_CALLDATA_COST
+
+    # EIP-7623/7976/7981: Floor includes all data tokens
+    total_data_tokens = tokens_in_calldata + tokens_in_access_list
+    floor_gas_cost = total_data_tokens * FLOOR_CALLDATA_COST + TX_BASE_COST
+
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
         auth_cost += Uint(PER_EMPTY_ACCOUNT_COST * len(tx.authorizations))
@@ -643,7 +666,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -33,14 +33,12 @@ Base cost of a transaction in gas units. This is the minimum amount of gas
 required to execute a transaction.
 """
 
-FLOOR_CALLDATA_COST = Uint(15)
+FLOOR_CALLDATA_COST = Uint(10)
 """
-Minimum gas cost per byte of calldata as per [EIP-7623] and [EIP-7976].
-Used to calculate the minimum gas cost for transactions that include
-calldata.
+Minimum gas cost per byte of calldata as per [EIP-7623]. Used to calculate
+the minimum gas cost for transactions that include calldata.
 
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
-[EIP-7976]: https://eips.ethereum.org/EIPS/eip-7976
 """
 
 STANDARD_CALLDATA_TOKEN_COST = Uint(4)
@@ -650,7 +648,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         # EIP-7981: Always charge data cost for access list
         access_list_cost += tokens_in_access_list * FLOOR_CALLDATA_COST
 
-    # EIP-7623/7976/7981: Floor includes all data tokens
+    # EIP-7623/7981: Floor includes all data tokens
     total_data_tokens = tokens_in_calldata + tokens_in_access_list
     floor_gas_cost = total_data_tokens * FLOOR_CALLDATA_COST + TX_BASE_COST
 


### PR DESCRIPTION
  ## 🗒️ Description
  This PR implements EIP-7981 into the specs.

  ## 🔗 Related Issues or PRs
  N/A.

  ## ✅ Checklist
  <!-- Please check off all required items. For those that don't apply remove them accordingly. -->

  - [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
      ```console
      uvx tox -e static
      ```
  - [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
  - [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
  - [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
  - [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
  - [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
  - [x] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

  #### Cute Animal Picture

  <img src="https://github.com/user-attachments/assets/651ddc02-bb69-4b58-8411-3044be596261" alt="958536_y" width="300" />
