### PR TITLE
feat(benchmarking): Optimize `IteratingBytecode`

### DIFF
--- a/packages/testing/src/execution_testing/test_types/helpers.py
+++ b/packages/testing/src/execution_testing/test_types/helpers.py
@@ -11,7 +11,7 @@ from execution_testing.base_types.conversions import (
     FixedSizeBytesConvertible,
 )
 from execution_testing.forks import Fork
-from execution_testing.vm import Op
+from execution_testing.vm import Bytecode, Op
 
 from .account_types import EOA
 from .utils import int_to_bytes
@@ -88,14 +88,18 @@ def compute_create_address(
 def compute_create2_address(
     address: FixedSizeBytesConvertible,
     salt: FixedSizeBytesConvertible,
-    initcode: BytesConvertible,
+    initcode: Bytecode | BytesConvertible,
 ) -> Address:
     """
     Compute address of the resulting contract created using the `CREATE2`
     opcode.
     """
+    if isinstance(initcode, Bytecode):
+        initcode_hash = initcode.keccak256()
+    else:
+        initcode_hash = Bytes(initcode).keccak256()
     hash_bytes = Bytes(
-        b"\xff" + Address(address) + Hash(salt) + Bytes(initcode).keccak256()
+        b"\xff" + Address(address) + Hash(salt) + initcode_hash
     ).keccak256()
     return Address(hash_bytes[-20:])
 

--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -34,6 +34,14 @@ class Bytecode:
     _name_: str = ""
     _bytes_: bytes
     _keccak_256_: Hash | None = None
+    _gas_cost_: int | None = None
+    _gas_cost_fork_: Type[ForkOpcodeInterface] | None = None
+    _gas_cost_block_number_: int | None = None
+    _gas_cost_timestamp_: int | None = None
+    _refund_: int | None = None
+    _refund_fork_: Type[ForkOpcodeInterface] | None = None
+    _refund_block_number_: int | None = None
+    _refund_timestamp_: int | None = None
 
     popped_stack_items: int
     pushed_stack_items: int
@@ -274,13 +282,22 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas used by this bytecode."""
-        opcode_gas_calculator = fork.opcode_gas_calculator(
-            block_number=block_number, timestamp=timestamp
-        )
-        total_gas = 0
-        for opcode in self.opcode_list:
-            total_gas += opcode_gas_calculator(opcode)
-        return total_gas
+        if (
+            self._gas_cost_ is None
+            or self._gas_cost_fork_ != fork
+            or self._gas_cost_block_number_ != block_number
+            or self._gas_cost_timestamp_ != timestamp
+        ):
+            self._gas_cost_fork_ = fork
+            self._gas_cost_block_number_ = block_number
+            self._gas_cost_timestamp_ = timestamp
+            opcode_gas_calculator = fork.opcode_gas_calculator(
+                block_number=block_number, timestamp=timestamp
+            )
+            self._gas_cost_ = 0
+            for opcode in self.opcode_list:
+                self._gas_cost_ += opcode_gas_calculator(opcode)
+        return self._gas_cost_
 
     def refund(
         self,
@@ -290,13 +307,22 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas refund from this bytecode."""
-        opcode_refund_calculator = fork.opcode_refund_calculator(
-            block_number=block_number, timestamp=timestamp
-        )
-        total_refund = 0
-        for opcode in self.opcode_list:
-            total_refund += opcode_refund_calculator(opcode)
-        return total_refund
+        if (
+            self._refund_ is None
+            or self._refund_fork_ != fork
+            or self._refund_block_number_ != block_number
+            or self._refund_timestamp_ != timestamp
+        ):
+            self._refund_fork_ = fork
+            self._refund_block_number_ = block_number
+            self._refund_timestamp_ = timestamp
+            opcode_refund_calculator = fork.opcode_refund_calculator(
+                block_number=block_number, timestamp=timestamp
+            )
+            self._refund_ = 0
+            for opcode in self.opcode_list:
+                self._refund_ += opcode_refund_calculator(opcode)
+        return self._refund_
 
     @classmethod
     def __get_pydantic_core_schema__(

--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -33,6 +33,7 @@ class Bytecode:
 
     _name_: str = ""
     _bytes_: bytes
+    _keccak_256_: Hash | None = None
 
     popped_stack_items: int
     pushed_stack_items: int
@@ -261,7 +262,9 @@ class Bytecode:
 
     def keccak256(self) -> Hash:
         """Return the keccak256 hash of the opcode byte representation."""
-        return Bytes(self._bytes_).keccak256()
+        if self._keccak_256_ is None:
+            self._keccak_256_ = Bytes(self._bytes_).keccak256()
+        return self._keccak_256_
 
     def gas_cost(
         self,

--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -1,5 +1,6 @@
 """Ethereum Virtual Machine bytecode primitives and utilities."""
 
+from functools import cache
 from typing import Any, List, Self, SupportsBytes, Type
 
 from pydantic import GetCoreSchemaHandler
@@ -34,14 +35,6 @@ class Bytecode:
     _name_: str = ""
     _bytes_: bytes
     _keccak_256_: Hash | None = None
-    _gas_cost_: int | None = None
-    _gas_cost_fork_: Type[ForkOpcodeInterface] | None = None
-    _gas_cost_block_number_: int | None = None
-    _gas_cost_timestamp_: int | None = None
-    _refund_: int | None = None
-    _refund_fork_: Type[ForkOpcodeInterface] | None = None
-    _refund_block_number_: int | None = None
-    _refund_timestamp_: int | None = None
 
     popped_stack_items: int
     pushed_stack_items: int
@@ -282,22 +275,7 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas used by this bytecode."""
-        if (
-            self._gas_cost_ is None
-            or self._gas_cost_fork_ != fork
-            or self._gas_cost_block_number_ != block_number
-            or self._gas_cost_timestamp_ != timestamp
-        ):
-            self._gas_cost_fork_ = fork
-            self._gas_cost_block_number_ = block_number
-            self._gas_cost_timestamp_ = timestamp
-            opcode_gas_calculator = fork.opcode_gas_calculator(
-                block_number=block_number, timestamp=timestamp
-            )
-            self._gas_cost_ = 0
-            for opcode in self.opcode_list:
-                self._gas_cost_ += opcode_gas_calculator(opcode)
-        return self._gas_cost_
+        return _bytecode_gas_cost(self, fork, block_number, timestamp)
 
     def refund(
         self,
@@ -307,22 +285,7 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas refund from this bytecode."""
-        if (
-            self._refund_ is None
-            or self._refund_fork_ != fork
-            or self._refund_block_number_ != block_number
-            or self._refund_timestamp_ != timestamp
-        ):
-            self._refund_fork_ = fork
-            self._refund_block_number_ = block_number
-            self._refund_timestamp_ = timestamp
-            opcode_refund_calculator = fork.opcode_refund_calculator(
-                block_number=block_number, timestamp=timestamp
-            )
-            self._refund_ = 0
-            for opcode in self.opcode_list:
-                self._refund_ += opcode_refund_calculator(opcode)
-        return self._refund_
+        return _bytecode_refund(self, fork, block_number, timestamp)
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -339,3 +302,37 @@ class Bytecode:
                 info_arg=False,
             ),
         )
+
+
+@cache
+def _bytecode_gas_cost(
+    bytecode: Bytecode,
+    fork: Type[ForkOpcodeInterface],
+    block_number: int,
+    timestamp: int,
+) -> int:
+    """Return cached gas cost for the given bytecode and fork parameters."""
+    opcode_gas_calculator = fork.opcode_gas_calculator(
+        block_number=block_number, timestamp=timestamp
+    )
+    total_gas = 0
+    for opcode in bytecode.opcode_list:
+        total_gas += opcode_gas_calculator(opcode)
+    return total_gas
+
+
+@cache
+def _bytecode_refund(
+    bytecode: Bytecode,
+    fork: Type[ForkOpcodeInterface],
+    block_number: int,
+    timestamp: int,
+) -> int:
+    """Return cached gas refund for the given bytecode and fork parameters."""
+    opcode_refund_calculator = fork.opcode_refund_calculator(
+        block_number=block_number, timestamp=timestamp
+    )
+    total_refund = 0
+    for opcode in bytecode.opcode_list:
+        total_refund += opcode_refund_calculator(opcode)
+    return total_refund

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -2,7 +2,7 @@
 
 import math
 from enum import Enum, auto
-from typing import Generator, Self, Sequence, cast
+from typing import Dict, Generator, Self, Sequence, cast
 
 from execution_testing import (
     EOA,
@@ -349,6 +349,8 @@ class CustomSizedContractFactory(IteratingBytecode):
 
     _cached_address: Address
     """Cached address to avoid expensive recomputation."""
+    _cached_created_contracts: Dict[int, Address]
+    """Cached created contract addresses to avoid expensive recomputation."""
     contract_size: int
     """The size of the contracts to deploy."""
 
@@ -418,6 +420,7 @@ class CustomSizedContractFactory(IteratingBytecode):
             initcode=Initcode(deploy_code=instance),
             fork=fork,
         )
+        instance._cached_created_contracts = {}
         instance.contract_size = initcode.contract_size
         deployed_address = pre.deterministic_deploy_contract(
             deploy_code=instance
@@ -494,8 +497,10 @@ class CustomSizedContractFactory(IteratingBytecode):
 
     def created_contract_address(self, *, salt: int) -> Address:
         """Get the deterministic address of the created contract."""
-        return compute_create2_address(
-            address=self.address(),
-            salt=salt,
-            initcode=self.initcode,
-        )
+        if salt not in self._cached_created_contracts:
+            self._cached_created_contracts[salt] = compute_create2_address(
+                address=self.address(),
+                salt=salt,
+                initcode=self.initcode,
+            )
+        return self._cached_created_contracts[salt]

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -13,7 +13,7 @@ Supported Opcodes:
 """
 
 import math
-from typing import Any
+from typing import Any, Dict
 
 import pytest
 from execution_testing import (
@@ -539,17 +539,25 @@ def test_account_query(
     # Access list generator for warm access tests.
     # When access_warm=True, include all contract addresses that will be
     # accessed in each transaction to warm them up via access list.
+    # Note: This access list generation is very expensive due to the binary
+    # search, which builds different access lists using the same elements
+    # over and over. Caching the elements helps a bit.
+    access_list_cache: Dict[int, AccessList] = {}
+
     def access_list_generator(
         iteration_count: int, start_iteration: int
     ) -> list[AccessList] | None:
         if not access_warm:
             return None
         return [
-            AccessList(
-                address=custom_sized_contract_factory.created_contract_address(
-                    salt=i
+            access_list_cache.setdefault(
+                i,
+                AccessList(
+                    address=custom_sized_contract_factory.created_contract_address(
+                        salt=i
+                    ),
+                    storage_keys=[],
                 ),
-                storage_keys=[],
             )
             for i in range(start_iteration, start_iteration + iteration_count)
         ]


### PR DESCRIPTION
## 🗒️ Description

Focuses on optimizing the test generation in benchmarking, particularly test `tests/benchmark/compute/instruction/test_account_query.py::test_account_query[fork_Osaka-blockchain_test_engine_x-value_sent_0-code_size_256-mem_size_32-access_warm_True-opcode_EXTCODECOPY-benchmark-gas-value_150M]`, which is the longest running test excluding t8n executions at 169.82s, by doing the following optimizations:

### Cache Bytecode.keccak256

This method is heavily used by tests that compute the `CREATE2` address to determine where a contract is going to be deployed.

This optimization simply caches the result of keccak inside a `Bytecode` object, and also makes `compute_create2_address` aware of the input potentially being a `Bytecode` to avoid converting to `Bytes` and wasting the optimization.

**After optimization: 169.82s -> 60.18s**

### Cache Bytecode.gas_cost(fork)/Bytecode.refund(fork)

Another simple cache to return the previous known value when the functions are called with the same parameters. The cache holds a single item because we rarely call this function with multiple forks in a single instance.

**After optimization: 60.18s -> 56.55s**

### `CustomSizedContractFactory.created_contract_address` Caching

Creates a dictionary cache inside of `CustomSizedContractFactory` to hold the calculated addresses of the different salts. The cache is not evicted, but it should be ok since the instance of `CustomSizedContractFactory` never makes it out of the test function, and the hash sizes are relatively small.

**After optimization: 56.55s -> 22.54s**

### Access List Caching in `test_account_query`

Finally, test `tests/benchmark/compute/instruction/test_account_query.py::test_account_query` uses a dynamic access list to warm up addresses of the contracts to be used during the attack, and this is done using a callback, which is repeatedly called many times due to the binary search performed by `IteratingBytecode` to find the max amount of iterations given the gas limit of the test.

**After optimization: 22.54s -> 9.31s**

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.natgeofe.com/k/771ecd45-98e6-463e-9bc7-babd821853d3/red-panda-cub.jpg?wp=1&w=1084.125&h=1044.75)
