### PR TITLE
fix(test-fill): skip test with regression issue for now

### DIFF
--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -34,6 +34,7 @@ from tests.benchmark.compute.helpers import MaxSizedContractFactory
         Op.EXTCODECOPY,
     ],
 )
+@pytest.mark.skip("Skip for now until we debug a regression in the test.")
 def test_unchunkified_bytecode(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,


### PR DESCRIPTION
## 🗒️ Description

This test is was likely not refactored appropriately and is causing a very significant regression in `fill` on a ~2hr time level. Skip this test for now so we can tag a new release.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

🐞 🐛 
