### PR TITLE
fix(test-ci): Fix benchmark artifact expectation for new builder prealloc

### DIFF
--- a/packages/testing/src/execution_testing/cli/extract_config.py
+++ b/packages/testing/src/execution_testing/cli/extract_config.py
@@ -36,7 +36,7 @@ from execution_testing.fixtures import (
 )
 from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.fixtures.file import Fixtures
-from execution_testing.fixtures.pre_alloc_groups import PreAllocGroup
+from execution_testing.fixtures.pre_alloc_groups import PreAllocGroupBuilder
 from execution_testing.forks import Fork
 
 
@@ -176,8 +176,9 @@ class GenesisState(BaseModel):
             pass
 
         try:
-            # Try to load pre-allocation group
-            pre_alloc_group = PreAllocGroup.model_validate_json(fixture_bytes)
+            # Load as builder format and compute genesis on-demand
+            builder = PreAllocGroupBuilder.model_validate_json(fixture_bytes)
+            pre_alloc_group = builder.build()
             return cls(
                 header=pre_alloc_group.genesis,
                 alloc=pre_alloc_group.pre,

--- a/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
+++ b/packages/testing/src/execution_testing/fixtures/pre_alloc_groups.py
@@ -17,7 +17,7 @@ from typing import (
     Tuple,
 )
 
-from pydantic import Field, PrivateAttr, ValidationError
+from pydantic import Field, PrivateAttr
 
 from execution_testing.base_types import (
     CamelModel,
@@ -340,21 +340,13 @@ class PreAllocGroup(PreAllocGroupBuilder):
         """
         Load a pre-allocation group from a JSON file.
 
-        Handles both builder format (without genesis) and full format (with
-        genesis). If genesis is missing, computes it from the pre-allocation
-        state. This ensures state root computation happens exactly once when
-        loading in Phase 2, not during Phase 1 merging.
+        Files are stored in builder format (without genesis). Genesis is
+        computed on-demand when loading, ensuring state root computation
+        happens exactly once in Phase 2, not during Phase 1 merging.
         """
         with open(file) as f:
             data = f.read()
 
-        # Try loading as full PreAllocGroup first (backwards compatibility)
-        try:
-            return cls.model_validate_json(data)
-        except ValidationError:
-            pass
-
-        # Load as builder format and compute genesis
         builder = PreAllocGroupBuilder.model_validate_json(data)
         built = builder.build()
         # Use cls.model_validate to ensure proper Self return type


### PR DESCRIPTION
## 🗒️ Description

New changes in last commit defer expensive MPT state root computation from build time (N workers calling build during phase 1) to consumption time (once per group when actually needed). The Benchmark Artifact CI run needs updating to expect calling `PreAllocGroupBuilder.build()` on consumption instead of having it already built.

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Related issues

Follow-up fix to #2140.
- #2140

#### Cute Animal Picture

<img width="499" height="523" alt="Screenshot 2026-02-04 at 20 35 33" src="https://github.com/user-attachments/assets/ff429693-f930-4dc2-aabb-aaeb253988f7" />