### PR TITLE
refactor(tests): Add fork parameter to Initcode generator

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -7,7 +7,7 @@ from pydantic import Field
 
 from execution_testing.base_types import Address, Bytes
 from execution_testing.forks import Fork, Frontier
-from execution_testing.test_types import EOA, Transaction, ceiling_division
+from execution_testing.test_types import EOA, Transaction
 from execution_testing.vm import Bytecode, ForkOpcodeInterface, Op
 
 
@@ -45,7 +45,6 @@ class Initcode(Bytecode):
         deploy_code: SupportsBytes | Bytes | None = None,
         initcode_length: int | None = None,
         initcode_prefix: Bytecode | None = None,
-        initcode_prefix_execution_gas: int = 0,
         padding_byte: int = 0x00,
         name: str = "",
         fork: Fork = Frontier,
@@ -62,24 +61,17 @@ class Initcode(Bytecode):
         if initcode_prefix is None:
             initcode_prefix = Bytecode()
 
-        gas_costs = fork.gas_costs()
-        memory_calculator = fork.memory_expansion_gas_calculator()
-
         initcode = initcode_prefix
         code_length = len(bytes(deploy_code))
-        execution_gas = initcode_prefix_execution_gas
 
         # PUSH2: length=<bytecode length>
         initcode += Op.PUSH2(code_length)
-        execution_gas = gas_costs.G_VERY_LOW
 
         # PUSH1: offset=0
         initcode += Op.PUSH1(0)
-        execution_gas += gas_costs.G_VERY_LOW
 
         # DUP2
         initcode += Op.DUP2
-        execution_gas += gas_costs.G_VERY_LOW
 
         # PUSH1: initcode_length=11 + len(initcode_prefix_bytes) (constant)
         no_prefix_length = 0x0B
@@ -87,21 +79,17 @@ class Initcode(Bytecode):
             "initcode prefix too long"
         )
         initcode += Op.PUSH1(no_prefix_length + len(initcode_prefix))
-        execution_gas += gas_costs.G_VERY_LOW
 
         # DUP3
         initcode += Op.DUP3
-        execution_gas += gas_costs.G_VERY_LOW
 
         # CODECOPY: destinationOffset=0, offset=0, length
-        initcode += Op.CODECOPY
-        word_copy_cost = gas_costs.G_COPY * ceiling_division(code_length, 32)
-        memory_cost = memory_calculator(new_bytes=code_length)
-        execution_gas += gas_costs.G_VERY_LOW + word_copy_cost + memory_cost
+        initcode += Op.CODECOPY(
+            data_size=code_length, new_memory_size=code_length
+        )
 
         # RETURN: offset=0, length
         initcode += Op.RETURN
-        execution_gas += 0
 
         initcode_plus_deploy_code = bytes(initcode) + bytes(deploy_code)
         padding_bytes = bytes()
@@ -127,10 +115,10 @@ class Initcode(Bytecode):
         )
         instance._name_ = name
         instance.deploy_code = deploy_code
-        instance.execution_gas = execution_gas
-        instance.deployment_gas = gas_costs.G_CODE_DEPOSIT_BYTE * len(
-            bytes(instance.deploy_code)
-        )
+        instance.execution_gas = initcode.gas_cost(fork)
+        instance.deployment_gas = Op.RETURN(
+            code_deposit_size=len(bytes(instance.deploy_code))
+        ).gas_cost(fork)
 
         return instance
 

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -6,11 +6,9 @@ from typing import Any, Dict, Generator, List, Self, SupportsBytes, Tuple, Type
 from pydantic import Field
 
 from execution_testing.base_types import Address, Bytes
-from execution_testing.forks import Fork
+from execution_testing.forks import Fork, Frontier
 from execution_testing.test_types import EOA, Transaction, ceiling_division
 from execution_testing.vm import Bytecode, ForkOpcodeInterface, Op
-
-GAS_PER_DEPLOYED_CODE_BYTE = 0xC8
 
 
 class Initcode(Bytecode):
@@ -50,15 +48,22 @@ class Initcode(Bytecode):
         initcode_prefix_execution_gas: int = 0,
         padding_byte: int = 0x00,
         name: str = "",
+        fork: Fork = Frontier,
     ) -> Self:
         """
         Generate legacy initcode that inits a contract with the specified code.
         The initcode can be padded to a specified length for testing purposes.
+
+        Gas costs are calculated using the fork's gas costs and memory
+        expansion formula. Defaults to Frontier if no fork is provided.
         """
         if deploy_code is None:
             deploy_code = Bytecode()
         if initcode_prefix is None:
             initcode_prefix = Bytecode()
+
+        gas_costs = fork.gas_costs()
+        memory_calculator = fork.memory_expansion_gas_calculator()
 
         initcode = initcode_prefix
         code_length = len(bytes(deploy_code))
@@ -66,15 +71,15 @@ class Initcode(Bytecode):
 
         # PUSH2: length=<bytecode length>
         initcode += Op.PUSH2(code_length)
-        execution_gas = 3
+        execution_gas = gas_costs.G_VERY_LOW
 
         # PUSH1: offset=0
         initcode += Op.PUSH1(0)
-        execution_gas += 3
+        execution_gas += gas_costs.G_VERY_LOW
 
         # DUP2
         initcode += Op.DUP2
-        execution_gas += 3
+        execution_gas += gas_costs.G_VERY_LOW
 
         # PUSH1: initcode_length=11 + len(initcode_prefix_bytes) (constant)
         no_prefix_length = 0x0B
@@ -82,20 +87,17 @@ class Initcode(Bytecode):
             "initcode prefix too long"
         )
         initcode += Op.PUSH1(no_prefix_length + len(initcode_prefix))
-        execution_gas += 3
+        execution_gas += gas_costs.G_VERY_LOW
 
         # DUP3
         initcode += Op.DUP3
-        execution_gas += 3
+        execution_gas += gas_costs.G_VERY_LOW
 
         # CODECOPY: destinationOffset=0, offset=0, length
         initcode += Op.CODECOPY
-        execution_gas += (
-            3
-            + (3 * ceiling_division(code_length, 32))
-            + (3 * code_length)
-            + ((code_length * code_length) // 512)
-        )
+        word_copy_cost = gas_costs.G_COPY * ceiling_division(code_length, 32)
+        memory_cost = memory_calculator(new_bytes=code_length)
+        execution_gas += gas_costs.G_VERY_LOW + word_copy_cost + memory_cost
 
         # RETURN: offset=0, length
         initcode += Op.RETURN
@@ -126,7 +128,7 @@ class Initcode(Bytecode):
         instance._name_ = name
         instance.deploy_code = deploy_code
         instance.execution_gas = execution_gas
-        instance.deployment_gas = GAS_PER_DEPLOYED_CODE_BYTE * len(
+        instance.deployment_gas = gas_costs.G_CODE_DEPOSIT_BYTE * len(
             bytes(instance.deploy_code)
         )
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
@@ -11,6 +11,7 @@ from execution_testing import (
     Op,
     Transaction,
 )
+from execution_testing.forks.helpers import Fork
 
 from .spec import ref_spec_1153
 
@@ -22,6 +23,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1153.version
 def test_tstore_clear_after_deployment_tx(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     First creates a contract, which TSTOREs a value 1 in slot 1. After creating
@@ -34,7 +36,9 @@ def test_tstore_clear_after_deployment_tx(
     init_code = Op.TSTORE(1, 1)
     deploy_code = Op.SSTORE(1, Op.TLOAD(1))
 
-    code = Initcode(deploy_code=deploy_code, initcode_prefix=init_code)
+    code = Initcode(
+        deploy_code=deploy_code, initcode_prefix=init_code, fork=fork
+    )
 
     sender = pre.fund_eoa()
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -17,6 +17,7 @@ from execution_testing import (
     Transaction,
     compute_create_address,
 )
+from execution_testing.forks.helpers import Fork
 
 from . import CreateOpcodeParams, PytestParameterEnum
 from .spec import ref_spec_1153
@@ -164,9 +165,12 @@ class TestTransientStorageInContractCreation:
         self,
         deploy_code: Bytecode,
         constructor_code: Bytecode,
+        fork: Fork,
     ) -> Initcode:
         return Initcode(
-            deploy_code=deploy_code, initcode_prefix=constructor_code
+            deploy_code=deploy_code,
+            initcode_prefix=constructor_code,
+            fork=fork,
         )
 
     @pytest.fixture()

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -32,7 +32,7 @@ from .helpers import (
     INITCODE_RESULTING_DEPLOYED_CODE,
     get_create_id,
 )
-from .spec import Spec, ref_spec_3860
+from .spec import ref_spec_3860
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_3860.git_path
 REFERENCE_SPEC_VERSION = ref_spec_3860.version
@@ -48,7 +48,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=Spec.MAX_INITCODE_SIZE,
+            initcode_length=fork.max_initcode_size(),
             padding_byte=0x01,
         )
     elif initcode_name == "max_size_zeros":
@@ -56,7 +56,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=Spec.MAX_INITCODE_SIZE,
+            initcode_length=fork.max_initcode_size(),
             padding_byte=0x00,
         )
     elif initcode_name == "over_limit_ones":
@@ -64,7 +64,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=Spec.MAX_INITCODE_SIZE + 1,
+            initcode_length=fork.max_initcode_size() + 1,
             padding_byte=0x01,
         )
     elif initcode_name == "over_limit_zeros":
@@ -72,7 +72,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=Spec.MAX_INITCODE_SIZE + 1,
+            initcode_length=fork.max_initcode_size() + 1,
             padding_byte=0x00,
         )
     elif initcode_name == "32_bytes":
@@ -91,20 +91,20 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
             initcode_length=33,
             padding_byte=0x00,
         )
-    elif initcode_name == "49120_bytes":
+    elif initcode_name == "max_size_minus_word":
         return Initcode(
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=49120,
+            initcode_length=fork.max_initcode_size() - 32,
             padding_byte=0x00,
         )
-    elif initcode_name == "49121_bytes":
+    elif initcode_name == "max_size_minus_word_plus_byte":
         return Initcode(
             name=initcode_name,
             fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-            initcode_length=49121,
+            initcode_length=fork.max_initcode_size() - 32 + 1,
             padding_byte=0x00,
         )
     elif initcode_name == "empty":
@@ -143,6 +143,7 @@ def test_contract_creating_tx(
     post: Alloc,
     sender: EOA,
     initcode: Initcode,
+    fork: Fork,
 ) -> None:
     """
     Test creating a contract with initcode that is on/over the allowed limit.
@@ -161,7 +162,7 @@ def test_contract_creating_tx(
         sender=sender,
     )
 
-    if len(initcode) > Spec.MAX_INITCODE_SIZE:
+    if len(initcode) > fork.max_initcode_size():
         # Initcode is above the max size, tx inclusion in the block makes
         # it invalid.
         post[create_contract_address] = Account.NONEXISTENT
@@ -211,8 +212,8 @@ def valid_gas_test_case(initcode_name: str, gas_case: str) -> bool:
             "single_byte",
             "32_bytes",
             "33_bytes",
-            "49120_bytes",
-            "49121_bytes",
+            "max_size_minus_word",
+            "max_size_minus_word_plus_byte",
         ]
         for g in [
             "too_little_intrinsic_gas",
@@ -410,8 +411,8 @@ class TestContractCreationGasUsage:
         "single_byte",
         "32_bytes",
         "33_bytes",
-        "49120_bytes",
-        "49121_bytes",
+        "max_size_minus_word",
+        "max_size_minus_word_plus_byte",
     ],
 )
 @pytest.mark.parametrize("opcode", [Op.CREATE, Op.CREATE2], ids=get_create_id)
@@ -569,6 +570,7 @@ class TestCreateInitcode:
         contract_creation_gas_cost: int,
         initcode_word_cost: int,
         create2_word_cost: int,
+        fork: Fork,
     ) -> None:
         """
         Test contract creation with valid and invalid initcode lengths.
@@ -576,7 +578,7 @@ class TestCreateInitcode:
         Test contract creation via CREATE/CREATE2, parametrized by initcode
         that is on/over the max allowed limit.
         """
-        if len(initcode) > Spec.MAX_INITCODE_SIZE:
+        if len(initcode) > fork.max_initcode_size():
             # Call returns 0 as out of gas s[0]==1
             post[caller_contract_address] = Account(
                 nonce=1,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -31,7 +31,6 @@ from execution_testing import (
 from .helpers import (
     INITCODE_RESULTING_DEPLOYED_CODE,
     get_create_id,
-    get_initcode_name,
 )
 from .spec import Spec, ref_spec_3860
 
@@ -41,94 +40,101 @@ REFERENCE_SPEC_VERSION = ref_spec_3860.version
 pytestmark = pytest.mark.valid_from("Shanghai")
 
 
-"""Initcode templates used throughout the tests"""
-INITCODE_ONES_MAX_LIMIT = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=Spec.MAX_INITCODE_SIZE,
-    padding_byte=0x01,
-    name="max_size_ones",
-)
+@pytest.fixture
+def initcode(fork: Fork, initcode_name: str) -> Initcode:
+    """Create an Initcode object with fork-specific gas calculations."""
+    if initcode_name == "max_size_ones":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=Spec.MAX_INITCODE_SIZE,
+            padding_byte=0x01,
+        )
+    elif initcode_name == "max_size_zeros":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=Spec.MAX_INITCODE_SIZE,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "over_limit_ones":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=Spec.MAX_INITCODE_SIZE + 1,
+            padding_byte=0x01,
+        )
+    elif initcode_name == "over_limit_zeros":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=Spec.MAX_INITCODE_SIZE + 1,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "32_bytes":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=32,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "33_bytes":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=33,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "49120_bytes":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=49120,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "49121_bytes":
+        return Initcode(
+            name=initcode_name,
+            fork=fork,
+            deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
+            initcode_length=49121,
+            padding_byte=0x00,
+        )
+    elif initcode_name == "empty":
+        ic = Initcode(name=initcode_name, fork=fork)
+        ic._bytes_ = bytes()
+        ic.deployment_gas = 0
+        ic.execution_gas = 0
+        return ic
+    elif initcode_name == "single_byte":
+        ic = Initcode(name=initcode_name, fork=fork)
+        ic._bytes_ = bytes(Op.STOP)
+        ic.deployment_gas = 0
+        ic.execution_gas = 0
+        return ic
+    else:
+        raise ValueError(f"Unknown initcode_name: {initcode_name}")
 
-INITCODE_ZEROS_MAX_LIMIT = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=Spec.MAX_INITCODE_SIZE,
-    padding_byte=0x00,
-    name="max_size_zeros",
-)
-
-INITCODE_ONES_OVER_LIMIT = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=Spec.MAX_INITCODE_SIZE + 1,
-    padding_byte=0x01,
-    name="over_limit_ones",
-)
-
-INITCODE_ZEROS_OVER_LIMIT = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=Spec.MAX_INITCODE_SIZE + 1,
-    padding_byte=0x00,
-    name="over_limit_zeros",
-)
-
-INITCODE_ZEROS_32_BYTES = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=32,
-    padding_byte=0x00,
-    name="32_bytes",
-)
-
-INITCODE_ZEROS_33_BYTES = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=33,
-    padding_byte=0x00,
-    name="33_bytes",
-)
-
-INITCODE_ZEROS_49120_BYTES = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=49120,
-    padding_byte=0x00,
-    name="49120_bytes",
-)
-
-INITCODE_ZEROS_49121_BYTES = Initcode(
-    deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
-    initcode_length=49121,
-    padding_byte=0x00,
-    name="49121_bytes",
-)
-
-EMPTY_INITCODE = Initcode(
-    name="empty",
-)
-EMPTY_INITCODE._bytes_ = bytes()
-EMPTY_INITCODE.deployment_gas = 0
-EMPTY_INITCODE.execution_gas = 0
-
-SINGLE_BYTE_INITCODE = Initcode(
-    name="single_byte",
-)
-SINGLE_BYTE_INITCODE._bytes_ = bytes(Op.STOP)
-SINGLE_BYTE_INITCODE.deployment_gas = 0
-SINGLE_BYTE_INITCODE.execution_gas = 0
 
 """Test cases using a contract creating transaction"""
 
 
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.parametrize(
-    "initcode",
+    "initcode_name",
     [
-        INITCODE_ZEROS_MAX_LIMIT,
-        INITCODE_ONES_MAX_LIMIT,
-        pytest.param(
-            INITCODE_ZEROS_OVER_LIMIT, marks=pytest.mark.exception_test
-        ),
-        pytest.param(
-            INITCODE_ONES_OVER_LIMIT, marks=pytest.mark.exception_test
-        ),
+        pytest.param("max_size_zeros"),
+        pytest.param("max_size_ones"),
+        pytest.param("over_limit_zeros", marks=pytest.mark.exception_test),
+        pytest.param("over_limit_ones", marks=pytest.mark.exception_test),
     ],
-    ids=get_initcode_name,
 )
 def test_contract_creating_tx(
     state_test: StateTestFiller,
@@ -173,15 +179,21 @@ def test_contract_creating_tx(
     )
 
 
-def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
-    """Filter out invalid gas test case/initcode combinations."""
-    if gas_test_case == "too_little_execution_gas":
-        return (initcode.deployment_gas + initcode.execution_gas) > 0
+ZERO_GAS_SPECS = {"empty", "single_byte"}
+
+
+def valid_gas_test_case(initcode_name: str, gas_case: str) -> bool:
+    """Filter invalid gas test case combinations."""
+    if (
+        gas_case == "too_little_execution_gas"
+        and initcode_name in ZERO_GAS_SPECS
+    ):
+        return False
     return True
 
 
 @pytest.mark.parametrize(
-    "initcode,gas_test_case",
+    "initcode_name,gas_test_case",
     [
         pytest.param(
             i,
@@ -193,14 +205,14 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
             ),
         )
         for i in [
-            INITCODE_ZEROS_MAX_LIMIT,
-            INITCODE_ONES_MAX_LIMIT,
-            EMPTY_INITCODE,
-            SINGLE_BYTE_INITCODE,
-            INITCODE_ZEROS_32_BYTES,
-            INITCODE_ZEROS_33_BYTES,
-            INITCODE_ZEROS_49120_BYTES,
-            INITCODE_ZEROS_49121_BYTES,
+            "max_size_zeros",
+            "max_size_ones",
+            "empty",
+            "single_byte",
+            "32_bytes",
+            "33_bytes",
+            "49120_bytes",
+            "49121_bytes",
         ]
         for g in [
             "too_little_intrinsic_gas",
@@ -210,9 +222,6 @@ def valid_gas_test_case(initcode: Initcode, gas_test_case: str) -> bool:
         ]
         if valid_gas_test_case(i, g)
     ],
-    ids=lambda x: (
-        f"{get_initcode_name(x[0])}-{x[1]}" if isinstance(x, tuple) else x
-    ),
 )
 class TestContractCreationGasUsage:
     """
@@ -391,20 +400,19 @@ class TestContractCreationGasUsage:
 
 
 @pytest.mark.parametrize(
-    "initcode",
+    "initcode_name",
     [
-        INITCODE_ZEROS_MAX_LIMIT,
-        INITCODE_ONES_MAX_LIMIT,
-        INITCODE_ZEROS_OVER_LIMIT,
-        INITCODE_ONES_OVER_LIMIT,
-        EMPTY_INITCODE,
-        SINGLE_BYTE_INITCODE,
-        INITCODE_ZEROS_32_BYTES,
-        INITCODE_ZEROS_33_BYTES,
-        INITCODE_ZEROS_49120_BYTES,
-        INITCODE_ZEROS_49121_BYTES,
+        "max_size_zeros",
+        "max_size_ones",
+        "over_limit_zeros",
+        "over_limit_ones",
+        "empty",
+        "single_byte",
+        "32_bytes",
+        "33_bytes",
+        "49120_bytes",
+        "49121_bytes",
     ],
-    ids=get_initcode_name,
 )
 @pytest.mark.parametrize("opcode", [Op.CREATE, Op.CREATE2], ids=get_create_id)
 class TestCreateInitcode:


### PR DESCRIPTION
## 🗒️ Description

Initcode class now uses fork-specific gas costs and memory expansion formula instead of hardcoded values.

This should make tests leveraging this generator less sensitive to gas repricings. An EIP-3860 test needed to be adapted a bit, to not hardcode `Initcode` instances in parameters.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
