### PR TITLE
chore(ci): use official rustup installer instead of apt

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -4,15 +4,18 @@ runs:
   using: "composite"
   steps:
     - name: Install Rust
+      uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
+      with:
+        toolchain: 1.89.0
+
+    - name: Install build-essential
       shell: bash
-      run: |
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential rustup
-        rustup update --no-self-update 1.89.0 && rustup default 1.89.0
+      run: sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes build-essential
 
     - name: Install Tox and any other packages
       shell: bash
       run: |
-        DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes build-essential pkg-config
         pip install 'tox>=4.11,<5' requests
 
     - name: Download Geth and add to $PATH


### PR DESCRIPTION
## 🗒️ Description

Fix CI failures caused by apt proxy timeout when installing rustup.

### Problem

```
Err:1 http://archive.ubuntu.com/ubuntu noble/universe amd64 rustup amd64 1.26.0-5build1
  Could not connect to 10.128.2.134:3142 (10.128.2.134), connection timed out
```

### Solution

Use `dtolnay/rust-toolchain` GitHub Action (pinned SHA) instead of `apt-get install rustup`:
- More secure than `curl | sh`
- Avoids apt proxy issues
- Widely used (1.4k+ stars)

Also fixes:
- Missing `sudo` on tox dependencies install  
- Removes deprecated `--force-yes` flag

## 🔗 Related Issues or PRs

All PRs in EELS are currently blocked due to this CI failure.