### PR TITLE
refactor(testing): Refactor `Initcode` to allign `gas_cost` behavior with `Bytecode`

### DIFF
--- a/packages/testing/src/execution_testing/tools/tests/test_code.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_code.py
@@ -202,15 +202,19 @@ def test_initcode(initcode: Initcode, bytecode: bytes) -> None:  # noqa: D103
         ),
     ],
 )
-def test_initcode_gas_cost(initcode: Initcode, reference: Bytecode) -> None:
+def test_initcode_gas_cost(initcode: Initcode, reference: Initcode) -> None:
     """
     Test that the gas cost of the initcode is calculated correctly.
     """
     assert initcode.gas_cost(Cancun) == reference.gas_cost(Cancun)
     if initcode.deploy_code != reference.deploy_code:
-        assert initcode.deploy_code.gas_cost(
+        initcode_deploy_code = initcode.deploy_code
+        assert isinstance(initcode_deploy_code, Bytecode)
+        reference_deploy_code = reference.deploy_code
+        assert isinstance(reference_deploy_code, Bytecode)
+        assert initcode_deploy_code.gas_cost(
             Cancun
-        ) != reference.deploy_code.gas_cost(Cancun)
+        ) != reference_deploy_code.gas_cost(Cancun)
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/tools/tests/test_code.py
+++ b/packages/testing/src/execution_testing/tools/tests/test_code.py
@@ -27,7 +27,7 @@ from execution_testing.forks import (
 )
 from execution_testing.specs import StateTest
 from execution_testing.test_types import Alloc, Environment, Transaction
-from execution_testing.vm import Op
+from execution_testing.vm import Bytecode, Op
 
 from ..tools_code import CalldataCase, Case, Conditional, Initcode, Switch
 
@@ -182,6 +182,35 @@ def expected_bytes(
 )
 def test_initcode(initcode: Initcode, bytecode: bytes) -> None:  # noqa: D103
     assert bytes(initcode) == bytecode
+
+
+@pytest.mark.parametrize(
+    "initcode,reference",
+    [
+        pytest.param(
+            Initcode(),
+            Initcode(),
+            id="empty-deployed-code",
+        ),
+        pytest.param(
+            # Both initcodes deploy code of the same size, but the execution
+            # cost of the deployed codes differ, make sure that `gas_cost`
+            # is not influenced by the deployed code's execution cost.
+            Initcode(deploy_code=Op.MSTORE(0, 0, new_memory_size=0)),
+            Initcode(deploy_code=Op.MSTORE(0xFF, 0, new_memory_size=0xFF)),
+            id="non-empty-deployed-code",
+        ),
+    ],
+)
+def test_initcode_gas_cost(initcode: Initcode, reference: Bytecode) -> None:
+    """
+    Test that the gas cost of the initcode is calculated correctly.
+    """
+    assert initcode.gas_cost(Cancun) == reference.gas_cost(Cancun)
+    if initcode.deploy_code != reference.deploy_code:
+        assert initcode.deploy_code.gas_cost(
+            Cancun
+        ) != reference.deploy_code.gas_cost(Cancun)
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -25,7 +25,7 @@ class Initcode(Bytecode):
     EIP-3860 are *not* taken into account by any of these calculated costs.
     """
 
-    deploy_code: SupportsBytes | Bytes
+    deploy_code: Bytes | Bytecode
     """
     Bytecode to be deployed by the initcode.
     """
@@ -48,11 +48,13 @@ class Initcode(Bytecode):
         """
         if deploy_code is None:
             deploy_code = Bytecode()
+        elif not isinstance(deploy_code, Bytecode):
+            deploy_code = Bytes(deploy_code)
         if initcode_prefix is None:
             initcode_prefix = Bytecode()
 
         initcode = initcode_prefix
-        code_length = len(bytes(deploy_code))
+        code_length = len(deploy_code)
 
         # PUSH2: length=<bytecode length>
         initcode += Op.PUSH2(code_length)
@@ -79,7 +81,7 @@ class Initcode(Bytecode):
         )
 
         # RETURN: offset=0, length
-        initcode += Op.RETURN(code_deposit_size=len(bytes(deploy_code)))
+        initcode += Op.RETURN(code_deposit_size=len(deploy_code))
 
         initcode_plus_deploy_code = bytes(initcode) + bytes(deploy_code)
         padding_bytes = bytes()
@@ -117,8 +119,8 @@ class Initcode(Bytecode):
         timestamp: int = 0,
     ) -> int:
         """
-        Gas cost of executing the initcode, without considering deployment gas
-        costs.
+        Gas cost of executing the initcode, charged before the code
+        deposit fee.
         """
         return self.gas_cost(
             fork,
@@ -138,7 +140,7 @@ class Initcode(Bytecode):
         timestamp: int = 0,
     ) -> int:
         """
-        Gas cost of deploying the cost, subtracted after initcode execution.
+        Gas cost of deploying the contract.
         """
         return Op.RETURN(
             code_deposit_size=len(bytes(self.deploy_code))

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -33,18 +33,15 @@ class Initcode(Bytecode):
     def __new__(
         cls,
         *,
-        deploy_code: SupportsBytes | Bytes | None = None,
+        deploy_code: Bytecode | SupportsBytes | None = None,
         initcode_length: int | None = None,
         initcode_prefix: Bytecode | None = None,
         padding_byte: int = 0x00,
         name: str = "",
     ) -> Self:
         """
-        Generate legacy initcode that inits a contract with the specified code.
+        Generate an initcode that returns a contract with the specified code.
         The initcode can be padded to a specified length for testing purposes.
-
-        Gas costs are calculated using the fork's gas costs and memory
-        expansion formula. Defaults to Frontier if no fork is provided.
         """
         if deploy_code is None:
             deploy_code = Bytecode()
@@ -142,9 +139,9 @@ class Initcode(Bytecode):
         """
         Gas cost of deploying the contract.
         """
-        return Op.RETURN(
-            code_deposit_size=len(bytes(self.deploy_code))
-        ).gas_cost(fork, block_number=block_number, timestamp=timestamp)
+        return Op.RETURN(code_deposit_size=len(self.deploy_code)).gas_cost(
+            fork, block_number=block_number, timestamp=timestamp
+        )
 
 
 class CodeGasMeasure(Bytecode):

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generator, List, Self, SupportsBytes, Tuple, Type
 from pydantic import Field
 
 from execution_testing.base_types import Address, Bytes
-from execution_testing.forks import Fork, Frontier
+from execution_testing.forks import Fork
 from execution_testing.test_types import EOA, Transaction
 from execution_testing.vm import Bytecode, ForkOpcodeInterface, Op
 
@@ -29,15 +29,6 @@ class Initcode(Bytecode):
     """
     Bytecode to be deployed by the initcode.
     """
-    execution_gas: int
-    """
-    Gas cost of executing the initcode, without considering deployment gas
-    costs.
-    """
-    deployment_gas: int
-    """
-    Gas cost of deploying the cost, subtracted after initcode execution,
-    """
 
     def __new__(
         cls,
@@ -47,7 +38,6 @@ class Initcode(Bytecode):
         initcode_prefix: Bytecode | None = None,
         padding_byte: int = 0x00,
         name: str = "",
-        fork: Fork = Frontier,
     ) -> Self:
         """
         Generate legacy initcode that inits a contract with the specified code.
@@ -89,7 +79,7 @@ class Initcode(Bytecode):
         )
 
         # RETURN: offset=0, length
-        initcode += Op.RETURN
+        initcode += Op.RETURN(code_deposit_size=len(bytes(deploy_code)))
 
         initcode_plus_deploy_code = bytes(initcode) + bytes(deploy_code)
         padding_bytes = bytes()
@@ -112,15 +102,47 @@ class Initcode(Bytecode):
             pushed_stack_items=initcode.pushed_stack_items,
             max_stack_height=initcode.max_stack_height,
             min_stack_height=initcode.min_stack_height,
+            name=name,
+            opcode_list=initcode.opcode_list,
         )
-        instance._name_ = name
         instance.deploy_code = deploy_code
-        instance.execution_gas = initcode.gas_cost(fork)
-        instance.deployment_gas = Op.RETURN(
-            code_deposit_size=len(bytes(instance.deploy_code))
-        ).gas_cost(fork)
 
         return instance
+
+    def execution_gas(
+        self,
+        fork: Type[ForkOpcodeInterface],
+        *,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """
+        Gas cost of executing the initcode, without considering deployment gas
+        costs.
+        """
+        return self.gas_cost(
+            fork,
+            block_number=block_number,
+            timestamp=timestamp,
+        ) - self.deployment_gas(
+            fork,
+            block_number=block_number,
+            timestamp=timestamp,
+        )
+
+    def deployment_gas(
+        self,
+        fork: Type[ForkOpcodeInterface],
+        *,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """
+        Gas cost of deploying the cost, subtracted after initcode execution.
+        """
+        return Op.RETURN(
+            code_deposit_size=len(bytes(self.deploy_code))
+        ).gas_cost(fork, block_number=block_number, timestamp=timestamp)
 
 
 class CodeGasMeasure(Bytecode):

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_eip7702.py
@@ -1207,8 +1207,7 @@ def test_bal_7702_delegated_create(
             authorization_list_or_count=tx.authorization_list,
         )
         + deployer_code.gas_cost(fork)
-        + init_code.execution_gas
-        + gsc.G_CODE_DEPOSIT_BYTE * len(deploy_code)
+        + init_code.gas_cost(fork)
     )
 
     refund_counter = gsc.R_AUTHORIZATION_EXISTING_AUTHORITY

--- a/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
@@ -36,9 +36,7 @@ def test_tstore_clear_after_deployment_tx(
     init_code = Op.TSTORE(1, 1)
     deploy_code = Op.SSTORE(1, Op.TLOAD(1))
 
-    code = Initcode(
-        deploy_code=deploy_code, initcode_prefix=init_code, fork=fork
-    )
+    code = Initcode(deploy_code=deploy_code, initcode_prefix=init_code)
 
     sender = pre.fund_eoa()
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -17,7 +17,6 @@ from execution_testing import (
     Transaction,
     compute_create_address,
 )
-from execution_testing.forks.helpers import Fork
 
 from . import CreateOpcodeParams, PytestParameterEnum
 from .spec import ref_spec_1153
@@ -165,12 +164,9 @@ class TestTransientStorageInContractCreation:
         self,
         deploy_code: Bytecode,
         constructor_code: Bytecode,
-        fork: Fork,
     ) -> Initcode:
         return Initcode(
-            deploy_code=deploy_code,
-            initcode_prefix=constructor_code,
-            fork=fork,
+            deploy_code=deploy_code, initcode_prefix=constructor_code
         )
 
     @pytest.fixture()

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -46,7 +46,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     if initcode_name == "max_size_ones":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size(),
             padding_byte=0x01,
@@ -54,7 +53,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "max_size_zeros":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size(),
             padding_byte=0x00,
@@ -62,7 +60,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "over_limit_ones":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size() + 1,
             padding_byte=0x01,
@@ -70,7 +67,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "over_limit_zeros":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size() + 1,
             padding_byte=0x00,
@@ -78,7 +74,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "32_bytes":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=32,
             padding_byte=0x00,
@@ -86,7 +81,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "33_bytes":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=33,
             padding_byte=0x00,
@@ -94,7 +88,6 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "max_size_minus_word":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size() - 32,
             padding_byte=0x00,
@@ -102,22 +95,16 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
     elif initcode_name == "max_size_minus_word_plus_byte":
         return Initcode(
             name=initcode_name,
-            fork=fork,
             deploy_code=INITCODE_RESULTING_DEPLOYED_CODE,
             initcode_length=fork.max_initcode_size() - 32 + 1,
             padding_byte=0x00,
         )
-    elif initcode_name == "empty":
-        ic = Initcode(name=initcode_name, fork=fork)
-        ic._bytes_ = bytes()
-        ic.deployment_gas = 0
-        ic.execution_gas = 0
-        return ic
-    elif initcode_name == "single_byte":
-        ic = Initcode(name=initcode_name, fork=fork)
-        ic._bytes_ = bytes(Op.STOP)
-        ic.deployment_gas = 0
-        ic.execution_gas = 0
+    elif initcode_name == "empty" or initcode_name == "single_byte":
+        ic_bytecode = Op.STOP if initcode_name == "single_byte" else Bytecode()
+        # We insist on using `Initcode` to preserve `initcode.deploy_code`
+        ic = Initcode(name=initcode_name)
+        ic._bytes_ = bytes(ic_bytecode)
+        ic.opcode_list = ic_bytecode.opcode_list
         return ic
     else:
         raise ValueError(f"Unknown initcode_name: {initcode_name}")
@@ -284,16 +271,12 @@ class TestContractCreationGasUsage:
 
     @pytest.fixture
     def exact_execution_gas(
-        self, exact_intrinsic_gas: int, initcode: Initcode
+        self, fork: Fork, exact_intrinsic_gas: int, initcode: Initcode
     ) -> int:
         """
         Calculate total execution gas cost.
         """
-        return (
-            exact_intrinsic_gas
-            + initcode.deployment_gas
-            + initcode.execution_gas
-        )
+        return exact_intrinsic_gas + initcode.gas_cost(fork)
 
     @pytest.fixture
     def tx_error(self, gas_test_case: str) -> TransactionException | None:
@@ -593,9 +576,7 @@ class TestCreateInitcode:
         else:
             expected_gas_usage = contract_creation_gas_cost
             # The initcode is only executed if the length check succeeds
-            expected_gas_usage += initcode.execution_gas
-            # The code is only deployed if the length check succeeds
-            expected_gas_usage += initcode.deployment_gas
+            expected_gas_usage += initcode.gas_cost(fork)
 
             # CREATE2 hashing cost should only be deducted if the initcode
             # does not exceed the max length


### PR DESCRIPTION
## 🗒️ Description

Refactors on top of #2176 to align behavior of `Initcode.gas_cost` with what is normally expected of `Bytecode.gas_cost`.

Method `gas_cost` now correctly returns the full cost of executing the initcode including the code deposit.

`execution_gas` and `deployment_gas`, previously set during instantiation, are now public methods which take the `fork` as parameter and return the gas cost excluding the code deposit and the code deposit cost, respectively.

The `fork` parameter requirement was removed from the instantiation of `Initcode`.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRlH7NTQiJlCXPZRYKhcYF9znNPQFManNpWNw&s)
