### PR TITLE
refactor(test-benchmark): compute benchmark via gas cost calculator

### DIFF
--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -179,27 +179,31 @@ def calculate_optimal_input_length(
         The optimal input length in bytes that maximizes total work.
 
     """
-    gsc = fork.gas_costs()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
+
+    precompile_call = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS,
+            address=0x01,  # Placeholder Address
+            args_offset=Op.PUSH0,
+            args_size=Op.PUSH0,
+            output_offset=Op.PUSH0,
+            output_size=Op.PUSH0,
+            # gas cost
+            address_warm=True,
+        )
+    )
+    basic_gas = precompile_call.gas_cost(fork)
 
     max_work = 0
     optimal_input_length = 0
 
     for input_length in range(1, 1_000_000, 32):
-        parameters_gas = (
-            gsc.G_BASE  # PUSH0 = arg offset
-            + gsc.G_BASE  # PUSH0 = arg size
-            + gsc.G_BASE  # PUSH0 = arg size
-            + gsc.G_VERY_LOW  # PUSH0 = arg offset
-            + gsc.G_VERY_LOW  # PUSHN = address
-            + gsc.G_BASE  # GAS
-        )
         iteration_gas_cost = (
-            parameters_gas
+            basic_gas
             + static_cost  # Precompile static cost
             + math.ceil(input_length / 32) * per_word_dynamic_cost
             # Precompile dynamic cost
-            + gsc.G_BASE  # POP
         )
 
         # From the available gas, subtract the memory expansion costs

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -187,8 +187,8 @@ def calculate_optimal_input_length(
             address=0x01,  # Placeholder Address
             args_offset=Op.PUSH0,
             args_size=Op.PUSH0,
-            output_offset=Op.PUSH0,
-            output_size=Op.PUSH0,
+            ret_offset=Op.PUSH0,
+            ret_size=Op.PUSH0,
             # gas cost
             address_warm=True,
         )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -274,15 +274,19 @@ def test_ext_account_query_cold(
 
     attack_gas_limit = gas_benchmark_value
 
-    gas_costs = fork.gas_costs()
     intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
+    cold_account_access_gas = opcode(
+        0,
+        # gas accounting
+        address_warm=False,
+    ).gas_cost(fork)
     # For calculation robustness, the calculation below ignores "glue" opcodes
     # like  PUSH and POP. It should be considered a worst-case number of
     # accounts, and a few of them might not be targeted before the attacking
     # transaction runs out of gas.
     num_target_accounts = (
         attack_gas_limit - intrinsic_gas_cost_calc()
-    ) // gas_costs.G_COLD_ACCOUNT_ACCESS
+    ) // cold_account_access_gas
 
     blocks = []
     post = {}
@@ -294,11 +298,9 @@ def test_ext_account_query_cold(
     addr_offset = int.from_bytes(pre.fund_eoa(amount=0))
 
     if not absent_accounts:
-        account_creation_gas = (
-            gas_costs.G_COLD_ACCOUNT_ACCESS
-            + gas_costs.G_CALL_VALUE
-            + gas_costs.G_NEW_ACCOUNT
-        )
+        account_creation_gas = Op.CALL(
+            value=1, address_warm=False, account_new=True
+        ).gas_cost(fork)
         # To avoid brittle/tight gas calculations of glue opcodes, we take
         # 90% of the maximum tx capacity. Even if this calculation fails
         # in the future, it will be caught by the post-state check.
@@ -372,7 +374,7 @@ def test_ext_account_query_cold(
     with TestPhaseManager.execution():
         max_target_per_tx = (
             tx_gas_limit - intrinsic_gas_cost_calc()
-        ) // gas_costs.G_COLD_ACCOUNT_ACCESS
+        ) // cold_account_access_gas
 
         num_execution_txs = math.ceil(num_target_accounts / max_target_per_tx)
         gas_used = 0

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -299,7 +299,7 @@ def test_ext_account_query_cold(
 
     if not absent_accounts:
         account_creation_gas = Op.CALL(
-            value=1, address_warm=False, account_new=True
+            value=1, address_warm=False, account_new=True, value_transfer=True
         ).gas_cost(fork)
         # To avoid brittle/tight gas calculations of glue opcodes, we take
         # 90% of the maximum tx capacity. Even if this calculation fails

--- a/tests/benchmark/compute/instruction/test_system.py
+++ b/tests/benchmark/compute/instruction/test_system.py
@@ -13,8 +13,6 @@ Supported Opcodes:
 - SELFDESTRUCT
 """
 
-import math
-
 import pytest
 from execution_testing import (
     Account,
@@ -23,14 +21,13 @@ from execution_testing import (
     Block,
     Bytecode,
     Create2PreimageLayout,
-    Environment,
     ExtCallGenerator,
     Fork,
     Hash,
+    IteratingBytecode,
     JumpLoopGenerator,
     Op,
     TestPhaseManager,
-    Transaction,
     While,
     compute_create2_address,
     compute_create_address,
@@ -194,20 +191,18 @@ def test_creates_collisions(
     # Note that these CREATE(2) calls will fail because in (**) below we pre-
     # alloc contracts with the same address as the ones that CREATE(2) will try
     # to create.
-    proxy_contract = pre.deploy_contract(
-        code=Op.CREATE2(
+    proxy_contract_code = (
+        Op.CREATE2(
             value=Op.PUSH0, salt=Op.PUSH0, offset=Op.PUSH0, size=Op.PUSH0
         )
         if opcode == Op.CREATE2
         else Op.CREATE(value=Op.PUSH0, offset=Op.PUSH0, size=Op.PUSH0)
     )
+    proxy_contract = pre.deploy_contract(code=proxy_contract_code)
 
-    gas_costs = fork.gas_costs()
     # The CALL to the proxy contract needs at a minimum gas corresponding to
     # the CREATE(2) plus extra required PUSH0s for arguments.
-    min_gas_required = gas_costs.G_CREATE + gas_costs.G_BASE * (
-        3 if opcode == Op.CREATE else 4
-    )
+    min_gas_required = proxy_contract_code.gas_cost(fork)
     setup = Op.PUSH20(proxy_contract) + Op.PUSH3(min_gas_required)
     attack_block = Op.POP(
         # DUP7 refers to the PUSH3 above.
@@ -224,7 +219,8 @@ def test_creates_collisions(
         pre.deploy_contract(address=addr, code=Op.INVALID)
     else:
         # Heuristic to have an upper bound.
-        max_contract_count = 2 * gas_benchmark_value // gas_costs.G_CREATE
+        creation_cost = proxy_contract_code.gas_cost(fork)
+        max_contract_count = 2 * gas_benchmark_value // creation_cost
         for nonce in range(max_contract_count):
             addr = compute_create_address(address=proxy_contract, nonce=nonce)
             pre.deploy_contract(address=addr, code=Op.INVALID)
@@ -285,173 +281,155 @@ def test_return_revert(
 @pytest.mark.parametrize("value_bearing", [True, False])
 def test_selfdestruct_existing(
     benchmark_test: BenchmarkTestFiller,
-    fork: Fork,
     pre: Alloc,
     value_bearing: bool,
+    fork: Fork,
     gas_benchmark_value: int,
-    tx_gas_limit: int,
 ) -> None:
-    """
-    Benchmark SELFDESTRUCT instruction for existing contracts.
-    contracts.
-    """
-    attack_gas_limit = gas_benchmark_value
-    fee_recipient = pre.fund_eoa(amount=1)
+    """Benchmark SELFDESTRUCT instruction for existing contracts."""
+    selfdestructable_contract = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
 
-    # Template code that will be used to deploy a large number of contracts.
-    selfdestructable_contract_addr = pre.deploy_contract(
-        code=Op.SELFDESTRUCT(Op.COINBASE)
-    )
-    initcode = Op.EXTCODECOPY(
-        address=selfdestructable_contract_addr,
-        dest_offset=0,
-        offset=0,
-        size=Op.EXTCODESIZE(selfdestructable_contract_addr),
-    ) + Op.RETURN(0, Op.EXTCODESIZE(selfdestructable_contract_addr))
-    initcode_address = pre.deploy_contract(code=initcode)
-
-    # Calculate the number of contracts that can be deployed with the available
-    # gas.
-    gas_costs = fork.gas_costs()
-    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
-    loop_cost = (
-        gas_costs.G_KECCAK_256  # KECCAK static cost
-        + math.ceil(85 / 32) * gas_costs.G_KECCAK_256_WORD  # KECCAK dynamic
-        # cost for CREATE2
-        + gas_costs.G_VERY_LOW * 3  # ~MSTOREs+ADDs
-        + gas_costs.G_COLD_ACCOUNT_ACCESS  # CALL to self-destructing contract
-        + gas_costs.G_BASE
-        + gas_costs.G_SELF_DESTRUCT
-        + 88  # ~Gluing opcodes
-    )
-    final_storage_gas = (
-        gas_costs.G_VERY_LOW  # ADD
-        + gas_costs.G_VERY_LOW * 3  # PUSHs
-        + gas_costs.G_COLD_SLOAD  # SSTORE cold
-        + gas_costs.G_STORAGE_RESET  # SSTORE new value
-    )
-    memory_expansion_cost = fork().memory_expansion_gas_calculator()(
-        new_bytes=96
-    )
-    base_costs = (
-        intrinsic_gas_cost_calc()
-        + (gas_costs.G_VERY_LOW * 12)  # 8 PUSHs + 4 MSTOREs
-        + final_storage_gas
-        + memory_expansion_cost
-    )
-    num_contracts = (attack_gas_limit - base_costs) // loop_cost
-
-    # Create a factory that deploys a new SELFDESTRUCT contract instance pre-
-    # funded depending on the value_bearing parameter. We use CREATE2 so the
-    # caller contract can easily reproduce the addresses in a loop for CALLs.
-    factory_code = (
-        Op.EXTCODECOPY(
-            address=initcode_address,
-            dest_offset=0,
-            offset=0,
-            size=Op.EXTCODESIZE(initcode_address),
-        )
-        + Op.MSTORE(
+    # Initcode
+    initcode = (
+        Op.MSTORE8(
             0,
+            Op.CALLER.int(),
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=2,
+        )
+        + Op.MSTORE8(1, Op.SELFDESTRUCT.int())
+        + Op.RETURN(0, 2, code_deposit_size=2)
+    )
+
+    # Factory Contract Setup
+    # CALLDATA[0:32] = start index
+    # CALLDATA[32:64] = end index
+    factory_setup = (
+        Op.MSTORE(
+            0,
+            initcode.hex(),
+            # Gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.ADD(1, Op.CALLDATALOAD(32))
+        + Op.CALLDATALOAD(0)
+    )
+
+    factory_iterating = While(
+        body=Op.POP(
             Op.CREATE2(
                 value=1 if value_bearing else 0,
-                offset=0,
-                size=Op.EXTCODESIZE(initcode_address),
-                salt=Op.SLOAD(0),
-            ),
-        )
-        + Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1))
-        + Op.RETURN(0, 32)
+                offset=32 - len(initcode),
+                size=len(initcode),
+                salt=Op.DUP1,
+                # gas accounting
+                init_code_size=len(initcode),
+            )
+        ),
+        condition=Op.PUSH1(1) + Op.ADD + Op.DUP1 + Op.DUP3 + Op.GT,
     )
 
-    required_balance = (
-        num_contracts if value_bearing else 0
-    )  # 1 wei per contract
+    factory_code = IteratingBytecode(
+        setup=factory_setup,
+        iterating=factory_iterating,
+        iterating_subcall=initcode,
+        cleanup=Op.STOP,
+    )
+
     factory_address = pre.deploy_contract(
-        code=factory_code, balance=required_balance
+        code=factory_code,
+        balance=10**18,
     )
 
-    factory_caller_code = Op.CALLDATALOAD(0) + While(
-        body=Op.POP(Op.CALL(address=factory_address)),
-        condition=Op.PUSH1(1)
-        + Op.SWAP1
-        + Op.SUB
-        + Op.DUP1
-        + Op.ISZERO
-        + Op.ISZERO,
+    create2_preimage = Create2PreimageLayout(
+        factory_address=factory_address,
+        salt=Op.CALLDATALOAD(0),
+        init_code_hash=initcode.keccak256(),
     )
-    factory_caller_address = pre.deploy_contract(code=factory_caller_code)
 
-    # The deployed code length is two-bytes. The dominant factor
-    # is the static cost, plus a few glue opcodes/memory-expansion costs.
-    estimated_gas_per_creation = gas_costs.G_CREATE + 3_000
-    max_creations_per_tx = int(tx_gas_limit // estimated_gas_per_creation)
-    num_setup_txs = math.ceil(num_contracts / max_creations_per_tx)
+    # Attack Contract Setup
+    # CALLDATA[0:32] = start index
+    # CALLDATA[32:64] = end index
+    attack_setup = (
+        create2_preimage + Op.ADD(1, Op.CALLDATALOAD(32)) + Op.CALLDATALOAD(0)
+    )
 
-    setup_txs = []
+    loop = While(
+        body=Op.POP(
+            Op.CALL(
+                address=create2_preimage.address_op(),
+                address_warm=False,
+            )
+        )
+        + create2_preimage.increment_salt_op(),
+        condition=Op.PUSH1(1) + Op.ADD + Op.DUP1 + Op.DUP3 + Op.GT,
+    )
+
+    attack_code = IteratingBytecode(
+        setup=attack_setup,
+        iterating=loop,
+        iterating_subcall=selfdestructable_contract,
+        cleanup=Op.STOP,
+    )
+
+    attack_code_address = pre.deploy_contract(code=attack_code)
+
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        index_end = iteration_count + start_iteration - 1
+        return Hash(start_iteration) + Hash(index_end)
+
+    # Compute iteration counts and expected gas from the gas model.
+    iteration_counts = list(
+        attack_code.tx_iterations_by_gas_limit(
+            fork=fork,
+            gas_limit=gas_benchmark_value,
+            calldata=calldata,
+        )
+    )
+    num_contracts = sum(iteration_counts)
+
+    start = 0
+    total_gas_cost = 0
+    for iters in iteration_counts:
+        total_gas_cost += attack_code.tx_gas_cost_by_iteration_count(
+            fork=fork,
+            iteration_count=iters,
+            start_iteration=start,
+            calldata=calldata,
+        )
+        start += iters
+
+    def factory_calldata(iteration_count: int, start_iteration: int) -> bytes:
+        index_end = iteration_count + start_iteration - 1
+        return Hash(start_iteration) + Hash(index_end)
+
     with TestPhaseManager.setup():
-        for i in range(num_setup_txs):
-            count = min(
-                max_creations_per_tx, num_contracts - i * max_creations_per_tx
-            )
-            setup_txs.append(
-                Transaction(
-                    to=factory_caller_address,
-                    gas_limit=tx_gas_limit,
-                    data=Hash(count),
-                    sender=pre.fund_eoa(),
-                )
-            )
-
-    code = (
-        (
-            create2_preimage := Create2PreimageLayout(
-                factory_address=factory_address,
-                salt=Op.CALLDATALOAD(0),
-                init_code_hash=initcode.keccak256(),
+        setup_sender = pre.fund_eoa()
+        setup_txs = list(
+            factory_code.transactions_by_total_iteration_count(
+                fork=fork,
+                total_iterations=num_contracts,
+                sender=setup_sender,
+                to=factory_address,
+                calldata=factory_calldata,
             )
         )
-        # Main loop
-        + While(
-            body=Op.POP(Op.CALL(address=create2_preimage.address_op()))
-            + create2_preimage.increment_salt_op(),
-            # Loop while we have enough gas AND within target count
-            condition=Op.GT(Op.GAS, final_storage_gas + loop_cost),
-        )
-        + Op.SSTORE(
-            0, Op.ADD(Op.SLOAD(0), 1)
-        )  # Done for successful tx execution assertion below.
-    )
-    assert len(code) <= fork.max_code_size()
 
-    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
-    code_addr = pre.deploy_contract(code=code, storage={0: 1})
-
-    # Calculate max targets per execution TX based on effective gas limit
-    max_targets_per_tx = (tx_gas_limit - base_costs) // loop_cost
-    num_exec_txs = math.ceil(num_contracts / max_targets_per_tx)
-
-    exec_txs = []
     with TestPhaseManager.execution():
-        for i in range(num_exec_txs):
-            start = i * max_targets_per_tx
-            count = min(max_targets_per_tx, num_contracts - start)
-            exec_txs.append(
-                Transaction(
-                    to=code_addr,
-                    gas_limit=tx_gas_limit,
-                    data=Hash(start),
-                    sender=pre.fund_eoa(),
-                )
+        attack_sender = pre.fund_eoa()
+        exec_txs = list(
+            attack_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=attack_sender,
+                to=attack_code_address,
+                calldata=calldata,
             )
+        )
 
-    post = {
-        factory_address: Account(storage={0: num_contracts}),
-        code_addr: Account(
-            storage={0: len(exec_txs) + 1}
-        ),  # Check for successful execution.
-    }
-    deployed_contract_addresses = []
+    post = {}
     for i in range(num_contracts):
         deployed_contract_address = compute_create2_address(
             address=factory_address,
@@ -459,16 +437,19 @@ def test_selfdestruct_existing(
             initcode=initcode,
         )
         post[deployed_contract_address] = Account(nonce=1)
-        deployed_contract_addresses.append(deployed_contract_address)
+
+    post[attack_code_address] = Account(
+        balance=num_contracts if value_bearing else 0
+    )
 
     benchmark_test(
         post=post,
         target_opcode=Op.SELFDESTRUCT,
         blocks=[
             Block(txs=setup_txs),
-            Block(txs=exec_txs, fee_recipient=fee_recipient),
+            Block(txs=exec_txs),
         ],
-        skip_gas_used_validation=True,
+        expected_benchmark_gas_used=total_gas_cost,
     )
 
 
@@ -478,128 +459,112 @@ def test_selfdestruct_created(
     pre: Alloc,
     value_bearing: bool,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
-    tx_gas_limit: int,
 ) -> None:
-    """
-    Benchmark SELFDESTRUCT instruction for deployed contracts within same tx.
-    """
-    # Avoid account creation costs in the SELFDESTRUCT recipient.
-    fee_recipient = pre.fund_eoa(amount=1)
-    env.fee_recipient = fee_recipient
+    """Benchmark SELFDESTRUCT instruction for contracts created in same tx."""
+    selfdestructable_contract = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
 
-    # SELFDESTRUCT(COINBASE) contract deployment
+    # Initcode
     initcode = (
-        Op.MSTORE8(0, Op.COINBASE.int())
+        Op.MSTORE8(
+            0,
+            Op.CALLER.int(),
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=2,
+        )
         + Op.MSTORE8(1, Op.SELFDESTRUCT.int())
-        + Op.RETURN(0, 2)
-    )
-    gas_costs = fork.gas_costs()
-    memory_expansion_calc = fork().memory_expansion_gas_calculator()
-    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
-
-    initcode_costs = (
-        gas_costs.G_VERY_LOW * 8  # MSTOREs, PUSHs
-        + memory_expansion_calc(new_bytes=2)  # return into memory
-    )
-    create_costs = (
-        initcode_costs
-        + gas_costs.G_CREATE
-        + gas_costs.G_VERY_LOW * 3  # Create Parameter PUSHs
-        + gas_costs.G_CODE_DEPOSIT_BYTE * 2
-        + gas_costs.G_INITCODE_WORD
-    )
-    call_costs = (
-        gas_costs.G_WARM_ACCOUNT_ACCESS
-        + gas_costs.G_BASE  # COINBASE
-        + gas_costs.G_SELF_DESTRUCT
-        + gas_costs.G_VERY_LOW * 5  # CALL Parameter PUSHs
-        + gas_costs.G_BASE  #  Parameter GAS
-    )
-    extra_costs = (
-        gas_costs.G_BASE * 2  # POP, GAS
-        + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, DUP, GT
-        + gas_costs.G_HIGH  # JUMPI
-        + gas_costs.G_JUMPDEST
-    )
-    loop_cost = create_costs + call_costs + extra_costs
-
-    prefix_cost = (
-        gas_costs.G_VERY_LOW * 3
-        + gas_costs.G_BASE
-        + memory_expansion_calc(new_bytes=32)
-    )
-    suffix_cost = (
-        gas_costs.G_VERY_LOW
-        + gas_costs.G_VERY_LOW * 3
-        + gas_costs.G_COLD_SLOAD
-        + gas_costs.G_STORAGE_RESET
+        + Op.RETURN(0, 2, code_deposit_size=2)
     )
 
-    base_costs = prefix_cost + suffix_cost + intrinsic_gas_cost_calc()
-
-    iterations = (gas_benchmark_value - base_costs) // loop_cost
-
-    code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
-    code_suffix = (
-        Op.SSTORE(
-            0, Op.ADD(Op.SLOAD(0), 1)
-        )  # Done for successful tx execution assertion below.
-        + Op.STOP
+    # CALLDATA[0:32] = iteration_count
+    setup = (
+        Op.MSTORE(
+            0,
+            initcode.hex(),
+            # Gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.CALLDATALOAD(0)
+        + Op.PUSH0
     )
-    loop_body = (
-        Op.POP(
+
+    loop = While(
+        body=Op.POP(
             Op.CALL(
                 address=Op.CREATE(
                     value=1 if value_bearing else 0,
                     offset=32 - len(initcode),
                     size=len(initcode),
-                )
+                    init_code_size=len(initcode),
+                ),
+                address_warm=True,
             )
-        )
-        + Op.PUSH1[1]
-        + Op.ADD
-        + Op.JUMPI(
-            len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost)
-        )
-    )
-    code = code_prefix + loop_body + code_suffix
-
-    max_iterations_per_tx = (tx_gas_limit - base_costs) // loop_cost
-    num_exec_txs = math.ceil(iterations / max_iterations_per_tx)
-    total_expected_iterations = max_iterations_per_tx * num_exec_txs
-
-    # The 0 storage slot is initialize to avoid creation costs in SSTORE above.
-    code_addr = pre.deploy_contract(
-        code=code,
-        balance=total_expected_iterations if value_bearing else 0,
-        storage={0: 1},
+        ),
+        condition=Op.PUSH1(1) + Op.ADD + Op.DUP1 + Op.DUP3 + Op.GT,
     )
 
-    exec_txs = []
+    attack_code = IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        iterating_subcall=selfdestructable_contract.gas_cost(fork)
+        + initcode.gas_cost(fork),
+        cleanup=Op.STOP,
+    )
+
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        del start_iteration
+        return Hash(iteration_count)
+
+    iteration_counts = list(
+        attack_code.tx_iterations_by_gas_limit(
+            fork=fork,
+            gas_limit=gas_benchmark_value,
+            calldata=calldata,
+        )
+    )
+    num_iterations = sum(iteration_counts)
+
+    total_gas_cost = sum(
+        attack_code.tx_gas_cost_by_iteration_count(
+            fork=fork,
+            iteration_count=iters,
+            calldata=calldata,
+        )
+        for iters in iteration_counts
+    )
+
+    attack_code_address = pre.deploy_contract(
+        code=attack_code,
+        balance=num_iterations if value_bearing else 0,
+    )
+
     with TestPhaseManager.execution():
-        for _ in range(num_exec_txs):
-            exec_txs.append(
-                Transaction(
-                    to=code_addr,
-                    gas_limit=tx_gas_limit,
-                    sender=pre.fund_eoa(),
-                )
+        sender = pre.fund_eoa()
+        exec_txs = list(
+            attack_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=sender,
+                to=attack_code_address,
+                calldata=calldata,
             )
+        )
 
     post = {
-        code_addr: Account(storage={0: len(exec_txs) + 1})
-    }  # Check for successful execution.
+        attack_code_address: Account(
+            balance=num_iterations if value_bearing else 0
+        )
+    }
+
     benchmark_test(
         post=post,
+        target_opcode=Op.SELFDESTRUCT,
         blocks=[
-            Block(txs=exec_txs, fee_recipient=fee_recipient),
+            Block(txs=exec_txs),
         ],
-        expected_benchmark_gas_used=(
-            max_iterations_per_tx * loop_cost + base_costs
-        )
-        * num_exec_txs,
+        expected_benchmark_gas_used=total_gas_cost,
     )
 
 
@@ -609,106 +574,93 @@ def test_selfdestruct_initcode(
     pre: Alloc,
     value_bearing: bool,
     fork: Fork,
-    env: Environment,
     gas_benchmark_value: int,
-    tx_gas_limit: int,
 ) -> None:
     """Benchmark SELFDESTRUCT instruction executed in initcode."""
-    # Avoid account creation costs in the SELFDESTRUCT recipient.
-    fee_recipient = pre.fund_eoa(amount=1)
-    env.fee_recipient = fee_recipient
+    initcode = Op.SELFDESTRUCT(Op.CALLER, address_warm=True)
 
-    gas_costs = fork.gas_costs()
-    memory_expansion_calc = fork().memory_expansion_gas_calculator()
-    intrinsic_gas_cost_calc = fork.transaction_intrinsic_cost_calculator()
-
-    initcode_costs = (
-        gas_costs.G_BASE  # COINBASE
-        + gas_costs.G_SELF_DESTRUCT
-    )
-    create_costs = (
-        initcode_costs
-        + gas_costs.G_CREATE
-        + gas_costs.G_VERY_LOW * 3  # Create Parameter PUSHs
-        + gas_costs.G_INITCODE_WORD
-    )
-    extra_costs = (
-        gas_costs.G_BASE * 2  # POP, GAS
-        + gas_costs.G_VERY_LOW * 5  # PUSHs, ADD, GT
-        + gas_costs.G_HIGH  # JUMPI
-        + gas_costs.G_JUMPDEST
-    )
-    loop_cost = create_costs + extra_costs
-
-    prefix_cost = (
-        gas_costs.G_VERY_LOW * 3
-        + gas_costs.G_BASE
-        + memory_expansion_calc(new_bytes=32)
-    )
-    suffix_cost = (
-        gas_costs.G_VERY_LOW
-        + gas_costs.G_VERY_LOW * 3
-        + gas_costs.G_COLD_SLOAD
-        + gas_costs.G_STORAGE_RESET
+    # CALLDATA[0:32] = iteration_count
+    setup = (
+        Op.MSTORE(
+            0,
+            initcode.hex(),
+            # Gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.CALLDATALOAD(0)
+        + Op.PUSH0
     )
 
-    base_costs = prefix_cost + suffix_cost + intrinsic_gas_cost_calc()
-
-    initcode = Op.SELFDESTRUCT(Op.COINBASE)
-    code_prefix = Op.MSTORE(0, initcode.hex()) + Op.PUSH0 + Op.JUMPDEST
-    code_suffix = (
-        Op.SSTORE(
-            0, Op.ADD(Op.SLOAD(0), 1)
-        )  # Done for successful tx execution assertion below.
-        + Op.STOP
-    )
-
-    loop_body = (
-        Op.POP(
+    loop = While(
+        body=Op.POP(
             Op.CREATE(
                 value=1 if value_bearing else 0,
                 offset=32 - len(initcode),
                 size=len(initcode),
+                init_code_size=len(initcode),
             )
-        )
-        + Op.PUSH1[1]
-        + Op.ADD
-        + Op.JUMPI(
-            len(code_prefix) - 1, Op.GT(Op.GAS, suffix_cost + loop_cost)
+        ),
+        condition=Op.PUSH1(1) + Op.ADD + Op.DUP1 + Op.DUP3 + Op.GT,
+    )
+
+    attack_code = IteratingBytecode(
+        setup=setup,
+        iterating=loop,
+        iterating_subcall=initcode,
+        cleanup=Op.STOP,
+    )
+
+    def calldata(iteration_count: int, start_iteration: int) -> bytes:
+        del start_iteration
+        return Hash(iteration_count)
+
+    iteration_counts = list(
+        attack_code.tx_iterations_by_gas_limit(
+            fork=fork,
+            gas_limit=gas_benchmark_value,
+            calldata=calldata,
         )
     )
-    code = code_prefix + loop_body + code_suffix
+    num_iterations = sum(iteration_counts)
 
-    # The 0 storage slot is initialized to avoid creation
-    # costs in SSTORE above.
-    code_addr = pre.deploy_contract(code=code, balance=100_000, storage={0: 1})
+    total_gas_cost = sum(
+        attack_code.tx_gas_cost_by_iteration_count(
+            fork=fork,
+            iteration_count=iters,
+            calldata=calldata,
+        )
+        for iters in iteration_counts
+    )
 
-    exec_txs = []
-    expected_benchmark_gas_used = 0
+    attack_code_address = pre.deploy_contract(
+        code=attack_code,
+        balance=num_iterations if value_bearing else 0,
+    )
+
     with TestPhaseManager.execution():
-        used_gas = 0
-        while used_gas < gas_benchmark_value:
-            gas_limit = min(tx_gas_limit, gas_benchmark_value - used_gas)
-            if gas_limit < intrinsic_gas_cost_calc():
-                break
-            exec_txs.append(
-                Transaction(
-                    to=code_addr,
-                    gas_limit=gas_limit,
-                    sender=pre.fund_eoa(),
-                )
+        sender = pre.fund_eoa()
+        exec_txs = list(
+            attack_code.transactions_by_gas_limit(
+                fork=fork,
+                gas_limit=gas_benchmark_value,
+                sender=sender,
+                to=attack_code_address,
+                calldata=calldata,
             )
-            used_gas += gas_limit
-            iterations = (gas_limit - base_costs) // loop_cost
-            expected_benchmark_gas_used += iterations * loop_cost + base_costs
+        )
 
     post = {
-        code_addr: Account(storage={0: len(exec_txs) + 1})
-    }  # Check for successful execution.
+        attack_code_address: Account(
+            balance=num_iterations if value_bearing else 0
+        )
+    }
+
     benchmark_test(
         post=post,
+        target_opcode=Op.SELFDESTRUCT,
         blocks=[
-            Block(txs=exec_txs, fee_recipient=fee_recipient),
+            Block(txs=exec_txs),
         ],
-        expected_benchmark_gas_used=expected_benchmark_gas_used,
+        expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -423,10 +423,11 @@ def test_bn128_pairings_amortized(
     tx_gas_limit: int,
 ) -> None:
     """Test running a block with as many BN128 pairings as possible."""
-    base_cost = 45_000
-    pairing_cost = 34_000
     size_per_pairing = 192
 
+    gsc = fork.gas_costs()
+    base_cost = gsc.G_PRECOMPILE_ECPAIRING_BASE
+    pairing_cost = gsc.G_PRECOMPILE_ECPAIRING_PER_POINT
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
     warm_account_access_cost = Op.STATICCALL(

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -427,9 +427,18 @@ def test_bn128_pairings_amortized(
     pairing_cost = 34_000
     size_per_pairing = 192
 
-    gsc = fork.gas_costs()
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     mem_exp_gas_calculator = fork.memory_expansion_gas_calculator()
+    warm_account_access_cost = Op.STATICCALL(
+        gas=Op.GAS,
+        address=Op.PUSH20(0),
+        argsOffset=Op.PUSH0,
+        argsSize=Op.PUSH0,
+        retOffset=Op.PUSH0,
+        retSize=Op.PUSH0,
+        # gas accounting
+        address_warm=True,
+    ).gas_cost(fork)
 
     # This is a theoretical maximum number of pairings that can be done in a
     # block. It is only used for an upper bound for calculating the optimal
@@ -458,10 +467,8 @@ def test_bn128_pairings_amortized(
             - mem_exp_gas_calculator(new_bytes=i * size_per_pairing),
         )
 
-        # This is ignoring "glue" opcodes, but helps to have a rough idea of
-        # the right cutting point.
         approx_gas_cost_per_call = (
-            gsc.G_WARM_ACCOUNT_ACCESS + base_cost + i * pairing_cost
+            warm_account_access_cost + base_cost + i * pairing_cost
         )
 
         num_precompile_calls = (

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -432,10 +432,10 @@ def test_bn128_pairings_amortized(
     warm_account_access_cost = Op.STATICCALL(
         gas=Op.GAS,
         address=Op.PUSH20(0),
-        argsOffset=Op.PUSH0,
-        argsSize=Op.PUSH0,
-        retOffset=Op.PUSH0,
-        retSize=Op.PUSH0,
+        args_offset=Op.PUSH0,
+        args_size=Op.PUSH0,
+        ret_offset=Op.PUSH0,
+        ret_size=Op.PUSH0,
         # gas accounting
         address_warm=True,
     ).gas_cost(fork)

--- a/tests/benchmark/compute/precompile/test_identity.py
+++ b/tests/benchmark/compute/precompile/test_identity.py
@@ -20,11 +20,12 @@ def test_identity(
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     gas_available = tx_gas_limit - intrinsic_gas_calculator()
 
+    gas_costs = fork.gas_costs()
     optimal_input_length = calculate_optimal_input_length(
         available_gas=gas_available,
         fork=fork,
-        static_cost=15,
-        per_word_dynamic_cost=3,
+        static_cost=gas_costs.G_PRECOMPILE_IDENTITY_BASE,
+        per_word_dynamic_cost=gas_costs.G_PRECOMPILE_IDENTITY_WORD,
         bytes_per_unit_of_work=1,
     )
 

--- a/tests/benchmark/compute/precompile/test_ripemd160.py
+++ b/tests/benchmark/compute/precompile/test_ripemd160.py
@@ -20,11 +20,12 @@ def test_ripemd160(
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     gas_available = tx_gas_limit - intrinsic_gas_calculator()
 
+    gas_costs = fork.gas_costs()
     optimal_input_length = calculate_optimal_input_length(
         available_gas=gas_available,
         fork=fork,
-        static_cost=600,
-        per_word_dynamic_cost=120,
+        static_cost=gas_costs.G_PRECOMPILE_RIPEMD160_BASE,
+        per_word_dynamic_cost=gas_costs.G_PRECOMPILE_RIPEMD160_WORD,
         bytes_per_unit_of_work=64,
     )
 

--- a/tests/benchmark/compute/precompile/test_sha256.py
+++ b/tests/benchmark/compute/precompile/test_sha256.py
@@ -20,11 +20,12 @@ def test_sha256(
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
     gas_available = tx_gas_limit - intrinsic_gas_calculator()
 
+    gas_costs = fork.gas_costs()
     optimal_input_length = calculate_optimal_input_length(
         available_gas=gas_available,
         fork=fork,
-        static_cost=60,
-        per_word_dynamic_cost=12,
+        static_cost=gas_costs.G_PRECOMPILE_SHA256_BASE,
+        per_word_dynamic_cost=gas_costs.G_PRECOMPILE_SHA256_WORD,
         bytes_per_unit_of_work=64,
     )
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Use bytecode.gas_cost(fork) in compute benchmark test.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Partially fixes #2049.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
