### PR TITLE
feat(test-client-clis): add stream-mode opcode count support for geth

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -258,6 +258,7 @@ class GethTransitionTool(GethEvm, TransitionTool):
     subcommand: Optional[str] = "t8n"
     trace: bool
     t8n_use_stream = True
+    supports_opcode_count: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -643,6 +643,23 @@ class TransitionTool(EthereumCLI):
                     },
                 )
 
+        if self.supports_opcode_count:
+            opcode_count_file_path = Path(temp_dir.name) / "opcodes.json"
+            if opcode_count_file_path.exists():
+                opcode_count = OpcodeCount.model_validate_json(
+                    opcode_count_file_path.read_text()
+                )
+                output.result.opcode_count = opcode_count
+
+                if debug_output_path:
+                    with profiler.pause():
+                        dump_files_to_directory(
+                            debug_output_path,
+                            {
+                                "opcodes.json": opcode_count.model_dump(),
+                            },
+                        )
+
         if self.trace:
             output.result.traces = self.collect_traces(
                 output.result.receipts, temp_dir, debug_output_path
@@ -694,8 +711,12 @@ class TransitionTool(EthereumCLI):
             f"--state.reward={reward}",
         ]
 
-        if self.trace and temp_dir:
-            args.extend([trace_flag, f"--output.basedir={temp_dir.name}"])
+        if temp_dir and (self.trace or self.supports_opcode_count):
+            args.append(f"--output.basedir={temp_dir.name}")
+        if self.trace:
+            args.append(trace_flag)
+        if self.supports_opcode_count and temp_dir:
+            args.extend(["--opcode.count", "opcodes.json"])
 
         return args
 

--- a/packages/testing/src/execution_testing/fixtures/common.py
+++ b/packages/testing/src/execution_testing/fixtures/common.py
@@ -2,7 +2,13 @@
 
 from typing import Any, ClassVar, Dict, List
 
-from pydantic import AliasChoices, Field, computed_field, model_validator
+from pydantic import (
+    AliasChoices,
+    ConfigDict,
+    Field,
+    computed_field,
+    model_validator,
+)
 
 from execution_testing.base_types import (
     BlobSchedule,
@@ -101,6 +107,8 @@ class FixtureAuthorizationTuple(
 
 class FixtureTransactionLog(CamelModel, RLPSerializable):
     """Fixture variant of the TransactionLog type."""
+
+    model_config = ConfigDict(extra="ignore")
 
     address: Address | None = None
     topics: List[Hash] | None = None

--- a/packages/testing/src/execution_testing/fixtures/common.py
+++ b/packages/testing/src/execution_testing/fixtures/common.py
@@ -4,7 +4,6 @@ from typing import Any, ClassVar, Dict, List
 
 from pydantic import (
     AliasChoices,
-    ConfigDict,
     Field,
     computed_field,
     model_validator,
@@ -108,7 +107,7 @@ class FixtureAuthorizationTuple(
 class FixtureTransactionLog(CamelModel, RLPSerializable):
     """Fixture variant of the TransactionLog type."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = CamelModel.model_config | {"extra": "ignore"}
 
     address: Address | None = None
     topics: List[Hash] | None = None

--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -17,15 +17,6 @@ from execution_testing.base_types import (
 class TransactionLog(CamelModel):
     """Transaction log."""
 
-    @model_validator(mode="before")
-    @classmethod
-    def strip_extra_fields(cls, data: Any) -> Any:
-        """Strip extra fields from t8n tool output not part of model."""
-        if isinstance(data, dict):
-            # geth includes extra fields in log entries
-            data.pop("blockTimestamp", None)
-        return data
-
     address: Address | None = None
     topics: List[Hash] | None = None
     data: Bytes | None = None
@@ -35,6 +26,7 @@ class TransactionLog(CamelModel):
     block_hash: Hash | None = None
     log_index: HexNumber | None = None
     removed: bool | None = None
+    block_timestamp: HexNumber | None = None
 
 
 class ReceiptDelegation(CamelModel):

--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -17,6 +17,15 @@ from execution_testing.base_types import (
 class TransactionLog(CamelModel):
     """Transaction log."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def strip_extra_fields(cls, data: Any) -> Any:
+        """Strip extra fields from t8n tool output not part of model."""
+        if isinstance(data, dict):
+            # geth includes extra fields in log entries
+            data.pop("blockTimestamp", None)
+        return data
+
     address: Address | None = None
     topics: List[Hash] | None = None
     data: Bytes | None = None


### PR DESCRIPTION
## 🗒️ Description

Extends `_evaluate_stream()` in `TransitionTool` to read opcode count output from `opcodes.json` (mirrors existing `_evaluate_filesystem()` logic), updates `safe_t8n_args()` to set `--output.basedir` and `--opcode.count` flags when `supports_opcode_count` is true (even without `--trace`), and enables `supports_opcode_count = True` for `GethTransitionTool`.

The EELS benchmark framework uses opcode frequency counts to verify that benchmark tests exercise the intended opcodes at the expected iteration counts. This is critical for the gas repricing work where we need precise control over how many times each opcode executes.

Currently, benchmark tests can only be filled with opcode count verification using evmone or EELS. However, for Amsterdam (which evmone does not support currently) we need to fill benchmark tests with geth. As geth has this implemented the hope is to use geth as the default benchmark test filler moving forward. EELS is too slow.

Previously, opcode count support in EELS was only wired for filesystem-mode tools (evmone). Since geth uses stream mode (`t8n_use_stream = True`), the `_evaluate_stream()` path needed the same opcode count file reading that `_evaluate_filesystem()` already had. This PR adds that wiring so geth has full feature parity with evmone for benchmark fills.

## 🔗 Related Issues or PRs

- **Original EELS request**: [ethereum/execution-specs#1554](https://github.com/ethereum/execution-specs/issues/1554) — feature request for opcode count support across t8n tools
- **evmone implementation**: [ipsilon/evmone#1256](https://github.com/ipsilon/evmone/issues/1256) (issue) → [ipsilon/evmone#1274](https://github.com/ipsilon/evmone/pull/1274) (merged PR)
- **EELS integration**: [ethereum/execution-spec-tests#1956](https://github.com/ethereum/execution-spec-tests/pull/1956) — Mario's PR adding EELS-side `--opcode.count` support
- **Geth `--opcode.count` PR**: [ethereum/go-ethereum#33800](https://github.com/ethereum/go-ethereum/pull/33800) — companion PR adding `--opcode.count` flag to geth's `evm t8n`

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/010.png)