### PR TITLE
fix(tests/benchmark): Max size contract deployment execution

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -1,7 +1,7 @@
 """Code generating classes and functions."""
 
 from dataclasses import dataclass
-from typing import Any, Generator, List, Self, SupportsBytes, Tuple, Type
+from typing import Any, Dict, Generator, List, Self, SupportsBytes, Tuple, Type
 
 from pydantic import Field
 
@@ -807,6 +807,16 @@ class IteratingBytecode(Bytecode):
             remaining_gas -= best_iterations_gas
             start_iteration += best_iterations
 
+    def _intrinsic_cost_is_constant(
+        self,
+        intrinsic_cost_kwargs: Dict[str, Any],
+    ) -> bool:
+        """If none of the kwarg values is callable, return True."""
+        for _, value in intrinsic_cost_kwargs.items():
+            if callable(value):
+                return False
+        return True
+
     def tx_iterations_by_total_iteration_count(
         self,
         *,
@@ -828,14 +838,19 @@ class IteratingBytecode(Bytecode):
             yield total_iterations
             return
         remaining_iterations = total_iterations
+        best_iterations: int | None = None
+        constant_intrinsic_gas_cost = self._intrinsic_cost_is_constant(
+            intrinsic_cost_kwargs
+        )
 
         while remaining_iterations > 0:
-            best_iterations, _ = self._binary_search_iterations(
-                fork=fork,
-                gas_limit=gas_limit_cap,
-                start_iteration=start_iteration,
-                **intrinsic_cost_kwargs,
-            )
+            if best_iterations is None or not constant_intrinsic_gas_cost:
+                best_iterations, _ = self._binary_search_iterations(
+                    fork=fork,
+                    gas_limit=gas_limit_cap,
+                    start_iteration=start_iteration,
+                    **intrinsic_cost_kwargs,
+                )
             if best_iterations >= remaining_iterations:
                 yield remaining_iterations
                 return

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -425,7 +425,7 @@ class MaxSizedContractFactory(IteratingBytecode):
         ):
             if (
                 tx_gas_limit is None
-                or tx_gas_limit is None
+                or tx_gas_cost is None
                 or iteration_count != last_iteration_count
             ):
                 tx_gas_limit = self.tx_gas_limit_by_iteration_count(

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -402,18 +402,53 @@ class MaxSizedContractFactory(IteratingBytecode):
         """
         to = self.address(fork=fork)
 
+        # Use a sensible hardcoded maximum for the calldata, to avoid
+        # binary searching.
+        max_number = (2 ** (contract_count.bit_length() + 1)) - 1
+        calldata_max = Hash(max_number) + Hash(max_number)
+
         def calldata(iteration_count: int, start_iteration: int) -> bytes:
             index_end = iteration_count + start_iteration - 1
             return Hash(start_iteration) + Hash(index_end)
 
-        yield from self.transactions_by_total_iteration_count(
+        start_iteration: int = contract_start_index
+
+        tx_gas_limit: int | None = None
+        tx_gas_cost: int | None = None
+        last_iteration_count: int = 0
+
+        for iteration_count in self.tx_iterations_by_total_iteration_count(
             fork=fork,
             total_iterations=contract_count,
-            start_iteration=contract_start_index,
-            sender=sender,
-            to=to,
-            calldata=calldata,
-        )
+            start_iteration=start_iteration,
+            calldata=calldata_max,
+        ):
+            if (
+                tx_gas_limit is None
+                or tx_gas_limit is None
+                or iteration_count != last_iteration_count
+            ):
+                tx_gas_limit = self.tx_gas_limit_by_iteration_count(
+                    fork=fork,
+                    iteration_count=iteration_count,
+                    start_iteration=start_iteration,
+                    calldata=calldata_max,
+                )
+                tx_gas_cost = self.tx_gas_cost_by_iteration_count(
+                    fork=fork,
+                    iteration_count=iteration_count,
+                    start_iteration=start_iteration,
+                    calldata=calldata_max,
+                )
+            yield TransactionWithCost(
+                to=to,
+                gas_limit=tx_gas_limit,
+                sender=sender,
+                gas_cost=tx_gas_cost,
+                data=calldata(iteration_count, start_iteration),
+            )
+            start_iteration += iteration_count
+            last_iteration_count = iteration_count
 
     def address(self, *, fork: Fork) -> Address:
         """Get the deterministic address of the initcode."""

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -227,6 +227,9 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
     fork's limits.
     """
 
+    _cached_address: Address
+    """Cached address to avoid expensive recomputation."""
+
     def __new__(cls, *, pre: Alloc, fork: Fork) -> Self:
         """
         Create a new MaxSizedContractInitcode instance.
@@ -292,19 +295,21 @@ class MaxSizedContractInitcode(FixedIterationsBytecode):
             cleanup=cleanup,
             iteration_count=iteration_count,
         )
+        # Cache the address to avoid expensive recomputation
+        instance._cached_address = compute_deterministic_create2_address(
+            salt=0,
+            initcode=Initcode(deploy_code=instance),
+            fork=fork,
+        )
         deployed_address = pre.deterministic_deploy_contract(
             deploy_code=instance
         )
-        assert deployed_address == instance.address(fork=fork)
+        assert deployed_address == instance._cached_address
         return instance
 
-    def address(self, *, fork: Fork) -> Address:
+    def address(self) -> Address:
         """Get the deterministic address of the initcode."""
-        return compute_deterministic_create2_address(
-            salt=0,
-            initcode=Initcode(deploy_code=self),
-            fork=fork,
-        )
+        return self._cached_address
 
 
 class MaxSizedContractFactory(IteratingBytecode):
@@ -322,6 +327,9 @@ class MaxSizedContractFactory(IteratingBytecode):
     initcode: MaxSizedContractInitcode
     """The initcode used to deploy maximum-sized contracts via CREATE2."""
 
+    _cached_address: Address
+    """Cached address to avoid expensive recomputation."""
+
     def __new__(cls, *, pre: Alloc, fork: Fork) -> Self:
         """
         Create a new MaxSizedContractFactory instance.
@@ -337,7 +345,7 @@ class MaxSizedContractFactory(IteratingBytecode):
 
         """
         initcode = MaxSizedContractInitcode(pre=pre, fork=fork)
-        initcode_address = initcode.address(fork=fork)
+        initcode_address = initcode.address()
         setup = (
             Op.EXTCODECOPY(
                 address=initcode_address,
@@ -381,10 +389,16 @@ class MaxSizedContractFactory(IteratingBytecode):
             cleanup=cleanup,
         )
         instance.initcode = initcode
+        # Cache the address to avoid expensive recomputation
+        instance._cached_address = compute_deterministic_create2_address(
+            salt=0,
+            initcode=Initcode(deploy_code=instance),
+            fork=fork,
+        )
         deployed_address = pre.deterministic_deploy_contract(
             deploy_code=instance
         )
-        assert deployed_address == instance.address(fork=fork)
+        assert deployed_address == instance._cached_address
         return instance
 
     def transactions_by_total_contract_count(
@@ -400,7 +414,7 @@ class MaxSizedContractFactory(IteratingBytecode):
         given number of contracts, each capped tx properly capped by the
         gas limit cap of the fork.
         """
-        to = self.address(fork=fork)
+        to = self.address()
 
         # Use a sensible hardcoded maximum for the calldata, to avoid
         # binary searching.
@@ -450,18 +464,14 @@ class MaxSizedContractFactory(IteratingBytecode):
             start_iteration += iteration_count
             last_iteration_count = iteration_count
 
-    def address(self, *, fork: Fork) -> Address:
-        """Get the deterministic address of the initcode."""
-        return compute_deterministic_create2_address(
-            salt=0,
-            initcode=Initcode(deploy_code=self),
-            fork=fork,
-        )
+    def address(self) -> Address:
+        """Get the deterministic address of the factory contract."""
+        return self._cached_address
 
-    def created_contract_address(self, *, fork: Fork, salt: int) -> Address:
+    def created_contract_address(self, *, salt: int) -> Address:
         """Get the deterministic address of the created contract."""
         return compute_create2_address(
-            address=self.address(fork=fork),
+            address=self.address(),
             salt=salt,
             initcode=self.initcode,
         )

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -51,7 +51,7 @@ def test_unchunkified_bytecode(
 
     # Create the max-sized fork-dependent contract factory.
     max_sized_contract_factory = MaxSizedContractFactory(pre=pre, fork=fork)
-    factory_address = max_sized_contract_factory.address(fork=fork)
+    factory_address = max_sized_contract_factory.address()
     initcode = max_sized_contract_factory.initcode
 
     # Prepare the attack iterating bytecode.
@@ -148,9 +148,7 @@ def test_unchunkified_bytecode(
     post = {}
     for i in range(num_contracts):
         deployed_contract_address = (
-            max_sized_contract_factory.created_contract_address(
-                fork=fork, salt=i
-            )
+            max_sized_contract_factory.created_contract_address(salt=i)
         )
         post[deployed_contract_address] = Account(nonce=1)
 


### PR DESCRIPTION
## 🗒️ Description
Fixes bottleneck of calculating the exact gas cost required for each max-sized contract deployment by reusing the same costs every time.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
