### PR TITLE
feat(test-benchmark): add dependency mode for benchmark

### DIFF
--- a/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
+++ b/packages/testing/src/execution_testing/benchmark/benchmark_code_generator.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass, field
 
 from execution_testing.base_types import Address, Storage
 from execution_testing.forks import Fork
-from execution_testing.specs.benchmark import BenchmarkCodeGenerator
+from execution_testing.specs.benchmark import (
+    DEPENDENCY_STORAGE_INIT_VALUE,
+    DEPENDENCY_STORAGE_SLOT,
+    BenchmarkCodeGenerator,
+)
 from execution_testing.test_types import Alloc
 from execution_testing.vm import Op
 
@@ -22,19 +26,24 @@ class JumpLoopGenerator(BenchmarkCodeGenerator):
     def deploy_contracts(self, *, pre: Alloc, fork: Fork) -> Address:
         """Deploy the looping contract."""
         # Benchmark Test Structure:
-        # setup + JUMPDEST +
+        # [dependency storage update] + setup + JUMPDEST +
         # attack + attack + ... + attack +
         # cleanup + JUMP(setup_length)
         code = self.generate_repeated_code(
             repeated_code=self.attack_block,
-            setup=self.setup,
+            setup=self._dependency_bytecode() + self.setup,
             cleanup=self.cleanup,
             fork=fork,
         )
+        storage = self.contract_storage
+        if self.with_dependency:
+            merged = dict(self.contract_storage.root)
+            merged[DEPENDENCY_STORAGE_SLOT] = DEPENDENCY_STORAGE_INIT_VALUE  # type: ignore[index,assignment]
+            storage = Storage(merged)
         self._contract_address = pre.deploy_contract(
             code=code,
             balance=self.contract_balance,
-            storage=self.contract_storage,
+            storage=storage,
         )
         return self._contract_address
 
@@ -116,12 +125,22 @@ class ExtCallGenerator(BenchmarkCodeGenerator):
             )
         )
 
+        caller_setup = self._dependency_bytecode() + Op.CALLDATACOPY(
+            Op.PUSH0, Op.PUSH0, Op.CALLDATASIZE
+        )
         caller_code = self.generate_repeated_code(
-            setup=Op.CALLDATACOPY(Op.PUSH0, Op.PUSH0, Op.CALLDATASIZE),
+            setup=caller_setup,
             repeated_code=code_sequence,
             cleanup=self.cleanup,
             fork=fork,
         )
-
-        self._contract_address = pre.deploy_contract(code=caller_code)
+        caller_storage: Storage | None = None
+        if self.with_dependency:
+            caller_storage = Storage(
+                {DEPENDENCY_STORAGE_SLOT: DEPENDENCY_STORAGE_INIT_VALUE}  # type: ignore[dict-item]
+            )
+        self._contract_address = pre.deploy_contract(
+            code=caller_code,
+            storage=caller_storage,
+        )
         return self._contract_address

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/benchmarking.py
@@ -8,6 +8,7 @@ from typing import ClassVar, Dict, List, Self
 import pytest
 from pydantic import BaseModel, Field, RootModel
 
+from execution_testing.forks import Fork
 from execution_testing.test_types import Environment, EnvironmentDefaults
 from execution_testing.tools import ParameterSet
 
@@ -49,6 +50,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Example: '0.5,1,2' runs 500, 1K, 2K opcodes. "
             "Without value, uses .fixed_opcode_counts.json config. "
             f"Cannot be used with {GasBenchmarkValues.flag}."
+        ),
+    )
+    benchmark_group.addoption(
+        "--with-dependency",
+        action="store",
+        dest="with_dependency",
+        type=str,
+        default=None,
+        help=(
+            "Add storage dependency to prevent parallel tx execution. "
+            "Accepts 'True'/'False'. "
+            "Default: True for Amsterdam+, False otherwise."
         ),
     )
 
@@ -482,6 +495,17 @@ def fixed_opcode_count(request: pytest.FixtureRequest) -> int | None:
         return request.param
 
     return None
+
+
+@pytest.fixture(scope="function")
+def with_dependency(request: pytest.FixtureRequest, fork: Fork) -> bool:
+    """Return whether to add storage dependency to benchmark txs."""
+    from execution_testing.forks import Amsterdam
+
+    cli_value = request.config.getoption("with_dependency", default=None)
+    if cli_value is not None:
+        return cli_value.lower() == "true"
+    return fork >= Amsterdam
 
 
 BENCHMARKING_MAX_GAS = 1_000_000_000_000

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -23,6 +23,7 @@ ALL_FIXTURE_PARAMETERS = {
     "fixed_opcode_count",
     "genesis_environment",
     "env",
+    "with_dependency",
 }
 """
 List of test parameters that have a default fixture value which can be

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -45,6 +45,9 @@ from execution_testing.vm import Bytecode, Op
 from .base import BaseTest
 from .blockchain import Block, BlockchainTest
 
+DEPENDENCY_STORAGE_SLOT = 0xDEADBEEF
+DEPENDENCY_STORAGE_INIT_VALUE = 0xDEADBEEF
+
 
 @dataclass(kw_only=True)
 class BenchmarkCodeGenerator(ABC):
@@ -56,6 +59,7 @@ class BenchmarkCodeGenerator(ABC):
     tx_kwargs: Dict[str, Any] = field(default_factory=dict)
     fixed_opcode_count: float | None = None
     code_padding_opcode: Op | None = None
+    with_dependency: bool = False
     _contract_address: Address | None = None
     _inner_iterations: int = 1000
 
@@ -265,6 +269,15 @@ class BenchmarkCodeGenerator(ABC):
                 f"allowed size {fork.max_code_size()}"
             )
 
+    def _dependency_bytecode(self) -> Bytecode:
+        """Generate SSTORE bytecode for inter-tx storage dependency."""
+        if not self.with_dependency:
+            return Bytecode()
+        return Op.SSTORE(
+            DEPENDENCY_STORAGE_SLOT,
+            Op.ADD(Op.SLOAD(DEPENDENCY_STORAGE_SLOT), Op.GAS),
+        )
+
 
 class BenchmarkTest(BaseTest):
     """Test type designed specifically for benchmark test cases."""
@@ -290,6 +303,7 @@ class BenchmarkTest(BaseTest):
     fixed_opcode_count: float | None = None
     target_opcode: Op | None = None
     code_generator: BenchmarkCodeGenerator | None = None
+    with_dependency: bool = False
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -351,6 +365,7 @@ class BenchmarkTest(BaseTest):
         if self.code_generator is not None:
             # Inject fixed_opcode_count into the code generator if provided
             self.code_generator.fixed_opcode_count = self.fixed_opcode_count
+            self.code_generator.with_dependency = self.with_dependency
 
             # In fixed opcode count mode, skip gas validation since we're
             # measuring performance by operation count, not gas usage
@@ -436,9 +451,10 @@ class BenchmarkTest(BaseTest):
         split_transactions = []
         for i in range(num_splits):
             split_tx = tx.model_copy()
-            split_tx.gas_limit = HexNumber(
-                remaining_gas if i == num_splits - 1 else gas_limit_cap
+            gas_limit = HexNumber(
+                (remaining_gas if i == num_splits - 1 else gas_limit_cap) - i
             )
+            split_tx.gas_limit = gas_limit
             remaining_gas -= gas_limit_cap
             split_tx.nonce = HexNumber(tx.nonce + i)
             split_transactions.append(split_tx)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

WIP

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
