### PR TITLE
feat(spec): bump `STANDARD_CALLDATA_TOKEN_COST` (EIP-7976)

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -33,12 +33,12 @@ Base cost of a transaction in gas units. This is the minimum amount of gas
 required to execute a transaction.
 """
 
-FLOOR_CALLDATA_COST = Uint(10)
+FLOOR_CALLDATA_COST = Uint(15)
 """
-Minimum gas cost per byte of calldata as per [EIP-7623]. Used to calculate
+Minimum gas cost per byte of calldata as per [EIP-7976]. Used to calculate
 the minimum gas cost for transactions that include calldata.
 
-[EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
+[EIP-7976]: https://eips.ethereum.org/EIPS/eip-7976
 """
 
 STANDARD_CALLDATA_TOKEN_COST = Uint(4)


### PR DESCRIPTION
## 🗒️ Description

Increases the `STANDARD_CALLDATA_TOKEN_COST` from `10` to `15`.

## 🔗 Related Issues or PRs

#1942

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.piefed.social/posts/us/qM/usqM9MJPZbGOgJz.jpg)
