### PR TITLE
chore(test-benchmark): skip `test_blockhash` tests

### DIFF
--- a/tests/benchmark/compute/instruction/test_block_context.py
+++ b/tests/benchmark/compute/instruction/test_block_context.py
@@ -48,6 +48,7 @@ def test_block_context_ops(
     )
 
 
+@pytest.mark.skip(reason="Temporarily disabled pending investigation")
 @pytest.mark.repricing
 @pytest.mark.parametrize(
     "index,chain_length",


### PR DESCRIPTION
## 🗒️ Description

Temporarily skip `test_blockhash` benchmark test pending investigation.

Needed for benchmark tests release.

## 🔗 Related Issues or PRs

N/A