### PR TITLE
fix(fw): Add slot_number (EIP-7843) to FixtureHeader and FixtureExecutionPayload

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -214,6 +214,10 @@ class FixtureHeader(CamelModel):
     block_access_list_hash: (
         Annotated[Hash, HeaderForkRequirement("bal_hash")] | None
     ) = Field(None, alias="blockAccessListHash")
+    slot_number: (
+        Annotated[ZeroPaddedHexNumber, HeaderForkRequirement("slot_number")]
+        | None
+    ) = Field(None)
 
     fork: Fork | None = Field(None, exclude=True)
 
@@ -422,6 +426,7 @@ class FixtureExecutionPayload(CamelModel):
     block_access_list: Bytes | None = Field(
         None, description="RLP-serialized EIP-7928 Block Access List"
     )
+    slot_number: HexNumber | None = Field(None)
 
     @classmethod
     def from_fixture_header(

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -977,6 +977,14 @@ class Frontier(BaseFork, solc_name="homestead"):
         return False
 
     @classmethod
+    def header_slot_number_required(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """At genesis, header must not contain slot number."""
+        del block_number, timestamp
+        return False
+
+    @classmethod
     def engine_new_payload_version(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> Optional[int]:
@@ -3356,6 +3364,16 @@ class Amsterdam(BPO2):
     ) -> bool:
         """
         From Amsterdam, header must contain block access list hash (EIP-7928).
+        """
+        del block_number, timestamp
+        return True
+
+    @classmethod
+    def header_slot_number_required(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> bool:
+        """
+        From Amsterdam, header must contain slot number (EIP-7843).
         """
         del block_number, timestamp
         return True


### PR DESCRIPTION
## 🗒️ Description
The FixtureExecutionPayload and FixtureHeader models were missing the slot_number field introduced by EIP-7843 (SLOTNUM opcode) for Amsterdam. Because both models use extra="ignore", the slotNumber field present in fixture JSON was silently dropped during Pydantic deserialization. This causes all Amsterdam engine tests to fail with block hash mismatches in our client tests, since the fixture blockHash was computed with slot_number but the payload sent to clients omitted it.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="241" height="330" alt="image" src="https://github.com/user-attachments/assets/80d5be1b-216f-43ea-bd23-7d201f58af65" />

