### PR TITLE
fix(benchmarks): correctly label test txs

### DIFF
--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -2,6 +2,7 @@
 
 from typing import ClassVar, Dict, List
 
+from execution_testing.test_types.phase_manager import TestPhase
 import pytest
 from pytest import FixtureRequest
 
@@ -106,7 +107,8 @@ class TransactionPost(BaseExecute):
                 )
                 phase = (
                     "testing"
-                    if (tx.test_phase == "execution" or tx.test_phase is None)
+                    if (tx.test_phase == TestPhase.EXECUTION
+                        or tx.test_phase is None)
                     else "setup"
                 )
                 tx.metadata = TransactionTestMetadata(


### PR DESCRIPTION
## 🗒️ Description
The "phase" of txs incorrectly (sometimes) ends up as "setup" while it is a "testing" transaction. This fixes at least some tests on my side. I was not aware that this is possible in Python and I also don't understand why in some situations it ends up being correct, while in others not.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
