### PR TITLE
fix(test-vm): Revert module-level cache to instance

### DIFF
--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -1,6 +1,5 @@
 """Ethereum Virtual Machine bytecode primitives and utilities."""
 
-from functools import cache
 from typing import Any, List, Self, SupportsBytes, Type
 
 from pydantic import GetCoreSchemaHandler
@@ -35,6 +34,14 @@ class Bytecode:
     _name_: str = ""
     _bytes_: bytes
     _keccak_256_: Hash | None = None
+    _gas_cost_: int | None = None
+    _gas_cost_fork_: Type[ForkOpcodeInterface] | None = None
+    _gas_cost_block_number_: int | None = None
+    _gas_cost_timestamp_: int | None = None
+    _refund_: int | None = None
+    _refund_fork_: Type[ForkOpcodeInterface] | None = None
+    _refund_block_number_: int | None = None
+    _refund_timestamp_: int | None = None
 
     popped_stack_items: int
     pushed_stack_items: int
@@ -275,7 +282,22 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas used by this bytecode."""
-        return _bytecode_gas_cost(self, fork, block_number, timestamp)
+        if (
+            self._gas_cost_ is None
+            or self._gas_cost_fork_ != fork
+            or self._gas_cost_block_number_ != block_number
+            or self._gas_cost_timestamp_ != timestamp
+        ):
+            self._gas_cost_fork_ = fork
+            self._gas_cost_block_number_ = block_number
+            self._gas_cost_timestamp_ = timestamp
+            opcode_gas_calculator = fork.opcode_gas_calculator(
+                block_number=block_number, timestamp=timestamp
+            )
+            self._gas_cost_ = 0
+            for opcode in self.opcode_list:
+                self._gas_cost_ += opcode_gas_calculator(opcode)
+        return self._gas_cost_
 
     def refund(
         self,
@@ -285,7 +307,22 @@ class Bytecode:
         timestamp: int = 0,
     ) -> int:
         """Use a fork object to calculate the gas refund from this bytecode."""
-        return _bytecode_refund(self, fork, block_number, timestamp)
+        if (
+            self._refund_ is None
+            or self._refund_fork_ != fork
+            or self._refund_block_number_ != block_number
+            or self._refund_timestamp_ != timestamp
+        ):
+            self._refund_fork_ = fork
+            self._refund_block_number_ = block_number
+            self._refund_timestamp_ = timestamp
+            opcode_refund_calculator = fork.opcode_refund_calculator(
+                block_number=block_number, timestamp=timestamp
+            )
+            self._refund_ = 0
+            for opcode in self.opcode_list:
+                self._refund_ += opcode_refund_calculator(opcode)
+        return self._refund_
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -302,37 +339,3 @@ class Bytecode:
                 info_arg=False,
             ),
         )
-
-
-@cache
-def _bytecode_gas_cost(
-    bytecode: Bytecode,
-    fork: Type[ForkOpcodeInterface],
-    block_number: int,
-    timestamp: int,
-) -> int:
-    """Return cached gas cost for the given bytecode and fork parameters."""
-    opcode_gas_calculator = fork.opcode_gas_calculator(
-        block_number=block_number, timestamp=timestamp
-    )
-    total_gas = 0
-    for opcode in bytecode.opcode_list:
-        total_gas += opcode_gas_calculator(opcode)
-    return total_gas
-
-
-@cache
-def _bytecode_refund(
-    bytecode: Bytecode,
-    fork: Type[ForkOpcodeInterface],
-    block_number: int,
-    timestamp: int,
-) -> int:
-    """Return cached gas refund for the given bytecode and fork parameters."""
-    opcode_refund_calculator = fork.opcode_refund_calculator(
-        block_number=block_number, timestamp=timestamp
-    )
-    total_refund = 0
-    for opcode in bytecode.opcode_list:
-        total_refund += opcode_refund_calculator(opcode)
-    return total_refund


### PR DESCRIPTION
## 🗒️ Description

Revert the module-level `@cache` on `_bytecode_gas_cost()` and `_bytecode_refund()` back to instance-level caching                                                                                                           

What's happening here is the module-level `@cache` refactor I introduced in #2184 relies on `__hash__` / `__eq__` to deduplicate across instances. However, `Bytecode.__hash__` / `__eq__` only considers bytes and stack properties, and `Opcode.__hash__` / `__eq__` only considers the byte value. Neither accounts for metadata... so bytecode with identical bytes but different metadata collide in the cache, returning incorrect gas costs. We sort of yeeted that last commit in assuming things would pass but this seems to have revealed a bug in these methods.

I think the "proper" / non-bandaid fix would be updating `__hash__` / `__eq__` to include metadata, but Opcode intentionally compares by byte value only and the `opcode_gas_map` relies on this for lookups. Changing it is a larger refactor.

I opted for the bandaid fix here but we should talk about the way we want `hash` and `eq` to ultimately behave.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%2Fid%2FOIP.wY0D_EMcr7-AIsi8WtyRdgHaEK%3Fpid%3DApi&f=1&ipt=7ca7afb5fe2e7acef94afc65e24467951c614cfd013ce1fcc12b10ea3d487100&ipo=images)
