### PR TITLE
chore(ci): switch benchmark fill from evmone to geth

### DIFF
--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -16,21 +16,51 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get latest geth commit
+      id: geth-sha
+      shell: bash
+      run: |
+        SHA=$(git ls-remote https://github.com/${{ inputs.repo }}.git refs/heads/${{ inputs.ref }} | cut -f1)
+        echo "sha=$SHA" >> $GITHUB_OUTPUT
+        echo "Latest geth commit: $SHA"
+    - name: Prepare cache target dir
+      shell: bash
+      run: mkdir -p "$GITHUB_WORKSPACE/go-ethereum/cmd/evm"
+    - name: Restore build cache
+      id: cache-restore
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path: |
+          ${{ github.workspace }}/go-ethereum/cmd/evm/evm
+        key: geth-evm-build-sha=${{ steps.geth-sha.outputs.sha }}
+        restore-keys: |
+          geth-evm-build-
     - name: Checkout go-ethereum
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         repository: ${{ inputs.repo }}
-        ref: ${{ inputs.ref }}
+        ref: ${{ steps.geth-sha.outputs.sha }}
         path: go-ethereum
     - name: Setup golang
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
       with:
         go-version: ${{ inputs.golang }}
         cache-dependency-path: go-ethereum/go.sum
     - name: Build evm cmd
+      if: steps.cache-restore.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p $GITHUB_WORKSPACE/bin
         cd $GITHUB_WORKSPACE/go-ethereum/cmd/evm
         go build .
-        echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH
+    - name: Add geth evm to PATH
+      shell: bash
+      run: echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH
+    - name: Save build cache
+      if: steps.cache-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      with:
+        path: |
+          ${{ github.workspace }}/go-ethereum/cmd/evm/evm
+        key: geth-evm-build-sha=${{ steps.geth-sha.outputs.sha }}

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -12,7 +12,6 @@ static:
   ref: master
   targets: ["evmone-t8n"]
 benchmark:
-  impl: evmone
-  repo: ethereum/evmone
+  impl: geth
+  repo: ethereum/go-ethereum
   ref: master
-  targets: ["evmone-t8n"]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py
@@ -1,6 +1,7 @@
 """Test the benchmarking pytest plugin for gas benchmark values."""
 
 import json
+import os
 import textwrap
 from pathlib import Path
 from typing import List
@@ -12,8 +13,8 @@ from execution_testing.cli.pytest_commands.plugins.shared.benchmarking import (
     OpcodeCountsConfig,
 )
 
-# EVM binary for tests that actually fill (not just collect)
-BENCHMARK_EVM_T8N = "evmone-t8n"
+# EVM binary for fill tests; defaults to geth evm
+BENCHMARK_EVM_T8N = os.environ.get("EVM_BIN", "evm")
 
 test_module_dummy = textwrap.dedent(
     """\

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -216,6 +216,7 @@ class Traces(EthereumTestRootModel):
 
 _opcode_synonyms = {
     "KECCAK256": "SHA3",
+    "DIFFICULTY": "PREVRANDAO",
 }
 
 

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -498,7 +498,6 @@ class BenchmarkTest(BaseTest):
     ) -> None:
         """Verify target opcode was executed the expected number of times."""
         # Skip validation if opcode count is not available
-        # (e.g. currently only supported for evmone filling)
         if opcode_count is None:
             return
 

--- a/tox.ini
+++ b/tox.ini
@@ -135,24 +135,6 @@ commands =
         {posargs} \
         tests
 
-[testenv:benchmark]
-description = Fill the benchmark tests using geth evm (with Python)
-passenv =
-    EVM_BIN
-commands =
-    fill \
-        --generate-all-formats \
-        --gas-benchmark-values 1 \
-        --evm-bin={env:EVM_BIN:evm} \
-        -m "benchmark and not state_test" \
-        -n auto --maxprocesses 10 --dist=loadgroup \
-        --basetemp="{temp_dir}/pytest" \
-        --log-to "{toxworkdir}/logs" \
-        --clean \
-        --fork Osaka \
-        {posargs} \
-        tests/benchmark
-
 [testenv:optimized]
 description = Run unit tests for optimized state and ethash
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -135,6 +135,24 @@ commands =
         {posargs} \
         tests
 
+[testenv:benchmark]
+description = Fill the benchmark tests using geth evm (with Python)
+passenv =
+    EVM_BIN
+commands =
+    fill \
+        --generate-all-formats \
+        --gas-benchmark-values 1 \
+        --evm-bin={env:EVM_BIN:evm} \
+        -m "benchmark and not state_test" \
+        -n auto --maxprocesses 10 --dist=loadgroup \
+        --basetemp="{temp_dir}/pytest" \
+        --log-to "{toxworkdir}/logs" \
+        --clean \
+        --fork Osaka \
+        {posargs} \
+        tests/benchmark
+
 [testenv:optimized]
 description = Run unit tests for optimized state and ethash
 passenv =
@@ -156,7 +174,7 @@ passenv =
     EVM_BIN
 commands =
     fill \
-        --evm-bin={env:EVM_BIN:evmone-t8n} \
+        --evm-bin={env:EVM_BIN:evm} \
         --gas-benchmark-values 1 \
         --generate-pre-alloc-groups \
         --fork Osaka \
@@ -174,9 +192,9 @@ passenv =
     EVM_BIN
 commands =
     fill \
-        --evm-bin={env:EVM_BIN:evmone-t8n} \
+        --evm-bin={env:EVM_BIN:evm} \
         --fixed-opcode-count 1 \
-        --fork Prague \
+        --fork Osaka \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         # TODO: remove skip once working for all precompiles PR#1955
@@ -194,9 +212,9 @@ passenv =
 commands =
     benchmark_parser
     fill \
-        --evm-bin={env:EVM_BIN:evmone-t8n} \
+        --evm-bin={env:EVM_BIN:evm} \
         --fixed-opcode-count \
-        --fork Prague \
+        --fork Osaka \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         # TODO: remove skip once working for all precompiles PR#1955


### PR DESCRIPTION
## 🗒️ Description
### Summary
Switches the benchmark test filler from evmone to geth in CI and tox config:
- Updates `.github/configs/evm.yaml` benchmark entry: `evmone` to `geth`
- Updates `tox.ini` benchmark testenv default: `evmone-t8n` to `evm`
- Adds build caching to the geth evm CI action (matching evmone's caching pattern)

### Why?
Geth will eventually support `--opcode.count` ([ethereum/go-ethereum#33800](https://github.com/ethereum/go-ethereum/pull/33800)) and the EELS stream mode wiring is in place ([#2170](https://github.com/ethereum/execution-specs/pull/2170)), giving geth feature parity with evmone for benchmark filling.

Switching to geth enables:
- Benchmark filling for Amsterdam (BALs / EIP-7928), which evmone does not yet support
- Using a single filler client across all forks (Prague, Osaka, Amsterdam)

## 🔗 Related Issues or PRs
Requires:
- [ethereum/go-ethereum#33800](https://github.com/ethereum/go-ethereum/pull/33800), geth `--opcode.count` and receipt logs fix
- [#2170](https://github.com/ethereum/execution-specs/pull/2170), EELS stream-mode opcode count wiring for geth

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![geth-gopher](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/009.png)