### PR TITLE
refactor(testing): Refactor specs to allow reusing logic for benchmark checks

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -650,6 +650,8 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
             )
 
         class BaseTestWrapper(cls):  # type: ignore
+            __is_base_test_wrapper__ = True
+
             def __init__(self, *args: Any, **kwargs: Any) -> None:
                 if "pre" not in kwargs:
                     kwargs["pre"] = pre

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -625,6 +625,8 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
         max_fee_per_blob_gas: int,
         max_gas_limit_per_test: int | None,
         gas_limit_accumulator: GasInfoAccumulator,
+        is_tx_gas_heavy_test: bool,
+        is_exception_test: bool,
     ) -> Type[BaseTest]:
         """
         Fixture used to instantiate an auto-fillable BaseTest object from
@@ -655,10 +657,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     raise ValueError(
                         "The pre-alloc object was modified by the test."
                     )
-                # Set default for expected_benchmark_gas_used
                 if "expected_benchmark_gas_used" not in kwargs:
                     kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
                 kwargs["fork"] = fork
+                kwargs["operation_mode"] = request.config.op_mode
+                kwargs["is_tx_gas_heavy_test"] = is_tx_gas_heavy_test
+                kwargs["is_exception_test"] = is_exception_test
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters
@@ -668,7 +672,6 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 request.node.config.sender_address = str(pre._sender)
 
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
-                self._request = request
                 execute = self.execute(execute_format=execute_format)
 
                 # get balances of required sender accounts
@@ -730,12 +733,17 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     [str(eoa) for eoa in pre._funded_eoa]
                 )
 
-                execute.execute(
+                execute_result = execute.execute(
                     fork=fork,
                     eth_rpc=eth_rpc,
                     engine_rpc=engine_rpc,
                     request=request,
                 )
+                self.validate_benchmark_gas(
+                    benchmark_gas_used=execute_result.benchmark_gas_used,
+                    gas_benchmark_value=gas_benchmark_value,
+                )
+
                 collector.collect(request.node.nodeid, execute)
 
         return BaseTestWrapper
@@ -744,7 +752,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
 
 
 # Dynamically generate a pytest fixture for each test spec type.
-for cls in BaseTest.spec_types.values():
+for name, cls in BaseTest.spec_types.items():
+    if getattr(cls, "__is_base_test_wrapper__", False):
+        raise RuntimeError(
+            f"Test spec type {name}: {cls.__name__} is already wrapped. "
+            f"{BaseTest.spec_types.items()}."
+        )
     # Fixture needs to be defined in the global scope so pytest can detect it.
     globals()[cls.pytest_parameter_name()] = base_test_parametrizer(cls)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -42,6 +42,7 @@ from execution_testing.client_clis.clis.geth import FixtureConsumerTool
 from execution_testing.fixtures import (
     BaseFixture,
     BlockchainEngineFixture,
+    BlockchainEngineXFixture,
     BlockchainFixture,
     FixtureCollector,
     FixtureConsumer,
@@ -66,7 +67,7 @@ from execution_testing.forks import (
     get_transition_forks,
 )
 from execution_testing.specs import BaseTest
-from execution_testing.specs.base import OpMode
+from execution_testing.specs.base import FillResult, OpMode
 from execution_testing.test_types import EnvironmentDefaults
 from execution_testing.tools.utility.versioning import (
     generate_github_url,
@@ -1706,12 +1707,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     )
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
+                fill_result: FillResult | None = None
                 try:
                     fill_result = self.generate(
                         t8n=t8n,
                         fixture_format=fixture_format,
                     )
-                    fixture = fill_result.fixture
                 finally:
                     if (
                         self.operation_mode == OpMode.OPTIMIZE_GAS
@@ -1725,8 +1726,13 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         # Force adding something to the list, even if it's
                         # None, to keep track of failed tests in the output
                         # file.
-                        gas_optimized_tests[request.node.nodeid] = None
-
+                        gas_optimized_tests[request.node.nodeid] = (
+                            fill_result.gas_optimization
+                            if fill_result is not None
+                            else None
+                        )
+                assert fill_result is not None
+                fixture = fill_result.fixture
                 # If operation mode is benchmarking, check the gas used.
                 self.validate_benchmark_gas(
                     benchmark_gas_used=fill_result.benchmark_gas_used,
@@ -1740,6 +1746,9 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     in fixture_format.format_phases
                     and pre_alloc_hash is not None
                 ):
+                    # TODO: This should be handled by the `generate` method
+                    # of the spec.
+                    assert isinstance(fixture, BlockchainEngineXFixture)
                     fixture.pre_hash = pre_alloc_hash
 
                     # Calculate state diff for efficiency

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1183,7 +1183,7 @@ def verify_fixtures_bin(request: pytest.FixtureRequest) -> Path | None:
 def session_t8n(
     request: pytest.FixtureRequest,
 ) -> Generator[TransitionTool, None, None]:
-    """Return configured transition tool."""
+    """Return configured transition tool for the session."""
     t8n: TransitionTool = request.config.t8n  # type: ignore
     if not t8n.exception_mapper.reliable:
         t8n_name = t8n.__class__.__name__
@@ -1600,6 +1600,8 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
         fixture_source_url: str,
         gas_benchmark_value: int,
         fixed_opcode_count: int | None,
+        is_tx_gas_heavy_test: bool,
+        is_exception_test: bool,
     ) -> Any:
         """
         Fixture used to instantiate an auto-fillable BaseTest object from
@@ -1623,12 +1625,27 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
             fork = request.node.fork
 
         class BaseTestWrapper(cls):  # type: ignore
+            __is_base_test_wrapper__ = True
+
             def __init__(self, *args: Any, **kwargs: Any) -> None:
                 if "pre" not in kwargs:
                     kwargs["pre"] = pre
                 if "expected_benchmark_gas_used" not in kwargs:
                     kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
                 kwargs["fork"] = fork
+                op_mode: OpMode = request.config.op_mode  # type: ignore
+                kwargs["operation_mode"] = op_mode
+                kwargs["is_tx_gas_heavy_test"] = is_tx_gas_heavy_test
+                kwargs["is_exception_test"] = is_exception_test
+                if (
+                    op_mode == OpMode.OPTIMIZE_GAS
+                    or op_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
+                ):
+                    kwargs["gas_optimization_max_gas_limit"] = (
+                        request.config.getoption(
+                            "optimize_gas_max_gas_limit", None
+                        )
+                    )
                 kwargs |= {
                     p: request.getfixturevalue(p)
                     for p in cls_fixture_parameters
@@ -1636,20 +1653,6 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 }
 
                 super(BaseTestWrapper, self).__init__(*args, **kwargs)
-                self._request = request
-                self._operation_mode = (
-                    request.config.op_mode  # type: ignore[attr-defined]
-                )
-                if (
-                    self._operation_mode == OpMode.OPTIMIZE_GAS
-                    or self._operation_mode
-                    == OpMode.OPTIMIZE_GAS_POST_PROCESSING
-                ):
-                    self._gas_optimization_max_gas_limit = (
-                        request.config.getoption(
-                            "optimize_gas_max_gas_limit", None
-                        )
-                    )
 
                 # Get the filling session from config
                 session: FillingSession = request.config.filling_session  # type: ignore
@@ -1704,15 +1707,15 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     group = session.get_pre_alloc_group(pre_alloc_hash)
                     self.pre = group.pre
                 try:
-                    fixture = self.generate(
+                    fill_result = self.generate(
                         t8n=t8n,
                         fixture_format=fixture_format,
                     )
+                    fixture = fill_result.fixture
                 finally:
                     if (
-                        request.config.op_mode  # type: ignore[attr-defined]
-                        == OpMode.OPTIMIZE_GAS
-                        or request.config.op_mode  # type: ignore[attr-defined]
+                        self.operation_mode == OpMode.OPTIMIZE_GAS
+                        or self.operation_mode
                         == OpMode.OPTIMIZE_GAS_POST_PROCESSING
                     ):
                         gas_optimized_tests = (
@@ -1725,6 +1728,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         gas_optimized_tests[request.node.nodeid] = (
                             self._gas_optimization
                         )
+
+                # If operation mode is benchmarking, check the gas used.
+                self.validate_benchmark_gas(
+                    benchmark_gas_used=fill_result.benchmark_gas_used,
+                    gas_benchmark_value=gas_benchmark_value,
+                )
 
                 # Post-process for Engine X format (add pre_hash and state
                 # diff)
@@ -1749,6 +1758,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     t8n.version(),
                     test_case_description,
                     fixture_source_url=fixture_source_url,
+                    opcode_count=t8n.opcode_count,
                     ref_spec=reference_spec,
                     _info_metadata=t8n._info_metadata,
                 )
@@ -1773,7 +1783,12 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
 
 
 # Dynamically generate a pytest fixture for each test spec type.
-for cls in BaseTest.spec_types.values():
+for name, cls in BaseTest.spec_types.items():
+    if getattr(cls, "__is_base_test_wrapper__", False):
+        raise RuntimeError(
+            f"Test spec type {name}: {cls.__name__} is already wrapped. "
+            f"{BaseTest.spec_types.items()}."
+        )
     # Fixture needs to be defined in the global scope so pytest can detect it.
     globals()[cls.pytest_parameter_name()] = base_test_parametrizer(cls)
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1725,9 +1725,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         # Force adding something to the list, even if it's
                         # None, to keep track of failed tests in the output
                         # file.
-                        gas_optimized_tests[request.node.nodeid] = (
-                            self._gas_optimization
-                        )
+                        gas_optimized_tests[request.node.nodeid] = None
 
                 # If operation mode is benchmarking, check the gas used.
                 self.validate_benchmark_gas(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_prealloc_group.py
@@ -8,9 +8,9 @@ from unittest.mock import Mock
 import pytest
 
 from execution_testing.base_types import Address
-from execution_testing.fixtures import BaseFixture, PreAllocGroups
+from execution_testing.fixtures import PreAllocGroups
 from execution_testing.forks import Fork, Prague
-from execution_testing.specs.base import BaseTest
+from execution_testing.specs.base import BaseTest, FillResult
 from execution_testing.test_types import Environment
 from execution_testing.vm import Op
 
@@ -30,7 +30,6 @@ class MockTest(BaseTest):
         pre: Alloc,
         fork: Fork,
         genesis_environment: Environment,
-        request: Mock | None = None,
     ) -> None:
         """Initialize mock test."""
         super().__init__(  # type: ignore
@@ -38,9 +37,8 @@ class MockTest(BaseTest):
             fork=fork,
             genesis_environment=genesis_environment,
         )
-        self._request = request
 
-    def generate(self, *args: Any, **kwargs: Any) -> BaseFixture:
+    def generate(self, *args: Any, **kwargs: Any) -> FillResult:
         """Mock generate method."""
         raise NotImplementedError("This is a mock test class")
 
@@ -98,9 +96,7 @@ def test_pre_alloc_group_separate() -> None:
     mock_marker.args = ("separate",)
     mock_request.node.get_closest_marker = Mock(return_value=mock_marker)
 
-    test2 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request, fork=fork
-    )
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env2 = test2.get_genesis_environment()
     # For "separate" marker, use the node ID as the salt
     hash2 = pre.compute_pre_alloc_group_hash(
@@ -136,9 +132,7 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker1.args = ("eip1234",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
-    )
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env1 = test1.get_genesis_environment()
     hash1 = pre.compute_pre_alloc_group_hash(
         fork=fork, genesis_environment=genesis_env1, group_salt="eip1234"
@@ -154,9 +148,7 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker2.args = ("eip1234",)  # Same group
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
-    )
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env2 = test2.get_genesis_environment()
     hash2 = pre.compute_pre_alloc_group_hash(
         fork=fork, genesis_environment=genesis_env2, group_salt="eip1234"
@@ -173,9 +165,7 @@ def test_pre_alloc_group_custom_salt() -> None:
     mock_marker3.args = ("eip5678",)  # Different group
     mock_request3.node.get_closest_marker = Mock(return_value=mock_marker3)
 
-    test3 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request3, fork=fork
-    )
+    test3 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env3 = test3.get_genesis_environment()
     hash3 = pre.compute_pre_alloc_group_hash(
         fork=fork, genesis_environment=genesis_env3, group_salt="eip5678"
@@ -200,9 +190,7 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker1.args = ("separate",)
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
-    )
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env1 = test1.get_genesis_environment()
     hash1 = pre.compute_pre_alloc_group_hash(
         fork=fork,
@@ -218,9 +206,7 @@ def test_pre_alloc_group_separate_different_nodeids() -> None:
     mock_marker2.args = ("separate",)
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
-    )
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env2 = test2.get_genesis_environment()
     hash2 = pre.compute_pre_alloc_group_hash(
         fork=fork,
@@ -244,9 +230,7 @@ def test_no_pre_alloc_group_marker() -> None:
     mock_request.node.nodeid = "test_module.py::test_function"
     mock_request.node.get_closest_marker = Mock(return_value=None)  # No marker
 
-    test1 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request, fork=fork
-    )
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env1 = test1.get_genesis_environment()
     hash1 = pre.compute_pre_alloc_group_hash(
         fork=fork, genesis_environment=genesis_env1, group_salt=None
@@ -280,9 +264,7 @@ def test_pre_alloc_group_with_reason() -> None:
     }
     mock_request1.node.get_closest_marker = Mock(return_value=mock_marker1)
 
-    test1 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request1, fork=fork
-    )
+    test1 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env1 = test1.get_genesis_environment()
     hash1 = pre.compute_pre_alloc_group_hash(
         fork=fork,
@@ -299,9 +281,7 @@ def test_pre_alloc_group_with_reason() -> None:
     mock_marker2.kwargs = {"reason": "Different reason but same group"}
     mock_request2.node.get_closest_marker = Mock(return_value=mock_marker2)
 
-    test2 = MockTest(
-        pre=pre, genesis_environment=env, request=mock_request2, fork=fork
-    )
+    test2 = MockTest(pre=pre, genesis_environment=env, fork=fork)
     genesis_env2 = test2.get_genesis_environment()
     hash2 = pre.compute_pre_alloc_group_hash(
         fork=fork,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -306,7 +306,10 @@ def alloc_flags(
 
 @pytest.fixture(scope="function")
 def is_tx_gas_heavy_test(request: pytest.FixtureRequest) -> bool:
-    """Check if the test is gas-heavy for transaction execution."""
+    """
+    Check, given the test node properties, whether the test is gas-heavy
+    for transaction execution.
+    """
     node = request.node
     has_slow_marker = node.get_closest_marker("slow") is not None
     has_benchmark_marker = node.get_closest_marker("benchmark") is not None
@@ -316,11 +319,8 @@ def is_tx_gas_heavy_test(request: pytest.FixtureRequest) -> bool:
 @pytest.fixture(scope="function")
 def is_exception_test(request: pytest.FixtureRequest) -> bool:
     """
-    Check if the test is an exception test (invalid block, invalid
-    transaction).
-
-    `None` is returned if it's not possible to determine if the test is
-    negative or not. This is the case when the test is not run in pytest.
+    Check, given the test node properties, whether the test is an exception
+    test (invalid block, invalid transaction).
     """
     return request.node.get_closest_marker("exception_test") is not None
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -304,6 +304,27 @@ def alloc_flags(
     return alloc_flags_from_test_markers
 
 
+@pytest.fixture(scope="function")
+def is_tx_gas_heavy_test(request: pytest.FixtureRequest) -> bool:
+    """Check if the test is gas-heavy for transaction execution."""
+    node = request.node
+    has_slow_marker = node.get_closest_marker("slow") is not None
+    has_benchmark_marker = node.get_closest_marker("benchmark") is not None
+    return has_slow_marker or has_benchmark_marker
+
+
+@pytest.fixture(scope="function")
+def is_exception_test(request: pytest.FixtureRequest) -> bool:
+    """
+    Check if the test is an exception test (invalid block, invalid
+    transaction).
+
+    `None` is returned if it's not possible to determine if the test is
+    negative or not. This is the case when the test is not run in pytest.
+    """
+    return request.node.get_closest_marker("exception_test") is not None
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add command-line options to pytest."""
     static_filler_group = parser.getgroup(

--- a/packages/testing/src/execution_testing/execution/base.py
+++ b/packages/testing/src/execution_testing/execution/base.py
@@ -11,8 +11,18 @@ from execution_testing.forks import Fork
 from execution_testing.rpc import EngineRPC, EthRPC
 
 
+class ExecuteResult(CamelModel):
+    """
+    Result of the execute operation.
+    """
+
+    benchmark_gas_used: int | None = None
+
+
 class BaseExecute(CamelModel):
     """Represents a base execution format."""
+
+    benchmark_mode: bool = False
 
     # Base Execute class properties
     formats: ClassVar[Dict[str, Type["BaseExecute"]]] = {}
@@ -56,7 +66,7 @@ class BaseExecute(CamelModel):
         eth_rpc: EthRPC,
         engine_rpc: EngineRPC | None,
         request: FixtureRequest,
-    ) -> None:
+    ) -> ExecuteResult:
         """Execute the format."""
         pass
 

--- a/packages/testing/src/execution_testing/execution/blob_transaction.py
+++ b/packages/testing/src/execution_testing/execution/blob_transaction.py
@@ -26,7 +26,7 @@ from execution_testing.test_types.transaction_types import (
     TransactionTestMetadata,
 )
 
-from .base import BaseExecute
+from .base import BaseExecute, ExecuteResult
 
 logger = get_logger(__name__)
 
@@ -104,7 +104,7 @@ class BlobTransaction(BaseExecute):
         eth_rpc: EthRPC,
         engine_rpc: EngineRPC | None,
         request: FixtureRequest,
-    ) -> None:
+    ) -> ExecuteResult:
         """Execute the format."""
         versioned_hashes: Dict[Hash, BlobAndProofV1 | BlobAndProofV2] = {}
         sent_txs: List[Transaction] = []
@@ -140,7 +140,9 @@ class BlobTransaction(BaseExecute):
             logger.info(
                 "Engine RPC is not available, skipping getBlobsV* validation."
             )
-            return
+            return ExecuteResult(
+                benchmark_gas_used=None,
+            )
 
         version = fork.engine_get_blobs_version()
         assert version is not None, (
@@ -172,7 +174,9 @@ class BlobTransaction(BaseExecute):
                     "the client correctly returned 'null')"
                 )
                 eth_rpc.wait_for_transactions(sent_txs)
-                return
+                return ExecuteResult(
+                    benchmark_gas_used=None,
+                )
 
         assert blob_response is not None
         local_blobs_and_proofs = list(versioned_hashes.values())
@@ -250,3 +254,6 @@ class BlobTransaction(BaseExecute):
                 )
 
         eth_rpc.wait_for_transactions(sent_txs)
+        return ExecuteResult(
+            benchmark_gas_used=None,
+        )

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -20,7 +20,7 @@ from execution_testing.test_types import (
     TransactionTestMetadata,
 )
 
-from .base import BaseExecute
+from .base import BaseExecute, ExecuteResult
 
 logger = get_logger(__name__)
 
@@ -32,13 +32,6 @@ class TransactionPost(BaseExecute):
 
     blocks: List[List[Transaction]]
     post: Alloc
-    # Gas validation fields for benchmark tests
-    expected_benchmark_gas_used: int | None = (
-        None  # Expected total gas to be consumed
-    )
-    skip_gas_used_validation: bool = (
-        False  # Skip gas validation even if expected is set
-    )
 
     format_name: ClassVar[str] = "transaction_post_test"
     description: ClassVar[str] = (
@@ -78,7 +71,7 @@ class TransactionPost(BaseExecute):
         eth_rpc: EthRPC,
         engine_rpc: EngineRPC | None,
         request: FixtureRequest,
-    ) -> None:
+    ) -> ExecuteResult:
         """Execute the format."""
         del fork
         del engine_rpc
@@ -92,7 +85,8 @@ class TransactionPost(BaseExecute):
                     )
 
         # Track transaction hashes for gas validation (benchmarking)
-        all_tx_hashes = []
+        all_tx_hashes: List[Hash] = []
+        last_block_tx_hashes: List[Hash] = []
 
         for block in self.blocks:
             signed_txs: List[Transaction] = []
@@ -117,11 +111,12 @@ class TransactionPost(BaseExecute):
                     tx_index=tx_index,
                 )
                 signed_txs.append(tx)
+            current_block_tx_hashes: List[Hash] = []
             if any(tx.error is not None for tx in signed_txs):
                 for transaction in signed_txs:
                     if transaction.error is None:
                         eth_rpc.send_wait_transaction(transaction)
-                        all_tx_hashes.append(transaction.hash)
+                        current_block_tx_hashes.append(transaction.hash)
                     else:
                         logger.info(
                             f"Sending transaction expecting rejection "
@@ -138,32 +133,21 @@ class TransactionPost(BaseExecute):
             else:
                 # Send transactions (batching is handled by eth_rpc internally)
                 eth_rpc.send_wait_transactions(signed_txs)
-                all_tx_hashes.extend([tx.hash for tx in signed_txs])
+                current_block_tx_hashes = [tx.hash for tx in signed_txs]
+            all_tx_hashes.extend(current_block_tx_hashes)
+            last_block_tx_hashes = current_block_tx_hashes
 
-        # Perform gas validation if required for benchmarking
-        # Ensures benchmark tests consume exactly the expected gas
-        if (
-            not self.skip_gas_used_validation
-            and self.expected_benchmark_gas_used is not None
-        ):
-            total_gas_used = 0
-            # Fetch transaction receipts to get actual gas used
-            for tx_hash in all_tx_hashes:
+        # Fetch transaction receipts to get actual gas used
+        benchmark_gas_used: int | None = None
+        if self.benchmark_mode:
+            benchmark_gas_used = 0
+            for tx_hash in last_block_tx_hashes:
                 receipt = eth_rpc.get_transaction_receipt(tx_hash)
                 assert receipt is not None, (
                     f"Failed to get receipt for transaction {tx_hash}"
                 )
                 gas_used = int(receipt["gasUsed"], 16)
-                total_gas_used += gas_used
-
-            # Verify that the total gas consumed matches expectations
-            expected_gas = self.expected_benchmark_gas_used
-            diff = total_gas_used - expected_gas
-            assert total_gas_used == expected_gas, (
-                f"Total gas used ({total_gas_used}) does not match "
-                f"expected benchmark gas ({expected_gas}), "
-                f"difference: {diff}"
-            )
+                benchmark_gas_used += gas_used
 
         for address, account in self.post.root.items():
             balance = eth_rpc.get_balance(address)
@@ -204,3 +188,7 @@ class TransactionPost(BaseExecute):
                             f"Storage value at {key} of {address} is "
                             f"{storage_value}, expected {value}."
                         )
+
+        return ExecuteResult(
+            benchmark_gas_used=benchmark_gas_used,
+        )

--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -168,7 +168,7 @@ class BaseFixture(CamelModel):
         fixture_source_url: str,
         opcode_count: OpcodeCount | None,
         ref_spec: ReferenceSpec | None,
-        _info_metadata: Dict[str, Any],
+        _info_metadata: Dict[str, Any] | None,
     ) -> None:
         """Fill the info field for this fixture."""
         if "comment" not in self.info:

--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -29,6 +29,7 @@ from pydantic import (
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from execution_testing.base_types import CamelModel, ReferenceSpec
+from execution_testing.client_clis.cli_types import OpcodeCount
 from execution_testing.forks import Fork
 
 
@@ -152,11 +153,20 @@ class BaseFixture(CamelModel):
             dict_with_info["_info"].update(self.info)
         return dict_with_info
 
+    def model_post_init(self, __context: Any, /) -> None:
+        """
+        Model post-init to assert that the custom pre-allocation was
+        provided and the default was not used.
+        """
+        super().model_post_init(__context)
+        self.info["fixture-format"] = self.format_name
+
     def fill_info(
         self,
         t8n_version: str,
         test_case_description: str,
         fixture_source_url: str,
+        opcode_count: OpcodeCount | None,
         ref_spec: ReferenceSpec | None,
         _info_metadata: Dict[str, Any],
     ) -> None:
@@ -166,7 +176,8 @@ class BaseFixture(CamelModel):
         self.info["filling-transition-tool"] = t8n_version
         self.info["description"] = test_case_description
         self.info["url"] = fixture_source_url
-        self.info["fixture-format"] = self.format_name
+        if opcode_count is not None:
+            self.info["opcode_count"] = opcode_count.model_dump()
         if ref_spec is not None:
             ref_spec.write_info(self.info)
         if _info_metadata:

--- a/packages/testing/src/execution_testing/fixtures/tests/test_base.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_base.py
@@ -149,6 +149,7 @@ def test_base_fixtures_parsing(fixture: BaseFixture) -> None:
         "t8n-version",
         "test_case_description",
         fixture_source_url="fixture_source_url",
+        opcode_count=None,
         ref_spec=None,
         _info_metadata={},
     )

--- a/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
@@ -1060,7 +1060,9 @@ fixture_header_ones = FixtureHeader(
                 ],
             ),
             {
-                "_info": {},
+                "_info": {
+                    "fixture-format": "blockchain_test_stateful_engine",
+                },
                 "network": "Prague",
                 "postStateHash": Hash(2).hex(),
                 "lastblockhash": Hash(1).hex(),

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -22,6 +22,7 @@ def _make_fixture(nonce: int = 0) -> TransactionFixture:
         f"test description {nonce}",
         fixture_source_url="http://example.com",
         ref_spec=None,
+        opcode_count=None,
         _info_metadata={},
     )
     return fixture

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -260,7 +260,7 @@ class BaseTest(BaseModel):
         the expectation of the benchmark test.
 
         Requires the following fields to be set:
-        - _benchmark_gas_used
+        - expected_benchmark_gas_used
         - operation_mode
         """
         if self.operation_mode != OpMode.BENCHMARKING:

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -17,11 +17,12 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, PrivateAttr
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Self
 
 from execution_testing.base_types import to_hex
 from execution_testing.client_clis import Result, TransitionTool
+from execution_testing.client_clis.cli_types import OpcodeCount
 from execution_testing.execution import (
     BaseExecute,
     ExecuteFormat,
@@ -81,6 +82,17 @@ class OpMode(StrEnum):
     OPTIMIZE_GAS_POST_PROCESSING = "optimize-gas-post-processing"
 
 
+class FillResult(BaseModel):
+    """
+    Result of the filling operation, returned by the `generate` method.
+    """
+
+    fixture: BaseFixture
+    gas_optimization: int | None
+    benchmark_gas_used: int | None = None
+    benchmark_opcode_count: OpcodeCount | None = None
+
+
 class BaseTest(BaseModel):
     """
     Represents a base Ethereum test which must return a single test fixture.
@@ -88,23 +100,20 @@ class BaseTest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    tag: str = ""
     fork: Fork = (
         BaseFork  # type: ignore[type-abstract]
         # default to BaseFork to allow the filler to set it,
         # instead of each test having to set it
     )
-
-    _request: pytest.FixtureRequest | None = PrivateAttr(None)
-    _operation_mode: OpMode | None = PrivateAttr(None)
-    _gas_optimization: int | None = PrivateAttr(None)
-    _gas_optimization_max_gas_limit: int | None = PrivateAttr(None)
-
+    operation_mode: OpMode | None = None
+    gas_optimization_max_gas_limit: int | None = None
     expected_benchmark_gas_used: int | None = None
     skip_gas_used_validation: bool = False
+    is_tx_gas_heavy_test: bool = False
+    is_exception_test: bool = False
 
+    # Class variables, to be set by subclasses
     spec_types: ClassVar[Dict[str, Type["BaseTest"]]] = {}
-
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
     ] = []
@@ -142,6 +151,12 @@ class BaseTest(BaseModel):
         Register all subclasses of BaseFixture with a fixture format name set
         as possible fixture formats.
         """
+        super().__pydantic_init_subclass__(**kwargs)
+
+        # Don't register dynamically generated wrapper classes
+        if getattr(cls, "__is_base_test_wrapper__", False):
+            return
+
         if cls.pytest_parameter_name():
             # Register the new fixture format
             BaseTest.spec_types[cls.pytest_parameter_name()] = cls
@@ -154,16 +169,10 @@ class BaseTest(BaseModel):
         **kwargs: Any,
     ) -> Self:
         """Create a test in a different format from a base test."""
-        new_instance = cls(
-            tag=base_test.tag,
-            fork=base_test.fork,
-            expected_benchmark_gas_used=base_test.expected_benchmark_gas_used,
-            skip_gas_used_validation=base_test.skip_gas_used_validation,
-            **kwargs,
-        )
-        new_instance._request = base_test._request
-        new_instance._operation_mode = base_test._operation_mode
-        return new_instance
+        for k in BaseTest.model_fields.keys():
+            if k not in kwargs:
+                kwargs[k] = getattr(base_test, k)
+        return cls(**kwargs)
 
     @classmethod
     def discard_execute_format_by_marks(
@@ -185,8 +194,8 @@ class BaseTest(BaseModel):
         *,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
-        """Generate the list of test fixtures."""
+    ) -> FillResult:
+        """Generate the test fixture using the given fixture format."""
         pass
 
     def execute(
@@ -211,48 +220,13 @@ class BaseTest(BaseModel):
             lambda x, y: x + ("_" if y.isupper() else "") + y, cls.__name__
         ).lower()
 
-    def is_tx_gas_heavy_test(self) -> bool:
-        """Check if the test is gas-heavy for transaction execution."""
-        if self._request is not None and hasattr(self._request, "node"):
-            node = self._request.node
-            has_slow_marker = node.get_closest_marker("slow") is not None
-            has_benchmark_marker = (
-                node.get_closest_marker("benchmark") is not None
-            )
-            return has_slow_marker or has_benchmark_marker
-        return False
-
-    def is_exception_test(self) -> bool | None:
-        """
-        Check if the test is an exception test (invalid block, invalid
-        transaction).
-
-        `None` is returned if it's not possible to determine if the test is
-        negative or not. This is the case when the test is not run in pytest.
-        """
-        if self._request is not None and hasattr(self._request, "node"):
-            return (
-                self._request.node.get_closest_marker("exception_test")
-                is not None
-            )
-        return None
-
-    def node(self) -> pytest.Item | pytest.Function | None:
-        """Return the pytest node of the test."""
-        if self._request is not None and hasattr(self._request, "node"):
-            return self._request.node
-        return None
-
     def check_exception_test(
         self,
         *,
         exception: bool,
     ) -> None:
         """Compare the test marker against the outcome of the test."""
-        negative_test_marker = self.is_exception_test()
-        if negative_test_marker is None:
-            return
-        if negative_test_marker != exception:
+        if self.is_exception_test != exception:
             if exception:
                 raise Exception(
                     "Test produced an invalid block or transaction but was "
@@ -276,6 +250,42 @@ class BaseTest(BaseModel):
         raise NotImplementedError(
             f"{self.__class__.__name__} must implement genesis environment "
             "access for use with pre-allocation groups."
+        )
+
+    def validate_benchmark_gas(
+        self, *, benchmark_gas_used: int | None, gas_benchmark_value: int
+    ) -> None:
+        """
+        Validates the total consumed gas of the last block in the test matches
+        the expectation of the benchmark test.
+
+        Requires the following fields to be set:
+        - _benchmark_gas_used
+        - operation_mode
+        """
+        if self.operation_mode != OpMode.BENCHMARKING:
+            return
+        assert benchmark_gas_used is not None, "_benchmark_gas_used is not set"
+        # Perform gas validation if required for benchmarking.
+        # Ensures benchmark tests consume exactly the expected gas.
+        if not self.skip_gas_used_validation:
+            # Verify that the total gas consumed in the last block
+            # matches expectations
+            expected_benchmark_gas_used = self.expected_benchmark_gas_used
+            if expected_benchmark_gas_used is None:
+                expected_benchmark_gas_used = gas_benchmark_value
+            diff = benchmark_gas_used - expected_benchmark_gas_used
+            assert benchmark_gas_used == expected_benchmark_gas_used, (
+                f"Total gas used ({benchmark_gas_used}) does not "
+                "match expected benchmark gas "
+                f"({expected_benchmark_gas_used}), "
+                f"difference: {diff}"
+            )
+        # Gas used should never exceed the maximum benchmark gas allowed.
+        assert benchmark_gas_used <= gas_benchmark_value, (
+            f"benchmark_gas_used ({benchmark_gas_used}) exceeds maximum "
+            "benchmark gas allowed for this configuration: "
+            f"{gas_benchmark_value}"
         )
 
 

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -31,7 +31,6 @@ from execution_testing.execution import (
     TransactionPost,
 )
 from execution_testing.fixtures import (
-    BaseFixture,
     BlockchainEngineFixture,
     BlockchainEngineXFixture,
     BlockchainFixture,
@@ -42,7 +41,7 @@ from execution_testing.forks import Fork
 from execution_testing.test_types import Alloc, Environment, Transaction
 from execution_testing.vm import Bytecode, Op
 
-from .base import BaseTest
+from .base import BaseTest, FillResult
 from .blockchain import Block, BlockchainTest
 
 
@@ -528,14 +527,13 @@ class BenchmarkTest(BaseTest):
         self,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
+    ) -> FillResult:
         """Generate the blockchain test fixture."""
         self.check_exception_test(
             exception=self.tx.error is not None if self.tx else False
         )
         if fixture_format in BlockchainTest.supported_fixture_formats:
-            blockchain_test = self.generate_blockchain_test()
-            fixture = blockchain_test.generate(
+            fill_result = self.generate_blockchain_test().generate(
                 t8n=t8n, fixture_format=fixture_format
             )
 
@@ -545,9 +543,9 @@ class BenchmarkTest(BaseTest):
                 and self.fixed_opcode_count is not None
             ):
                 self._verify_target_opcode_count(
-                    blockchain_test._benchmark_opcode_count
+                    fill_result.benchmark_opcode_count
                 )
-            return fixture
+            return fill_result
         else:
             raise Exception(f"Unsupported fixture format: {fixture_format}")
 
@@ -562,6 +560,7 @@ class BenchmarkTest(BaseTest):
             return TransactionPost(
                 blocks=[block.txs for block in self.blocks],
                 post=self.post,
+                benchmark_mode=True,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/packages/testing/src/execution_testing/specs/blobs.py
+++ b/packages/testing/src/execution_testing/specs/blobs.py
@@ -7,7 +7,6 @@ from execution_testing.base_types.base_types import Hash
 from execution_testing.client_clis import TransitionTool
 from execution_testing.execution import BaseExecute, BlobTransaction
 from execution_testing.fixtures import (
-    BaseFixture,
     FixtureFormat,
 )
 from execution_testing.test_types import (
@@ -15,7 +14,7 @@ from execution_testing.test_types import (
     Transaction,
 )
 
-from .base import BaseTest, ExecuteFormat, LabeledExecuteFormat
+from .base import BaseTest, ExecuteFormat, FillResult, LabeledExecuteFormat
 
 
 class BlobsTest(BaseTest):
@@ -38,7 +37,7 @@ class BlobsTest(BaseTest):
         *,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
+    ) -> FillResult:
         """Generate the list of test fixtures."""
         del t8n
         raise Exception(f"Unknown fixture format: {fixture_format}")

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -17,7 +17,6 @@ import pytest
 from pydantic import (
     ConfigDict,
     Field,
-    PrivateAttr,
     field_validator,
     model_serializer,
 )
@@ -89,7 +88,7 @@ from execution_testing.test_types.block_access_list import (
     BlockAccessListExpectation,
 )
 
-from .base import BaseTest, OpMode, verify_result
+from .base import BaseTest, FillResult, OpMode, verify_result
 from .debugging import print_traces
 from .helpers import verify_block, verify_transactions
 
@@ -516,8 +515,6 @@ class BlockchainTest(BaseTest):
     Include transaction receipts in the fixture output.
     """
 
-    _benchmark_opcode_count: OpcodeCount | None = PrivateAttr(None)
-
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
     ] = [
@@ -613,7 +610,6 @@ class BlockchainTest(BaseTest):
         block: Block,
         previous_env: Environment,
         previous_alloc: Alloc | LazyAlloc,
-        last_block: bool,
     ) -> BuiltBlock:
         """
         Generate common block data for both make_fixture and make_hive_fixture.
@@ -646,7 +642,7 @@ class BlockchainTest(BaseTest):
                 ),
                 blob_schedule=self.fork.blob_schedule(),
             ),
-            slow_request=self.is_tx_gas_heavy_test(),
+            slow_request=self.is_tx_gas_heavy_test,
         )
 
         # One special case of the invalid transactions is the blob gas used,
@@ -686,25 +682,6 @@ class BlockchainTest(BaseTest):
                 raise Exception(
                     f"Verification of block {int(env.number)} failed"
                 ) from e
-
-        if last_block and self._operation_mode == OpMode.BENCHMARKING:
-            expected_benchmark_gas_used = self.expected_benchmark_gas_used
-            assert expected_benchmark_gas_used is not None, (
-                "expected_benchmark_gas_used is not set"
-            )
-            gas_used = int(transition_tool_output.result.gas_used)
-
-            if not self.skip_gas_used_validation:
-                diff = gas_used - expected_benchmark_gas_used
-                assert gas_used == expected_benchmark_gas_used, (
-                    f"gas_used ({gas_used}) does not match "
-                    f"expected_benchmark_gas_used "
-                    f"({expected_benchmark_gas_used}), difference: {diff}"
-                )
-
-            self._benchmark_opcode_count = (
-                transition_tool_output.result.opcode_count
-            )
 
         requests_list: List[Bytes] | None = None
         if self.fork.header_requests_required(
@@ -862,7 +839,7 @@ class BlockchainTest(BaseTest):
     def make_fixture(
         self,
         t8n: TransitionTool,
-    ) -> BlockchainFixture:
+    ) -> FillResult:
         """Create a fixture from the blockchain test definition."""
         fixture_blocks: List[FixtureBlock | InvalidFixtureBlock] = []
 
@@ -873,6 +850,8 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head = genesis.header.block_hash
         invalid_blocks = 0
+        benchmark_gas_used: int | None = None
+        benchmark_opcode_count: OpcodeCount | None = None
         for i, block in enumerate(self.blocks):
             is_last_block = i == len(self.blocks) - 1
             # This is the most common case, the RLP needs to be constructed
@@ -883,8 +862,10 @@ class BlockchainTest(BaseTest):
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
-                last_block=is_last_block,
             )
+            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
+                benchmark_gas_used = int(built_block.result.gas_used)
+                benchmark_opcode_count = built_block.result.opcode_count
             include_receipts = (
                 block.include_receipts_in_output
                 if block.include_receipts_in_output is not None
@@ -919,10 +900,7 @@ class BlockchainTest(BaseTest):
         self.check_exception_test(exception=invalid_blocks > 0)
         alloc = alloc.get() if isinstance(alloc, LazyAlloc) else alloc
         self.verify_post_state(t8n, t8n_state=alloc)
-        info = {}
-        if t8n.opcode_count is not None:
-            info["opcode_count"] = t8n.opcode_count.model_dump()
-        return BlockchainFixture(
+        fixture = BlockchainFixture(
             fork=self.fork,
             genesis=genesis.header,
             genesis_rlp=genesis.rlp,
@@ -942,18 +920,19 @@ class BlockchainTest(BaseTest):
                 ),
                 chain_id=self.chain_id,
             ),
-            info=info,
+        )
+        return FillResult(
+            fixture=fixture,
+            gas_optimization=None,
+            benchmark_gas_used=benchmark_gas_used,
+            benchmark_opcode_count=benchmark_opcode_count,
         )
 
     def make_hive_fixture(
         self,
         t8n: TransitionTool,
         fixture_format: FixtureFormat = BlockchainEngineFixture,
-    ) -> (
-        BlockchainEngineFixture
-        | BlockchainEngineXFixture
-        | BlockchainEngineSyncFixture
-    ):
+    ) -> FillResult:
         """Create a hive fixture from the blocktest definition."""
         fixture_payloads: List[FixtureEngineNewPayload] = []
 
@@ -966,14 +945,19 @@ class BlockchainTest(BaseTest):
         env = environment_from_parent_header(genesis.header)
         head_hash = genesis.header.block_hash
         invalid_blocks = 0
+        benchmark_gas_used: int | None = None
+        benchmark_opcode_count: OpcodeCount | None = None
         for i, block in enumerate(self.blocks):
+            is_last_block = i == len(self.blocks) - 1
             built_block = self.generate_block_data(
                 t8n=t8n,
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
-                last_block=i == len(self.blocks) - 1,
             )
+            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
+                benchmark_gas_used = int(built_block.result.gas_used)
+                benchmark_opcode_count = built_block.result.opcode_count
             fixture_payloads.append(
                 built_block.get_fixture_engine_new_payload()
             )
@@ -1007,9 +991,6 @@ class BlockchainTest(BaseTest):
         self.verify_post_state(t8n, t8n_state=alloc)
 
         # Create base fixture data, common to all fixture formats
-        info = {}
-        if t8n.opcode_count is not None:
-            info["opcode_count"] = t8n.opcode_count.model_dump()
         fixture_data = {
             "fork": self.fork,
             "genesis": genesis.header,
@@ -1025,10 +1006,10 @@ class BlockchainTest(BaseTest):
                     self.fork.blob_schedule()
                 ),
             ),
-            "info": info,
         }
 
         # Add format-specific fields
+        fixture: BaseFixture
         if fixture_format == BlockchainEngineXFixture:
             # For Engine X format, exclude pre (will be provided via shared
             # state) and prepare for state diff optimization
@@ -1040,7 +1021,7 @@ class BlockchainTest(BaseTest):
                     "pre_hash": "",  # Will be set by BaseTestWrapper
                 }
             )
-            return BlockchainEngineXFixture(**fixture_data)
+            fixture = BlockchainEngineXFixture(**fixture_data)
         elif fixture_format == BlockchainEngineSyncFixture:
             # Sync fixture format
             assert genesis.header.block_hash != head_hash, (
@@ -1055,7 +1036,6 @@ class BlockchainTest(BaseTest):
                 block=Block(),
                 previous_env=env,
                 previous_alloc=alloc,
-                last_block=False,
             )
             fixture_data.update(
                 {
@@ -1068,7 +1048,7 @@ class BlockchainTest(BaseTest):
                     else None,
                 }
             )
-            return BlockchainEngineSyncFixture(**fixture_data)
+            fixture = BlockchainEngineSyncFixture(**fixture_data)
         else:
             # Standard engine fixture
             fixture_data.update(
@@ -1079,13 +1059,20 @@ class BlockchainTest(BaseTest):
                     else None,
                 }
             )
-            return BlockchainEngineFixture(**fixture_data)
+            fixture = BlockchainEngineFixture(**fixture_data)
+
+        return FillResult(
+            fixture=fixture,
+            gas_optimization=None,
+            benchmark_gas_used=benchmark_gas_used,
+            benchmark_opcode_count=benchmark_opcode_count,
+        )
 
     def generate(
         self,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
+    ) -> FillResult:
         """Generate the BlockchainTest fixture."""
         if fixture_format in [
             BlockchainEngineFixture,
@@ -1110,14 +1097,14 @@ class BlockchainTest(BaseTest):
                 blocks += [block.txs]
             # Pass gas validation params for benchmark tests
             # If not benchmark mode, skip gas used validation
-            if self._operation_mode != OpMode.BENCHMARKING:
+            if self.operation_mode != OpMode.BENCHMARKING:
                 self.skip_gas_used_validation = True
 
+            benchmark_mode = self.operation_mode == OpMode.BENCHMARKING
             return TransactionPost(
                 blocks=blocks,
                 post=self.post,
-                expected_benchmark_gas_used=self.expected_benchmark_gas_used,
-                skip_gas_used_validation=self.skip_gas_used_validation,
+                benchmark_mode=benchmark_mode,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -33,7 +33,6 @@ from execution_testing.execution import (
     TransactionPost,
 )
 from execution_testing.fixtures import (
-    BaseFixture,
     FixtureFormat,
     LabeledFixtureFormat,
     StateFixture,
@@ -57,7 +56,7 @@ from execution_testing.test_types import (
     Transaction,
 )
 
-from .base import BaseTest, OpMode
+from .base import BaseTest, FillResult, OpMode
 from .blockchain import Block, BlockchainTest, Header
 from .debugging import print_traces
 from .helpers import verify_transactions
@@ -153,7 +152,7 @@ class StateTest(BaseTest):
                 blob_schedule=fork.blob_schedule(),
                 state_test=True,
             ),
-            slow_request=self.is_tx_gas_heavy_test(),
+            slow_request=self.is_tx_gas_heavy_test,
         )
         modified_traces = modified_tool_output.result.traces
         assert modified_traces is not None, (
@@ -337,7 +336,7 @@ class StateTest(BaseTest):
     def make_state_test_fixture(
         self,
         t8n: TransitionTool,
-    ) -> StateFixture:
+    ) -> FillResult:
         """Create a fixture from the state test definition."""
         # We can't generate a state test fixture that names a transition fork,
         # so we get the fork at the block number and timestamp of the state
@@ -366,7 +365,7 @@ class StateTest(BaseTest):
                 blob_schedule=fork.blob_schedule(),
                 state_test=True,
             ),
-            slow_request=self.is_tx_gas_heavy_test(),
+            slow_request=self.is_tx_gas_heavy_test,
         )
         output_alloc = transition_tool_output.alloc.get()
 
@@ -388,12 +387,14 @@ class StateTest(BaseTest):
             pprint(output_alloc)
             raise e
 
+        gas_optimization: int | None = None
+
         if (
-            self._operation_mode == OpMode.OPTIMIZE_GAS
-            or self._operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
+            self.operation_mode == OpMode.OPTIMIZE_GAS
+            or self.operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
         ):
             enable_post_processing = (
-                self._operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
+                self.operation_mode == OpMode.OPTIMIZE_GAS_POST_PROCESSING
             )
             base_tool_output = transition_tool_output
             base_tool_alloc = base_tool_output.alloc.get()
@@ -434,13 +435,13 @@ class StateTest(BaseTest):
                     else:
                         minimum_gas_limit = current_gas_limit + 1
                         if (
-                            self._gas_optimization_max_gas_limit is not None
+                            self.gas_optimization_max_gas_limit is not None
                             and minimum_gas_limit
-                            > self._gas_optimization_max_gas_limit
+                            > self.gas_optimization_max_gas_limit
                         ):
                             raise Exception(
                                 "Requires more than the minimum "
-                                f"{self._gas_optimization_max_gas_limit} "
+                                f"{self.gas_optimization_max_gas_limit} "
                                 "wanted."
                             )
 
@@ -454,23 +455,10 @@ class StateTest(BaseTest):
                     env=env,
                     enable_post_processing=enable_post_processing,
                 )
-                self._gas_optimization = current_gas_limit
+                gas_optimization = current_gas_limit
             else:
                 raise Exception("Impossible to compare.")
 
-        if self._operation_mode == OpMode.BENCHMARKING:
-            expected_benchmark_gas_used = self.expected_benchmark_gas_used
-            assert expected_benchmark_gas_used is not None, (
-                "expected_benchmark_gas_used is not set"
-            )
-            gas_used = int(transition_tool_output.result.gas_used)
-            if not self.skip_gas_used_validation:
-                diff = gas_used - expected_benchmark_gas_used
-                assert gas_used == expected_benchmark_gas_used, (
-                    f"gas_used ({gas_used}) does not match "
-                    f"expected_benchmark_gas_used "
-                    f"({expected_benchmark_gas_used}), difference: {diff}"
-                )
         if len(transition_tool_output.result.receipts) == 1:
             receipt = FixtureTransactionReceipt.from_transaction_receipt(
                 transition_tool_output.result.receipts[0], tx
@@ -487,7 +475,7 @@ class StateTest(BaseTest):
         else:
             receipt = None
 
-        return StateFixture(
+        fixture = StateFixture(
             env=FixtureEnvironment(**env.model_dump(exclude_none=True)),
             pre=pre_alloc,
             post={
@@ -510,6 +498,12 @@ class StateTest(BaseTest):
                 chain_id=self.chain_id,
             ),
         )
+        return FillResult(
+            fixture=fixture,
+            gas_optimization=gas_optimization,
+            benchmark_gas_used=transition_tool_output.result.gas_used,
+            benchmark_opcode_count=transition_tool_output.result.opcode_count,
+        )
 
     def get_genesis_environment(self) -> Environment:
         """Get the genesis environment for pre-allocation groups."""
@@ -519,7 +513,7 @@ class StateTest(BaseTest):
         self,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
+    ) -> FillResult:
         """Generate the BlockchainTest fixture."""
         self.check_exception_test(exception=self.tx.error is not None)
         if fixture_format in BlockchainTest.supported_fixture_formats:
@@ -540,13 +534,13 @@ class StateTest(BaseTest):
         if execute_format == TransactionPost:
             # Pass gas validation params for benchmark tests
             # If not benchmark mode, skip gas used validation
-            if self._operation_mode != OpMode.BENCHMARKING:
+            if self.operation_mode != OpMode.BENCHMARKING:
                 self.skip_gas_used_validation = True
+            benchmark_mode = self.operation_mode == OpMode.BENCHMARKING
             return TransactionPost(
                 blocks=[[self.tx]],
                 post=self.post,
-                expected_benchmark_gas_used=self.expected_benchmark_gas_used,
-                skip_gas_used_validation=self.skip_gas_used_validation,
+                benchmark_mode=benchmark_mode,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/packages/testing/src/execution_testing/specs/tests/test_expect.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_expect.py
@@ -74,11 +74,17 @@ def fork() -> Fork:  # noqa: D103
 
 
 @pytest.fixture
+def is_exception_test() -> bool:  # noqa: D103
+    return False
+
+
+@pytest.fixture
 def state_test(  # noqa: D103
     pre: Mapping[Any, Any],
     post: Mapping[Any, Any],
     tx: Transaction,
     fork: Fork,
+    is_exception_test: bool,
 ) -> StateTest:
     return StateTest(
         env=Environment(),
@@ -86,6 +92,7 @@ def state_test(  # noqa: D103
         post=post,
         tx=tx,
         fork=fork,
+        is_exception_test=is_exception_test,
     )
 
 
@@ -368,7 +375,7 @@ def test_post_account_mismatch(
 
 # Transaction result mismatch tests
 @pytest.mark.parametrize(
-    "tx,exception_type",
+    "tx,exception_type,is_exception_test",
     [
         pytest.param(
             Transaction(
@@ -377,6 +384,7 @@ def test_post_account_mismatch(
                 error=TransactionException.SENDER_NOT_EOA,
             ),
             ExecutionExceptionMismatchError,
+            True,
             id="TransactionExecutionExceptionMismatchError",
         ),
         pytest.param(
@@ -388,6 +396,7 @@ def test_post_account_mismatch(
                 ),
             ),
             UnexpectedExecutionSuccessError,
+            True,
             id="TransactionUnexpectedExecutionSuccessError",
         ),
         pytest.param(
@@ -399,6 +408,7 @@ def test_post_account_mismatch(
                 ),
             ),
             UnexpectedExecutionFailError,
+            False,
             id="TransactionUnexpectedExecutionFailError",
         ),
         pytest.param(
@@ -409,6 +419,7 @@ def test_post_account_mismatch(
                 ),
             ),
             TransactionReceiptMismatchError,
+            False,
             id="TransactionReceiptMismatchError",
         ),
         pytest.param(
@@ -420,6 +431,7 @@ def test_post_account_mismatch(
                 ),
             ),
             UnexpectedExecutionFailError,
+            False,
             id="TransactionUnexpectedExecutionFailError+TransactionReceiptMismatchError",
         ),
         pytest.param(
@@ -431,6 +443,7 @@ def test_post_account_mismatch(
                 ),
             ),
             UnexpectedExecutionSuccessError,
+            True,
             id="TransactionUnexpectedExecutionSuccessError+TransactionReceiptMismatchError",
         ),
     ],

--- a/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
@@ -108,14 +108,17 @@ def test_make_genesis(  # noqa: D103
         }
     )
 
-    fixture = BlockchainTest(
-        fork=fork,
-        genesis_environment=env,
-        pre=pre,
-        post={},
-        blocks=[],
-        tag="some_state_test",
-    ).generate(t8n=default_t8n, fixture_format=BlockchainFixture)
+    fixture = (
+        BlockchainTest(
+            fork=fork,
+            genesis_environment=env,
+            pre=pre,
+            post={},
+            blocks=[],
+        )
+        .generate(t8n=default_t8n, fixture_format=BlockchainFixture)
+        .fixture
+    )
     assert isinstance(fixture, BlockchainFixture)
     assert fixture.genesis is not None
 
@@ -193,14 +196,17 @@ def test_fill_state_test(
         ),
     }
 
-    generated_fixture = StateTest(
-        fork=fork,
-        env=env,
-        pre=pre,
-        post=post,
-        tx=tx,
-        tag="my_chain_id_test",
-    ).generate(t8n=default_t8n, fixture_format=fixture_format)
+    generated_fixture = (
+        StateTest(
+            fork=fork,
+            env=env,
+            pre=pre,
+            post=post,
+            tx=tx,
+        )
+        .generate(t8n=default_t8n, fixture_format=fixture_format)
+        .fixture
+    )
     assert generated_fixture.__class__ == fixture_format
     fixture_key = f"000/my_chain_id_test/{fork}/tx_type_{tx_type}"
     fixture = {
@@ -521,14 +527,17 @@ class TestFillBlockchainValidTxs:
         fixture_format: FixtureFormat,
         default_t8n: TransitionTool,
     ) -> BaseFixture:
-        return BlockchainTest(
-            fork=fork,
-            pre=pre,
-            post=post,
-            blocks=blocks,
-            genesis_environment=genesis_environment,
-            tag="my_blockchain_test_valid_txs",
-        ).generate(t8n=default_t8n, fixture_format=fixture_format)
+        return (
+            BlockchainTest(
+                fork=fork,
+                pre=pre,
+                post=post,
+                blocks=blocks,
+                genesis_environment=genesis_environment,
+            )
+            .generate(t8n=default_t8n, fixture_format=fixture_format)
+            .fixture
+        )
 
     @pytest.mark.parametrize("fork", [London, Shanghai], indirect=True)
     def test_fill_blockchain_valid_txs(  # noqa: D102
@@ -922,13 +931,18 @@ def test_fill_blockchain_invalid_txs(
     fixture_format: FixtureFormat = (
         BlockchainEngineFixture if check_hive else BlockchainFixture
     )
-    generated_fixture = BlockchainTest(
-        fork=fork,
-        pre=pre,
-        post=post,
-        blocks=blocks,
-        genesis_environment=genesis_environment,
-    ).generate(t8n=default_t8n, fixture_format=fixture_format)
+    generated_fixture = (
+        BlockchainTest(
+            fork=fork,
+            pre=pre,
+            post=post,
+            blocks=blocks,
+            genesis_environment=genesis_environment,
+            is_exception_test=True,
+        )
+        .generate(t8n=default_t8n, fixture_format=fixture_format)
+        .fixture
+    )
     assert generated_fixture.__class__ == fixture_format
     # BlockchainEngineFixture inherits from BlockchainEngineFixtureCommon
     # (not BlockchainFixtureCommon)

--- a/packages/testing/src/execution_testing/specs/tests/test_transaction.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_transaction.py
@@ -27,12 +27,16 @@ def test_transaction_test_filling(
     name: str, tx: Transaction, fork: Fork
 ) -> None:
     """Test the transaction test filling."""
-    generated_fixture = TransactionTest(
-        tx=tx.with_signature_and_sender(),
-        fork=fork,
-    ).generate(
-        t8n=None,  # type: ignore
-        fixture_format=TransactionFixture,
+    generated_fixture = (
+        TransactionTest(
+            tx=tx.with_signature_and_sender(),
+            fork=fork,
+        )
+        .generate(
+            t8n=None,  # type: ignore
+            fixture_format=TransactionFixture,
+        )
+        .fixture
     )
     assert generated_fixture.__class__ == TransactionFixture
     fixture_json_dict = generated_fixture.json_dict_with_info()

--- a/packages/testing/src/execution_testing/specs/transaction.py
+++ b/packages/testing/src/execution_testing/specs/transaction.py
@@ -10,7 +10,6 @@ from execution_testing.execution import (
     TransactionPost,
 )
 from execution_testing.fixtures import (
-    BaseFixture,
     FixtureFormat,
     LabeledFixtureFormat,
     TransactionFixture,
@@ -18,7 +17,7 @@ from execution_testing.fixtures import (
 from execution_testing.fixtures.transaction import FixtureResult
 from execution_testing.test_types import Alloc, Transaction
 
-from .base import BaseTest
+from .base import BaseTest, FillResult, OpMode
 
 
 class TransactionTest(BaseTest):
@@ -44,7 +43,7 @@ class TransactionTest(BaseTest):
 
     def make_transaction_test_fixture(
         self,
-    ) -> TransactionFixture:
+    ) -> FillResult:
         """Create a fixture from the transaction test definition."""
         if self.tx.error is not None:
             result = FixtureResult(
@@ -70,18 +69,24 @@ class TransactionTest(BaseTest):
                 sender=self.tx.sender,
             )
 
-        return TransactionFixture(
+        fixture = TransactionFixture(
             result={
                 self.fork: result,
             },
             transaction=self.tx.with_signature_and_sender().rlp(),
+        )
+        return FillResult(
+            fixture=fixture,
+            gas_optimization=None,
+            benchmark_gas_used=None,
+            benchmark_opcode_count=None,
         )
 
     def generate(
         self,
         t8n: TransitionTool,
         fixture_format: FixtureFormat,
-    ) -> BaseFixture:
+    ) -> FillResult:
         """Generate the TransactionTest fixture."""
         del t8n
 
@@ -98,9 +103,11 @@ class TransactionTest(BaseTest):
     ) -> BaseExecute:
         """Execute the transaction test by sending it to the live network."""
         if execute_format == TransactionPost:
+            benchmark_mode = self.operation_mode == OpMode.BENCHMARKING
             return TransactionPost(
                 blocks=[[self.tx]],
                 post={},
+                benchmark_mode=benchmark_mode,
             )
         raise Exception(f"Unsupported execute format: {execute_format}")
 

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas.py
@@ -332,7 +332,6 @@ def test_correct_excess_blob_gas_calculation(
         post=post,
         blocks=blocks,
         genesis_environment=env,
-        tag=f"expected_excess_blob_gas:{hex(correct_excess_blob_gas)}",
     )
 
 
@@ -399,7 +398,6 @@ def test_correct_increasing_blob_gas_costs(
         post=post,
         blocks=blocks,
         genesis_environment=env,
-        tag=f"expected_excess_blob_gas:{hex(correct_excess_blob_gas)}",
     )
 
 
@@ -431,7 +429,6 @@ def test_correct_decreasing_blob_gas_costs(
         post=post,
         blocks=blocks,
         genesis_environment=env,
-        tag=f"expected_excess_blob_gas:{hex(correct_excess_blob_gas)}",
     )
 
 
@@ -466,12 +463,6 @@ def test_invalid_zero_excess_blob_gas_in_header(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -517,12 +508,6 @@ def test_invalid_blob_gas_used_in_header(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(new_blobs * blob_gas_per_blob)}",
-                f"header:{hex(header_blob_gas_used)}",
-            ]
-        ),
     )
 
 
@@ -573,12 +558,6 @@ def test_invalid_excess_blob_gas_above_target_change(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -617,12 +596,6 @@ def test_invalid_static_excess_blob_gas(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(parent_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -662,12 +635,6 @@ def test_invalid_excess_blob_gas_target_blobs_increase_from_zero(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -707,12 +674,6 @@ def test_invalid_static_excess_blob_gas_from_zero_on_blobs_above_target(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -761,12 +722,6 @@ def test_invalid_excess_blob_gas_change(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -814,12 +769,6 @@ def test_invalid_negative_excess_blob_gas(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )
 
 
@@ -867,10 +816,4 @@ def test_invalid_non_multiple_excess_blob_gas(
         post={},
         blocks=blocks,
         genesis_environment=env,
-        tag="-".join(
-            [
-                f"correct:{hex(correct_excess_blob_gas)}",
-                f"header:{hex(header_excess_blob_gas)}",
-            ]
-        ),
     )

--- a/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
+++ b/tests/shanghai/eip3651_warm_coinbase/test_warm_coinbase.py
@@ -119,7 +119,6 @@ def test_warm_coinbase_call_out_of_gas(
         pre=pre,
         post=post,
         tx=tx,
-        tag="opcode_" + opcode,
     )
 
 
@@ -205,5 +204,4 @@ def test_warm_coinbase_gas_usage(
         pre=pre,
         post=post,
         tx=tx,
-        tag="opcode_" + opcode.lower(),
     )

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -356,7 +356,6 @@ class TestMultipleWithdrawalsSameAddress:
     def test_multiple_withdrawals_same_address(
         self,
         blockchain_test: BlockchainTestFiller,
-        test_case: str,
         pre: Alloc,
         addresses: List[Address],
         blocks: List[Block],
@@ -372,7 +371,7 @@ class TestMultipleWithdrawalsSameAddress:
                 storage={},
             )
 
-        blockchain_test(pre=pre, post=post, blocks=blocks, tag=test_case)
+        blockchain_test(pre=pre, post=post, blocks=blocks)
 
 
 def test_many_withdrawals(
@@ -710,7 +709,6 @@ def test_zero_amount(
         # to allow for Account.NONEXISTENT
         post=post,
         blocks=[Block(withdrawals=withdrawals)],
-        tag=test_case.value,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description

This PR refactors the fill/execute processes to enable reuse of verification logic across both modes.

### Remove Mutable Fields from `BaseTest`

This PR removes all fields from `BaseTest` that were mutated as part of `generate` or `execute` and were (incorrectly) used as implicit outputs of those methods. These fields represented runtime-derived state rather than declarative test specification.

Removed fields:

- `_gas_optimization`: Previously used to store the result of the gas optimization process.
- `_opcode_count`: Output of opcode counting from the t8n tool (moved to the T8N class).
- `t8n_dump_dir`: Output directory for dumping state transition results (moved to the T8N class).
- `t8n_call_counter`: Counter tracking how many times the test invoked the t8n tool (moved to the T8N class).

Other removed fields:
- `_request`: Previously used for test introspection.
- `tag`: Unused leftover field from pre-pytest logic.

New input fields that supersede the removed ones:

- `operation_mode`: Set by the filler or executor and used by the test to determine whether benchmark or gas optimization modes are enabled.
- `is_tx_gas_heavy_test`/`is_exception_test`: Replace the previous introspection logic based on `_request`. These are now explicitly set by the filler or executor.

### Introduce `FillResult` and `ExecuteResult`

This PR introduces `FillResult` and `ExecuteResult`, which encapsulate the outputs of the `generate`/`execute` methods when used by fill and execute, respectively.

By returning structured result objects instead of mutating spec fields, the test specification becomes reusable across execution modes. This also allows benchmark validation logic to be extracted from the test spec classes and shared between `fill` and `execute`.

The change was motivated by this comment: https://github.com/ethereum/execution-specs/pull/2203#discussion_r2802420845
where we had different logic for the verification in `StateTest` and `BlockchainTest`.


### Abstract T8N Information Away from the Specs

This PR makes the distinction between `session_t8n` and `t8n`:
- `session_t8n`: A global instance shared across all tests executed within a process.
- `t8n`: A per-test configured instance derived from `session_t8n`.

At the start of each test, the t8n instance is prepared with the following setup:
- The opcode counter is reset
- The debug output path (if configured) is set for the specific test.
- The execution counter is reset to zero.

This removes t8n-related runtime state from the test specification and centralizes it within the T8N instance, and it's now responsibility of the filler or executor to properly extract and use the information.

 ### Fix Bug that Re-Wrapped Spec Class in Fill and Execute

The `BaseTest.__pydantic_init_subclass__` method now verifies that newly created subclasses are not wrapper classes generated by `base_test_parametrizer_func`.

Previously, dynamically created `BaseTestWrapper` subclasses would overwrite entries in `BaseTest.spec_types`, causing classes to be re-wrapped unintentionally.

This issue only manifested when the filler plugin was imported multiple times within the same process (e.g., during unit tests or pre-alloc grouping phase 1 execution). In those cases, tests could be executed twice because `__init__` was effectively re-entering due to repeated wrapping, and also caused multiple tests to reuse the same T8N instance that was configured for another test, causing unintended state-sharing.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1076432222/photo/siamese-kitten.jpg?s=612x612&w=0&k=20&c=KjJzsMuiJYBzlxDpVeOBv9bYcjZQlnEd7W-dP7oEUh0=)
