### PR TITLE
fix(testing/execute): Phase not being correctly passed as tx request ID

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/contracts.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/contracts.py
@@ -9,6 +9,7 @@ from execution_testing.test_types import (
     DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
     Transaction,
+    TransactionTestMetadata,
 )
 
 logger = get_logger(__name__)
@@ -38,7 +39,8 @@ def deploy_deterministic_factory_contract(
     eth_rpc: EthRPC,
     seed_key: EOA,
     gas_price: int,
-) -> None:
+    tx_index: int = 0,
+) -> int:
     """Deploy the deterministic deployment contract."""
     deploy_tx_gas_price = 0x174876E800
     deploy_tx_gas_limit = 0x0186A0
@@ -79,11 +81,27 @@ def deploy_deterministic_factory_contract(
             gas_price=gas_price,
             sender=seed_key,
         )
+        fund_tx.metadata = TransactionTestMetadata(
+            test_id="global",
+            phase="setup",
+            action="fund_eoa",
+            target="Deterministic Factory Deployer",
+            tx_index=tx_index,
+        )
+        tx_index += 1
         eth_rpc.send_wait_transaction(fund_tx)
         logger.info(f"Funding transaction mined: {fund_tx.hash}")
 
     # Add deployment transaction.
     logger.info("Sending deployment transaction...")
+    deploy_tx.metadata = TransactionTestMetadata(
+        test_id="global",
+        phase="setup",
+        action="deploy_contract",
+        target="Deterministic Factory",
+        tx_index=tx_index,
+    )
+    tx_index += 1
     eth_rpc.send_wait_transaction(deploy_tx)
     logger.info(f"Deployment transaction mined: {deploy_tx.hash}")
     deployment_contract_code = eth_rpc.get_code(DETERMINISTIC_FACTORY_ADDRESS)
@@ -92,3 +110,4 @@ def deploy_deterministic_factory_contract(
         f"Deployment contract code is not the expected code: "
         f"{deployment_contract_code} != {DETERMINISTIC_FACTORY_BYTECODE}"
     )
+    return tx_index

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -192,6 +192,7 @@ def execute_required_contracts(
         logger.info(
             "Checking if deterministic factory contract is already deployed"
         )
+        tx_index = 0
         if (
             check_deterministic_factory_deployment(
                 eth_rpc=eth_rpc, fork=session_fork
@@ -199,10 +200,11 @@ def execute_required_contracts(
             is None
         ):
             try:
-                deploy_deterministic_factory_contract(
+                tx_index = deploy_deterministic_factory_contract(
                     eth_rpc=eth_rpc,
                     seed_key=session_worker_key,
                     gas_price=sender_funding_transactions_gas_price,
+                    tx_index=tx_index,
                 )
             except Exception as e:
                 raise RuntimeError(

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -15,6 +15,7 @@ from execution_testing.rpc import (
 )
 from execution_testing.test_types import (
     NetworkWrappedTransaction,
+    TestPhase,
     Transaction,
     TransactionTestMetadata,
 )
@@ -105,9 +106,9 @@ class TransactionPost(BaseExecute):
                     else None
                 )
                 phase = (
-                    "testing"
-                    if (tx.test_phase == "execution" or tx.test_phase is None)
-                    else "setup"
+                    tx.test_phase
+                    if tx.test_phase is not None
+                    else TestPhase.SETUP
                 )
                 tx.metadata = TransactionTestMetadata(
                     test_id=request.node.nodeid,

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -108,7 +108,7 @@ class TransactionPost(BaseExecute):
                 phase = (
                     tx.test_phase
                     if tx.test_phase is not None
-                    else TestPhase.SETUP
+                    else TestPhase.EXECUTION
                 )
                 tx.metadata = TransactionTestMetadata(
                     test_id=request.node.nodeid,

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -39,7 +39,12 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
 )
 from execution_testing.forks import Fork
-from execution_testing.test_types import Alloc, Environment, Transaction
+from execution_testing.test_types import (
+    Alloc,
+    Environment,
+    TestPhaseManager,
+    Transaction,
+)
 from execution_testing.vm import Bytecode, Op
 
 from .base import BaseTest
@@ -453,9 +458,10 @@ class BenchmarkTest(BaseTest):
         gas_limit = (
             self.fork.transaction_gas_limit_cap() or self.gas_benchmark_value
         )
-        benchmark_tx = self.code_generator.generate_transaction(
-            pre=self.pre, gas_benchmark_value=gas_limit
-        )
+        with TestPhaseManager.execution():
+            benchmark_tx = self.code_generator.generate_transaction(
+                pre=self.pre, gas_benchmark_value=gas_limit
+            )
 
         execution_txs = self.split_transaction(benchmark_tx, gas_limit)
         execution_block = Block(txs=execution_txs)
@@ -472,9 +478,10 @@ class BenchmarkTest(BaseTest):
         gas_limit = (
             self.fork.transaction_gas_limit_cap() or self.gas_benchmark_value
         )
-        benchmark_tx = self.code_generator.generate_transaction(
-            pre=self.pre, gas_benchmark_value=gas_limit
-        )
+        with TestPhaseManager.execution():
+            benchmark_tx = self.code_generator.generate_transaction(
+                pre=self.pre, gas_benchmark_value=gas_limit
+            )
         execution_block = Block(txs=[benchmark_tx])
         return [execution_block]
 

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -39,12 +39,7 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
 )
 from execution_testing.forks import Fork
-from execution_testing.test_types import (
-    Alloc,
-    Environment,
-    TestPhaseManager,
-    Transaction,
-)
+from execution_testing.test_types import Alloc, Environment, Transaction
 from execution_testing.vm import Bytecode, Op
 
 from .base import BaseTest
@@ -458,10 +453,9 @@ class BenchmarkTest(BaseTest):
         gas_limit = (
             self.fork.transaction_gas_limit_cap() or self.gas_benchmark_value
         )
-        with TestPhaseManager.execution():
-            benchmark_tx = self.code_generator.generate_transaction(
-                pre=self.pre, gas_benchmark_value=gas_limit
-            )
+        benchmark_tx = self.code_generator.generate_transaction(
+            pre=self.pre, gas_benchmark_value=gas_limit
+        )
 
         execution_txs = self.split_transaction(benchmark_tx, gas_limit)
         execution_block = Block(txs=execution_txs)
@@ -478,10 +472,9 @@ class BenchmarkTest(BaseTest):
         gas_limit = (
             self.fork.transaction_gas_limit_cap() or self.gas_benchmark_value
         )
-        with TestPhaseManager.execution():
-            benchmark_tx = self.code_generator.generate_transaction(
-                pre=self.pre, gas_benchmark_value=gas_limit
-            )
+        benchmark_tx = self.code_generator.generate_transaction(
+            pre=self.pre, gas_benchmark_value=gas_limit
+        )
         execution_block = Block(txs=[benchmark_tx])
         return [execution_block]
 

--- a/packages/testing/src/execution_testing/test_types/phase_manager.py
+++ b/packages/testing/src/execution_testing/test_types/phase_manager.py
@@ -5,28 +5,31 @@ from enum import Enum
 from typing import ClassVar, Iterator, Optional
 
 
-class TestPhase(Enum):
+class TestPhase(str, Enum):
     """Test phase for state and blockchain tests."""
 
     SETUP = "setup"
-    EXECUTION = "execution"
+    # TODO: Change string to "execution", remain as "testing" for backwards
+    # compatibility
+    EXECUTION = "testing"
+    CLEANUP = "cleanup"
 
 
 class TestPhaseManager:
     """
     Manages test phases for transactions and blocks.
 
-    This singleton class provides context managers for "setup" and
-    "execution" phases. Transactions automatically detect and tag
+    This singleton class provides context managers for SETUP and
+    EXECUTION phases. Transactions automatically detect and tag
     themselves with the current phase.
 
     Usage:
         with TestPhaseManager.setup():
-            # Transactions created here have test_phase = "setup"
+            # Transactions created here have test_phase = SETUP
             setup_tx = Transaction(...)
 
         with TestPhaseManager.execution():
-            # Transactions created here have test_phase = "execution"
+            # Transactions created here have test_phase = EXECUTION
             benchmark_tx = Transaction(...)
     """
 

--- a/packages/testing/src/execution_testing/test_types/tests/test_phase_manager.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_phase_manager.py
@@ -17,7 +17,8 @@ def reset_phase_manager() -> None:
 def test_test_phase_enum_values() -> None:
     """Test that TestPhase enum has correct values."""
     assert TestPhase.SETUP.value == "setup"
-    assert TestPhase.EXECUTION.value == "execution"
+    assert TestPhase.EXECUTION.value == "testing"
+    assert TestPhase.CLEANUP.value == "cleanup"
 
 
 def test_phase_manager_class_state() -> None:

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -279,7 +279,7 @@ class TransactionTestMetadata(CamelModel):
     """Represents the metadata for a transaction."""
 
     test_id: str | None = None
-    phase: str | None = None
+    phase: TestPhase | None = None
     action: str | None = None  # e.g. deploy / fund / execute
     target: str | None = None  # account/contract label
     tx_index: int | None = None  # index within this phase


### PR DESCRIPTION
## 🗒️ Description
Transaction's test phase was not being correctly populated in some instances:

- During deployment of the deterministic contract address and the funding of the EOA that sent the contract at the start of the `execute` session.
- During the execution of the testing/execution phase transactions due to a bad comparison.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/2s6aso8rn1721.jpg?width=1080&crop=smart&auto=webp&s=500effcc4deeee87840aea53d9573a47097b4f10)
