### PR TITLE
refactor(test-tests): migrate frontier to shanghai gas costs to `bytecode.gas_cost(fork)`

### DIFF
--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -162,11 +162,11 @@ def test_precompile_warming(
     successor = get_transition_fork_successor(fork)
 
     def get_expected_gas(precompile_present: bool, fork: Fork) -> int:
-        balance_cost = Bytecode(
-            Op.BALANCE(address_warm=precompile_present)
-        ).gas_cost(fork)
+        balance_cost = Op.BALANCE(address_warm=precompile_present).gas_cost(
+            fork
+        )
         # Overhead: GAS + POP + SUB
-        overhead_cost = Bytecode(Op.GAS + Op.POP + Op.SUB).gas_cost(fork)
+        overhead_cost = (Op.GAS + Op.POP + Op.SUB).gas_cost(fork)
         return balance_cost + overhead_cost
 
     expected_gas_before = get_expected_gas(

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -15,6 +15,7 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     EIPChecklist,
     Op,
     Transaction,
@@ -161,14 +162,12 @@ def test_precompile_warming(
     successor = get_transition_fork_successor(fork)
 
     def get_expected_gas(precompile_present: bool, fork: Fork) -> int:
-        gas_costs = fork.gas_costs()
-        warm_access_cost = gas_costs.G_WARM_ACCOUNT_ACCESS
-        cold_access_cost = gas_costs.G_COLD_ACCOUNT_ACCESS
-        extra_cost = gas_costs.G_BASE * 2 + gas_costs.G_VERY_LOW
-        if precompile_present:
-            return warm_access_cost + extra_cost
-        else:
-            return cold_access_cost + extra_cost
+        balance_cost = Bytecode(
+            Op.BALANCE(address_warm=precompile_present)
+        ).gas_cost(fork)
+        # Overhead: GAS + POP + SUB
+        overhead_cost = Bytecode(Op.GAS + Op.POP + Op.SUB).gas_cost(fork)
+        return balance_cost + overhead_cost
 
     expected_gas_before = get_expected_gas(
         precompile_in_predecessor, predecessor

--- a/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py
@@ -15,7 +15,6 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
-    Bytecode,
     EIPChecklist,
     Op,
     Transaction,

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -8,7 +8,6 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
-    Bytecode,
     CodeGasMeasure,
     Environment,
     Fork,

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -8,6 +8,7 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    Bytecode,
     CodeGasMeasure,
     Environment,
     Fork,
@@ -42,15 +43,15 @@ def test_account_storage_warm_cold_state(
 ) -> None:
     """Test type 1 transaction."""
     env = Environment()
-    gas_costs = fork.gas_costs()
 
     storage_reader_contract = pre.deploy_contract(Op.SLOAD(1) + Op.STOP)
-    overhead_cost = (
-        gas_costs.G_VERY_LOW
-        * (Op.CALL.popped_stack_items - 1)  # Call stack items
-        + gas_costs.G_BASE  # Call gas
-        + gas_costs.G_VERY_LOW  # SLOAD Push
-    )
+    # Overhead: PUSH args for CALL (popped_stack_items - 1)
+    # + GAS opcode + PUSH for SLOAD
+    overhead_cost = Bytecode(
+        Op.PUSH1(0) * (Op.CALL.popped_stack_items - 1)
+        + Op.GAS
+        + Op.PUSH1(0)  # SLOAD push
+    ).gas_cost(fork)
     contract_address = pre.deploy_contract(
         CodeGasMeasure(
             code=Op.CALL(address=storage_reader_contract),
@@ -59,19 +60,16 @@ def test_account_storage_warm_cold_state(
             sstore_key=0,
         )
     )
-    expected_gas_cost = 0
     access_list_address = Address(0)
     access_list_storage_key = Hash(0)
+    # Expected gas: CALL access cost + SLOAD cost
+    expected_gas_cost = Bytecode(Op.CALL(address_warm=account_warm)).gas_cost(
+        fork
+    ) + Bytecode(Op.SLOAD(key_warm=storage_key_warm)).gas_cost(fork)
     if account_warm:
-        expected_gas_cost += gas_costs.G_WARM_ACCOUNT_ACCESS
         access_list_address = storage_reader_contract
-    else:
-        expected_gas_cost += gas_costs.G_COLD_ACCOUNT_ACCESS
     if storage_key_warm:
-        expected_gas_cost += gas_costs.G_WARM_SLOAD
         access_list_storage_key = Hash(1)
-    else:
-        expected_gas_cost += gas_costs.G_COLD_SLOAD
 
     access_lists: List[AccessList] = [
         AccessList(
@@ -288,12 +286,15 @@ def test_repeated_address_acl(
     of each access in order to make debugging easier.
     """
     sender = pre.fund_eoa()
-    gsc = fork.gas_costs()
+
+    # Cost of pushing SLOAD args
+    sload_push_cost = Bytecode(Op.PUSH1(0) * len(Op.SLOAD.kwargs)).gas_cost(
+        fork
+    )
 
     sload0_measure = CodeGasMeasure(
         code=Op.SLOAD(0),
-        overhead_cost=gsc.G_VERY_LOW
-        * len(Op.SLOAD.kwargs),  # Cost of pushing SLOAD args
+        overhead_cost=sload_push_cost,
         extra_stack_items=1,  # SLOAD pushes 1 item to the stack
         sstore_key=0,
         stop=False,  # Because it's the first CodeGasMeasure
@@ -301,8 +302,7 @@ def test_repeated_address_acl(
 
     sload1_measure = CodeGasMeasure(
         code=Op.SLOAD(1),
-        overhead_cost=gsc.G_VERY_LOW
-        * len(Op.SLOAD.kwargs),  # Cost of pushing SLOAD args
+        overhead_cost=sload_push_cost,
         extra_stack_items=1,  # SLOAD pushes 1 item to the stack
         sstore_key=1,
     )
@@ -326,7 +326,7 @@ def test_repeated_address_acl(
         ],
     )
 
-    sload_cost = gsc.G_WARM_ACCOUNT_ACCESS
+    sload_cost = Bytecode(Op.SLOAD(key_warm=True)).gas_cost(fork)
 
     state_test(
         env=Environment(),

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -47,7 +47,7 @@ def test_account_storage_warm_cold_state(
     storage_reader_contract = pre.deploy_contract(Op.SLOAD(1) + Op.STOP)
     # Overhead: PUSH args for CALL (popped_stack_items - 1)
     # + GAS opcode + PUSH for SLOAD
-    overhead_cost = Bytecode(
+    overhead_cost = (
         Op.PUSH1(0) * (Op.CALL.popped_stack_items - 1)
         + Op.GAS
         + Op.PUSH1(0)  # SLOAD push
@@ -63,9 +63,9 @@ def test_account_storage_warm_cold_state(
     access_list_address = Address(0)
     access_list_storage_key = Hash(0)
     # Expected gas: CALL access cost + SLOAD cost
-    expected_gas_cost = Bytecode(Op.CALL(address_warm=account_warm)).gas_cost(
+    expected_gas_cost = Op.CALL(address_warm=account_warm).gas_cost(
         fork
-    ) + Bytecode(Op.SLOAD(key_warm=storage_key_warm)).gas_cost(fork)
+    ) + Op.SLOAD(key_warm=storage_key_warm).gas_cost(fork)
     if account_warm:
         access_list_address = storage_reader_contract
     if storage_key_warm:
@@ -288,9 +288,7 @@ def test_repeated_address_acl(
     sender = pre.fund_eoa()
 
     # Cost of pushing SLOAD args
-    sload_push_cost = Bytecode(Op.PUSH1(0) * len(Op.SLOAD.kwargs)).gas_cost(
-        fork
-    )
+    sload_push_cost = (Op.PUSH1(0) * len(Op.SLOAD.kwargs)).gas_cost(fork)
 
     sload0_measure = CodeGasMeasure(
         code=Op.SLOAD(0),
@@ -326,7 +324,7 @@ def test_repeated_address_acl(
         ],
     )
 
-    sload_cost = Bytecode(Op.SLOAD(key_warm=True)).gas_cost(fork)
+    sload_cost = Op.SLOAD(key_warm=True).gas_cost(fork)
 
     state_test(
         env=Environment(),

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -4,7 +4,6 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
-    Bytecode,
     CodeGasMeasure,
     Environment,
     Fork,

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -4,6 +4,7 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
+    Bytecode,
     CodeGasMeasure,
     Environment,
     Fork,
@@ -31,21 +32,24 @@ def test_call_large_offset_mstore(
     """
     sender = pre.fund_eoa()
 
-    gsc = fork.gas_costs()
     mem_offset = 128  # arbitrary number
+
+    # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
+    call_push_cost = Bytecode(Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
+    mstore_push_cost = Bytecode(Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(
+        fork
+    )
 
     call_measure = CodeGasMeasure(
         code=Op.CALL(gas=0, ret_offset=mem_offset, ret_size=0),
-        # Cost of pushing CALL args
-        overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),
+        overhead_cost=call_push_cost,
         extra_stack_items=1,  # Because CALL pushes 1 item to the stack
         sstore_key=0,
         stop=False,  # Because it's the first CodeGasMeasure
     )
     mstore_measure = CodeGasMeasure(
         code=Op.MSTORE(offset=mem_offset, value=1),
-        # Cost of pushing MSTORE args
-        overhead_cost=gsc.G_VERY_LOW * len(Op.MSTORE.kwargs),
+        overhead_cost=mstore_push_cost,
         extra_stack_items=0,
         sstore_key=1,
     )
@@ -60,13 +64,12 @@ def test_call_large_offset_mstore(
     )
 
     # this call cost is just the address_access_cost
-    call_cost = gsc.G_COLD_ACCOUNT_ACCESS
+    call_cost = Bytecode(Op.CALL(address_warm=False)).gas_cost(fork)
 
-    memory_expansion_gas_calc = fork.memory_expansion_gas_calculator()
     # mstore cost: base cost + expansion cost
-    mstore_cost = gsc.G_MEMORY + memory_expansion_gas_calc(
-        new_bytes=mem_offset + 1
-    )
+    mstore_cost = Bytecode(
+        Op.MSTORE(new_memory_size=mem_offset + 32)
+    ).gas_cost(fork)
     state_test(
         env=Environment(),
         pre=pre,
@@ -100,15 +103,19 @@ def test_call_memory_expands_on_early_revert(
     """
     sender = pre.fund_eoa()
 
-    gsc = fork.gas_costs()
     # arbitrary number, greater than memory size to trigger an expansion
     ret_size = 128
+
+    # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
+    call_push_cost = Bytecode(Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
+    mstore_push_cost = Bytecode(Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(
+        fork
+    )
 
     call_measure = CodeGasMeasure(
         # CALL with value
         code=Op.CALL(gas=0, value=100, ret_size=ret_size),
-        # Cost of pushing CALL args
-        overhead_cost=gsc.G_VERY_LOW * len(Op.CALL.kwargs),
+        overhead_cost=call_push_cost,
         # Because CALL pushes 1 item to the stack
         extra_stack_items=1,
         sstore_key=0,
@@ -118,8 +125,7 @@ def test_call_memory_expands_on_early_revert(
     mstore_measure = CodeGasMeasure(
         # Low offset for not expanding memory
         code=Op.MSTORE(offset=ret_size // 2, value=1),
-        # Cost of pushing MSTORE args
-        overhead_cost=gsc.G_VERY_LOW * len(Op.MSTORE.kwargs),
+        overhead_cost=mstore_push_cost,
         extra_stack_items=0,
         sstore_key=1,
     )
@@ -136,20 +142,25 @@ def test_call_memory_expands_on_early_revert(
         sender=sender,
     )
 
-    memory_expansion_gas_calc = fork.memory_expansion_gas_calculator()
     # call cost:
     #   address_access_cost+new_acc_cost+memory_expansion_cost+value-stipend
+    # G_CALL_STIPEND is a threshold check, not a gas cost — keep from gas_costs
+    gsc = fork.gas_costs()
     call_cost = (
-        gsc.G_COLD_ACCOUNT_ACCESS
-        + gsc.G_NEW_ACCOUNT
-        + memory_expansion_gas_calc(new_bytes=ret_size)
-        + gsc.G_CALL_VALUE
+        Bytecode(
+            Op.CALL(
+                address_warm=False,
+                value_transfer=True,
+                account_new=True,
+                new_memory_size=ret_size,
+            )
+        ).gas_cost(fork)
         - gsc.G_CALL_STIPEND
     )
 
     # mstore cost: base cost. No memory expansion cost needed, it was expanded
     # on CALL.
-    mstore_cost = gsc.G_MEMORY
+    mstore_cost = Bytecode(Op.MSTORE(new_memory_size=0)).gas_cost(fork)
     state_test(
         env=Environment(),
         pre=pre,
@@ -182,13 +193,14 @@ def test_call_large_args_offset_size_zero(
     """
     sender = pre.fund_eoa()
 
-    gsc = fork.gas_costs()
     very_large_offset = 2**100
+
+    # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
+    push_cost = Bytecode(Op.PUSH1(0) * len(call_opcode.kwargs)).gas_cost(fork)
 
     call_measure = CodeGasMeasure(
         code=call_opcode(gas=0, args_offset=very_large_offset, args_size=0),
-        # Cost of pushing xCALL args
-        overhead_cost=gsc.G_VERY_LOW * len(call_opcode.kwargs),
+        overhead_cost=push_cost,
         extra_stack_items=1,  # Because xCALL pushes 1 item to the stack
         sstore_key=0,
     )
@@ -203,7 +215,7 @@ def test_call_large_args_offset_size_zero(
     )
 
     # this call cost is just the address_access_cost
-    call_cost = gsc.G_COLD_ACCOUNT_ACCESS
+    call_cost = Bytecode(call_opcode(address_warm=False)).gas_cost(fork)
 
     state_test(
         env=Environment(),

--- a/tests/frontier/opcodes/test_call.py
+++ b/tests/frontier/opcodes/test_call.py
@@ -35,10 +35,8 @@ def test_call_large_offset_mstore(
     mem_offset = 128  # arbitrary number
 
     # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
-    call_push_cost = Bytecode(Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
-    mstore_push_cost = Bytecode(Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(
-        fork
-    )
+    call_push_cost = (Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
+    mstore_push_cost = (Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(fork)
 
     call_measure = CodeGasMeasure(
         code=Op.CALL(gas=0, ret_offset=mem_offset, ret_size=0),
@@ -64,12 +62,10 @@ def test_call_large_offset_mstore(
     )
 
     # this call cost is just the address_access_cost
-    call_cost = Bytecode(Op.CALL(address_warm=False)).gas_cost(fork)
+    call_cost = Op.CALL(address_warm=False).gas_cost(fork)
 
     # mstore cost: base cost + expansion cost
-    mstore_cost = Bytecode(
-        Op.MSTORE(new_memory_size=mem_offset + 32)
-    ).gas_cost(fork)
+    mstore_cost = Op.MSTORE(new_memory_size=mem_offset + 32).gas_cost(fork)
     state_test(
         env=Environment(),
         pre=pre,
@@ -107,10 +103,8 @@ def test_call_memory_expands_on_early_revert(
     ret_size = 128
 
     # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
-    call_push_cost = Bytecode(Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
-    mstore_push_cost = Bytecode(Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(
-        fork
-    )
+    call_push_cost = (Op.PUSH1(0) * len(Op.CALL.kwargs)).gas_cost(fork)
+    mstore_push_cost = (Op.PUSH1(0) * len(Op.MSTORE.kwargs)).gas_cost(fork)
 
     call_measure = CodeGasMeasure(
         # CALL with value
@@ -147,20 +141,18 @@ def test_call_memory_expands_on_early_revert(
     # G_CALL_STIPEND is a threshold check, not a gas cost — keep from gas_costs
     gsc = fork.gas_costs()
     call_cost = (
-        Bytecode(
-            Op.CALL(
-                address_warm=False,
-                value_transfer=True,
-                account_new=True,
-                new_memory_size=ret_size,
-            )
+        Op.CALL(
+            address_warm=False,
+            value_transfer=True,
+            account_new=True,
+            new_memory_size=ret_size,
         ).gas_cost(fork)
         - gsc.G_CALL_STIPEND
     )
 
     # mstore cost: base cost. No memory expansion cost needed, it was expanded
     # on CALL.
-    mstore_cost = Bytecode(Op.MSTORE(new_memory_size=0)).gas_cost(fork)
+    mstore_cost = Op.MSTORE(new_memory_size=0).gas_cost(fork)
     state_test(
         env=Environment(),
         pre=pre,
@@ -196,7 +188,7 @@ def test_call_large_args_offset_size_zero(
     very_large_offset = 2**100
 
     # Cost of pushing args onto the stack (each PUSH costs G_VERY_LOW)
-    push_cost = Bytecode(Op.PUSH1(0) * len(call_opcode.kwargs)).gas_cost(fork)
+    push_cost = (Op.PUSH1(0) * len(call_opcode.kwargs)).gas_cost(fork)
 
     call_measure = CodeGasMeasure(
         code=call_opcode(gas=0, args_offset=very_large_offset, args_size=0),
@@ -215,7 +207,7 @@ def test_call_large_args_offset_size_zero(
     )
 
     # this call cost is just the address_access_cost
-    call_cost = Bytecode(call_opcode(address_warm=False)).gas_cost(fork)
+    call_cost = call_opcode(address_warm=False).gas_cost(fork)
 
     state_test(
         env=Environment(),

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -66,10 +66,10 @@ def callee_init_stack_gas(callee_opcode: Op, fork: Fork) -> int:
     """
     if fork < Byzantium:
         # all *CALL arguments handled with PUSHes
-        return Bytecode(Op.PUSH1(0) * len(callee_opcode.kwargs)).gas_cost(fork)
+        return (Op.PUSH1(0) * len(callee_opcode.kwargs)).gas_cost(fork)
     else:
         # gas argument handled with GAS which is cheaper
-        return Bytecode(
+        return (
             Op.PUSH1(0) * (len(callee_opcode.kwargs) - 1) + Op.GAS
         ).gas_cost(fork)
 
@@ -89,7 +89,7 @@ def sufficient_gas(
         if is_value_call:
             metadata["value_transfer"] = True
             metadata["account_new"] = callee_opcode == Op.CALL
-        cost = Bytecode(callee_opcode(**metadata)).gas_cost(fork)
+        cost = callee_opcode(**metadata).gas_cost(fork)
     elif Byzantium <= fork < Berlin:
         cost = 700  # Pre-Berlin call cost
         gas_costs = fork.gas_costs()

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -66,10 +66,12 @@ def callee_init_stack_gas(callee_opcode: Op, fork: Fork) -> int:
     """
     if fork < Byzantium:
         # all *CALL arguments handled with PUSHes
-        return len(callee_opcode.kwargs) * 3
+        return Bytecode(Op.PUSH1(0) * len(callee_opcode.kwargs)).gas_cost(fork)
     else:
         # gas argument handled with GAS which is cheaper
-        return (len(callee_opcode.kwargs) - 1) * 3 + 2
+        return Bytecode(
+            Op.PUSH1(0) * (len(callee_opcode.kwargs) - 1) + Op.GAS
+        ).gas_cost(fork)
 
 
 @pytest.fixture
@@ -80,30 +82,33 @@ def sufficient_gas(
     Calculate the sufficient gas for the nested call opcode with positive
     value transfer.
     """
-    gas_costs = fork.gas_costs()
-
-    cost = 0
+    is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
 
     if fork >= Berlin:
-        cost += gas_costs.G_COLD_ACCOUNT_ACCESS
+        metadata: dict = {"address_warm": False}
+        if is_value_call:
+            metadata["value_transfer"] = True
+            metadata["account_new"] = callee_opcode == Op.CALL
+        cost = Bytecode(callee_opcode(**metadata)).gas_cost(fork)
     elif Byzantium <= fork < Berlin:
-        cost += 700  # Pre-Berlin warm call cost
+        cost = 700  # Pre-Berlin call cost
+        gas_costs = fork.gas_costs()
+        if is_value_call:
+            cost += gas_costs.G_CALL_VALUE
+        if callee_opcode == Op.CALL:
+            cost += gas_costs.G_NEW_ACCOUNT
     elif fork == Homestead:
-        cost += 40  # Homestead call cost
+        cost = 40  # Homestead call cost
         cost += 1  # mandatory callee gas allowance
+        gas_costs = fork.gas_costs()
+        if is_value_call:
+            cost += gas_costs.G_CALL_VALUE
+        if callee_opcode == Op.CALL:
+            cost += gas_costs.G_NEW_ACCOUNT
     else:
         raise Exception("Only forks Homestead and >=Byzantium supported")
 
-    is_value_call = callee_opcode in [Op.CALL, Op.CALLCODE]
-    if is_value_call:
-        cost += gas_costs.G_CALL_VALUE
-
-    if callee_opcode == Op.CALL:
-        cost += gas_costs.G_NEW_ACCOUNT
-
-    sufficient = callee_init_stack_gas + cost
-
-    return sufficient
+    return callee_init_stack_gas + cost
 
 
 @pytest.fixture

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -25,10 +25,6 @@ from .spec import ref_spec_3651
 REFERENCE_SPEC_GIT_PATH = ref_spec_3651.git_path
 REFERENCE_SPEC_VERSION = ref_spec_3651.version
 
-# Amount of gas required to make a call to a warm account.
-# Calling a cold account with this amount of gas results in exception.
-GAS_REQUIRED_CALL_WARM_ACCOUNT = 100
-
 
 @pytest.mark.valid_from("Shanghai")
 @pytest.mark.parametrize(
@@ -37,32 +33,12 @@ GAS_REQUIRED_CALL_WARM_ACCOUNT = 100
     ids=["sufficient_gas", "insufficient_gas"],
 )
 @pytest.mark.parametrize(
-    "opcode,contract_under_test_code,call_gas_exact",
+    "opcode,call_opcode",
     [
-        (
-            "call",
-            Op.POP(Op.CALL(0, Op.COINBASE, 0, 0, 0, 0, 0)),
-            # Extra gas: COINBASE + 4*PUSH1 + 2*DUP1 + POP
-            GAS_REQUIRED_CALL_WARM_ACCOUNT + 22,
-        ),
-        (
-            "callcode",
-            Op.POP(Op.CALLCODE(0, Op.COINBASE, 0, 0, 0, 0, 0)),
-            # Extra gas: COINBASE + 4*PUSH1 + 2*DUP1 + POP
-            GAS_REQUIRED_CALL_WARM_ACCOUNT + 22,
-        ),
-        (
-            "delegatecall",
-            Op.POP(Op.DELEGATECALL(0, Op.COINBASE, 0, 0, 0, 0)),
-            # Extra: COINBASE + 3*PUSH1 + 2*DUP1 + POP
-            GAS_REQUIRED_CALL_WARM_ACCOUNT + 19,
-        ),
-        (
-            "staticcall",
-            Op.POP(Op.STATICCALL(0, Op.COINBASE, 0, 0, 0, 0)),
-            # Extra: COINBASE + 3*PUSH1 + 2*DUP1 + POP
-            GAS_REQUIRED_CALL_WARM_ACCOUNT + 19,
-        ),
+        ("call", Op.CALL),
+        ("callcode", Op.CALLCODE),
+        ("delegatecall", Op.DELEGATECALL),
+        ("staticcall", Op.STATICCALL),
     ],
     ids=["CALL", "CALLCODE", "DELEGATECALL", "STATICCALL"],
 )
@@ -74,8 +50,7 @@ def test_warm_coinbase_call_out_of_gas(
     sender: Address,
     fork: Fork,
     opcode: str,
-    contract_under_test_code: Bytecode,
-    call_gas_exact: int,
+    call_opcode: Op,
     use_sufficient_gas: bool,
 ) -> None:
     """
@@ -87,7 +62,25 @@ def test_warm_coinbase_call_out_of_gas(
     - DELEGATECALL
     - STATICCALL
     """
+    # Build contract code: POP(xCALL(0, COINBASE, 0, ...))
+    if call_opcode in (Op.CALL, Op.CALLCODE):
+        contract_under_test_code = Op.POP(
+            call_opcode(0, Op.COINBASE, 0, 0, 0, 0, 0)
+        )
+    else:
+        contract_under_test_code = Op.POP(
+            call_opcode(0, Op.COINBASE, 0, 0, 0, 0)
+        )
+
     contract_under_test_address = pre.deploy_contract(contract_under_test_code)
+
+    # Compute exact gas: warm call cost + overhead
+    # (COINBASE, PUSHes, DUPs, POP)
+    warm_call_cost = Bytecode(call_opcode(address_warm=True)).gas_cost(fork)
+    # Overhead = total cost (with cold default) minus the cold call cost
+    cold_call_cost = Bytecode(call_opcode(address_warm=False)).gas_cost(fork)
+    total_with_cold = Bytecode(contract_under_test_code).gas_cost(fork)
+    call_gas_exact = warm_call_cost + (total_with_cold - cold_call_cost)
 
     if not use_sufficient_gas:
         call_gas_exact -= 1
@@ -130,77 +123,23 @@ def test_warm_coinbase_call_out_of_gas(
     )
 
 
-# List of opcodes that are affected by EIP-3651
+# List of opcodes that are affected by EIP-3651, with their code and
+# extra_stack_items. Overhead cost is computed at test time via gas_cost(fork).
 gas_measured_opcodes = [
-    (
-        "EXTCODESIZE",
-        CodeGasMeasure(
-            code=Op.EXTCODESIZE(Op.COINBASE),
-            overhead_cost=2,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "EXTCODECOPY",
-        CodeGasMeasure(
-            code=Op.EXTCODECOPY(Op.COINBASE, 0, 0, 0),
-            overhead_cost=2 + 3 + 3 + 3,
-        ),
-    ),
-    (
-        "EXTCODEHASH",
-        CodeGasMeasure(
-            code=Op.EXTCODEHASH(Op.COINBASE),
-            overhead_cost=2,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "BALANCE",
-        CodeGasMeasure(
-            code=Op.BALANCE(Op.COINBASE),
-            overhead_cost=2,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "CALL",
-        CodeGasMeasure(
-            code=Op.CALL(0xFF, Op.COINBASE, 0, 0, 0, 0, 0),
-            overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "CALLCODE",
-        CodeGasMeasure(
-            code=Op.CALLCODE(0xFF, Op.COINBASE, 0, 0, 0, 0, 0),
-            overhead_cost=3 + 2 + 3 + 3 + 3 + 3 + 3,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "DELEGATECALL",
-        CodeGasMeasure(
-            code=Op.DELEGATECALL(0xFF, Op.COINBASE, 0, 0, 0, 0),
-            overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
-            extra_stack_items=1,
-        ),
-    ),
-    (
-        "STATICCALL",
-        CodeGasMeasure(
-            code=Op.STATICCALL(0xFF, Op.COINBASE, 0, 0, 0, 0),
-            overhead_cost=3 + 2 + 3 + 3 + 3 + 3,
-            extra_stack_items=1,
-        ),
-    ),
+    ("EXTCODESIZE", Op.EXTCODESIZE(Op.COINBASE), 1),
+    ("EXTCODECOPY", Op.EXTCODECOPY(Op.COINBASE, 0, 0, 0), 0),
+    ("EXTCODEHASH", Op.EXTCODEHASH(Op.COINBASE), 1),
+    ("BALANCE", Op.BALANCE(Op.COINBASE), 1),
+    ("CALL", Op.CALL(0xFF, Op.COINBASE, 0, 0, 0, 0, 0), 1),
+    ("CALLCODE", Op.CALLCODE(0xFF, Op.COINBASE, 0, 0, 0, 0, 0), 1),
+    ("DELEGATECALL", Op.DELEGATECALL(0xFF, Op.COINBASE, 0, 0, 0, 0), 1),
+    ("STATICCALL", Op.STATICCALL(0xFF, Op.COINBASE, 0, 0, 0, 0), 1),
 ]
 
 
 @pytest.mark.valid_from("Berlin")  # these tests fill for fork >= Berlin
 @pytest.mark.parametrize(
-    "opcode,code_gas_measure",
+    "opcode,measured_code,extra_stack_items",
     gas_measured_opcodes,
     ids=[i[0] for i in gas_measured_opcodes],
 )
@@ -211,7 +150,8 @@ def test_warm_coinbase_gas_usage(
     sender: Address,
     fork: Fork,
     opcode: str,
-    code_gas_measure: Bytecode,
+    measured_code: Bytecode,
+    extra_stack_items: int,
 ) -> None:
     """
     Test the gas usage of opcodes affected by assuming a warm coinbase.
@@ -225,14 +165,28 @@ def test_warm_coinbase_gas_usage(
     - DELEGATECALL
     - STATICCALL
     """
+    # Compute overhead cost: total bytecode cost minus the
+    # opcode-under-test cost
+    # The opcode-under-test cost (warm or cold) is what we're measuring
+    total_code_cost = Bytecode(measured_code).gas_cost(fork)
+    # The opcode cost with default (cold) metadata
+    opcode_cold_cost = Bytecode(Op.BALANCE(address_warm=False)).gas_cost(fork)
+    overhead_cost = total_code_cost - opcode_cold_cost
+
+    code_gas_measure = CodeGasMeasure(
+        code=measured_code,
+        overhead_cost=overhead_cost,
+        extra_stack_items=extra_stack_items,
+    )
+
     measure_address = pre.deploy_contract(
         code=code_gas_measure,
     )
 
-    if fork >= Shanghai:  # Warm account access cost after EIP-3651
-        expected_gas = GAS_REQUIRED_CALL_WARM_ACCOUNT
-    else:
-        expected_gas = 2600  # Cold account access cost before EIP-3651
+    # Coinbase is warm after EIP-3651 (Shanghai+), cold before
+    expected_gas = Bytecode(
+        Op.BALANCE(address_warm=(fork >= Shanghai))
+    ).gas_cost(fork)
 
     tx = Transaction(
         to=measure_address,

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -76,10 +76,10 @@ def test_warm_coinbase_call_out_of_gas(
 
     # Compute exact gas: warm call cost + overhead
     # (COINBASE, PUSHes, DUPs, POP)
-    warm_call_cost = Bytecode(call_opcode(address_warm=True)).gas_cost(fork)
+    warm_call_cost = call_opcode(address_warm=True).gas_cost(fork)
     # Overhead = total cost (with cold default) minus the cold call cost
-    cold_call_cost = Bytecode(call_opcode(address_warm=False)).gas_cost(fork)
-    total_with_cold = Bytecode(contract_under_test_code).gas_cost(fork)
+    cold_call_cost = call_opcode(address_warm=False).gas_cost(fork)
+    total_with_cold = contract_under_test_code.gas_cost(fork)
     call_gas_exact = warm_call_cost + (total_with_cold - cold_call_cost)
 
     if not use_sufficient_gas:
@@ -168,9 +168,9 @@ def test_warm_coinbase_gas_usage(
     # Compute overhead cost: total bytecode cost minus the
     # opcode-under-test cost
     # The opcode-under-test cost (warm or cold) is what we're measuring
-    total_code_cost = Bytecode(measured_code).gas_cost(fork)
+    total_code_cost = measured_code.gas_cost(fork)
     # The opcode cost with default (cold) metadata
-    opcode_cold_cost = Bytecode(Op.BALANCE(address_warm=False)).gas_cost(fork)
+    opcode_cold_cost = Op.BALANCE(address_warm=False).gas_cost(fork)
     overhead_cost = total_code_cost - opcode_cold_cost
 
     code_gas_measure = CodeGasMeasure(
@@ -184,9 +184,7 @@ def test_warm_coinbase_gas_usage(
     )
 
     # Coinbase is warm after EIP-3651 (Shanghai+), cold before
-    expected_gas = Bytecode(
-        Op.BALANCE(address_warm=(fork >= Shanghai))
-    ).gas_cost(fork)
+    expected_gas = Op.BALANCE(address_warm=(fork >= Shanghai)).gas_cost(fork)
 
     tx = Transaction(
         to=measure_address,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -517,23 +517,16 @@ class TestCreateInitcode:
         )
 
     @pytest.fixture
-    def contract_creation_gas_cost(self, fork: Fork, opcode: Op) -> int:
+    def contract_creation_gas_cost(
+        self, fork: Fork, opcode: Op, create2_salt: int
+    ) -> int:
         """Calculate gas cost of the contract creation operation."""
-        gas_costs = fork.gas_costs()
-
-        create_contract_base_gas = gas_costs.G_CREATE
-        gas_opcode_gas = gas_costs.G_BASE
-        push_dup_opcode_gas = gas_costs.G_VERY_LOW
-        calldatasize_opcode_gas = gas_costs.G_BASE
-        contract_creation_gas_usage = (
-            create_contract_base_gas
-            + gas_opcode_gas
-            + (2 * push_dup_opcode_gas)
-            + calldatasize_opcode_gas
+        create_code = (
+            opcode(size=Op.CALLDATASIZE, salt=create2_salt)
+            if opcode == Op.CREATE2
+            else opcode(size=Op.CALLDATASIZE)
         )
-        if opcode == Op.CREATE2:  # Extra push operation
-            contract_creation_gas_usage += push_dup_opcode_gas
-        return contract_creation_gas_usage
+        return Bytecode(create_code + Op.GAS).gas_cost(fork)
 
     @pytest.fixture
     def initcode_word_cost(self, fork: Fork, initcode: Initcode) -> int:

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -526,7 +526,7 @@ class TestCreateInitcode:
             if opcode == Op.CREATE2
             else opcode(size=Op.CALLDATASIZE)
         )
-        return Bytecode(create_code + Op.GAS).gas_cost(fork)
+        return (create_code + Op.GAS).gas_cost(fork)
 
     @pytest.fixture
     def initcode_word_cost(self, fork: Fork, initcode: Initcode) -> int:

--- a/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
+++ b/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
@@ -66,12 +66,10 @@ def calculate_selfdestruct_gas(
             needs_new_account = True
 
     # PUSH + SELFDESTRUCT (with metadata for warm/cold and new account)
-    return Bytecode(
-        Op.SELFDESTRUCT(
-            0,  # beneficiary address (generates a PUSH)
-            address_warm=beneficiary_warm or fork < Berlin,
-            account_new=needs_new_account,
-        )
+    return Op.SELFDESTRUCT(
+        0,  # beneficiary address (generates a PUSH)
+        address_warm=beneficiary_warm or fork < Berlin,
+        account_new=needs_new_account,
     ).gas_cost(fork)
 
 
@@ -489,12 +487,10 @@ def test_selfdestruct_state_access_boundary(
 
     # Calculate gas for state access boundary only (base + cold access)
     # Does NOT include G_NEW_ACCOUNT
-    inner_call_gas = Bytecode(
-        Op.SELFDESTRUCT(
-            0,  # beneficiary address (generates a PUSH)
-            address_warm=warm or fork < Berlin,
-            account_new=False,
-        )
+    inner_call_gas = Op.SELFDESTRUCT(
+        0,  # beneficiary address (generates a PUSH)
+        address_warm=warm or fork < Berlin,
+        account_new=False,
     ).gas_cost(fork)
 
     if not is_success:
@@ -718,8 +714,8 @@ def test_selfdestruct_to_precompile_state_access_boundary(
 
     # State access boundary: base cost only (no G_NEW_ACCOUNT)
     # Precompiles are always warm
-    inner_call_gas = Bytecode(
-        Op.SELFDESTRUCT(0, address_warm=True, account_new=False)
+    inner_call_gas = Op.SELFDESTRUCT(
+        0, address_warm=True, account_new=False
     ).gas_cost(fork)
 
     if not is_success:
@@ -973,8 +969,8 @@ def test_selfdestruct_to_self(
     victim_code = Op.SELFDESTRUCT(Op.ADDRESS)
 
     # Gas: ADDRESS + SELFDESTRUCT (no cold access, no G_NEW_ACCOUNT)
-    base_gas = Bytecode(
-        Op.SELFDESTRUCT(Op.ADDRESS, address_warm=True, account_new=False)
+    base_gas = Op.SELFDESTRUCT(
+        Op.ADDRESS, address_warm=True, account_new=False
     ).gas_cost(fork)
     inner_call_gas = base_gas if is_success else base_gas - 1
 

--- a/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
+++ b/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
@@ -21,7 +21,6 @@ from execution_testing import (
     Block,
     BlockAccessListExpectation,
     BlockchainTestFiller,
-    Bytecode,
     Initcode,
     Op,
     Transaction,

--- a/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
+++ b/tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Block,
     BlockAccessListExpectation,
     BlockchainTestFiller,
+    Bytecode,
     Initcode,
     Op,
     Transaction,
@@ -52,29 +53,26 @@ def calculate_selfdestruct_gas(
     originator_balance: int,
 ) -> int:
     """Calculate exact gas needed for SELFDESTRUCT."""
-    gas_costs = fork.gas_costs()
-    gas = (
-        # PUSH + SELFDESTRUCT
-        gas_costs.G_VERY_LOW + gas_costs.G_SELF_DESTRUCT
-    )
-
-    # Cold access cost (>=Berlin only)
-    if fork >= Berlin and not beneficiary_warm:
-        gas += gas_costs.G_COLD_ACCOUNT_ACCESS
-
     # G_NEW_ACCOUNT:
     # - Pre-EIP-161 (TangerineWhistle): charged when beneficiary is dead
     # - Post-EIP-161 (>=SpuriousDragon): charged when beneficiary is dead
     #   AND originator has balance > 0
+    needs_new_account = False
     if beneficiary_dead:
         if fork >= SpuriousDragon:
-            if originator_balance > 0:
-                gas += gas_costs.G_NEW_ACCOUNT
+            needs_new_account = originator_balance > 0
         else:
             # Pre-EIP-161: always charged when beneficiary is dead
-            gas += gas_costs.G_NEW_ACCOUNT
+            needs_new_account = True
 
-    return gas
+    # PUSH + SELFDESTRUCT (with metadata for warm/cold and new account)
+    return Bytecode(
+        Op.SELFDESTRUCT(
+            0,  # beneficiary address (generates a PUSH)
+            address_warm=beneficiary_warm or fork < Berlin,
+            account_new=needs_new_account,
+        )
+    ).gas_cost(fork)
 
 
 def setup_selfdestruct_test(
@@ -491,10 +489,13 @@ def test_selfdestruct_state_access_boundary(
 
     # Calculate gas for state access boundary only (base + cold access)
     # Does NOT include G_NEW_ACCOUNT
-    gas_costs = fork.gas_costs()
-    inner_call_gas = gas_costs.G_VERY_LOW + gas_costs.G_SELF_DESTRUCT
-    if fork >= Berlin and not warm:
-        inner_call_gas += gas_costs.G_COLD_ACCOUNT_ACCESS
+    inner_call_gas = Bytecode(
+        Op.SELFDESTRUCT(
+            0,  # beneficiary address (generates a PUSH)
+            address_warm=warm or fork < Berlin,
+            account_new=False,
+        )
+    ).gas_cost(fork)
 
     if not is_success:
         inner_call_gas -= 1
@@ -716,8 +717,10 @@ def test_selfdestruct_to_precompile_state_access_boundary(
     beneficiary_dead = beneficiary_initial_balance == 0
 
     # State access boundary: base cost only (no G_NEW_ACCOUNT)
-    gas_costs = fork.gas_costs()
-    inner_call_gas = gas_costs.G_VERY_LOW + gas_costs.G_SELF_DESTRUCT
+    # Precompiles are always warm
+    inner_call_gas = Bytecode(
+        Op.SELFDESTRUCT(0, address_warm=True, account_new=False)
+    ).gas_cost(fork)
 
     if not is_success:
         inner_call_gas -= 1
@@ -970,9 +973,9 @@ def test_selfdestruct_to_self(
     victim_code = Op.SELFDESTRUCT(Op.ADDRESS)
 
     # Gas: ADDRESS + SELFDESTRUCT (no cold access, no G_NEW_ACCOUNT)
-    # Note: ADDRESS opcode costs G_BASE, not G_VERY_LOW like PUSH
-    gas_costs = fork.gas_costs()
-    base_gas = gas_costs.G_BASE + gas_costs.G_SELF_DESTRUCT
+    base_gas = Bytecode(
+        Op.SELFDESTRUCT(Op.ADDRESS, address_warm=True, account_new=False)
+    ).gas_cost(fork)
     inner_call_gas = base_gas if is_success else base_gas - 1
 
     if same_tx:


### PR DESCRIPTION
## 🗒️ Description

Migrate remaining Frontier, Berlin, TangerineWhistle, and Shanghai test files from manual `fork.gas_costs()` calculations to `bytecode.gas_cost(fork)`.

This is a pure refactor with no functional change, all exact gas-boundary test fixtures produce identical output (verified via fixture hash comparison).

The benefit is maintainability: tests now declare intent via opcode metadata (e.g., `address_warm=False`, `value_transfer=True`) and delegate gas calculation to the framework's `opcode_gas_map()`, so future gas schedule changes only need updating in one place.

Files migrated:
- `tests/frontier/opcodes/test_call.py`
- `tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py`
- `tests/berlin/eip2929_gas_cost_increases/test_precompile_warming.py`
- `tests/berlin/eip2930_access_list/test_acl.py`
- `tests/tangerine_whistle/eip150_operation_gas_costs/test_eip150_selfdestruct.py`
- `tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py`
- `tests/shanghai/eip3860_initcode/test_initcode.py`

Pre-Berlin hardcoded values (700 for Byzantium-Berlin CALL, 40 for Homestead CALL) are kept where the framework's `opcode_gas_map` doesn't model pre-EIP-2929 costs. The remaining `fork.gas_costs().G_CALL_STIPEND` reference is intentional, it's a threshold check, not a gas cost. Per-word costs (`G_INITCODE_WORD`, `G_KECCAK_256_WORD`) are kept as-is since they aren't expressible via `bytecode.gas_cost`.

## 🔗 Related Issues or PRs

Partially fixes #2049.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![arcanine](https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/detail/013.png)