### PR TITLE
feat(tests): adds EIP-7981 test and required framework changes

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -76,7 +76,12 @@ class TransactionDataFloorCostCalculator(Protocol):
     Calculate the transaction floor cost due to its calldata for a given fork.
     """
 
-    def __call__(self, *, data: BytesConvertible) -> int:
+    def __call__(
+        self,
+        *,
+        data: BytesConvertible,
+        access_list: List[AccessList] | None = None,
+    ) -> int:
         """Return transaction gas cost of calldata given its contents."""
         pass
 

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -806,8 +806,12 @@ class Frontier(BaseFork, solc_name="homestead"):
         """At frontier, the transaction data floor cost is a constant zero."""
         del block_number, timestamp
 
-        def fn(*, data: BytesConvertible) -> int:
-            del data
+        def fn(
+            *,
+            data: BytesConvertible,
+            access_list: List[AccessList] | None = None,
+        ) -> int:
+            del data, access_list
             return 0
 
         return fn
@@ -2862,7 +2866,12 @@ class Prague(Cancun):
             block_number=block_number, timestamp=timestamp
         )
 
-        def fn(*, data: BytesConvertible) -> int:
+        def fn(
+            *,
+            data: BytesConvertible,
+            access_list: List[AccessList] | None = None,
+        ) -> int:
+            del access_list
             return (
                 calldata_gas_calculator(data=data, floor=True)
                 + gas_costs.G_TRANSACTION
@@ -3422,6 +3431,110 @@ class Amsterdam(BPO2):
     def is_deployed(cls) -> bool:
         """Return True if this fork is deployed."""
         return False
+
+    @classmethod
+    def _access_list_token_count(
+        cls, access_list: List[AccessList] | None
+    ) -> int:
+        """
+        Return the total number of data tokens contributed by an access list.
+
+        Tokens are counted per EIP-7981:
+        - zero byte = 1 token
+        - non-zero byte = 4 tokens
+        """
+        if not access_list:
+            return 0
+
+        tokens = 0
+        for access in access_list:
+            for b in access.address:
+                tokens += 1 if b == 0 else 4
+            for slot in access.storage_keys:
+                for b in slot:
+                    tokens += 1 if b == 0 else 4
+        return tokens
+
+    @classmethod
+    def transaction_data_floor_cost_calculator(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> TransactionDataFloorCostCalculator:
+        """
+        On Amsterdam, the floor cost includes calldata and access list tokens
+        per EIP-7981.
+        """
+        calldata_gas_calculator = cls.calldata_gas_calculator(
+            block_number=block_number, timestamp=timestamp
+        )
+        gas_costs = cls.gas_costs(
+            block_number=block_number, timestamp=timestamp
+        )
+
+        def fn(
+            *,
+            data: BytesConvertible,
+            access_list: List[AccessList] | None = None,
+        ) -> int:
+            access_list_tokens = cls._access_list_token_count(access_list)
+            return (
+                calldata_gas_calculator(data=data, floor=True)
+                + access_list_tokens * gas_costs.G_TX_DATA_FLOOR_TOKEN_COST
+                + gas_costs.G_TRANSACTION
+            )
+
+        return fn
+
+    @classmethod
+    def transaction_intrinsic_cost_calculator(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> TransactionIntrinsicCostCalculator:
+        """
+        On Amsterdam, access list data is charged at the floor token cost and
+        contributes to the floor gas cost per EIP-7981.
+        """
+        super_fn = super(Amsterdam, cls).transaction_intrinsic_cost_calculator(
+            block_number=block_number, timestamp=timestamp
+        )
+        gas_costs = cls.gas_costs(
+            block_number=block_number, timestamp=timestamp
+        )
+        transaction_data_floor_cost_calculator = (
+            cls.transaction_data_floor_cost_calculator(
+                block_number=block_number, timestamp=timestamp
+            )
+        )
+
+        def fn(
+            *,
+            calldata: BytesConvertible = b"",
+            contract_creation: bool = False,
+            access_list: List[AccessList] | None = None,
+            authorization_list_or_count: Sized | int | None = None,
+            return_cost_deducted_prior_execution: bool = False,
+        ) -> int:
+            intrinsic_cost: int = super_fn(
+                calldata=calldata,
+                contract_creation=contract_creation,
+                access_list=access_list,
+                authorization_list_or_count=authorization_list_or_count,
+                return_cost_deducted_prior_execution=True,
+            )
+            access_list_tokens = cls._access_list_token_count(access_list)
+            intrinsic_cost += (
+                access_list_tokens * gas_costs.G_TX_DATA_FLOOR_TOKEN_COST
+            )
+
+            if return_cost_deducted_prior_execution:
+                return intrinsic_cost
+
+            transaction_floor_data_cost = (
+                transaction_data_floor_cost_calculator(
+                    data=calldata, access_list=access_list
+                )
+            )
+            return max(intrinsic_cost, transaction_floor_data_cost)
+
+        return fn
 
     @classmethod
     def engine_new_payload_version(

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -570,6 +570,18 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, calldata_floor_gas_cost
 
 
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the tokens in an arbitrary input data.
+    """
+    zero_bytes = 0
+    for byte in data:
+        if byte == 0:
+            zero_bytes += 1
+
+    return Uint(zero_bytes + (len(data) - zero_bytes) * 4)
+
+
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -588,26 +600,22 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
     4. Cost for access list entries (if applicable)
-    5. Cost for authorizations (if applicable)
+    5. Cost for access list data (EIP-7981)
+    6. Cost for authorizations (if applicable)
 
+    Per EIP-7981, access lists now incur data costs in addition to storage
+    access costs. The data cost is calculated based on the number of bytes
+    in the access list (addresses and storage keys), with zero bytes costing
+    1 token and non-zero bytes costing 4 tokens.
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
-    transaction based on the calldata size.
+    transaction based on the calldata and access list size.
     """
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
-        tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
-    )
+    tokens_in_calldata = count_tokens_in_data(tx.data)
 
     data_cost = tokens_in_calldata * STANDARD_CALLDATA_TOKEN_COST
 
@@ -616,7 +624,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     else:
         create_cost = Uint(0)
 
+    # EIP-7981: Calculate access list tokens and costs
     access_list_cost = Uint(0)
+    tokens_in_access_list = Uint(0)
     if isinstance(
         tx,
         (
@@ -627,14 +637,31 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
     ):
         for access in tx.access_list:
+            # Storage access costs (EIP-2930)
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
             access_list_cost += (
                 ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
             )
 
+        # EIP-7981: Count data tokens in access list
+        access_list_data = b""
+        for access in tx.access_list:
+            access_list_data += bytes(access.account)
+            for slot in access.slots:
+                access_list_data += bytes(slot)
+        tokens_in_access_list = count_tokens_in_data(access_list_data)
+        # EIP-7981: Always charge data cost for access list
+        access_list_cost += tokens_in_access_list * FLOOR_CALLDATA_COST
+
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
         auth_cost += Uint(PER_EMPTY_ACCOUNT_COST * len(tx.authorizations))
+
+    # EIP-7623/7981: Floor includes all data tokens
+    total_data_tokens = tokens_in_calldata + tokens_in_access_list
+    calldata_floor_gas_cost = (
+        total_data_tokens * FLOOR_CALLDATA_COST + TX_BASE_COST
+    )
 
     return (
         Uint(

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -580,20 +580,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -684,6 +670,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -602,12 +602,19 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     6. Cost for authorizations (if applicable)
 
     Access lists incur data costs in addition to storage access costs. Token
-    counting uses `CALLDATA_TOKENS_PER_ZERO_BYTE` and
-    `CALLDATA_TOKENS_PER_NONZERO_BYTE`.
+    counting uses
+    [`CALLDATA_TOKENS_PER_ZERO_BYTE`](
+        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_ZERO_BYTE
+    )
+    and
+    [`CALLDATA_TOKENS_PER_NONZERO_BYTE`](
+        ref:ethereum.forks.amsterdam.transactions.CALLDATA_TOKENS_PER_NONZERO_BYTE
+    ).
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
     transaction based on the calldata and access list size.
+
     """
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -50,6 +50,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -557,8 +567,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -567,19 +577,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
 
 
 def count_tokens_in_data(data: bytes) -> Uint:
     """
-    Count the tokens in an arbitrary input data.
+    Count the data tokens in arbitrary input bytes.
     """
-    zero_bytes = 0
+    tokens = Uint(0)
     for byte in data:
         if byte == 0:
-            zero_bytes += 1
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
 
-    return Uint(zero_bytes + (len(data) - zero_bytes) * 4)
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -600,13 +612,12 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     2. Cost for data (zero and non-zero bytes)
     3. Cost for contract creation (if applicable)
     4. Cost for access list entries (if applicable)
-    5. Cost for access list data (EIP-7981)
+    5. Cost for access list data (if applicable)
     6. Cost for authorizations (if applicable)
 
-    Per EIP-7981, access lists now incur data costs in addition to storage
-    access costs. The data cost is calculated based on the number of bytes
-    in the access list (addresses and storage keys), with zero bytes costing
-    1 token and non-zero bytes costing 4 tokens.
+    Access lists incur data costs in addition to storage access costs. Token
+    counting uses `CALLDATA_TOKENS_PER_ZERO_BYTE` and
+    `CALLDATA_TOKENS_PER_NONZERO_BYTE`.
 
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction and the minimum gas cost used by the
@@ -624,7 +635,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     else:
         create_cost = Uint(0)
 
-    # EIP-7981: Calculate access list tokens and costs
+    # Calculate access-list tokens and costs.
     access_list_cost = Uint(0)
     tokens_in_access_list = Uint(0)
     if isinstance(
@@ -637,29 +648,29 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
     ):
         for access in tx.access_list:
-            # Storage access costs (EIP-2930)
+            # Storage access costs.
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
             access_list_cost += (
                 ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
             )
 
-        # EIP-7981: Count data tokens in access list
+        # Count data tokens in the access list.
         access_list_data = b""
         for access in tx.access_list:
             access_list_data += bytes(access.account)
             for slot in access.slots:
                 access_list_data += bytes(slot)
         tokens_in_access_list = count_tokens_in_data(access_list_data)
-        # EIP-7981: Always charge data cost for access list
+        # Always charge data cost for the access list.
         access_list_cost += tokens_in_access_list * FLOOR_CALLDATA_COST
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
         auth_cost += Uint(PER_EMPTY_ACCOUNT_COST * len(tx.authorizations))
 
-    # EIP-7623/7981: Floor includes all data tokens
+    # Floor includes all data tokens.
     total_data_tokens = tokens_in_calldata + tokens_in_access_list
-    calldata_floor_gas_cost = (
+    data_floor_gas_cost = (
         total_data_tokens * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -671,7 +682,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/arrow_glacier/transactions.py
+++ b/src/ethereum/forks/arrow_glacier/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -378,13 +388,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -400,6 +405,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/berlin/transactions.py
+++ b/src/ethereum/forks/berlin/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -295,13 +305,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -317,6 +322,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -489,13 +499,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST + init_code_cost(ulen(tx.data))
@@ -513,6 +518,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/gray_glacier/transactions.py
+++ b/src/ethereum/forks/gray_glacier/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -378,13 +388,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -400,6 +405,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/london/transactions.py
+++ b/src/ethereum/forks/london/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -378,13 +388,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -400,6 +405,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -49,6 +49,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -556,8 +566,8 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
@@ -566,7 +576,21 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     if tx.gas > TX_MAX_GAS_LIMIT:
         raise TransactionGasLimitExceededError("Gas limit too high")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -597,14 +621,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -643,7 +662,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -579,20 +579,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -664,6 +650,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -378,13 +388,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -400,6 +405,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -39,16 +39,6 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
-CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
-"""
-Token count contribution of each zero byte in transaction data.
-"""
-
-CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
-"""
-Token count contribution of each non-zero byte in transaction data.
-"""
-
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -388,8 +378,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    tokens_in_calldata = count_tokens_in_data(tx.data)
-    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
+    data_cost = count_gas_in_data(tx.data)
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST
@@ -407,18 +396,18 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
+def count_gas_in_data(data: bytes) -> Uint:
     """
-    Count the data tokens in arbitrary input bytes.
+    Count the calldata gas in arbitrary input bytes.
     """
-    tokens = Uint(0)
+    gas_cost = Uint(0)
     for byte in data:
         if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+            gas_cost += TX_DATA_COST_PER_ZERO
         else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+            gas_cost += TX_DATA_COST_PER_NON_ZERO
 
-    return tokens
+    return gas_cost
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -45,6 +45,16 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -550,15 +560,29 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     from .vm.interpreter import MAX_INIT_CODE_SIZE
 
-    intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
-    if max(intrinsic_gas, calldata_floor_gas_cost) > tx.gas:
+    intrinsic_gas, data_floor_gas_cost = calculate_intrinsic_cost(tx)
+    if max(intrinsic_gas, data_floor_gas_cost) > tx.gas:
         raise InsufficientTransactionGasError("Insufficient gas")
     if U256(tx.nonce) >= U256(U64.MAX_VALUE):
         raise NonceOverflowError("Nonce too high")
     if tx.to == Bytes0(b"") and len(tx.data) > MAX_INIT_CODE_SIZE:
         raise InitCodeTooLargeError("Code size too large")
 
-    return intrinsic_gas, calldata_floor_gas_cost
+    return intrinsic_gas, data_floor_gas_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -589,14 +613,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import PER_EMPTY_ACCOUNT_COST
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
-
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
-    # EIP-7623 floor price (note: no EVM costs)
-    calldata_floor_gas_cost = (
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    # Floor price excludes EVM execution costs.
+    data_floor_gas_cost = (
         tokens_in_calldata * FLOOR_CALLDATA_COST + TX_BASE_COST
     )
 
@@ -635,7 +654,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
             + access_list_cost
             + auth_cost
         ),
-        calldata_floor_gas_cost,
+        data_floor_gas_cost,
     )
 
 

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -571,20 +571,6 @@ def validate_transaction(tx: Transaction) -> Tuple[Uint, Uint]:
     return intrinsic_gas, data_floor_gas_cost
 
 
-def count_tokens_in_data(data: bytes) -> Uint:
-    """
-    Count the data tokens in arbitrary input bytes.
-    """
-    tokens = Uint(0)
-    for byte in data:
-        if byte == 0:
-            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
-        else:
-            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
-
-    return tokens
-
-
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
     Calculates the gas that is charged before execution is started.
@@ -656,6 +642,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         ),
         data_floor_gas_cost,
     )
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/src/ethereum/forks/shanghai/transactions.py
+++ b/src/ethereum/forks/shanghai/transactions.py
@@ -39,6 +39,16 @@ TX_DATA_COST_PER_ZERO = Uint(4)
 Gas cost per zero byte in the transaction data.
 """
 
+CALLDATA_TOKENS_PER_ZERO_BYTE = Uint(1)
+"""
+Token count contribution of each zero byte in transaction data.
+"""
+
+CALLDATA_TOKENS_PER_NONZERO_BYTE = Uint(4)
+"""
+Token count contribution of each non-zero byte in transaction data.
+"""
+
 TX_CREATE_COST = Uint(32000)
 """
 Additional gas cost for creating a new contract.
@@ -390,13 +400,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += TX_DATA_COST_PER_ZERO
-        else:
-            data_cost += TX_DATA_COST_PER_NON_ZERO
+    tokens_in_calldata = count_tokens_in_data(tx.data)
+    data_cost = tokens_in_calldata * TX_DATA_COST_PER_ZERO
 
     if tx.to == Bytes0(b""):
         create_cost = TX_CREATE_COST + init_code_cost(ulen(tx.data))
@@ -412,6 +417,20 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
             )
 
     return TX_BASE_COST + data_cost + create_cost + access_list_cost
+
+
+def count_tokens_in_data(data: bytes) -> Uint:
+    """
+    Count the data tokens in arbitrary input bytes.
+    """
+    tokens = Uint(0)
+    for byte in data:
+        if byte == 0:
+            tokens += CALLDATA_TOKENS_PER_ZERO_BYTE
+        else:
+            tokens += CALLDATA_TOKENS_PER_NONZERO_BYTE
+
+    return tokens
 
 
 def recover_sender(chain_id: U64, tx: Transaction) -> Address:

--- a/tests/amsterdam/eip7981_increase_access_list_cost/__init__.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EIP-7981: Increase Access List Cost."""

--- a/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/conftest.py
@@ -1,0 +1,285 @@
+"""Fixtures for the EIP-7981 tests."""
+
+from typing import List, Sequence
+
+import pytest
+from execution_testing import (
+    EOA,
+    AccessList,
+    Address,
+    Alloc,
+    AuthorizationTuple,
+    Bytecode,
+    Bytes,
+    Fork,
+    Hash,
+    Op,
+    Transaction,
+    TransactionException,
+    add_kzg_version,
+)
+
+from ...cancun.eip4844_blobs.spec import Spec as EIP_4844_Spec
+
+
+@pytest.fixture
+def to(
+    request: pytest.FixtureRequest,
+    pre: Alloc,
+) -> Address | None:
+    """Create the recipient address."""
+    if hasattr(request, "param"):
+        param = request.param
+    else:
+        param = Op.STOP
+
+    if param is None:
+        return None
+    if isinstance(param, str) and param == "eoa":
+        return pre.fund_eoa(amount=0)
+    if isinstance(param, Bytecode):
+        return pre.deploy_contract(param)
+
+    raise ValueError(f"Invalid value for `to` fixture: {param}")
+
+
+@pytest.fixture
+def protected() -> bool:
+    """
+    Return whether the transaction is protected or not. Only valid for type-0
+    transactions.
+    """
+    return True
+
+
+@pytest.fixture
+def access_list() -> List[AccessList] | None:
+    """Access list for the transaction."""
+    return None
+
+
+@pytest.fixture
+def authorization_refund() -> bool:
+    """
+    Return whether the transaction has an existing authority in the
+    authorization list.
+    """
+    return False
+
+
+@pytest.fixture
+def authorization_list(
+    request: pytest.FixtureRequest,
+    pre: Alloc,
+    authorization_refund: bool,
+    tx_type: int,
+) -> List[AuthorizationTuple] | None:
+    """
+    Authorization-list for the transaction.
+
+    This fixture needs to be parametrized indirectly in order to generate the
+    authorizations with valid signers using `pre` in this function, and the
+    parametrized value should be a list of addresses.
+    """
+    if not hasattr(request, "param"):
+        if tx_type == 4:
+            return [
+                AuthorizationTuple(
+                    signer=pre.fund_eoa(1 if authorization_refund else 0),
+                    address=Address(1),
+                )
+            ]
+        return None
+    if request.param is None:
+        if tx_type == 4:
+            return [
+                AuthorizationTuple(
+                    signer=pre.fund_eoa(1 if authorization_refund else 0),
+                    address=Address(1),
+                )
+            ]
+        return None
+    return [
+        AuthorizationTuple(
+            signer=pre.fund_eoa(1 if authorization_refund else 0),
+            address=address,
+        )
+        for address in request.param
+    ]
+
+
+@pytest.fixture
+def blob_versioned_hashes(tx_type: int) -> Sequence[Hash] | None:
+    """Versioned hashes for the transaction."""
+    return (
+        add_kzg_version(
+            [Hash(1)],
+            EIP_4844_Spec.BLOB_COMMITMENT_VERSION_KZG,
+        )
+        if tx_type == 3
+        else None
+    )
+
+
+@pytest.fixture
+def contract_creating_tx(to: Address | None) -> bool:
+    """Return whether the transaction creates a contract or not."""
+    return to is None
+
+
+@pytest.fixture
+def tx_data() -> Bytes:
+    """
+    Transaction data.
+
+    Default is empty, but can be parametrized to test different scenarios.
+    """
+    return Bytes(b"")
+
+
+@pytest.fixture
+def tx_gas_delta() -> int:
+    """
+    Gas delta to modify the gas amount included with the transaction.
+
+    If negative, the transaction will be invalid because the intrinsic gas cost
+    is greater than the gas limit.
+
+    This value operates regardless of whether the floor data gas cost is
+    reached or not.
+
+    If the value is greater than zero, the transaction will also be valid and
+    the test will check that transaction processing does not consume more gas
+    than it should.
+    """
+    return 0
+
+
+@pytest.fixture
+def tx_intrinsic_gas_cost_before_execution(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    contract_creating_tx: bool,
+) -> int:
+    """
+    Return the intrinsic gas cost that is applied before the execution start.
+
+    This value never includes the floor data gas cost.
+    """
+    intrinsic_gas_cost_calculator = (
+        fork.transaction_intrinsic_cost_calculator()
+    )
+    return intrinsic_gas_cost_calculator(
+        calldata=tx_data,
+        contract_creation=contract_creating_tx,
+        access_list=access_list,
+        authorization_list_or_count=authorization_list,
+        return_cost_deducted_prior_execution=True,
+    )
+
+
+@pytest.fixture
+def tx_intrinsic_gas_cost_including_floor_data_cost(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    contract_creating_tx: bool,
+) -> int:
+    """
+    Transaction intrinsic gas cost.
+
+    The calculated value takes into account the normal intrinsic gas cost and
+    the floor data gas cost if it is greater than the intrinsic gas cost.
+
+    In other words, this is the value that is required for the transaction to
+    be valid.
+    """
+    intrinsic_gas_cost_calculator = (
+        fork.transaction_intrinsic_cost_calculator()
+    )
+    return intrinsic_gas_cost_calculator(
+        calldata=tx_data,
+        contract_creation=contract_creating_tx,
+        access_list=access_list,
+        authorization_list_or_count=authorization_list,
+    )
+
+
+@pytest.fixture
+def tx_floor_data_cost(
+    fork: Fork,
+    tx_data: Bytes,
+    access_list: List[AccessList] | None,
+) -> int:
+    """
+    Floor data cost for the given transaction data and access list.
+
+    This includes both calldata tokens and access list tokens.
+
+    Note: This is calculated by the fork's intrinsic cost calculator,
+    so we return the same value as
+    tx_intrinsic_gas_cost_including_floor_data_cost.
+    """
+    fork_data_floor_cost_calculator = (
+        fork.transaction_data_floor_cost_calculator()
+    )
+
+    # Calculate calldata floor cost
+    return fork_data_floor_cost_calculator(
+        data=tx_data, access_list=access_list
+    )
+
+
+@pytest.fixture
+def tx_gas_limit(
+    tx_intrinsic_gas_cost_including_floor_data_cost: int,
+    tx_gas_delta: int,
+) -> int:
+    """
+    Gas limit for the transaction.
+
+    The gas delta is added to the intrinsic gas cost to generate different test
+    scenarios.
+    """
+    return tx_intrinsic_gas_cost_including_floor_data_cost + tx_gas_delta
+
+
+@pytest.fixture
+def tx_error(
+    tx_gas_delta: int,
+) -> TransactionException | None:
+    """Transaction error, only expected if the gas delta is negative."""
+    if tx_gas_delta < 0:
+        return TransactionException.INTRINSIC_GAS_TOO_LOW
+    return None
+
+
+@pytest.fixture
+def tx(
+    sender: EOA,
+    tx_type: int,
+    tx_data: Bytes,
+    to: Address | None,
+    protected: bool,
+    access_list: List[AccessList] | None,
+    authorization_list: List[AuthorizationTuple] | None,
+    blob_versioned_hashes: Sequence[Hash] | None,
+    tx_gas_limit: int,
+    tx_error: TransactionException | None,
+) -> Transaction:
+    """Create the transaction used in each test."""
+    return Transaction(
+        ty=tx_type,
+        sender=sender,
+        data=tx_data,
+        to=to,
+        protected=protected,
+        access_list=access_list,
+        authorization_list=authorization_list,
+        gas_limit=tx_gas_limit,
+        blob_versioned_hashes=blob_versioned_hashes,
+        error=tx_error,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
@@ -1,0 +1,38 @@
+"""Helpers for testing EIP-7981."""
+
+from typing import List
+
+from execution_testing import AccessList
+
+
+def calculate_access_list_tokens(access_list: List[AccessList]) -> int:
+    """
+    Calculate the number of tokens in an access list.
+
+    According to EIP-7981, tokens are calculated as:
+    tokens = zero_bytes + nonzero_bytes * 4
+
+    Where bytes come from:
+    - 20 bytes per address
+    - 32 bytes per storage key
+    """
+    zero_bytes = 0
+    nonzero_bytes = 0
+
+    for access in access_list:
+        # Count bytes in address (20 bytes)
+        for byte in access.address:
+            if byte == 0:
+                zero_bytes += 1
+            else:
+                nonzero_bytes += 1
+
+        # Count bytes in each storage key (32 bytes each)
+        for slot in access.storage_keys:
+            for byte in slot:
+                if byte == 0:
+                    zero_bytes += 1
+                else:
+                    nonzero_bytes += 1
+
+    return zero_bytes + nonzero_bytes * 4

--- a/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/helpers.py
@@ -5,34 +5,26 @@ from typing import List
 from execution_testing import AccessList
 
 
-def calculate_access_list_tokens(access_list: List[AccessList]) -> int:
+def calculate_access_list_floor_tokens(access_list: List[AccessList]) -> int:
     """
-    Calculate the number of tokens in an access list.
+    Calculate the number of floor tokens in an access list.
 
-    According to EIP-7981, tokens are calculated as:
-    tokens = zero_bytes + nonzero_bytes * 4
+    According to EIP-7981 (aligned with EIP-7976), floor tokens are
+    calculated from the raw access list byte length:
+    floor_tokens = total_bytes * 4
 
     Where bytes come from:
     - 20 bytes per address
     - 32 bytes per storage key
     """
-    zero_bytes = 0
-    nonzero_bytes = 0
+    total_bytes = 0
 
     for access in access_list:
         # Count bytes in address (20 bytes)
-        for byte in access.address:
-            if byte == 0:
-                zero_bytes += 1
-            else:
-                nonzero_bytes += 1
+        total_bytes += len(access.address)
 
         # Count bytes in each storage key (32 bytes each)
         for slot in access.storage_keys:
-            for byte in slot:
-                if byte == 0:
-                    zero_bytes += 1
-                else:
-                    nonzero_bytes += 1
+            total_bytes += len(slot)
 
-    return zero_bytes + nonzero_bytes * 4
+    return total_bytes * 4

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -1,0 +1,29 @@
+"""Defines EIP-7981 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7981 = ReferenceSpec(
+    "EIPS/eip-7981.md", "235b789d502b1d5b0f8023554a2f415406de81d1"
+)
+
+
+# Constants
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-7981 specifications as defined at
+    https://eips.ethereum.org/EIPS/eip-7981.
+    """
+
+    ACCESS_LIST_ADDRESS_COST = 2400
+    ACCESS_LIST_STORAGE_KEY_COST = 1900
+    TOTAL_COST_FLOOR_PER_TOKEN = 10

--- a/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/spec.py
@@ -12,7 +12,7 @@ class ReferenceSpec:
 
 
 ref_spec_7981 = ReferenceSpec(
-    "EIPS/eip-7981.md", "235b789d502b1d5b0f8023554a2f415406de81d1"
+    "EIPS/eip-7981.md", "be5f9861f233bfd0c0576cfa3dd027a2c4edcd4e"
 )
 
 
@@ -26,4 +26,4 @@ class Spec:
 
     ACCESS_LIST_ADDRESS_COST = 2400
     ACCESS_LIST_STORAGE_KEY_COST = 1900
-    TOTAL_COST_FLOOR_PER_TOKEN = 10
+    TOTAL_COST_FLOOR_PER_TOKEN = 16

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -14,7 +14,7 @@ from execution_testing import (
     TransactionReceipt,
 )
 
-from .helpers import calculate_access_list_tokens
+from .helpers import calculate_access_list_floor_tokens
 from .spec import ref_spec_7981
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
@@ -25,12 +25,12 @@ pytestmark = pytest.mark.valid_at("Amsterdam")
 
 @pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
 @pytest.mark.parametrize(
-    "access_list,expected_tokens",
+    "access_list,expected_floor_tokens",
     [
         pytest.param(
             [AccessList(address=Address(0), storage_keys=[])],
-            # 20 bytes, all zeros: 20 * 1 = 20 tokens
-            20,
+            # 20 bytes total: 20 * 4 = 80 floor tokens
+            80,
             id="single_zero_address_no_keys",
         ),
         pytest.param(
@@ -42,16 +42,14 @@ pytestmark = pytest.mark.valid_at("Amsterdam")
                     storage_keys=[],
                 )
             ],
-            # 20 bytes, all non-zero: 20 * 4 = 80 tokens
+            # 20 bytes total: 20 * 4 = 80 floor tokens
             80,
             id="single_nonzero_address_no_keys",
         ),
         pytest.param(
             [AccessList(address=Address(0), storage_keys=[Hash(0)])],
-            # Address: 20 zeros = 20 tokens
-            # Storage key: 32 zeros = 32 tokens
-            # Total: 52 tokens
-            52,
+            # Total bytes: 20 + 32 = 52, floor tokens: 52 * 4 = 208
+            208,
             id="zero_address_zero_key",
         ),
         pytest.param(
@@ -67,9 +65,7 @@ pytestmark = pytest.mark.valid_at("Amsterdam")
                     ],
                 )
             ],
-            # Address: 20 non-zero = 80 tokens
-            # Storage key: 32 non-zero = 128 tokens
-            # Total: 208 tokens
+            # Total bytes: 20 + 32 = 52, floor tokens: 52 * 4 = 208
             208,
             id="nonzero_address_nonzero_key",
         ),
@@ -80,12 +76,8 @@ pytestmark = pytest.mark.valid_at("Amsterdam")
                     storage_keys=[Hash(0), Hash(1), Hash(2)],
                 )
             ],
-            # Address: 19 zeros + 1 non-zero = 19 + 4 = 23 tokens
-            # Key 0: 32 zeros = 32 tokens
-            # Key 1: 31 zeros + 1 non-zero = 31 + 4 = 35 tokens
-            # Key 2: 31 zeros + 1 non-zero = 31 + 4 = 35 tokens
-            # Total: 23 + 32 + 35 + 35 = 125 tokens
-            125,
+            # Total bytes: 20 + (3 * 32) = 116, floor tokens: 116 * 4 = 464
+            464,
             id="one_address_three_keys",
         ),
         pytest.param(
@@ -93,12 +85,8 @@ pytestmark = pytest.mark.valid_at("Amsterdam")
                 AccessList(address=Address(1), storage_keys=[Hash(0)]),
                 AccessList(address=Address(2), storage_keys=[Hash(1)]),
             ],
-            # Address 1: 19 zeros + 1 non-zero = 23 tokens
-            # Key 0: 32 zeros = 32 tokens
-            # Address 2: 19 zeros + 1 non-zero = 23 tokens
-            # Key 1: 31 zeros + 1 non-zero = 35 tokens
-            # Total: 23 + 32 + 23 + 35 = 113 tokens
-            113,
+            # Total bytes: 2 * (20 + 32) = 104, floor tokens: 104 * 4 = 416
+            416,
             id="two_addresses_with_keys",
         ),
     ],
@@ -113,19 +101,20 @@ def test_access_list_token_calculation(
     pre: Alloc,
     tx: Transaction,
     access_list: list,
-    expected_tokens: int,
+    expected_floor_tokens: int,
 ) -> None:
     """
-    Test that access list tokens are calculated correctly.
+    Test that access list floor tokens are calculated correctly.
 
     This test verifies the token counting mechanism:
-    - Zero bytes contribute 1 token each
-    - Non-zero bytes contribute 4 tokens each
+    - Each access list byte contributes 4 floor tokens
     """
-    # Verify our helper calculates tokens correctly
-    calculated_tokens = calculate_access_list_tokens(access_list)
-    assert calculated_tokens == expected_tokens, (
-        f"Expected {expected_tokens} tokens, got {calculated_tokens}"
+    # Verify our helper calculates floor tokens correctly
+    calculated_floor_tokens = calculate_access_list_floor_tokens(access_list)
+    assert calculated_floor_tokens == expected_floor_tokens, (
+        "Expected "
+        f"{expected_floor_tokens} tokens, got "
+        f"{calculated_floor_tokens}"
     )
 
     # The transaction should be valid with correct gas
@@ -173,8 +162,10 @@ def test_access_list_floor_cost_with_calldata(
     and calldata tokens.
 
     According to EIP-7981:
-    - total_data_tokens = tokens_in_calldata + tokens_in_access_list
-    - floor_gas = TX_BASE_COST + total_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
+    - total_floor_data_tokens =
+      floor_tokens_in_calldata + floor_tokens_in_access_list
+    - floor_gas =
+      TX_BASE_COST + total_floor_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
     """
     tx.expected_receipt = TransactionReceipt(
         cumulative_gas_used=tx_intrinsic_gas_cost_including_floor_data_cost
@@ -218,7 +209,7 @@ def test_large_access_list_cost(
 
     With EIP-7981, large access lists should incur:
     1. Storage access costs (2400 per address + 1900 per key)
-    2. Data footprint costs (10 per token)
+    2. Data footprint costs (16 per floor token)
     """
     state_test(
         pre=pre,

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_access_list_cost.py
@@ -1,0 +1,263 @@
+"""
+abstract: Tests for access list cost calculations in [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Bytes,
+    Hash,
+    StateTestFiller,
+    Transaction,
+    TransactionReceipt,
+)
+
+from .helpers import calculate_access_list_tokens
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at("Amsterdam")
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,expected_tokens",
+    [
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[])],
+            # 20 bytes, all zeros: 20 * 1 = 20 tokens
+            20,
+            id="single_zero_address_no_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[],
+                )
+            ],
+            # 20 bytes, all non-zero: 20 * 4 = 80 tokens
+            80,
+            id="single_nonzero_address_no_keys",
+        ),
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0)])],
+            # Address: 20 zeros = 20 tokens
+            # Storage key: 32 zeros = 32 tokens
+            # Total: 52 tokens
+            52,
+            id="zero_address_zero_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                    ],
+                )
+            ],
+            # Address: 20 non-zero = 80 tokens
+            # Storage key: 32 non-zero = 128 tokens
+            # Total: 208 tokens
+            208,
+            id="nonzero_address_nonzero_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(0), Hash(1), Hash(2)],
+                )
+            ],
+            # Address: 19 zeros + 1 non-zero = 19 + 4 = 23 tokens
+            # Key 0: 32 zeros = 32 tokens
+            # Key 1: 31 zeros + 1 non-zero = 31 + 4 = 35 tokens
+            # Key 2: 31 zeros + 1 non-zero = 31 + 4 = 35 tokens
+            # Total: 23 + 32 + 35 + 35 = 125 tokens
+            125,
+            id="one_address_three_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(2), storage_keys=[Hash(1)]),
+            ],
+            # Address 1: 19 zeros + 1 non-zero = 23 tokens
+            # Key 0: 32 zeros = 32 tokens
+            # Address 2: 19 zeros + 1 non-zero = 23 tokens
+            # Key 1: 31 zeros + 1 non-zero = 35 tokens
+            # Total: 23 + 32 + 23 + 35 = 113 tokens
+            113,
+            id="two_addresses_with_keys",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_access_list_token_calculation(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    access_list: list,
+    expected_tokens: int,
+) -> None:
+    """
+    Test that access list tokens are calculated correctly.
+
+    This test verifies the token counting mechanism:
+    - Zero bytes contribute 1 token each
+    - Non-zero bytes contribute 4 tokens each
+    """
+    # Verify our helper calculates tokens correctly
+    calculated_tokens = calculate_access_list_tokens(access_list)
+    assert calculated_tokens == expected_tokens, (
+        f"Expected {expected_tokens} tokens, got {calculated_tokens}"
+    )
+
+    # The transaction should be valid with correct gas
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x01" * 100),
+            id="access_list_and_calldata",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(i) for i in range(10)],
+                )
+            ],
+            Bytes(b"\x00" * 50 + b"\x01" * 50),
+            id="large_access_list_mixed_calldata",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_access_list_floor_cost_with_calldata(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    tx_intrinsic_gas_cost_including_floor_data_cost: int,
+) -> None:
+    """
+    Test that the floor cost correctly accounts for both access list
+    and calldata tokens.
+
+    According to EIP-7981:
+    - total_data_tokens = tokens_in_calldata + tokens_in_access_list
+    - floor_gas = TX_BASE_COST + total_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
+    """
+    tx.expected_receipt = TransactionReceipt(
+        cumulative_gas_used=tx_intrinsic_gas_cost_including_floor_data_cost
+    )
+
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(i),
+                    storage_keys=[Hash(j) for j in range(5)],
+                )
+                for i in range(1, 6)
+            ],
+            id="five_addresses_five_keys_each",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_large_access_list_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test gas costs for large access lists.
+
+    With EIP-7981, large access lists should incur:
+    1. Storage access costs (2400 per address + 1900 per key)
+    2. Data footprint costs (10 per token)
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+            ],
+            id="duplicate_access_list_entries",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_duplicate_access_list_entries(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that duplicate access list entries are charged multiple times.
+
+    According to EIP-2930, non-unique addresses and storage keys are allowed
+    and charged multiple times. EIP-7981 should maintain this behavior.
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_eip_mainnet.py
@@ -1,0 +1,149 @@
+"""
+abstract: Crafted tests for mainnet of [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Hash,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            id="single_address_single_key",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(0), Hash(1), Hash(2)],
+                )
+            ],
+            id="single_address_multiple_keys",
+        ),
+        pytest.param(
+            [
+                AccessList(address=Address(1), storage_keys=[Hash(0)]),
+                AccessList(address=Address(2), storage_keys=[Hash(1)]),
+            ],
+            id="multiple_addresses",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xDE0B295669A9FD93D5F28D9EC85E40F4CB697BAE
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0x0000000000000000000000000000000000000000000000000000000000000003
+                        ),
+                        Hash(
+                            0x0000000000000000000000000000000000000000000000000000000000000007
+                        ),
+                    ],
+                )
+            ],
+            id="realistic_address_and_keys",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [
+        pytest.param("eoa", id="to_eoa"),
+    ],
+    indirect=True,
+)
+def test_access_list_gas_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with access lists are charged correctly
+    according to EIP-7981.
+
+    The test verifies that:
+    1. Access lists are charged for storage access (existing behavior)
+    2. Access lists are charged for their data footprint (new in EIP-7981)
+    3. Access list data contributes to the floor gas cost
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list",
+    [
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(0),
+                    storage_keys=[Hash(0) for _ in range(10)],
+                )
+            ],
+            id="all_zero_bytes",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                        for _ in range(5)
+                    ],
+                )
+            ],
+            id="all_nonzero_bytes",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [
+        pytest.param("eoa", id=""),
+    ],
+    indirect=True,
+)
+def test_access_list_data_cost_edge_cases(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test edge cases for access list data costs.
+
+    Tests include:
+    - All zero bytes in access list
+    - All non-zero bytes in access list
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -1,0 +1,273 @@
+"""
+abstract: Tests for transaction validity with [EIP-7981: Increase Access List Cost](https://eips.ethereum.org/EIPS/eip-7981).
+"""  # noqa: E501
+
+import pytest
+from execution_testing import (
+    AccessList,
+    Address,
+    Alloc,
+    Bytes,
+    Hash,
+    StateTestFiller,
+    Transaction,
+)
+
+from .spec import ref_spec_7981
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7981.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7981.version
+
+pytestmark = pytest.mark.valid_at("Amsterdam")
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            -1,
+            id="insufficient_gas_by_one",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            -100,
+            id="insufficient_gas_by_hundred",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(1),
+                    storage_keys=[Hash(i) for i in range(10)],
+                )
+            ],
+            -1,
+            id="large_access_list_insufficient_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_insufficient_gas_for_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with insufficient gas for access list costs
+    are rejected.
+
+    With EIP-7981, the intrinsic gas must cover:
+    - Base transaction cost
+    - Calldata costs
+    - Access list storage costs
+    - Access list data costs (new in EIP-7981)
+    - Floor cost including access list tokens
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            Bytes(b"\x01" * 1000),
+            -1,
+            id="large_calldata_and_access_list_insufficient_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_floor_cost_validation_with_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that the floor cost validation includes access list tokens.
+
+    According to EIP-7981:
+    - Any transaction with a gas limit below the floor cost is invalid
+    - Floor cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN *
+      total_data_tokens
+    - total_data_tokens = tokens_in_calldata + tokens_in_access_list
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_gas_delta",
+    [
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            0,
+            id="exact_gas",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            1,
+            id="one_extra_gas",
+        ),
+        pytest.param(
+            [AccessList(address=Address(1), storage_keys=[Hash(0)])],
+            1000,
+            id="plenty_extra_gas",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+def test_valid_gas_limits_with_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions with sufficient gas are valid.
+
+    Tests various gas limit scenarios:
+    - Exact intrinsic gas
+    - Slightly more than intrinsic gas
+    - Much more than intrinsic gas
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.with_all_tx_types(selector=lambda tx_type: tx_type >= 1)
+@pytest.mark.parametrize(
+    "access_list,tx_data",
+    [
+        pytest.param(
+            [AccessList(address=Address(0), storage_keys=[Hash(0)] * 100)],
+            Bytes(b"\x00" * 1000),
+            id="zero_heavy_data_and_access_list",
+        ),
+        pytest.param(
+            [
+                AccessList(
+                    address=Address(
+                        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                    ),
+                    storage_keys=[
+                        Hash(
+                            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                        )
+                    ]
+                    * 50,
+                )
+            ],
+            Bytes(b"\xff" * 500),
+            id="nonzero_heavy_data_and_access_list",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "tx_gas_delta",
+    [pytest.param(0, id="")],
+)
+def test_mixed_zero_nonzero_bytes_floor_cost(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test floor cost calculation with mixed zero and non-zero bytes.
+
+    This tests the token calculation where:
+    - Zero bytes contribute 1 token each
+    - Non-zero bytes contribute 4 tokens each
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )
+
+
+@pytest.mark.parametrize(
+    "tx_type,access_list",
+    [
+        pytest.param(
+            0,
+            None,
+            id="type_0_no_access_list",
+        ),
+        pytest.param(
+            1,
+            [],
+            id="type_1_empty_access_list",
+        ),
+        pytest.param(
+            2,
+            [],
+            id="type_2_empty_access_list",
+        ),
+        pytest.param(
+            3,
+            [],
+            id="type_3_empty_access_list",
+        ),
+        pytest.param(
+            4,
+            [],
+            id="type_4_empty_access_list",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "to",
+    [pytest.param("eoa", id="")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "tx_gas_delta",
+    [pytest.param(0, id="")],
+)
+def test_transactions_without_access_list(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+) -> None:
+    """
+    Test that transactions without access lists still work correctly.
+
+    EIP-7981 should only affect transactions with non-empty access lists.
+    """
+    state_test(
+        pre=pre,
+        post={},
+        tx=tx,
+    )

--- a/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
+++ b/tests/amsterdam/eip7981_increase_access_list_cost/test_transaction_validity.py
@@ -105,8 +105,9 @@ def test_floor_cost_validation_with_access_list(
     According to EIP-7981:
     - Any transaction with a gas limit below the floor cost is invalid
     - Floor cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN *
-      total_data_tokens
-    - total_data_tokens = tokens_in_calldata + tokens_in_access_list
+      total_floor_data_tokens
+    - total_floor_data_tokens =
+      floor_tokens_in_calldata + floor_tokens_in_access_list
     """
     state_test(
         pre=pre,
@@ -206,9 +207,8 @@ def test_mixed_zero_nonzero_bytes_floor_cost(
     """
     Test floor cost calculation with mixed zero and non-zero bytes.
 
-    This tests the token calculation where:
-    - Zero bytes contribute 1 token each
-    - Non-zero bytes contribute 4 tokens each
+    This ensures floor gas uses floor token counting:
+    - Each data byte contributes 4 floor tokens
     """
     state_test(
         pre=pre,


### PR DESCRIPTION
## 🗒️ Description
`uv run fill -v -s --clean ./tests/amsterdam/eip7981_increase_access_list_cost/ --until=amsterdam`
TODO: test against clients

## 🔗 Related Issues or PRs
Solves [Implementation Tracker](https://github.com/ethereum/execution-specs/issues/1943)
[EIP 7981](https://eips.ethereum.org/EIPS/eip-7981)
[Toni PR](https://github.com/ethereum/execution-specs/pull/2133)


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
