### PR TITLE
fix(test): use `pre_alloc_mutable` for eip7708 test

### DIFF
--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -648,7 +648,7 @@ def test_stack_underflow_no_log(
     state_test(env=env, pre=pre, post={}, tx=tx)
 
 
-@pytest.mark.pre_alloc_modify
+@pytest.mark.pre_alloc_mutable
 @pytest.mark.with_all_create_opcodes
 def test_create_collision_no_log(
     state_test: StateTestFiller,


### PR DESCRIPTION
## 🗒️ Description

Rebased the eip branch and this test breaks due to a downstream update to test markers. We need to use `pre_alloc_mutable` instead.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%2Fid%2FOIP.89CYIe1nDSCZJ8k8zyCy4QHaDt%3Fpid%3DApi&f=1&ipt=108dc91ac2cfc3e8e8e210f4b4036871ae533d3e81a66be15657d8ea2ab509b8&ipo=images)
