### PR TITLE
feat(tests): add warm and cold account query benchmark

### DIFF
--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -8,6 +8,7 @@ from execution_testing import (
     EOA,
     Address,
     Alloc,
+    Bytecode,
     BytesConcatenation,
     FixedIterationsBytecode,
     Fork,
@@ -255,7 +256,6 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
         if contract_size is None:
             contract_size = fork.max_code_size()
         xor_table_byte_size = XOR_TABLE_SIZE * 32
-        iteration_count = ((contract_size - 32) // xor_table_byte_size) + 1
         setup = Op.MSTORE(
             0,
             Op.ADDRESS,
@@ -263,25 +263,32 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
             old_memory_size=0,
             new_memory_size=32,
         )
-        iterating = While(
-            body=(
-                Op.SHA3(Op.SUB(Op.MSIZE, 32), 32, data_size=32)
-                # Use a xor table to avoid having to call the "expensive" sha3
-                # opcode as much
-                + sum(
-                    (
-                        Op.PUSH32[xor_value]
-                        + Op.XOR
-                        + Op.DUP1
-                        + Op.MSIZE
-                        + Op.MSTORE
+        if contract_size > 32:
+            iteration_count = ((contract_size - 32) // xor_table_byte_size) + 1
+            iterating = While(
+                body=(
+                    Op.SHA3(Op.SUB(Op.MSIZE, 32), 32, data_size=32)
+                    # Use a xor table to avoid having to call the "expensive" sha3
+                    # opcode as much
+                    + sum(
+                        (
+                            Op.PUSH32[xor_value]
+                            + Op.XOR
+                            + Op.DUP1
+                            + Op.MSIZE
+                            + Op.MSTORE
+                        )
+                        for xor_value in XOR_TABLE
                     )
-                    for xor_value in XOR_TABLE
-                )
-                + Op.POP
-            ),
-            condition=Op.LT(Op.MSIZE, contract_size),
-        )
+                    + Op.POP
+                ),
+                condition=Op.LT(Op.MSIZE, contract_size),
+            )
+            final_memory_size = (xor_table_byte_size * iteration_count) + 32
+        else:
+            iteration_count = 0
+            iterating = Bytecode()
+            final_memory_size = 32
         cleanup = (
             # Despite the whole contract has random bytecode, we need the first
             # opcode be a STOP so CALL-like attacks return as soon as possible.
@@ -294,7 +301,7 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
                 code_deposit_size=contract_size,
                 # Memory is not expanded here, but it is expanded in the loop.
                 old_memory_size=32,
-                new_memory_size=(xor_table_byte_size * iteration_count) + 32,
+                new_memory_size=final_memory_size,
             )
         )
         instance = super(CustomSizedContractInitcode, cls).__new__(
@@ -393,12 +400,7 @@ class CustomSizedContractFactory(IteratingBytecode):
                     init_code_size=len(initcode),
                 )
             ),
-            condition=Op.PUSH1(1)
-            + Op.ADD
-            + Op.DUP1
-            + Op.DUP3
-            + Op.LT
-            + Op.ISZERO,
+            condition=Op.PUSH1(1) + Op.ADD + Op.DUP1 + Op.DUP3 + Op.GT,
         )
         cleanup = Op.STOP
         instance = super(CustomSizedContractFactory, cls).__new__(

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -268,8 +268,8 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
             iterating = While(
                 body=(
                     Op.SHA3(Op.SUB(Op.MSIZE, 32), 32, data_size=32)
-                    # Use a xor table to avoid having to call the "expensive" sha3
-                    # opcode as much
+                    # Use a xor table to avoid having to call the "expensive"
+                    # sha3 opcode as much
                     + sum(
                         (
                             Op.PUSH32[xor_value]

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -221,32 +221,41 @@ def calculate_optimal_input_length(
     return optimal_input_length
 
 
-class MaxSizedContractInitcode(FixedIterationsBytecode):
+class CustomSizedContractInitcode(FixedIterationsBytecode):
     """
-    Initcode that deploys a random and maximum-sized contract for the given
-    fork's limits.
+    Initcode that deploys a random contract with a custom size.
+
+    If no contract size is provided, the maximum contract size for the given
+    fork is used.
     """
 
     _cached_address: Address
     """Cached address to avoid expensive recomputation."""
+    contract_size: int
+    """The size of the contract to deploy."""
 
-    def __new__(cls, *, pre: Alloc, fork: Fork) -> Self:
+    def __new__(
+        cls, *, pre: Alloc, fork: Fork, contract_size: int | None = None
+    ) -> Self:
         """
-        Create a new MaxSizedContractInitcode instance.
+        Create a new CustomSizedContractInitcode instance.
 
         Args:
             pre: The pre-allocation state where the contract will be
                 deployed.
             fork: The fork to use for determining maximum contract size
                 limits.
+            contract_size: The size of the contract to deploy. If None,
+                the maximum contract size for the fork is used.
 
         Returns:
-            A new MaxSizedContractInitcode instance.
+            A new CustomSizedContractInitcode instance.
 
         """
-        max_contract_size = fork.max_code_size()
+        if contract_size is None:
+            contract_size = fork.max_code_size()
         xor_table_byte_size = XOR_TABLE_SIZE * 32
-        iteration_count = ((max_contract_size - 32) // xor_table_byte_size) + 1
+        iteration_count = ((contract_size - 32) // xor_table_byte_size) + 1
         setup = Op.MSTORE(
             0,
             Op.ADDRESS,
@@ -271,7 +280,7 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
                 )
                 + Op.POP
             ),
-            condition=Op.LT(Op.MSIZE, max_contract_size),
+            condition=Op.LT(Op.MSIZE, contract_size),
         )
         cleanup = (
             # Despite the whole contract has random bytecode, we need the first
@@ -280,15 +289,15 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
             # are always zero, so no need to do anything but return.
             Op.RETURN(
                 0,
-                max_contract_size,
+                contract_size,
                 # Gas accounting
-                code_deposit_size=max_contract_size,
+                code_deposit_size=contract_size,
                 # Memory is not expanded here, but it is expanded in the loop.
                 old_memory_size=32,
                 new_memory_size=(xor_table_byte_size * iteration_count) + 32,
             )
         )
-        instance = super(MaxSizedContractInitcode, cls).__new__(
+        instance = super(CustomSizedContractInitcode, cls).__new__(
             cls,
             setup=setup,
             iterating=iterating,
@@ -301,6 +310,7 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
             initcode=Initcode(deploy_code=instance),
             fork=fork,
         )
+        instance.contract_size = contract_size
         deployed_address = pre.deterministic_deploy_contract(
             deploy_code=instance
         )
@@ -312,39 +322,49 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
         return self._cached_address
 
 
-class MaxSizedContractFactory(IteratingBytecode):
+class CustomSizedContractFactory(IteratingBytecode):
     """
-    Factory contract that creates maximum-sized contracts.
+    Factory contract that creates contracts with a custom size.
 
     The contract takes two 32-byte arguments in the calldata:
     - start_index: the starting index of the contract to deploy
     - end_index: the ending index of the contract to deploy
 
-    The contract will deploy a maximum-sized contract for each index in the
-    range, inclusive.
+    The contract will deploy a contract for each index in the range, inclusive.
+
+    If no contract size is provided, the maximum contract size for the given
+    fork is used.
     """
 
-    initcode: MaxSizedContractInitcode
-    """The initcode used to deploy maximum-sized contracts via CREATE2."""
+    initcode: CustomSizedContractInitcode
+    """The initcode used to deploy contracts via CREATE2."""
 
     _cached_address: Address
     """Cached address to avoid expensive recomputation."""
+    contract_size: int
+    """The size of the contracts to deploy."""
 
-    def __new__(cls, *, pre: Alloc, fork: Fork) -> Self:
+    def __new__(
+        cls, *, pre: Alloc, fork: Fork, contract_size: int | None = None
+    ) -> Self:
         """
-        Create a new MaxSizedContractFactory instance.
+        Create a new CustomSizedContractFactory instance.
 
         Args:
             pre: The pre-allocation state where the factory will be
                 deployed.
             fork: The fork to use for gas calculations and contract
                 size limits.
+            contract_size: The size of the contracts to deploy. If None,
+                the maximum contract size for the fork is used.
 
         Returns:
-            A new MaxSizedContractFactory instance.
+            A new CustomSizedContractFactory instance.
 
         """
-        initcode = MaxSizedContractInitcode(pre=pre, fork=fork)
+        initcode = CustomSizedContractInitcode(
+            pre=pre, fork=fork, contract_size=contract_size
+        )
         initcode_address = initcode.address()
         setup = (
             Op.EXTCODECOPY(
@@ -381,7 +401,7 @@ class MaxSizedContractFactory(IteratingBytecode):
             + Op.ISZERO,
         )
         cleanup = Op.STOP
-        instance = super(MaxSizedContractFactory, cls).__new__(
+        instance = super(CustomSizedContractFactory, cls).__new__(
             cls,
             setup=setup,
             iterating=iterating,
@@ -395,6 +415,7 @@ class MaxSizedContractFactory(IteratingBytecode):
             initcode=Initcode(deploy_code=instance),
             fork=fork,
         )
+        instance.contract_size = initcode.contract_size
         deployed_address = pre.deterministic_deploy_contract(
             deploy_code=instance
         )

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -263,6 +263,7 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
             old_memory_size=0,
             new_memory_size=32,
         )
+        iterating: While | Bytecode
         if contract_size > 32:
             iteration_count = ((contract_size - 32) // xor_table_byte_size) + 1
             iterating = While(

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -17,21 +17,26 @@ from typing import Any
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Address,
     Alloc,
     BenchmarkTestFiller,
     Block,
     Bytecode,
+    Create2PreimageLayout,
     ExtCallGenerator,
     Fork,
     Hash,
+    IteratingBytecode,
     JumpLoopGenerator,
     Op,
     TestPhaseManager,
     Transaction,
     While,
 )
+
+from tests.benchmark.compute.helpers import CustomSizedContractFactory
 
 
 @pytest.mark.repricing(contract_balance=1)
@@ -394,4 +399,204 @@ def test_ext_account_query_cold(
         target_opcode=opcode,
         post=post,
         blocks=blocks,
+    )
+
+
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.BALANCE,
+        # CALL*
+        Op.CALL,
+        Op.CALLCODE,
+        Op.DELEGATECALL,
+        Op.STATICCALL,
+        # EXTCODE*
+        Op.EXTCODESIZE,
+        Op.EXTCODEHASH,
+        Op.EXTCODECOPY,
+    ],
+)
+@pytest.mark.parametrize("access_warm", [True, False])
+@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
+@pytest.mark.parametrize("code_size", [0, 32, 256, 1024, 24576])
+@pytest.mark.parametrize("value_sent", [0, 1])
+def test_account_query(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    opcode: Op,
+    access_warm: bool,
+    mem_size: int,
+    code_size: int,
+    value_sent: int,
+    gas_benchmark_value: int,
+) -> None:
+    """Benchmark scenario of accessing max-code size bytecode."""
+    if (
+        opcode in (Op.EXTCODESIZE, Op.EXTCODEHASH, Op.BALANCE)
+        and mem_size != 0
+    ):
+        pytest.skip(f"No memory size configuration for {opcode}")
+
+    if opcode in (Op.CALL, Op.CALLCODE) and value_sent > 0:
+        pytest.skip(f"No value configuration for {opcode}")
+
+    attack_gas_limit = gas_benchmark_value
+
+    # Create the max-sized fork-dependent contract factory.
+    custom_sized_contract_factory = CustomSizedContractFactory(
+        pre=pre, fork=fork, contract_size=code_size
+    )
+    factory_address = custom_sized_contract_factory.address()
+    initcode = custom_sized_contract_factory.initcode
+
+    # Prepare the attack iterating bytecode.
+    # Setup is just placing the CREATE2 Preimage in memory.
+    create2_preimage = Create2PreimageLayout(
+        factory_address=factory_address,
+        salt=Op.CALLDATALOAD(0),
+        init_code_hash=initcode.keccak256(),
+    )
+    setup_code: Bytecode = create2_preimage
+
+    if mem_size > 96:
+        setup_code += Op.MSTORE8(
+            mem_size - 1,
+            0,
+            # Gas accounting
+            old_memory_size=96,
+            new_memory_size=mem_size,
+        )
+
+    if opcode == Op.EXTCODECOPY:
+        attack_call = Op.EXTCODECOPY(
+            address=create2_preimage.address_op(),
+            dest_offset=0,
+            size=mem_size,
+            # Gas accounting
+            data_size=mem_size,
+            address_warm=access_warm,
+        )
+    elif opcode in (Op.CALL, Op.CALLCODE):
+        # CALL and CALLCODE accept value parameter
+        attack_call = Op.POP(
+            opcode(
+                address=create2_preimage.address_op(),
+                value=value_sent,
+                args_size=mem_size,
+                # Gas accounting
+                address_warm=access_warm,
+                new_memory_size=max(mem_size, 96),
+            )
+        )
+    elif opcode in (Op.STATICCALL, Op.DELEGATECALL):
+        # STATICCALL and DELEGATECALL don't have value parameter
+        attack_call = Op.POP(
+            opcode(
+                address=create2_preimage.address_op(),
+                args_size=mem_size,
+                # Gas accounting
+                address_warm=access_warm,
+                new_memory_size=max(mem_size, 96),
+            )
+        )
+    else:
+        # BALANCE, EXTCODESIZE, EXTCODEHASH
+        attack_call = Op.POP(
+            opcode(
+                address=create2_preimage.address_op(),
+                # Gas accounting
+                address_warm=access_warm,
+            )
+        )
+
+    loop_code = While(
+        body=attack_call + create2_preimage.increment_salt_op(),
+    )
+
+    attack_code = IteratingBytecode(
+        setup=setup_code,
+        iterating=loop_code,
+        # Since the target contract is guaranteed to have a STOP as the first
+        # instruction, we can use a STOP as the iterating subcall code.
+        iterating_subcall=Op.STOP,
+    )
+
+    # Calldata generator for each transaction of the iterating bytecode.
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        del iteration_count
+        # We only pass the start iteration index as calldata for this bytecode
+        return Hash(start_iteration)
+
+    # Access list generator for warm access tests.
+    # When access_warm=True, include all contract addresses that will be
+    # accessed in each transaction to warm them up via access list.
+    def access_list_generator(
+        iteration_count: int, start_iteration: int
+    ) -> list[AccessList] | None:
+        if not access_warm:
+            return None
+        return [
+            AccessList(
+                address=custom_sized_contract_factory.created_contract_address(
+                    salt=i
+                ),
+                storage_keys=[],
+            )
+            for i in range(start_iteration, start_iteration + iteration_count)
+        ]
+
+    attack_address = pre.deploy_contract(code=attack_code)
+
+    # Calculate the number of contracts to be targeted.
+    num_contracts = sum(
+        attack_code.tx_iterations_by_gas_limit(
+            fork=fork,
+            gas_limit=attack_gas_limit,
+            calldata=calldata,
+            access_list=access_list_generator,
+        )
+    )
+
+    # Deploy num_contracts via multiple txs (each capped by tx gas limit).
+    with TestPhaseManager.setup():
+        setup_sender = pre.fund_eoa()
+        contracts_deployment_txs = list(
+            custom_sized_contract_factory.transactions_by_total_contract_count(
+                fork=fork,
+                sender=setup_sender,
+                contract_count=num_contracts,
+            )
+        )
+
+    with TestPhaseManager.execution():
+        attack_sender = pre.fund_eoa()
+        attack_txs = list(
+            attack_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=attack_gas_limit,
+                sender=attack_sender,
+                to=attack_address,
+                calldata=calldata,
+                access_list=access_list_generator,
+            )
+        )
+        total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
+
+    post = {}
+    for i in range(num_contracts):
+        deployed_contract_address = (
+            custom_sized_contract_factory.created_contract_address(salt=i)
+        )
+        post[deployed_contract_address] = Account(nonce=1)
+
+    benchmark_test(
+        pre=pre,
+        post=post,
+        blocks=[
+            Block(txs=contracts_deployment_txs),
+            Block(txs=attack_txs),
+        ],
+        expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -435,9 +435,8 @@ def test_account_query(
     gas_benchmark_value: int,
 ) -> None:
     """Benchmark scenario of accessing max-code size bytecode."""
-    if (
-        opcode in (Op.EXTCODESIZE, Op.EXTCODEHASH, Op.BALANCE)
-        and mem_size != 0
+    if opcode in (Op.EXTCODESIZE, Op.EXTCODEHASH, Op.BALANCE) and (
+        mem_size != 0 or code_size != 0
     ):
         pytest.skip(f"No memory size configuration for {opcode}")
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -419,7 +419,9 @@ def test_ext_account_query_cold(
 )
 @pytest.mark.parametrize("access_warm", [True, False])
 @pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
-@pytest.mark.parametrize("code_size", [0, 32, 256, 1024, 24576])
+@pytest.mark.parametrize(
+    "code_size", [0, 32, 256, 1024, pytest.param(None, id="max_code_size")]
+)
 @pytest.mark.parametrize("value_sent", [0, 1])
 def test_account_query(
     benchmark_test: BenchmarkTestFiller,
@@ -585,11 +587,12 @@ def test_account_query(
         total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
 
     post = {}
-    for i in range(num_contracts):
-        deployed_contract_address = (
-            custom_sized_contract_factory.created_contract_address(salt=i)
-        )
-        post[deployed_contract_address] = Account(nonce=1)
+    if custom_sized_contract_factory.contract_size > 0:
+        for i in range(num_contracts):
+            deployed_contract_address = (
+                custom_sized_contract_factory.created_contract_address(salt=i)
+            )
+            post[deployed_contract_address] = Account(nonce=1)
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -446,7 +446,7 @@ def test_account_query(
 
     if (
         opcode in (Op.CALL, Op.CALLCODE, Op.STATICCALL, Op.DELEGATECALL)
-        and code_size > 0
+        and code_size != 0
     ):
         pytest.skip(f"No code size configuration for {opcode}")
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -547,7 +547,7 @@ def test_account_query(
             for i in range(start_iteration, start_iteration + iteration_count)
         ]
 
-    attack_address = pre.deploy_contract(code=attack_code)
+    attack_address = pre.deploy_contract(code=attack_code, balance=10**21)
 
     # Calculate the number of contracts to be targeted.
     num_contracts = sum(

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -441,8 +441,14 @@ def test_account_query(
     ):
         pytest.skip(f"No memory size configuration for {opcode}")
 
-    if opcode in (Op.CALL, Op.CALLCODE) and value_sent > 0:
+    if opcode not in (Op.CALL, Op.CALLCODE) and value_sent > 0:
         pytest.skip(f"No value configuration for {opcode}")
+
+    if (
+        opcode in (Op.CALL, Op.CALLCODE, Op.STATICCALL, Op.DELEGATECALL)
+        and code_size > 0
+    ):
+        pytest.skip(f"No code size configuration for {opcode}")
 
     attack_gas_limit = gas_benchmark_value
 

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -19,7 +19,7 @@ from execution_testing import (
     While,
 )
 
-from tests.benchmark.compute.helpers import MaxSizedContractFactory
+from tests.benchmark.compute.helpers import CustomSizedContractFactory
 
 
 @pytest.mark.parametrize(
@@ -50,9 +50,11 @@ def test_unchunkified_bytecode(
     attack_gas_limit = gas_benchmark_value
 
     # Create the max-sized fork-dependent contract factory.
-    max_sized_contract_factory = MaxSizedContractFactory(pre=pre, fork=fork)
-    factory_address = max_sized_contract_factory.address()
-    initcode = max_sized_contract_factory.initcode
+    custom_sized_contract_factory = CustomSizedContractFactory(
+        pre=pre, fork=fork
+    )
+    factory_address = custom_sized_contract_factory.address()
+    initcode = custom_sized_contract_factory.initcode
 
     # Prepare the attack iterating bytecode.
     # Setup is just placing the CREATE2 Preimage in memory.
@@ -125,7 +127,7 @@ def test_unchunkified_bytecode(
     with TestPhaseManager.setup():
         setup_sender = pre.fund_eoa()
         contracts_deployment_txs = list(
-            max_sized_contract_factory.transactions_by_total_contract_count(
+            custom_sized_contract_factory.transactions_by_total_contract_count(
                 fork=fork,
                 sender=setup_sender,
                 contract_count=num_contracts,
@@ -148,7 +150,7 @@ def test_unchunkified_bytecode(
     post = {}
     for i in range(num_contracts):
         deployed_contract_address = (
-            max_sized_contract_factory.created_contract_address(salt=i)
+            custom_sized_contract_factory.created_contract_address(salt=i)
         )
         post[deployed_contract_address] = Account(nonce=1)
 

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -7,8 +7,8 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
-    Block,
     BenchmarkTestFiller,
+    Block,
     Bytecode,
     Create2PreimageLayout,
     Fork,

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -8,7 +8,7 @@ from execution_testing import (
     Account,
     Alloc,
     Block,
-    BlockchainTestFiller,
+    BenchmarkTestFiller,
     Bytecode,
     Create2PreimageLayout,
     Fork,
@@ -35,7 +35,7 @@ from tests.benchmark.compute.helpers import CustomSizedContractFactory
     ],
 )
 def test_unchunkified_bytecode(
-    blockchain_test: BlockchainTestFiller,
+    benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,
     opcode: Op,
@@ -154,13 +154,12 @@ def test_unchunkified_bytecode(
         )
         post[deployed_contract_address] = Account(nonce=1)
 
-    blockchain_test(
+    benchmark_test(
         pre=pre,
         post=post,
         blocks=[
             Block(txs=contracts_deployment_txs),
             Block(txs=attack_txs),
         ],
-        exclude_full_post_state_in_output=True,
         expected_benchmark_gas_used=total_gas_cost,
     )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add missing configurations for `CALL`, `CALLCODE`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODESIZE`, `EXTCODECOPY`, `BALANCE`.

| Opcode         | Variants / Dimensions                                                                 |
|----------------|----------------------------------------------------------------------------------------|
| STATICCALL     | warm / cold; memory size                                                               |
| CALL           | warm / cold; memory size; value / no-value                                             |
| CALLCODE       | warm / cold; memory size                                                               |
| DELEGATECALL   | warm / cold; memory size                                                               |
| EXTCODEHASH   | warm / cold                                                                            |
| EXTCODECOPY   | warm / cold; code size; memory size                                                    |
| EXTCODESIZE   | warm / cold                                                                            |
| BALANCE       | warm / cold                                                                            |
| SLOAD          | warm / cold; no-slot / slot                                                            |
| SSTORE         | warm / cold; no-slot / slot; same-value / new-value                                   |

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
