### PR TITLE
feat(test-benchmark): add gas limit check for `BLS12_G2_MSM` benchmark

### DIFF
--- a/tests/benchmark/compute/precompile/test_bls12_381.py
+++ b/tests/benchmark/compute/precompile/test_bls12_381.py
@@ -177,6 +177,7 @@ def test_bls12_g1_msm(
 def test_bls12_g2_msm(
     benchmark_test: BenchmarkTestFiller,
     fork: Fork,
+    gas_benchmark_value: int,
     k: int,
 ) -> None:
     """Benchmark BLS12_G2_MSM precompile with varying number of points."""
@@ -189,6 +190,13 @@ def test_bls12_g2_msm(
         (bls12381_spec.Spec.P2 + bls12381_spec.Scalar(bls12381_spec.Spec.Q))
         * k
     )
+
+    intrinsic_gas_cost = fork.transaction_intrinsic_cost_calculator()(
+        calldata=calldata
+    )
+
+    if intrinsic_gas_cost > gas_benchmark_value:
+        pytest.skip("k configuration exceeds the gas limit")
 
     attack_block = Op.POP(
         Op.STATICCALL(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

The request gas repricing analysis benchmark for `test_bls12_g2_msm` is 1, 16, 64, 128, which is the configuration for `k` parameter.

However, constructing the calldata for k = 128 alone, cost more than 1.5M gas. This leads to the failure when the block gas limit is configured to 1M only. This PR skips the scenario that instrinsic gas cost for the required calldata is less than the block gas limit.

This should fix the error for the [release](https://github.com/ethereum/execution-specs/actions/runs/21692454965/job/62555225207) build.

This issue was caught earlier in Jan, but back at that time, we mark it slow so it is ignored by the CI.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

I have been re-watching old season of spongebob recently.

![bob](https://github.com/user-attachments/assets/809625cd-9647-4abe-9ec6-3080e0d261ee)
