### PR TITLE
fix(tests): add BAL related mappings to ethrex exception mapper

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -116,6 +116,9 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"Gas allowance exceeded.*"
         ),
+        BlockException.GAS_USED_OVERFLOW: (
+            r"Block gas used overflow.*"
+        ),
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob count exceeded.*"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -38,6 +38,22 @@ class EthrexExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BASEFEE_PER_GAS: (
             "Base fee per gas is incorrect"
         ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            "Block access list hash does not match the one in "
+            "the header after executing"
+        ),
+        BlockException.INVALID_BAL_HASH: (
+            "Block access list hash does not match the one in "
+            "the header after executing"
+        ),
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            "Block access list hash does not match the one in "
+            "the header after executing"
+        ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            "Block access list hash does not match the one in "
+            "the header after executing"
+        ),
     }
     mapping_regex = {
         TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS: (
@@ -116,9 +132,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"Gas allowance exceeded.*"
         ),
-        BlockException.GAS_USED_OVERFLOW: (
-            r"Block gas used overflow.*"
-        ),
+        BlockException.GAS_USED_OVERFLOW: (r"Block gas used overflow.*"),
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob count exceeded.*"
         ),
@@ -147,5 +161,17 @@ class EthrexExceptionMapper(ExceptionMapper):
         ),
         BlockException.RLP_BLOCK_LIMIT_EXCEEDED: (
             r"Maximum block size exceeded.*"
+        ),
+        BlockException.INVALID_BLOCK_ACCESS_LIST: (
+            r"Block access list contains index \d+ "
+            r"exceeding max valid index \d+|"
+            r"Failed to RLP decode BAL"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"Block access list hash does not match "
+            r"the one in the header after executing|"
+            r"Block access list contains index \d+ "
+            r"exceeding max valid index \d+|"
+            r"Failed to RLP decode BAL"
         ),
     }


### PR DESCRIPTION

## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add BAL related mappings to the ethrex exception mapper

This is needed because some hive tests fail due to this with ethrex when testing BAL/Amsterdam

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
