### PR TITLE
fix(test-ci): fix issues with recent changes to checklist

### DIFF
--- a/.github/workflows/test-checklist.yaml
+++ b/.github/workflows/test-checklist.yaml
@@ -1,0 +1,37 @@
+name: Test checklist consistency
+
+on:
+  push:
+    branches:
+      - master
+      - mainnet
+    paths: &checklist_paths
+      - "docs/writing_tests/checklist_templates/**"
+      - "packages/testing/src/execution_testing/checklists/eip_checklist.py"
+      - "packages/testing/src/execution_testing/checklists/eip_checklist.pyi"
+      - "packages/testing/src/execution_testing/checklists/tests/test_checklist_template_consistency.py"
+      - ".github/workflows/test-checklist.yaml"
+  pull_request:
+    paths: *checklist_paths
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  checklist-consistency:
+    name: Test checklist template consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ethereum/execution-specs
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          version: ${{ vars.UV_VERSION }}
+          python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
+      - name: Run checklist consistency test
+        run: uvx tox -e tests_pytest_py3 -- -k test_checklist_template_consistency

--- a/packages/testing/src/execution_testing/checklists/eip_checklist.py
+++ b/packages/testing/src/execution_testing/checklists/eip_checklist.py
@@ -133,6 +133,11 @@ class EIPChecklist:
 
                 pass
 
+            class MissedLines(ChecklistItem):
+                """Document missed lines in coverage reports."""
+
+                pass
+
             class SecondClient(ChecklistItem):
                 """Second client code coverage."""
 

--- a/packages/testing/src/execution_testing/checklists/eip_checklist.pyi
+++ b/packages/testing/src/execution_testing/checklists/eip_checklist.pyi
@@ -107,6 +107,7 @@ class EIPChecklist:
     class General(_CallableChecklistItem):
         class CodeCoverage(_CallableChecklistItem):
             Eels: _CallableChecklistItem
+            MissedLines: _CallableChecklistItem
             SecondClient: _CallableChecklistItem
             TestCoverage: _CallableChecklistItem
 


### PR DESCRIPTION
## 🗒️ Description

- PR #2137 made a change to the eip checklist template that required an update to checklists. There was a test for this but the CI on that PR did not run this test because it doesn't know to look there since this was only a docs change. This also adds a lightweight workflow that triggers this test when there are changes to this doc. I could not see a better way but open to a different suggestion here other than the workflow.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="692" height="746" alt="Screenshot 2026-02-05 at 14 15 19" src="https://github.com/user-attachments/assets/4cdb85d6-05bf-41e9-b9ac-04a3435acb3f" />