### PR TITLE
feat(specs): Replace mutable `State` with `PreState` + `StateTracker`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,24 +121,6 @@ jobs:
       - name: Run json infra tests
         run: tox -e json_infra -- --file-list="${{ steps.get-changed-files.outputs.file_list }}"
 
-  optimized:
-    runs-on: [self-hosted-ghr, size-xl-x64]
-    needs: static
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-        with:
-          submodules: recursive
-          fetch-depth: 0  # Fetch full history for commit comparison
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: "3.11"
-      - uses: ./.github/actions/setup-env
-      - uses: ./.github/actions/get-changed-files
-        id: get-changed-files
-      - name: Run optimized tests
-        run: tox -e optimized -- --file-list="${{ steps.get-changed-files.outputs.file_list }}"
-
   tests_pytest_py3:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static

--- a/src/ethereum/forks/amsterdam/block_access_lists/__init__.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists/__init__.py
@@ -11,6 +11,7 @@ from .builder import (
     add_storage_write,
     add_touched_account,
     build_block_access_list,
+    update_builder_from_tx,
 )
 from .rlp_utils import compute_block_access_list_hash
 
@@ -24,4 +25,5 @@ __all__ = [
     "add_touched_account",
     "build_block_access_list",
     "compute_block_access_list_hash",
+    "update_builder_from_tx",
 ]

--- a/src/ethereum/forks/amsterdam/block_access_lists/builder.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists/builder.py
@@ -14,12 +14,14 @@ The builder follows a two-phase approach:
 """  # noqa: E501
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Set
+from typing import Dict, List, Optional, Set
 
-from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U64, U256
+from ethereum_types.bytes import Bytes, Bytes32
+from ethereum_types.numeric import U64, U256, Uint
 
-from ..fork_types import Address
+from ethereum.state import Account, Address, PreState
+
+from ..state_tracker import BlockState, TransactionState
 from .rlp_types import (
     AccountChanges,
     BalanceChange,
@@ -30,9 +32,6 @@ from .rlp_types import (
     SlotChanges,
     StorageChange,
 )
-
-if TYPE_CHECKING:
-    from ..state_tracker import StateChanges
 
 
 @dataclass
@@ -89,6 +88,15 @@ class BlockAccessListBuilder:
     [`BlockAccessList`]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
     """  # noqa: E501
 
+    block_access_index: BlockAccessIndex = BlockAccessIndex(0)
+    """
+    Current block access index.  Set by the caller before each
+    [`incorporate_tx_into_block`] call (0 for system txs, i+1 for the
+    i-th user tx, N+1 for post-execution operations).
+
+    [`incorporate_tx_into_block`]: ref:ethereum.forks.amsterdam.state_tracker.incorporate_tx_into_block
+    """  # noqa: E501
+
     accounts: Dict[Address, AccountData] = field(default_factory=dict)
     """
     Mapping from account address to its tracked changes during block execution.
@@ -104,7 +112,6 @@ def ensure_account(builder: BlockAccessListBuilder, address: Address) -> None:
     multiple times for the same address.
 
     [`AccountData`]: ref:ethereum.forks.amsterdam.block_access_lists.builder.AccountData
-
     """  # noqa: E501
     if address not in builder.accounts:
         builder.accounts[address] = AccountData()
@@ -156,8 +163,6 @@ def add_storage_read(
     Records that a storage slot was read during execution. Storage slots
     that are both read and written will only appear in the storage changes
     list, not in the storage reads list, as per [EIP-7928].
-
-    [EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
     """
     ensure_account(builder, address)
     builder.accounts[address].storage_reads.add(slot)
@@ -358,58 +363,111 @@ def _build_from_builder(
     return block_access_list
 
 
-def build_block_access_list(
-    state_changes: "StateChanges",
-) -> BlockAccessList:
+def _get_pre_tx_account(
+    pre_tx_accounts: Dict[Address, Optional[Account]],
+    pre_state: PreState,
+    address: Address,
+) -> Optional[Account]:
     """
-    Build a [`BlockAccessList`] from a StateChanges frame.
+    Look up an account in cumulative state, falling back to `pre_state`.
 
-    Converts the accumulated state changes from the frame-based architecture
-    into the final deterministic BlockAccessList format.
+    The cumulative account state (`pre_tx_accounts`) should contain state up
+    to (but not including) the current transaction.
 
-    [`BlockAccessList`]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
-    [`StateChanges`]: ref:ethereum.forks.amsterdam.state_tracker.StateChanges
-    """  # noqa: E501
-    builder = BlockAccessListBuilder()
+    Returns `None` if the `address` does not exist.
+    """
+    if address in pre_tx_accounts:
+        return pre_tx_accounts[address]
+    return pre_state.get_account_optional(address)
 
-    # Add all touched addresses
-    for address in state_changes.touched_addresses:
-        add_touched_account(builder, address)
 
-    # Add all storage reads
-    for address, slot in state_changes.storage_reads:
-        add_storage_read(builder, address, U256(int.from_bytes(slot)))
+def _get_pre_tx_storage(
+    pre_tx_storage: Dict[Address, Dict[Bytes32, U256]],
+    pre_state: PreState,
+    address: Address,
+    key: Bytes32,
+) -> U256:
+    """
+    Look up a storage value in cumulative state, falling back to `pre_state`.
 
-    # Add all storage writes
-    # Net-zero filtering happens at transaction commit time, not here.
-    # At block level, we track ALL writes at their respective indices.
-    for (
-        address,
-        slot,
-        block_access_index,
-    ), value in state_changes.storage_writes.items():
-        u256_slot = U256(int.from_bytes(slot))
-        add_storage_write(
-            builder, address, u256_slot, block_access_index, value
+    Returns `0` if not set.
+    """
+    if address in pre_tx_storage and key in pre_tx_storage[address]:
+        return pre_tx_storage[address][key]
+    return pre_state.get_storage(address, key)
+
+
+def update_builder_from_tx(
+    builder: BlockAccessListBuilder,
+    tx_state: TransactionState,
+) -> None:
+    """
+    Update the BAL builder with changes from a single transaction.
+
+    Compare the transaction's writes against the block's cumulative
+    state (falling back to `pre_state`) to extract balance, nonce, code, and
+    storage changes.  Net-zero filtering is automatic: if the pre-tx value
+    equals the post-tx value, no change is recorded.
+
+    Must be called **before** the transaction's writes are merged into
+    the block state.
+    """
+    block_state = tx_state.parent
+    pre_state = block_state.pre_state
+    idx = builder.block_access_index
+
+    # Compare account writes against block cumulative state
+    for address, post_account in tx_state.account_writes.items():
+        pre_account = _get_pre_tx_account(
+            block_state.account_writes, pre_state, address
         )
 
-    # Add all balance changes (balance_changes is keyed by (address, index))
-    for (
-        address,
-        block_access_index,
-    ), new_balance in state_changes.balance_changes.items():
-        add_balance_change(builder, address, block_access_index, new_balance)
+        pre_balance = pre_account.balance if pre_account else U256(0)
+        post_balance = post_account.balance if post_account else U256(0)
+        if pre_balance != post_balance:
+            add_balance_change(builder, address, idx, post_balance)
 
-    # Add all nonce changes
-    for address, block_access_index, new_nonce in state_changes.nonce_changes:
-        add_nonce_change(builder, address, block_access_index, new_nonce)
+        pre_nonce = pre_account.nonce if pre_account else Uint(0)
+        post_nonce = post_account.nonce if post_account else Uint(0)
+        if pre_nonce != post_nonce:
+            add_nonce_change(builder, address, idx, U64(post_nonce))
 
-    # Add all code changes
-    # Filtering happens at transaction level in eoa_delegation.py
-    for (
-        address,
-        block_access_index,
-    ), new_code in state_changes.code_changes.items():
-        add_code_change(builder, address, block_access_index, new_code)
+        pre_code = pre_account.code if pre_account else b""
+        post_code = post_account.code if post_account else b""
+        if pre_code != post_code:
+            add_code_change(builder, address, idx, post_code)
+
+    # Compare storage writes against block cumulative state
+    for address, slots in tx_state.storage_writes.items():
+        for key, post_value in slots.items():
+            pre_value = _get_pre_tx_storage(
+                block_state.storage_writes, pre_state, address, key
+            )
+            if pre_value != post_value:
+                # Convert slot from internal Bytes32 format to U256 for BAL.
+                # EIP-7928 uses U256 as it's more space-efficient in RLP.
+                u256_slot = U256.from_be_bytes(key)
+                add_storage_write(builder, address, u256_slot, idx, post_value)
+
+
+def build_block_access_list(
+    builder: BlockAccessListBuilder,
+    block_state: BlockState,
+) -> BlockAccessList:
+    """
+    Build a [`BlockAccessList`] from the builder and block state.
+
+    Feed accumulated reads from the block state into the builder, then produce
+    the final sorted and encoded block access list.
+
+    [`BlockAccessList`]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
+    """  # noqa: E501
+    # Add storage reads (convert Bytes32 to U256 for BAL encoding)
+    for address, slot in block_state.storage_reads:
+        add_storage_read(builder, address, U256.from_be_bytes(slot))
+
+    # Add touched addresses
+    for address in block_state.account_reads:
+        add_touched_account(builder, address)
 
     return _build_from_builder(builder)

--- a/src/ethereum/forks/amsterdam/block_access_lists/rlp_types.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists/rlp_types.py
@@ -14,7 +14,7 @@ from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U16, U64, U256
 
-from ..fork_types import Address
+from ethereum.state import Address
 
 # Type aliases for clarity (matching EIP-7928 specification)
 StorageKey: TypeAlias = U256
@@ -33,7 +33,7 @@ class StorageChange:
     storage slot.
 
     [slot]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.SlotChanges
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
     block_access_index: BlockAccessIndex
@@ -48,7 +48,7 @@ class BalanceChange:
     balance.
 
     [bal]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
     block_access_index: BlockAccessIndex
@@ -63,7 +63,7 @@ class NonceChange:
     nonce.
 
     [bal]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
     block_access_index: BlockAccessIndex
@@ -78,7 +78,7 @@ class CodeChange:
     code.
 
     [bal]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
     block_access_index: BlockAccessIndex
@@ -93,7 +93,7 @@ class SlotChanges:
     storage.
 
     [bal]: ref:ethereum.forks.amsterdam.block_access_lists.rlp_types.BlockAccessList
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
     slot: StorageKey
@@ -106,7 +106,7 @@ class AccountChanges:
     """
     All changes for a single [`Account`], grouped by field type.
 
-    [`Account`]: ref:ethereum.forks.amsterdam.fork_types.Account
+    [`Account`]: ref:ethereum.state.Account
     """
 
     address: Address

--- a/src/ethereum/forks/amsterdam/blocks.py
+++ b/src/ethereum/forks/amsterdam/blocks.py
@@ -18,8 +18,9 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.state import Address, Root
 
-from .fork_types import Address, Bloom, Root
+from .fork_types import Bloom
 from .transactions import (
     AccessListTransaction,
     BlobTransaction,
@@ -106,13 +107,14 @@ class Header:
     Root hash ([`keccak256`]) of the state trie after executing all
     transactions in this block. It represents the state of the Ethereum Virtual
     Machine (EVM) after all transactions in this block have been processed. It
-    is computed using the [`state_root()`] function, which computes the root
-    of the Merkle-Patricia [Trie] representing the Ethereum world state.
+    is computed using [`compute_state_root_and_trie_changes()`][changes],
+    which computes the root of the Merkle-Patricia [Trie] representing the
+    Ethereum world state after applying the block's state changes.
 
     [`keccak256`]: ref:ethereum.crypto.hash.keccak256
-    [`state_root()`]: ref:ethereum.forks.amsterdam.state.state_root
+    [changes]: ref:ethereum.forks.amsterdam.state.State.compute_state_root_and_trie_changes
     [Trie]: ref:ethereum.forks.amsterdam.trie.Trie
-    """
+    """  # noqa: E501
 
     transactions_root: Root
     """

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -27,9 +27,14 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
+from ethereum.state import Address
 
 from . import vm
-from .block_access_lists.builder import build_block_access_list
+from .block_access_lists.builder import (
+    BlockAccessListBuilder,
+    build_block_access_list,
+)
+from .block_access_lists.rlp_types import BlockAccessIndex
 from .block_access_lists.rlp_utils import compute_block_access_list_hash
 from .blocks import Block, Header, Log, Receipt, Withdrawal, encode_receipt
 from .bloom import logs_bloom
@@ -44,7 +49,7 @@ from .exceptions import (
     PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
 )
-from .fork_types import Account, Address, Authorization, VersionedHash
+from .fork_types import Authorization, VersionedHash
 from .requests import (
     CONSOLIDATION_REQUEST_TYPE,
     DEPOSIT_REQUEST_TYPE,
@@ -54,26 +59,19 @@ from .requests import (
 )
 from .state import (
     State,
-    TransientStorage,
-    account_exists_and_is_empty,
-    destroy_account,
-    get_account,
-    increment_nonce,
-    modify_state,
-    set_account_balance,
-    state_root,
+    apply_changes_to_state,
 )
 from .state_tracker import (
-    StateChanges,
-    capture_pre_balance,
-    commit_transaction_frame,
-    create_child_frame,
-    filter_net_zero_frame_changes,
-    increment_block_access_index,
+    BlockState,
+    TransactionState,
+    account_exists_and_is_empty,
+    destroy_account,
+    extract_block_diffs,
+    get_account,
+    incorporate_tx_into_block,
+    increment_nonce,
+    set_account_balance,
     track_address,
-    track_balance_change,
-    track_nonce_change,
-    track_selfdestruct,
 )
 from .transactions import (
     AccessListTransaction,
@@ -115,6 +113,7 @@ BEACON_ROOTS_ADDRESS = hex_to_address(
 SYSTEM_TRANSACTION_GAS = Uint(30000000)
 MAX_BLOB_GAS_PER_BLOCK = BLOB_SCHEDULE_MAX * GAS_PER_BLOB
 VERSIONED_HASH_VERSION_KZG = b"\x01"
+GWEI_TO_WEI = U256(10**9)
 
 WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS = hex_to_address(
     "0x00000961Ef480Eb55e80D19ad83579A64c007002"
@@ -236,9 +235,11 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     if block.ommers != ():
         raise InvalidBlock
 
+    block_state = BlockState(pre_state=chain.state)
+
     block_env = vm.BlockEnvironment(
         chain_id=chain.chain_id,
-        state=chain.state,
+        state=block_state,
         block_gas_limit=block.header.gas_limit,
         block_hashes=get_last_256_block_hashes(chain),
         coinbase=block.header.coinbase,
@@ -248,7 +249,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         prev_randao=block.header.prev_randao,
         excess_blob_gas=block.header.excess_blob_gas,
         parent_beacon_block_root=block.header.parent_beacon_block_root,
-        state_changes=StateChanges(),
+        block_access_list_builder=BlockAccessListBuilder(),
     )
 
     block_output = apply_body(
@@ -256,7 +257,11 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         transactions=block.transactions,
         withdrawals=block.withdrawals,
     )
-    block_state_root = state_root(block_env.state)
+    account_changes, storage_changes = extract_block_diffs(block_state)
+    block_state_root, _ = chain.state.compute_state_root_and_trie_changes(
+        account_changes, storage_changes
+    )
+    apply_changes_to_state(chain.state, account_changes, storage_changes)
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
     block_logs_bloom = logs_bloom(block_output.block_logs)
@@ -418,6 +423,7 @@ def check_transaction(
     block_env: vm.BlockEnvironment,
     block_output: vm.BlockOutput,
     tx: Transaction,
+    tx_state: TransactionState,
 ) -> Tuple[Address, Uint, Tuple[VersionedHash, ...], U64]:
     """
     Check if the transaction is includable in the block.
@@ -430,6 +436,8 @@ def check_transaction(
         The block output for the current block.
     tx :
         The transaction.
+    tx_state :
+        The transaction state tracker.
 
     Returns
     -------
@@ -488,7 +496,7 @@ def check_transaction(
         raise BlobGasLimitExceededError("blob gas limit exceeded")
 
     sender_address = recover_sender(block_env.chain_id, tx)
-    sender_account = get_account(block_env.state, sender_address)
+    sender_account = get_account(tx_state, sender_address)
 
     if isinstance(
         tx, (FeeMarketTransaction, BlobTransaction, SetCodeTransaction)
@@ -634,9 +642,7 @@ def process_system_transaction(
         Output of processing the system transaction.
 
     """
-    # EIP-7928: Create a child frame for system transaction
-    # This allows proper pre-state capture for net-zero filtering
-    system_tx_state_changes = create_child_frame(block_env.state_changes)
+    system_tx_state = TransactionState(parent=block_env.state)
 
     tx_env = vm.TransactionEnvironment(
         origin=SYSTEM_ADDRESS,
@@ -644,16 +650,12 @@ def process_system_transaction(
         gas=SYSTEM_TRANSACTION_GAS,
         access_list_addresses=set(),
         access_list_storage_keys=set(),
-        transient_storage=TransientStorage(),
+        state=system_tx_state,
         blob_versioned_hashes=(),
         authorizations=(),
         index_in_block=None,
         tx_hash=None,
-        state_changes=system_tx_state_changes,
     )
-
-    # Create call frame as child of tx frame
-    call_frame = create_child_frame(tx_env.state_changes)
 
     system_tx_message = Message(
         block_env=block_env,
@@ -674,14 +676,13 @@ def process_system_transaction(
         disable_precompiles=False,
         parent_evm=None,
         is_create=False,
-        state_changes=call_frame,
     )
 
     system_tx_output = process_message_call(system_tx_message)
 
-    # Commit system transaction changes to block frame
-    # System transactions always succeed (or block is invalid)
-    commit_transaction_frame(tx_env.state_changes)
+    incorporate_tx_into_block(
+        system_tx_state, block_env.block_access_list_builder
+    )
 
     return system_tx_output
 
@@ -710,7 +711,8 @@ def process_checked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_contract_code = get_account(block_env.state, target_address).code
+    system_tx_state = TransactionState(parent=block_env.state)
+    system_contract_code = get_account(system_tx_state, target_address).code
 
     if len(system_contract_code) == 0:
         raise InvalidBlock(
@@ -758,7 +760,8 @@ def process_unchecked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_contract_code = get_account(block_env.state, target_address).code
+    system_tx_state = TransactionState(parent=block_env.state)
+    system_contract_code = get_account(system_tx_state, target_address).code
     return process_system_transaction(
         block_env,
         target_address,
@@ -799,10 +802,6 @@ def apply_body(
     """
     block_output = vm.BlockOutput()
 
-    # EIP-7928: System contracts use block_access_index 0
-    # The block frame already starts at index 0, so system transactions
-    # naturally use that index through the block frame
-
     process_unchecked_system_transaction(
         block_env=block_env,
         target_address=BEACON_ROOTS_ADDRESS,
@@ -818,10 +817,10 @@ def apply_body(
     for i, tx in enumerate(map(decode_transaction, transactions)):
         process_transaction(block_env, block_output, tx, Uint(i))
 
-    # EIP-7928: Increment block frame to post-execution index
-    # After N transactions, block frame is at index N
-    # Post-execution operations (withdrawals, etc.) use index N+1
-    increment_block_access_index(block_env.state_changes)
+    # EIP-7928: Post-execution operations use index N+1
+    block_env.block_access_list_builder.block_access_index = BlockAccessIndex(
+        Uint(len(transactions)) + Uint(1)
+    )
 
     process_withdrawals(block_env, block_output, withdrawals)
 
@@ -829,9 +828,9 @@ def apply_body(
         block_env=block_env,
         block_output=block_output,
     )
-    # Build block access list from block_env.state_changes
+
     block_output.block_access_list = build_block_access_list(
-        block_env.state_changes
+        block_env.block_access_list_builder, block_env.state
     )
 
     return block_output
@@ -912,19 +911,12 @@ def process_transaction(
         Index of the transaction in the block.
 
     """
-    # EIP-7928: Create a transaction-level StateChanges frame
-    # The frame will read the current block_access_index from the block frame
-    increment_block_access_index(block_env.state_changes)
-    tx_state_changes = create_child_frame(block_env.state_changes)
-
-    # Capture coinbase pre-balance for net-zero filtering
-    coinbase_pre_balance = get_account(
-        block_env.state, block_env.coinbase
-    ).balance
-    track_address(tx_state_changes, block_env.coinbase)
-    capture_pre_balance(
-        tx_state_changes, block_env.coinbase, coinbase_pre_balance
+    block_env.block_access_list_builder.block_access_index = BlockAccessIndex(
+        index + Uint(1)
     )
+    tx_state = TransactionState(parent=block_env.state)
+
+    track_address(tx_state, block_env.coinbase)
 
     trie_set(
         block_output.transactions_trie,
@@ -943,9 +935,10 @@ def process_transaction(
         block_env=block_env,
         block_output=block_output,
         tx=tx,
+        tx_state=tx_state,
     )
 
-    sender_account = get_account(block_env.state, sender)
+    sender_account = get_account(tx_state, sender)
 
     if isinstance(tx, BlobTransaction):
         blob_gas_fee = calculate_data_fee(block_env.excess_blob_gas, tx)
@@ -956,27 +949,13 @@ def process_transaction(
 
     gas = tx.gas - intrinsic_gas
 
-    # Track sender nonce increment
-    increment_nonce(block_env.state, sender)
-    sender_nonce_after = get_account(block_env.state, sender).nonce
-    track_nonce_change(tx_state_changes, sender, U64(sender_nonce_after))
-
-    # Track sender balance deduction for gas fee
-    sender_balance_before = get_account(block_env.state, sender).balance
-    track_address(tx_state_changes, sender)
-    capture_pre_balance(tx_state_changes, sender, sender_balance_before)
+    increment_nonce(tx_state, sender)
+    track_address(tx_state, sender)
 
     sender_balance_after_gas_fee = (
         Uint(sender_account.balance) - effective_gas_fee - blob_gas_fee
     )
-    set_account_balance(
-        block_env.state, sender, U256(sender_balance_after_gas_fee)
-    )
-    track_balance_change(
-        tx_state_changes,
-        sender,
-        U256(sender_balance_after_gas_fee),
-    )
+    set_account_balance(tx_state, sender, U256(sender_balance_after_gas_fee))
 
     access_list_addresses = set()
     access_list_storage_keys = set()
@@ -1005,12 +984,11 @@ def process_transaction(
         gas=gas,
         access_list_addresses=access_list_addresses,
         access_list_storage_keys=access_list_storage_keys,
-        transient_storage=TransientStorage(),
+        state=tx_state,
         blob_versioned_hashes=blob_versioned_hashes,
         authorizations=authorizations,
         index_in_block=index,
         tx_hash=get_transaction_hash(encode_transaction(tx)),
-        state_changes=tx_state_changes,
     )
 
     message = prepare_message(
@@ -1043,33 +1021,23 @@ def process_transaction(
     transaction_fee = tx_gas_used_after_refund * priority_fee_per_gas
 
     # refund gas
-    sender_balance_after_refund = get_account(
-        block_env.state, sender
-    ).balance + U256(gas_refund_amount)
-    set_account_balance(block_env.state, sender, sender_balance_after_refund)
-    track_balance_change(
-        tx_env.state_changes,
-        sender,
-        sender_balance_after_refund,
+    sender_balance_after_refund = get_account(tx_state, sender).balance + U256(
+        gas_refund_amount
     )
+    set_account_balance(tx_state, sender, sender_balance_after_refund)
 
     coinbase_balance_after_mining_fee = get_account(
-        block_env.state, block_env.coinbase
+        tx_state, block_env.coinbase
     ).balance + U256(transaction_fee)
 
     set_account_balance(
-        block_env.state, block_env.coinbase, coinbase_balance_after_mining_fee
-    )
-    track_balance_change(
-        tx_env.state_changes,
-        block_env.coinbase,
-        coinbase_balance_after_mining_fee,
+        tx_state, block_env.coinbase, coinbase_balance_after_mining_fee
     )
 
     if coinbase_balance_after_mining_fee == 0 and account_exists_and_is_empty(
-        block_env.state, block_env.coinbase
+        tx_state, block_env.coinbase
     ):
-        destroy_account(block_env.state, block_env.coinbase)
+        destroy_account(tx_state, block_env.coinbase)
 
     block_output.block_gas_used += tx_gas_used_after_refund
     block_output.blob_gas_used += tx_blob_gas_used
@@ -1090,12 +1058,9 @@ def process_transaction(
     block_output.block_logs += tx_output.logs
 
     for address in tx_output.accounts_to_delete:
-        destroy_account(block_env.state, address)
-        track_selfdestruct(tx_env.state_changes, address)
+        destroy_account(tx_state, address)
 
-    # EIP-7928: Commit transaction frame (includes net-zero filtering).
-    # Must happen AFTER destroy_account so filtering sees correct state.
-    commit_transaction_frame(tx_env.state_changes)
+    incorporate_tx_into_block(tx_state, block_env.block_access_list_builder)
 
 
 def process_withdrawals(
@@ -1106,15 +1071,7 @@ def process_withdrawals(
     """
     Increase the balance of the withdrawing account.
     """
-    # Capture pre-state for withdrawal balance filtering
-    withdrawal_addresses = {wd.address for wd in withdrawals}
-    for address in withdrawal_addresses:
-        pre_balance = get_account(block_env.state, address).balance
-        track_address(block_env.state_changes, address)
-        capture_pre_balance(block_env.state_changes, address, pre_balance)
-
-    def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += wd.amount * U256(10**9)
+    wd_state = TransactionState(parent=block_env.state)
 
     for i, wd in enumerate(withdrawals):
         trie_set(
@@ -1123,20 +1080,12 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        modify_state(block_env.state, wd.address, increase_recipient_balance)
+        track_address(wd_state, wd.address)
+        current_balance = get_account(wd_state, wd.address).balance
+        new_balance = current_balance + wd.amount * GWEI_TO_WEI
+        set_account_balance(wd_state, wd.address, new_balance)
 
-        new_balance = get_account(block_env.state, wd.address).balance
-        track_balance_change(
-            block_env.state_changes,
-            wd.address,
-            new_balance,
-        )
-
-        if account_exists_and_is_empty(block_env.state, wd.address):
-            destroy_account(block_env.state, wd.address)
-
-    # EIP-7928: Filter net-zero balance changes for withdrawals
-    filter_net_zero_frame_changes(block_env.state_changes)
+    incorporate_tx_into_block(wd_state, block_env.block_access_list_builder)
 
 
 def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:

--- a/src/ethereum/forks/amsterdam/fork_types.py
+++ b/src/ethereum/forks/amsterdam/fork_types.py
@@ -14,36 +14,16 @@ Types reused throughout the specification, which are specific to Ethereum.
 from dataclasses import dataclass
 
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes, Bytes20, Bytes256
+from ethereum_types.bytes import Bytes, Bytes256
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U8, U64, U256, Uint
+from ethereum_types.numeric import U8, U64, U256
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.state import Account, Address
 
-Address = Bytes20
-Root = Hash32
 VersionedHash = Hash32
 
 Bloom = Bytes256
-
-
-@slotted_freezable
-@dataclass
-class Account:
-    """
-    State associated with an address.
-    """
-
-    nonce: Uint
-    balance: U256
-    code: Bytes
-
-
-EMPTY_ACCOUNT = Account(
-    nonce=Uint(0),
-    balance=U256(0),
-    code=b"",
-)
 
 
 def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:

--- a/src/ethereum/forks/amsterdam/state.py
+++ b/src/ethereum/forks/amsterdam/state.py
@@ -17,17 +17,14 @@ There is a distinction between an account that does not exist and
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
-from ethereum_types.bytes import Bytes, Bytes32
-from ethereum_types.frozen import modify
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.bytes import Bytes32
+from ethereum_types.numeric import U256
 
-from .fork_types import EMPTY_ACCOUNT, Account, Address, Root
+from ethereum.state import Account, Address, InternalNode, Root
+
 from .trie import EMPTY_TRIE_ROOT, Trie, copy_trie, root, trie_get, trie_set
-
-if TYPE_CHECKING:
-    from .vm import BlockEnvironment  # noqa: F401
 
 
 @dataclass
@@ -42,26 +39,75 @@ class State:
     _storage_tries: Dict[Address, Trie[Bytes32, U256]] = field(
         default_factory=dict
     )
-    _snapshots: List[
-        Tuple[
-            Trie[Address, Optional[Account]],
-            Dict[Address, Trie[Bytes32, U256]],
-        ]
-    ] = field(default_factory=list)
-    created_accounts: Set[Address] = field(default_factory=set)
 
+    def get_account_optional(self, address: Address) -> Optional[Account]:
+        """
+        Get the account at an address.
 
-@dataclass
-class TransientStorage:
-    """
-    Contains all information that is preserved between message calls
-    within a transaction.
-    """
+        Return ``None`` if there is no account at the address.
+        """
+        return trie_get(self._main_trie, address)
 
-    _tries: Dict[Address, Trie[Bytes32, U256]] = field(default_factory=dict)
-    _snapshots: List[Dict[Address, Trie[Bytes32, U256]]] = field(
-        default_factory=list
-    )
+    def get_storage(self, address: Address, key: Bytes32) -> U256:
+        """
+        Get a storage value.
+
+        Return ``U256(0)`` if the key has not been set.
+        """
+        trie = self._storage_tries.get(address)
+        if trie is None:
+            return U256(0)
+
+        value = trie_get(trie, key)
+
+        assert isinstance(value, U256)
+        return value
+
+    def account_has_storage(self, address: Address) -> bool:
+        """
+        Check whether an account has any storage.
+
+        Only needed for EIP-7610.
+        """
+        return address in self._storage_tries
+
+    def compute_state_root_and_trie_changes(
+        self,
+        account_changes: Dict[Address, Optional[Account]],
+        storage_changes: Dict[Address, Dict[Bytes32, U256]],
+    ) -> Tuple[Root, List[InternalNode]]:
+        """
+        Compute the state root after applying changes to the pre-state.
+
+        Return the new state root together with the internal trie nodes
+        that were created or modified.
+        """
+        main_trie = copy_trie(self._main_trie)
+        storage_tries = {
+            k: copy_trie(v) for k, v in self._storage_tries.items()
+        }
+
+        for address, account in account_changes.items():
+            trie_set(main_trie, address, account)
+
+        for address, slots in storage_changes.items():
+            trie = storage_tries.get(address)
+            if trie is None:
+                trie = Trie(secured=True, default=U256(0))
+                storage_tries[address] = trie
+            for key, value in slots.items():
+                trie_set(trie, key, value)
+            if trie._data == {}:
+                del storage_tries[address]
+
+        def get_storage_root(addr: Address) -> Root:
+            if addr in storage_tries:
+                return root(storage_tries[addr])
+            return EMPTY_TRIE_ROOT
+
+        state_root_value = root(main_trie, get_storage_root=get_storage_root)
+
+        return state_root_value, []
 
 
 def close_state(state: State) -> None:
@@ -71,257 +117,63 @@ def close_state(state: State) -> None:
     """
     del state._main_trie
     del state._storage_tries
-    del state._snapshots
-    del state.created_accounts
 
 
-def begin_transaction(
-    state: State, transient_storage: TransientStorage
+def apply_changes_to_state(
+    state: State,
+    account_changes: Dict[Address, Optional[Account]],
+    storage_changes: Dict[Address, Dict[Bytes32, U256]],
 ) -> None:
     """
-    Start a state transaction.
-
-    Transactions are entirely implicit and can be nested. It is not possible to
-    calculate the state root during a transaction.
+    Apply block-level diffs to the ``State`` for the next block.
 
     Parameters
     ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
+    state :
+        The state to update.
+    account_changes :
+        Account changes to apply.
+    storage_changes :
+        Storage changes to apply.
 
     """
-    state._snapshots.append(
-        (
-            copy_trie(state._main_trie),
-            {k: copy_trie(t) for (k, t) in state._storage_tries.items()},
-        )
-    )
-    transient_storage._snapshots.append(
-        {k: copy_trie(t) for (k, t) in transient_storage._tries.items()}
-    )
+    for address, account in account_changes.items():
+        trie_set(state._main_trie, address, account)
 
-
-def commit_transaction(
-    state: State, transient_storage: TransientStorage
-) -> None:
-    """
-    Commit a state transaction.
-
-    Parameters
-    ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
-
-    """
-    state._snapshots.pop()
-    if not state._snapshots:
-        state.created_accounts.clear()
-
-    transient_storage._snapshots.pop()
-
-
-def rollback_transaction(
-    state: State, transient_storage: TransientStorage
-) -> None:
-    """
-    Rollback a state transaction, resetting the state to the point when the
-    corresponding `begin_transaction()` call was made.
-
-    Parameters
-    ----------
-    state : State
-        The state.
-    transient_storage : TransientStorage
-        The transient storage of the transaction.
-
-    """
-    state._main_trie, state._storage_tries = state._snapshots.pop()
-    if not state._snapshots:
-        state.created_accounts.clear()
-
-    transient_storage._tries = transient_storage._snapshots.pop()
-
-
-def get_account(state: State, address: Address) -> Account:
-    """
-    Get the `Account` object at an address. Returns `EMPTY_ACCOUNT` if there
-    is no account at the address.
-
-    Use `get_account_optional()` if you care about the difference between a
-    non-existent account and `EMPTY_ACCOUNT`.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address to lookup.
-
-    Returns
-    -------
-    account : `Account`
-        Account at address.
-
-    """
-    account = get_account_optional(state, address)
-    if isinstance(account, Account):
-        return account
-    else:
-        return EMPTY_ACCOUNT
-
-
-def get_account_optional(state: State, address: Address) -> Optional[Account]:
-    """
-    Get the `Account` object at an address. Returns `None` (rather than
-    `EMPTY_ACCOUNT`) if there is no account at the address.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address to lookup.
-
-    Returns
-    -------
-    account : `Account`
-        Account at address.
-
-    """
-    account = trie_get(state._main_trie, address)
-    return account
+    for address, slots in storage_changes.items():
+        trie = state._storage_tries.get(address)
+        if trie is None:
+            trie = Trie(secured=True, default=U256(0))
+            state._storage_tries[address] = trie
+        for key, value in slots.items():
+            trie_set(trie, key, value)
+        if trie._data == {}:
+            del state._storage_tries[address]
 
 
 def set_account(
-    state: State, address: Address, account: Optional[Account]
+    state: State,
+    address: Address,
+    account: Optional[Account],
 ) -> None:
     """
-    Set the `Account` object at an address. Setting to `None` deletes
-    the account (but not its storage, see `destroy_account()`).
+    Set an account in a ``State``.
 
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address to set.
-    account : `Account`
-        Account to set at address.
-
+    Setting to ``None`` deletes the account.
     """
     trie_set(state._main_trie, address, account)
 
 
-def destroy_account(state: State, address: Address) -> None:
-    """
-    Completely remove the account at `address` and all of its storage.
-
-    This function is made available exclusively for the `SELFDESTRUCT`
-    opcode. It is expected that `SELFDESTRUCT` will be disabled in a future
-    hardfork and this function will be removed.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address of account to destroy.
-
-    """
-    destroy_storage(state, address)
-    set_account(state, address, None)
-
-
-def destroy_storage(state: State, address: Address) -> None:
-    """
-    Completely remove the storage at `address`.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address of account whose storage is to be deleted.
-
-    """
-    if address in state._storage_tries:
-        del state._storage_tries[address]
-
-
-def mark_account_created(state: State, address: Address) -> None:
-    """
-    Mark an account as having been created in the current transaction.
-    This information is used by `get_storage_original()` to handle an obscure
-    edgecase, and to respect the constraints added to SELFDESTRUCT by
-    EIP-6780.
-
-    The marker is not removed even if the account creation reverts. Since the
-    account cannot have had code prior to its creation and can't call
-    `get_storage_original()`, this is harmless.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address of the account that has been created.
-
-    """
-    state.created_accounts.add(address)
-
-
-def get_storage(state: State, address: Address, key: Bytes32) -> U256:
-    """
-    Get a value at a storage key on an account. Returns `U256(0)` if the
-    storage key has not been set previously.
-
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to lookup.
-
-    Returns
-    -------
-    value : `U256`
-        Value at the key.
-
-    """
-    trie = state._storage_tries.get(address)
-    if trie is None:
-        return U256(0)
-
-    value = trie_get(trie, key)
-
-    assert isinstance(value, U256)
-    return value
-
-
 def set_storage(
-    state: State, address: Address, key: Bytes32, value: U256
+    state: State,
+    address: Address,
+    key: Bytes32,
+    value: U256,
 ) -> None:
     """
-    Set a value at a storage key on an account. Setting to `U256(0)` deletes
-    the key.
+    Set a storage value in a ``State``.
 
-    Parameters
-    ----------
-    state: `State`
-        The state
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to set.
-    value : `U256`
-        Value to set at the key.
-
+    Setting to ``U256(0)`` deletes the key.
     """
     assert trie_get(state._main_trie, address) is not None
 
@@ -334,368 +186,9 @@ def set_storage(
         del state._storage_tries[address]
 
 
-def storage_root(state: State, address: Address) -> Root:
-    """
-    Calculate the storage root of an account.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address :
-        Address of the account.
-
-    Returns
-    -------
-    root : `Root`
-        Storage root of the account.
-
-    """
-    assert not state._snapshots
-    if address in state._storage_tries:
-        return root(state._storage_tries[address])
-    else:
-        return EMPTY_TRIE_ROOT
-
-
 def state_root(state: State) -> Root:
     """
-    Calculate the state root.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-
-    Returns
-    -------
-    root : `Root`
-        The state root.
-
+    Compute the state root of the current state.
     """
-    assert not state._snapshots
-
-    def get_storage_root(address: Address) -> Root:
-        return storage_root(state, address)
-
-    return root(state._main_trie, get_storage_root=get_storage_root)
-
-
-def account_exists(state: State, address: Address) -> bool:
-    """
-    Checks if an account exists in the state trie.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address:
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    account_exists : `bool`
-        True if account exists in the state trie, False otherwise
-
-    """
-    return get_account_optional(state, address) is not None
-
-
-def account_has_code_or_nonce(state: State, address: Address) -> bool:
-    """
-    Checks if an account has non-zero nonce or non-empty code.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address:
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_code_or_nonce : `bool`
-        True if the account has non-zero nonce or non-empty code,
-        False otherwise.
-
-    """
-    account = get_account(state, address)
-    return account.nonce != Uint(0) or account.code != b""
-
-
-def account_has_storage(state: State, address: Address) -> bool:
-    """
-    Checks if an account has storage.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address:
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    has_storage : `bool`
-        True if the account has storage, False otherwise.
-
-    """
-    return address in state._storage_tries
-
-
-def account_exists_and_is_empty(state: State, address: Address) -> bool:
-    """
-    Checks if an account exists and has zero nonce, empty code and zero
-    balance.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address:
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    exists_and_is_empty : `bool`
-        True if an account exists and has zero nonce, empty code and zero
-        balance, False otherwise.
-
-    """
-    account = get_account_optional(state, address)
-    return (
-        account is not None
-        and account.nonce == Uint(0)
-        and account.code == b""
-        and account.balance == 0
-    )
-
-
-def is_account_alive(state: State, address: Address) -> bool:
-    """
-    Check whether an account is both in the state and non-empty.
-
-    Parameters
-    ----------
-    state:
-        The state
-    address:
-        Address of the account that needs to be checked.
-
-    Returns
-    -------
-    is_alive : `bool`
-        True if the account is alive.
-
-    """
-    account = get_account_optional(state, address)
-    return account is not None and account != EMPTY_ACCOUNT
-
-
-def modify_state(
-    state: State, address: Address, f: Callable[[Account], None]
-) -> None:
-    """
-    Modify an `Account` in the `State`. If, after modification, the account
-    exists and has zero nonce, empty code, and zero balance, it is destroyed.
-    """
-    set_account(state, address, modify(get_account(state, address), f))
-    if account_exists_and_is_empty(state, address):
-        destroy_account(state, address)
-
-
-def move_ether(
-    state: State,
-    sender_address: Address,
-    recipient_address: Address,
-    amount: U256,
-) -> None:
-    """
-    Move funds between accounts.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-    sender_address:
-        Address of the sender.
-    recipient_address:
-        Address of the recipient.
-    amount:
-        The amount to transfer.
-
-    """
-
-    def reduce_sender_balance(sender: Account) -> None:
-        if sender.balance < amount:
-            raise AssertionError
-        sender.balance -= amount
-
-    def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
-
-    modify_state(state, sender_address, reduce_sender_balance)
-    modify_state(state, recipient_address, increase_recipient_balance)
-
-
-def set_account_balance(state: State, address: Address, amount: U256) -> None:
-    """
-    Sets the balance of an account.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-
-    address:
-        Address of the account whose balance needs to be set.
-
-    amount:
-        The amount that needs to be set in the balance.
-
-    """
-
-    def set_balance(account: Account) -> None:
-        account.balance = amount
-
-    modify_state(state, address, set_balance)
-
-
-def increment_nonce(state: State, address: Address) -> None:
-    """
-    Increments the nonce of an account.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-
-    address:
-        Address of the account whose nonce needs to be incremented.
-
-    """
-
-    def increase_nonce(sender: Account) -> None:
-        sender.nonce += Uint(1)
-
-    modify_state(state, address, increase_nonce)
-
-
-def set_code(state: State, address: Address, code: Bytes) -> None:
-    """
-    Sets Account code.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-
-    address:
-        Address of the account whose code needs to be updated.
-
-    code:
-        The bytecode that needs to be set.
-
-    """
-
-    def write_code(sender: Account) -> None:
-        sender.code = code
-
-    modify_state(state, address, write_code)
-
-
-def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
-    """
-    Get the original value in a storage slot i.e. the value before the current
-    transaction began. This function reads the value from the snapshots taken
-    before executing the transaction.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-    address:
-        Address of the account to read the value from.
-    key:
-        Key of the storage slot.
-
-    """
-    # In the transaction where an account is created, its preexisting storage
-    # is ignored.
-    if address in state.created_accounts:
-        return U256(0)
-
-    _, original_trie = state._snapshots[0]
-    original_account_trie = original_trie.get(address)
-
-    if original_account_trie is None:
-        original_value = U256(0)
-    else:
-        original_value = trie_get(original_account_trie, key)
-
-    assert isinstance(original_value, U256)
-
-    return original_value
-
-
-def get_transient_storage(
-    transient_storage: TransientStorage, address: Address, key: Bytes32
-) -> U256:
-    """
-    Get a value at a storage key on an account from transient storage.
-    Returns `U256(0)` if the storage key has not been set previously.
-
-    Parameters
-    ----------
-    transient_storage: `TransientStorage`
-        The transient storage
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to lookup.
-
-    Returns
-    -------
-    value : `U256`
-        Value at the key.
-
-    """
-    trie = transient_storage._tries.get(address)
-    if trie is None:
-        return U256(0)
-
-    value = trie_get(trie, key)
-
-    assert isinstance(value, U256)
-    return value
-
-
-def set_transient_storage(
-    transient_storage: TransientStorage,
-    address: Address,
-    key: Bytes32,
-    value: U256,
-) -> None:
-    """
-    Set a value at a storage key on an account. Setting to `U256(0)` deletes
-    the key.
-
-    Parameters
-    ----------
-    transient_storage: `TransientStorage`
-        The transient storage
-    address : `Address`
-        Address of the account.
-    key : `Bytes`
-        Key to set.
-    value : `U256`
-        Value to set at the key.
-
-    """
-    trie = transient_storage._tries.get(address)
-    if trie is None:
-        trie = Trie(secured=True, default=U256(0))
-        transient_storage._tries[address] = trie
-    trie_set(trie, key, value)
-    if trie._data == {}:
-        del transient_storage._tries[address]
+    root_value, _ = state.compute_state_root_and_trie_changes({}, {})
+    return root_value

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -1,556 +1,760 @@
 """
-EIP-7928 Block Access Lists: Hierarchical State Change Tracking.
+State Tracking for Block Execution.
 
-Frame hierarchy mirrors EVM execution: Block -> Transaction -> Call frames.
-Each frame tracks state accesses and merges to parent on completion.
+Track state changes on top of a read-only ``PreState``.  At block end,
+accumulated diffs feed into
+``PreState.compute_state_root_and_trie_changes()``.
 
-On success, changes merge upward with net-zero filtering (pre-state vs final).
-On failure, only reads merge (writes discarded). Pre-state captures use
-first-write-wins semantics and are stored at the transaction frame level.
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
 
-[EIP-7928]: https://eips.ethereum.org/EIPS/eip-7928
+Introduction
+------------
+
+Replace the mutable ``State`` class with lightweight state trackers that
+record diffs.  ``BlockState`` accumulates committed transaction
+changes across a block.  ``TransactionState`` tracks in-flight changes
+within a single transaction and supports copy-on-write rollback.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
-from ethereum_types.numeric import U16, U64, U256
+from ethereum_types.frozen import modify
+from ethereum_types.numeric import U256, Uint
 
-from .block_access_lists.rlp_types import BlockAccessIndex
-from .fork_types import Address
+from ethereum.state import EMPTY_ACCOUNT, Account, Address, PreState
+
+if TYPE_CHECKING:
+    from .block_access_lists.builder import BlockAccessListBuilder
 
 
 @dataclass
-class StateChanges:
+class BlockState:
     """
-    Tracks state changes within a single execution frame.
+    Accumulate committed transaction-level changes across a block.
 
-    Frames form a hierarchy (Block -> Transaction -> Call) linked by parent
-    references. The block_access_index is stored at the root frame. Pre-state
-    captures (pre_balances, etc.) are only populated at the transaction level.
+    Read chain: block writes -> pre_state.
+
+    ``account_reads`` and ``storage_reads`` accumulate across all
+    transactions for BAL generation.
     """
 
-    parent: Optional["StateChanges"] = None
-    block_access_index: BlockAccessIndex = BlockAccessIndex(0)
-
-    touched_addresses: Set[Address] = field(default_factory=set)
+    pre_state: PreState
+    account_reads: Set[Address] = field(default_factory=set)
+    account_writes: Dict[Address, Optional[Account]] = field(
+        default_factory=dict
+    )
     storage_reads: Set[Tuple[Address, Bytes32]] = field(default_factory=set)
-    storage_writes: Dict[Tuple[Address, Bytes32, BlockAccessIndex], U256] = (
-        field(default_factory=dict)
-    )
-
-    balance_changes: Dict[Tuple[Address, BlockAccessIndex], U256] = field(
-        default_factory=dict
-    )
-    nonce_changes: Set[Tuple[Address, BlockAccessIndex, U64]] = field(
-        default_factory=set
-    )
-    code_changes: Dict[Tuple[Address, BlockAccessIndex], Bytes] = field(
+    storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
 
-    # Pre-state captures (transaction-scoped, only populated at tx frame)
-    pre_balances: Dict[Address, U256] = field(default_factory=dict)
-    pre_storage: Dict[Tuple[Address, Bytes32], U256] = field(
-        default_factory=dict
-    )
-    pre_code: Dict[Address, Bytes] = field(default_factory=dict)
 
-
-def get_block_frame(state_changes: StateChanges) -> StateChanges:
+@dataclass
+class TransactionState:
     """
-    Walk to the root (block-level) frame.
+    Track in-flight state changes within a single transaction.
+
+    Read chain: tx writes -> block writes -> pre_state.
+
+    ``storage_reads`` and ``account_reads`` are shared references
+    that survive rollback (reads from failed calls still appear in the
+    Block Access List).
+    """
+
+    parent: BlockState
+    account_reads: Set[Address] = field(default_factory=set)
+    account_writes: Dict[Address, Optional[Account]] = field(
+        default_factory=dict
+    )
+    storage_reads: Set[Tuple[Address, Bytes32]] = field(default_factory=set)
+    storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
+        default_factory=dict
+    )
+    created_accounts: Set[Address] = field(default_factory=set)
+    transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
+        default_factory=dict
+    )
+
+
+def get_account_optional(
+    tx_state: TransactionState, address: Address
+) -> Optional[Account]:
+    """
+    Get the ``Account`` object at an address. Return ``None`` (rather than
+    ``EMPTY_ACCOUNT``) if there is no account at the address.
 
     Parameters
     ----------
-    state_changes :
-        Any frame in the hierarchy.
+    tx_state :
+        The transaction state.
+    address :
+        Address to look up.
 
     Returns
     -------
-    block_frame : StateChanges
-        The root block-level frame.
+    account : ``Optional[Account]``
+        Account at address.
 
     """
-    block_frame = state_changes
-    while block_frame.parent is not None:
-        block_frame = block_frame.parent
-    return block_frame
+    if address in tx_state.account_writes:
+        return tx_state.account_writes[address]
+    if address in tx_state.parent.account_writes:
+        return tx_state.parent.account_writes[address]
+    return tx_state.parent.pre_state.get_account_optional(address)
 
 
-def increment_block_access_index(root_frame: StateChanges) -> None:
+def get_account(tx_state: TransactionState, address: Address) -> Account:
     """
-    Increment the block access index in the root frame.
+    Get the ``Account`` object at an address. Return ``EMPTY_ACCOUNT``
+    if there is no account at the address.
+
+    Use ``get_account_optional()`` if you care about the difference
+    between a non-existent account and ``EMPTY_ACCOUNT``.
 
     Parameters
     ----------
-    root_frame :
-        The root block-level frame.
-
-    """
-    root_frame.block_access_index = root_frame.block_access_index + U16(1)
-
-
-def get_transaction_frame(state_changes: StateChanges) -> StateChanges:
-    """
-    Walk to the transaction-level frame (child of block frame).
-
-    Parameters
-    ----------
-    state_changes :
-        Any frame in the hierarchy.
+    tx_state :
+        The transaction state.
+    address :
+        Address to look up.
 
     Returns
     -------
-    tx_frame : StateChanges
-        The transaction-level frame.
+    account : ``Account``
+        Account at address.
 
     """
-    tx_frame = state_changes
-    while tx_frame.parent is not None and tx_frame.parent.parent is not None:
-        tx_frame = tx_frame.parent
-    return tx_frame
+    account = get_account_optional(tx_state, address)
+    if isinstance(account, Account):
+        return account
+    else:
+        return EMPTY_ACCOUNT
 
 
-def capture_pre_balance(
-    tx_frame: StateChanges, address: Address, balance: U256
-) -> None:
+def get_storage(
+    tx_state: TransactionState, address: Address, key: Bytes32
+) -> U256:
     """
-    Capture pre-balance if not already captured (first-write-wins).
+    Get a value at a storage key on an account. Return ``U256(0)`` if
+    the storage key has not been set previously.
 
     Parameters
     ----------
-    tx_frame :
-        The transaction-level frame.
+    tx_state :
+        The transaction state.
     address :
-        The address whose balance to capture.
-    balance :
-        The current balance value.
-
-    """
-    # Only capture pre-values in a transaction level
-    # or block level frame
-    assert tx_frame.parent is None or tx_frame.parent.parent is None
-    if address not in tx_frame.pre_balances:
-        tx_frame.pre_balances[address] = balance
-
-
-def capture_pre_storage(
-    tx_frame: StateChanges, address: Address, key: Bytes32, value: U256
-) -> None:
-    """
-    Capture pre-storage value if not already captured (first-write-wins).
-
-    Parameters
-    ----------
-    tx_frame :
-        The transaction-level frame.
-    address :
-        The address whose storage to capture.
+        Address of the account.
     key :
-        The storage key.
-    value :
-        The current storage value.
+        Key to look up.
+
+    Returns
+    -------
+    value : ``U256``
+        Value at the key.
 
     """
-    # Only capture pre-values in a transaction level
-    # or block level frame
-    assert tx_frame.parent is None or tx_frame.parent.parent is None
-    slot = (address, key)
-    if slot not in tx_frame.pre_storage:
-        tx_frame.pre_storage[slot] = value
+    if address in tx_state.storage_writes:
+        if key in tx_state.storage_writes[address]:
+            return tx_state.storage_writes[address][key]
+    if address in tx_state.parent.storage_writes:
+        if key in tx_state.parent.storage_writes[address]:
+            return tx_state.parent.storage_writes[address][key]
+    return tx_state.parent.pre_state.get_storage(address, key)
 
 
-def capture_pre_code(
-    tx_frame: StateChanges, address: Address, code: Bytes
-) -> None:
+def get_storage_original(
+    tx_state: TransactionState, address: Address, key: Bytes32
+) -> U256:
     """
-    Capture pre-code if not already captured (first-write-wins).
+    Get the original value in a storage slot i.e. the value before the
+    current transaction began. Read from block-level writes, then
+    pre_state. Return ``U256(0)`` for accounts created in the current
+    transaction.
 
     Parameters
     ----------
-    tx_frame :
-        The transaction-level frame.
+    tx_state :
+        The transaction state.
     address :
-        The address whose code to capture.
-    code :
-        The current code value.
+        Address of the account to read the value from.
+    key :
+        Key of the storage slot.
 
     """
-    # Only capture pre-values in a transaction level
-    # or block level frame
-    assert tx_frame.parent is None or tx_frame.parent.parent is None
-    if address not in tx_frame.pre_code:
-        tx_frame.pre_code[address] = code
+    if address in tx_state.created_accounts:
+        return U256(0)
+    if address in tx_state.parent.storage_writes:
+        if key in tx_state.parent.storage_writes[address]:
+            return tx_state.parent.storage_writes[address][key]
+    return tx_state.parent.pre_state.get_storage(address, key)
 
 
-def track_address(state_changes: StateChanges, address: Address) -> None:
+def get_transient_storage(
+    tx_state: TransactionState, address: Address, key: Bytes32
+) -> U256:
+    """
+    Get a value at a storage key on an account from transient storage.
+    Return ``U256(0)`` if the storage key has not been set previously.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account.
+    key :
+        Key to look up.
+
+    Returns
+    -------
+    value : ``U256``
+        Value at the key.
+
+    """
+    return tx_state.transient_storage.get((address, key), U256(0))
+
+
+def account_exists(tx_state: TransactionState, address: Address) -> bool:
+    """
+    Check if an account exists in the state trie.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    account_exists : ``bool``
+        True if account exists in the state trie, False otherwise.
+
+    """
+    return get_account_optional(tx_state, address) is not None
+
+
+def account_has_code_or_nonce(
+    tx_state: TransactionState, address: Address
+) -> bool:
+    """
+    Check if an account has non-zero nonce or non-empty code.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    has_code_or_nonce : ``bool``
+        True if the account has non-zero nonce or non-empty code,
+        False otherwise.
+
+    """
+    account = get_account(tx_state, address)
+    return account.nonce != Uint(0) or account.code != b""
+
+
+def account_has_storage(tx_state: TransactionState, address: Address) -> bool:
+    """
+    Check if an account has storage.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    has_storage : ``bool``
+        True if the account has storage, False otherwise.
+
+    """
+    if tx_state.storage_writes.get(address):
+        return True
+    if tx_state.parent.storage_writes.get(address):
+        return True
+    return tx_state.parent.pre_state.account_has_storage(address)
+
+
+def account_exists_and_is_empty(
+    tx_state: TransactionState, address: Address
+) -> bool:
+    """
+    Check if an account exists and has zero nonce, empty code and zero
+    balance.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    exists_and_is_empty : ``bool``
+        True if an account exists and has zero nonce, empty code and
+        zero balance, False otherwise.
+
+    """
+    account = get_account_optional(tx_state, address)
+    return (
+        account is not None
+        and account.nonce == Uint(0)
+        and account.code == b""
+        and account.balance == 0
+    )
+
+
+def is_account_alive(tx_state: TransactionState, address: Address) -> bool:
+    """
+    Check whether an account is both in the state and non-empty.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that needs to be checked.
+
+    Returns
+    -------
+    is_alive : ``bool``
+        True if the account is alive.
+
+    """
+    account = get_account_optional(tx_state, address)
+    return account is not None and account != EMPTY_ACCOUNT
+
+
+def set_account(
+    tx_state: TransactionState,
+    address: Address,
+    account: Optional[Account],
+) -> None:
+    """
+    Set the ``Account`` object at an address. Setting to ``None``
+    deletes the account (but not its storage, see
+    ``destroy_account()``).
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address to set.
+    account :
+        Account to set at address.
+
+    """
+    tx_state.account_writes[address] = account
+
+
+def set_storage(
+    tx_state: TransactionState,
+    address: Address,
+    key: Bytes32,
+    value: U256,
+) -> None:
+    """
+    Set a value at a storage key on an account.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account.
+    key :
+        Key to set.
+    value :
+        Value to set at the key.
+
+    """
+    assert get_account_optional(tx_state, address) is not None
+    if address not in tx_state.storage_writes:
+        tx_state.storage_writes[address] = {}
+    tx_state.storage_writes[address][key] = value
+
+
+def destroy_account(tx_state: TransactionState, address: Address) -> None:
+    """
+    Completely remove the account at ``address`` and all of its storage.
+
+    This function is made available exclusively for the ``SELFDESTRUCT``
+    opcode. It is expected that ``SELFDESTRUCT`` will be disabled in a
+    future hardfork and this function will be removed. Only supports same
+    transaction destruction.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of account to destroy.
+
+    """
+    destroy_storage(tx_state, address)
+    set_account(tx_state, address, None)
+
+
+def destroy_storage(tx_state: TransactionState, address: Address) -> None:
+    """
+    Completely remove the storage at ``address``.
+
+    Convert storage writes to reads before deleting so that accesses
+    from created-then-destroyed accounts appear in the Block Access
+    List. Only supports same transaction destruction.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of account whose storage is to be deleted.
+
+    """
+    if address in tx_state.storage_writes:
+        for key in tx_state.storage_writes[address]:
+            tx_state.storage_reads.add((address, key))
+        del tx_state.storage_writes[address]
+
+
+def mark_account_created(tx_state: TransactionState, address: Address) -> None:
+    """
+    Mark an account as having been created in the current transaction.
+    This information is used by ``get_storage_original()`` to handle an
+    obscure edgecase, and to respect the constraints added to
+    SELFDESTRUCT by EIP-6780.
+
+    The marker is not removed even if the account creation reverts.
+    Since the account cannot have had code prior to its creation and
+    can't call ``get_storage_original()``, this is harmless.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account that has been created.
+
+    """
+    tx_state.created_accounts.add(address)
+
+
+def set_transient_storage(
+    tx_state: TransactionState,
+    address: Address,
+    key: Bytes32,
+    value: U256,
+) -> None:
+    """
+    Set a value at a storage key on an account in transient storage.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account.
+    key :
+        Key to set.
+    value :
+        Value to set at the key.
+
+    """
+    if value == U256(0):
+        tx_state.transient_storage.pop((address, key), None)
+    else:
+        tx_state.transient_storage[(address, key)] = value
+
+
+def modify_state(
+    tx_state: TransactionState,
+    address: Address,
+    f: Callable[[Account], None],
+) -> None:
+    """
+    Modify an ``Account`` in the state. If, after modification, the
+    account exists and has zero nonce, empty code, and zero balance, it
+    is destroyed.
+    """
+    set_account(tx_state, address, modify(get_account(tx_state, address), f))
+    if account_exists_and_is_empty(tx_state, address):
+        destroy_account(tx_state, address)
+
+
+def move_ether(
+    tx_state: TransactionState,
+    sender_address: Address,
+    recipient_address: Address,
+    amount: U256,
+) -> None:
+    """
+    Move funds between accounts.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    sender_address :
+        Address of the sender.
+    recipient_address :
+        Address of the recipient.
+    amount :
+        The amount to transfer.
+
+    """
+
+    def reduce_sender_balance(sender: Account) -> None:
+        if sender.balance < amount:
+            raise AssertionError
+        sender.balance -= amount
+
+    def increase_recipient_balance(recipient: Account) -> None:
+        recipient.balance += amount
+
+    modify_state(tx_state, sender_address, reduce_sender_balance)
+    modify_state(tx_state, recipient_address, increase_recipient_balance)
+
+
+def set_account_balance(
+    tx_state: TransactionState, address: Address, amount: U256
+) -> None:
+    """
+    Set the balance of an account.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account whose balance needs to be set.
+    amount :
+        The amount that needs to be set in the balance.
+
+    """
+
+    def set_balance(account: Account) -> None:
+        account.balance = amount
+
+    modify_state(tx_state, address, set_balance)
+
+
+def increment_nonce(tx_state: TransactionState, address: Address) -> None:
+    """
+    Increment the nonce of an account.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account whose nonce needs to be incremented.
+
+    """
+
+    def increase_nonce(sender: Account) -> None:
+        sender.nonce += Uint(1)
+
+    modify_state(tx_state, address, increase_nonce)
+
+
+def set_code(
+    tx_state: TransactionState, address: Address, code: Bytes
+) -> None:
+    """
+    Set Account code.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state.
+    address :
+        Address of the account whose code needs to be updated.
+    code :
+        The bytecode that needs to be set.
+
+    """
+
+    def write_code(sender: Account) -> None:
+        sender.code = code
+
+    modify_state(tx_state, address, write_code)
+
+
+# -- Snapshot / Rollback ---------------------------------------------------
+
+
+def copy_tx_state(tx_state: TransactionState) -> TransactionState:
+    """
+    Create a snapshot of the transaction state for rollback.
+
+    Deep-copy writes and transient storage.  The parent reference,
+    ``created_accounts``, ``storage_reads``, and ``account_reads``
+    are shared (not rolled back).
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state to snapshot.
+
+    Returns
+    -------
+    snapshot : ``TransactionState``
+        A copy of the transaction state.
+
+    """
+    return TransactionState(
+        parent=tx_state.parent,
+        account_writes=dict(tx_state.account_writes),
+        storage_writes={
+            addr: dict(slots)
+            for addr, slots in tx_state.storage_writes.items()
+        },
+        created_accounts=tx_state.created_accounts,
+        transient_storage=dict(tx_state.transient_storage),
+        storage_reads=tx_state.storage_reads,
+        account_reads=tx_state.account_reads,
+    )
+
+
+def restore_tx_state(
+    tx_state: TransactionState, snapshot: TransactionState
+) -> None:
+    """
+    Restore transaction state from a snapshot (rollback on failure).
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state to restore.
+    snapshot :
+        The snapshot to restore from.
+
+    """
+    tx_state.account_writes = snapshot.account_writes
+    tx_state.storage_writes = snapshot.storage_writes
+    tx_state.transient_storage = snapshot.transient_storage
+
+
+# -- Lifecycle --------------------------------------------------------------
+
+
+def incorporate_tx_into_block(
+    tx_state: TransactionState,
+    builder: "BlockAccessListBuilder",
+) -> None:
+    """
+    Merge transaction writes into the block state and clear for reuse.
+
+    Update the BAL builder incrementally by diffing this transaction's
+    writes against the block's cumulative state.  Merge reads and
+    touches into block-level sets.
+
+    Parameters
+    ----------
+    tx_state :
+        The transaction state to commit.
+    builder :
+        The BAL builder for incremental updates.
+
+    """
+    from .block_access_lists.builder import update_builder_from_tx
+
+    block = tx_state.parent
+
+    # Update BAL builder before merging writes into block state
+    update_builder_from_tx(builder, tx_state)
+
+    # Merge reads and touches into block-level sets
+    block.storage_reads.update(tx_state.storage_reads)
+    block.account_reads.update(tx_state.account_reads)
+
+    # Merge cumulative writes
+    for address, account in tx_state.account_writes.items():
+        block.account_writes[address] = account
+
+    for address, slots in tx_state.storage_writes.items():
+        if address not in block.storage_writes:
+            block.storage_writes[address] = {}
+        block.storage_writes[address].update(slots)
+
+    tx_state.account_writes.clear()
+    tx_state.storage_writes.clear()
+    tx_state.created_accounts.clear()
+    tx_state.transient_storage.clear()
+    tx_state.storage_reads = set()
+    tx_state.account_reads = set()
+
+
+def extract_block_diffs(
+    block_state: BlockState,
+) -> Tuple[
+    Dict[Address, Optional[Account]],
+    Dict[Address, Dict[Bytes32, U256]],
+]:
+    """
+    Extract account and storage diffs from the block state.
+
+    Parameters
+    ----------
+    block_state :
+        The block state.
+
+    Returns
+    -------
+    account_diffs :
+        Account changes to apply.
+    storage_diffs :
+        Storage changes to apply.
+
+    """
+    return block_state.account_writes, block_state.storage_writes
+
+
+# -- BAL Tracking -----------------------------------------------------------
+
+
+def track_address(tx_state: TransactionState, address: Address) -> None:
     """
     Record that an address was accessed.
 
     Parameters
     ----------
-    state_changes :
-        The state changes frame.
+    tx_state :
+        The transaction state.
     address :
         The address that was accessed.
 
     """
-    state_changes.touched_addresses.add(address)
+    tx_state.account_reads.add(address)
 
 
 def track_storage_read(
-    state_changes: StateChanges, address: Address, key: Bytes32
+    tx_state: TransactionState, address: Address, key: Bytes32
 ) -> None:
     """
     Record a storage read operation.
 
     Parameters
     ----------
-    state_changes :
-        The state changes frame.
+    tx_state :
+        The transaction state.
     address :
         The address whose storage was read.
     key :
         The storage key that was read.
 
     """
-    state_changes.storage_reads.add((address, key))
-
-
-def track_storage_write(
-    state_changes: StateChanges,
-    address: Address,
-    key: Bytes32,
-    value: U256,
-) -> None:
-    """
-    Record a storage write keyed by (address, key, block_access_index).
-
-    Parameters
-    ----------
-    state_changes :
-        The state changes frame.
-    address :
-        The address whose storage was written.
-    key :
-        The storage key that was written.
-    value :
-        The new storage value.
-
-    """
-    idx = state_changes.block_access_index
-    state_changes.storage_writes[(address, key, idx)] = value
-
-
-def track_balance_change(
-    state_changes: StateChanges,
-    address: Address,
-    new_balance: U256,
-) -> None:
-    """
-    Record a balance change keyed by (address, block_access_index).
-
-    Parameters
-    ----------
-    state_changes :
-        The state changes frame.
-    address :
-        The address whose balance changed.
-    new_balance :
-        The new balance value.
-
-    """
-    idx = state_changes.block_access_index
-    state_changes.balance_changes[(address, idx)] = new_balance
-
-
-def track_nonce_change(
-    state_changes: StateChanges,
-    address: Address,
-    new_nonce: U64,
-) -> None:
-    """
-    Record a nonce change as (address, block_access_index, new_nonce).
-
-    Parameters
-    ----------
-    state_changes :
-        The state changes frame.
-    address :
-        The address whose nonce changed.
-    new_nonce :
-        The new nonce value.
-
-    """
-    idx = state_changes.block_access_index
-    state_changes.nonce_changes.add((address, idx, new_nonce))
-
-
-def track_code_change(
-    state_changes: StateChanges,
-    address: Address,
-    new_code: Bytes,
-) -> None:
-    """
-    Record a code change keyed by (address, block_access_index).
-
-    Parameters
-    ----------
-    state_changes :
-        The state changes frame.
-    address :
-        The address whose code changed.
-    new_code :
-        The new code value.
-
-    """
-    idx = state_changes.block_access_index
-    state_changes.code_changes[(address, idx)] = new_code
-
-
-def track_selfdestruct(
-    tx_frame: StateChanges,
-    address: Address,
-) -> None:
-    """
-    Handle selfdestruct of account created in same transaction.
-
-    Per EIP-7928/EIP-6780: removes nonce/code changes, converts storage
-    writes to reads. Balance changes handled by net-zero filtering.
-
-    Parameters
-    ----------
-    tx_frame :
-        The state changes tracker. Should be a transaction frame.
-    address :
-        The address that self-destructed.
-
-    """
-    # Has to be a transaction frame
-    assert tx_frame.parent is not None and tx_frame.parent.parent is None
-
-    idx = tx_frame.block_access_index
-
-    # Remove nonce changes from current transaction
-    tx_frame.nonce_changes = {
-        (addr, i, nonce)
-        for addr, i, nonce in tx_frame.nonce_changes
-        if not (addr == address and i == idx)
-    }
-
-    # Remove balance changes from current transaction
-    if (address, idx) in tx_frame.balance_changes:
-        pre_balance = tx_frame.pre_balances[address]
-        if pre_balance == U256(0):
-            # Post balance will be U256(0) after deletion.
-            # So no change and hence bal does not need to
-            # capture anything.
-            del tx_frame.balance_changes[(address, idx)]
-
-    # Remove code changes from current transaction
-    if (address, idx) in tx_frame.code_changes:
-        del tx_frame.code_changes[(address, idx)]
-
-    # Convert storage writes from current transaction to reads
-    for addr, key, i in list(tx_frame.storage_writes.keys()):
-        if addr == address and i == idx:
-            del tx_frame.storage_writes[(addr, key, i)]
-            tx_frame.storage_reads.add((addr, key))
-
-
-def merge_on_success(child_frame: StateChanges) -> None:
-    """
-    Merge child frame into parent on success.
-
-    Child values overwrite parent values (most recent wins). No net-zero
-    filtering here - that happens once at transaction commit via
-    normalize_transaction().
-
-    Parameters
-    ----------
-    child_frame :
-        The child frame being merged.
-
-    """
-    assert child_frame.parent is not None
-    parent_frame = child_frame.parent
-
-    # Merge address accesses
-    parent_frame.touched_addresses.update(child_frame.touched_addresses)
-
-    # Merge storage: reads union, writes overwrite (child supersedes parent)
-    parent_frame.storage_reads.update(child_frame.storage_reads)
-    for storage_key, storage_value in child_frame.storage_writes.items():
-        parent_frame.storage_writes[storage_key] = storage_value
-
-    # Merge balance changes: child overwrites parent for same key
-    for balance_key, balance_value in child_frame.balance_changes.items():
-        parent_frame.balance_changes[balance_key] = balance_value
-
-    # Merge nonce changes: keep highest nonce per address
-    address_final_nonces: Dict[Address, Tuple[BlockAccessIndex, U64]] = {}
-    for addr, idx, nonce in child_frame.nonce_changes:
-        if (
-            addr not in address_final_nonces
-            or nonce > address_final_nonces[addr][1]
-        ):
-            address_final_nonces[addr] = (idx, nonce)
-    for addr, (idx, final_nonce) in address_final_nonces.items():
-        parent_frame.nonce_changes.add((addr, idx, final_nonce))
-
-    # Merge code changes: child overwrites parent for same key
-    for code_key, code_value in child_frame.code_changes.items():
-        parent_frame.code_changes[code_key] = code_value
-
-
-def merge_on_failure(child_frame: StateChanges) -> None:
-    """
-    Merge child frame into parent on failure/revert.
-
-    Only reads merge; writes are discarded (converted to reads).
-
-    Parameters
-    ----------
-    child_frame :
-        The failed child frame.
-
-    """
-    assert child_frame.parent is not None
-    parent_frame = child_frame.parent
-    # Only merge reads and address accesses on failure
-    parent_frame.touched_addresses.update(child_frame.touched_addresses)
-    parent_frame.storage_reads.update(child_frame.storage_reads)
-
-    # Convert writes to reads (failed writes still accessed the slots)
-    for address, key, _idx in child_frame.storage_writes.keys():
-        parent_frame.storage_reads.add((address, key))
-
-    # Note: balance_changes, nonce_changes, and code_changes are NOT
-    # merged on failure - they are discarded
-
-
-def commit_transaction_frame(tx_frame: StateChanges) -> None:
-    """
-    Commit transaction frame to block frame.
-
-    Filters net-zero changes before merging to ensure only actual state
-    modifications are recorded in the block access list.
-
-    Parameters
-    ----------
-    tx_frame :
-        The transaction frame to commit.
-
-    """
-    assert tx_frame.parent is not None
-    block_frame = tx_frame.parent
-
-    # Filter net-zero changes before committing
-    filter_net_zero_frame_changes(tx_frame)
-
-    # Merge address accesses
-    block_frame.touched_addresses.update(tx_frame.touched_addresses)
-
-    # Merge storage operations
-    block_frame.storage_reads.update(tx_frame.storage_reads)
-    for (addr, key, idx), value in tx_frame.storage_writes.items():
-        block_frame.storage_writes[(addr, key, idx)] = value
-
-    # Merge balance changes
-    for (addr, idx), final_balance in tx_frame.balance_changes.items():
-        block_frame.balance_changes[(addr, idx)] = final_balance
-
-    # Merge nonce changes
-    for addr, idx, nonce in tx_frame.nonce_changes:
-        block_frame.nonce_changes.add((addr, idx, nonce))
-
-    # Merge code changes
-    for (addr, idx), final_code in tx_frame.code_changes.items():
-        block_frame.code_changes[(addr, idx)] = final_code
-
-
-def create_child_frame(parent: StateChanges) -> StateChanges:
-    """
-    Create a child frame linked to the given parent.
-
-    Inherits block_access_index from parent so track functions can
-    access it directly without walking up the frame hierarchy.
-
-    Parameters
-    ----------
-    parent :
-        The parent frame.
-
-    Returns
-    -------
-    child : StateChanges
-        A new child frame with parent reference and inherited
-        block_access_index.
-
-    """
-    return StateChanges(
-        parent=parent,
-        block_access_index=parent.block_access_index,
-    )
-
-
-def filter_net_zero_frame_changes(tx_frame: StateChanges) -> None:
-    """
-    Filter net-zero changes from transaction frame before commit.
-
-    Compares final values against pre-tx state for storage, balance, and code.
-    Net-zero storage writes are converted to reads. Net-zero balance/code
-    changes are removed entirely. Nonces are not filtered (only increment).
-
-    Parameters
-    ----------
-    tx_frame :
-        The transaction-level state changes frame.
-
-    """
-    idx = tx_frame.block_access_index
-
-    # Filter storage: compare against pre_storage, convert net-zero to reads
-    addresses_to_check_storage = [
-        (addr, key)
-        for (addr, key, i) in tx_frame.storage_writes.keys()
-        if i == idx
-    ]
-    for addr, key in addresses_to_check_storage:
-        # For any (address, key) whose balance has changed, its
-        # pre-value should have been captured
-        assert (addr, key) in tx_frame.pre_storage
-        pre_value = tx_frame.pre_storage[(addr, key)]
-        post_value = tx_frame.storage_writes[(addr, key, idx)]
-        if pre_value == post_value:
-            # Net-zero write - convert to read
-            del tx_frame.storage_writes[(addr, key, idx)]
-            tx_frame.storage_reads.add((addr, key))
-
-    # Filter balance: compare pre vs post, remove if equal
-    addresses_to_check_balance = [
-        addr for (addr, i) in tx_frame.balance_changes.keys() if i == idx
-    ]
-    for addr in addresses_to_check_balance:
-        # For any account whose balance has changed, its
-        # pre-balance should have been captured
-        assert addr in tx_frame.pre_balances
-        pre_balance = tx_frame.pre_balances[addr]
-        post_balance = tx_frame.balance_changes[(addr, idx)]
-        if pre_balance == post_balance:
-            del tx_frame.balance_changes[(addr, idx)]
-
-    # Filter code: compare pre vs post, remove if equal
-    addresses_to_check_code = [
-        addr for (addr, i) in tx_frame.code_changes.keys() if i == idx
-    ]
-    for addr in addresses_to_check_code:
-        assert addr in tx_frame.pre_code
-        pre_code = tx_frame.pre_code[addr]
-        post_code = tx_frame.code_changes[(addr, idx)]
-        if pre_code == post_code:
-            del tx_frame.code_changes[(addr, idx)]
-
-    # Nonces: no filtering needed (nonces only increment, never net-zero)
+    tx_state.storage_reads.add((address, key))

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -19,13 +19,14 @@ from ethereum.exceptions import (
     InvalidSignatureError,
     NonceOverflowError,
 )
+from ethereum.state import Address
 
 from .exceptions import (
     InitCodeTooLargeError,
     TransactionGasLimitExceededError,
     TransactionTypeError,
 )
-from .fork_types import Address, Authorization, VersionedHash
+from .fork_types import Authorization, VersionedHash
 
 TX_BASE_COST = Uint(21000)
 """

--- a/src/ethereum/forks/amsterdam/trie.py
+++ b/src/ethereum/forks/amsterdam/trie.py
@@ -30,16 +30,25 @@ from typing import (
 
 from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes
-from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 from typing_extensions import assert_type
 
 from ethereum.crypto.hash import keccak256
 from ethereum.forks.bpo5 import trie as previous_trie
+from ethereum.state import (
+    Account,
+    Address,
+    BranchNode,
+    BranchSubnodes,
+    ExtensionNode,
+    InternalNode,
+    LeafNode,
+    Root,
+)
 from ethereum.utils.hexadecimal import hex_to_bytes
 
 from .blocks import Receipt, Withdrawal
-from .fork_types import Account, Address, Root, encode_account
+from .fork_types import encode_account
 from .transactions import LegacyTransaction
 
 # note: an empty trie (regardless of whether it is secured) has root:
@@ -83,56 +92,6 @@ V = TypeVar(
     Uint,
     U256,
 )
-
-
-@slotted_freezable
-@dataclass
-class LeafNode:
-    """Leaf node in the Merkle Trie."""
-
-    rest_of_key: Bytes
-    value: Extended
-
-
-@slotted_freezable
-@dataclass
-class ExtensionNode:
-    """Extension node in the Merkle Trie."""
-
-    key_segment: Bytes
-    subnode: Extended
-
-
-BranchSubnodes = Tuple[
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-    Extended,
-]
-
-
-@slotted_freezable
-@dataclass
-class BranchNode:
-    """Branch node in the Merkle Trie."""
-
-    subnodes: BranchSubnodes
-    value: Extended
-
-
-InternalNode = LeafNode | ExtensionNode | BranchNode
 
 
 def encode_internal_node(node: Optional[InternalNode]) -> Extended:

--- a/src/ethereum/forks/amsterdam/utils/address.py
+++ b/src/ethereum/forks/amsterdam/utils/address.py
@@ -17,9 +17,8 @@ from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import keccak256
+from ethereum.state import Address
 from ethereum.utils.byte import left_pad_zero_bytes
-
-from ..fork_types import Address
 
 
 def to_address_masked(data: Uint | U256) -> Address:

--- a/src/ethereum/forks/amsterdam/utils/hexadecimal.py
+++ b/src/ethereum/forks/amsterdam/utils/hexadecimal.py
@@ -14,9 +14,8 @@ Amsterdam types.
 
 from ethereum_types.bytes import Bytes
 
+from ethereum.state import Address, Root
 from ethereum.utils.hexadecimal import remove_hex_prefix
-
-from ..fork_types import Address, Root
 
 
 def hex_to_root(hex_string: str) -> Root:

--- a/src/ethereum/forks/amsterdam/utils/message.py
+++ b/src/ethereum/forks/amsterdam/utils/message.py
@@ -15,9 +15,9 @@ specification.
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.numeric import Uint
 
-from ..fork_types import Address
-from ..state import get_account
-from ..state_tracker import create_child_frame
+from ethereum.state import Address
+
+from ..state_tracker import get_account
 from ..transactions import Transaction
 from ..vm import BlockEnvironment, Message, TransactionEnvironment
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
@@ -55,7 +55,7 @@ def prepare_message(
     if isinstance(tx.to, Bytes0):
         current_target = compute_contract_address(
             tx_env.origin,
-            get_account(block_env.state, tx_env.origin).nonce - Uint(1),
+            get_account(tx_env.state, tx_env.origin).nonce - Uint(1),
         )
         msg_data = Bytes(b"")
         code = tx.data
@@ -63,15 +63,12 @@ def prepare_message(
     elif isinstance(tx.to, Address):
         current_target = tx.to
         msg_data = tx.data
-        code = get_account(block_env.state, tx.to).code
+        code = get_account(tx_env.state, tx.to).code
         code_address = tx.to
     else:
         raise AssertionError("Target must be address or empty bytes")
 
     accessed_addresses.add(current_target)
-
-    # Create call frame as child of transaction frame
-    call_frame = create_child_frame(tx_env.state_changes)
 
     return Message(
         block_env=block_env,
@@ -92,5 +89,4 @@ def prepare_message(
         disable_precompiles=False,
         parent_evm=None,
         is_create=isinstance(tx.to, Bytes0),
-        state_changes=call_frame,
     )

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -20,12 +20,13 @@ from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
 from ethereum.exceptions import EthereumException
+from ethereum.state import Address
 
+from ..block_access_lists.builder import BlockAccessListBuilder
 from ..block_access_lists.rlp_types import BlockAccessList
 from ..blocks import Log, Receipt, Withdrawal
-from ..fork_types import Address, Authorization, VersionedHash
-from ..state import State, TransientStorage
-from ..state_tracker import StateChanges, merge_on_failure, merge_on_success
+from ..fork_types import Authorization, VersionedHash
+from ..state_tracker import BlockState, TransactionState
 from ..transactions import LegacyTransaction
 from ..trie import Trie
 
@@ -39,7 +40,7 @@ class BlockEnvironment:
     """
 
     chain_id: U64
-    state: State
+    state: BlockState
     block_gas_limit: Uint
     block_hashes: List[Hash32]
     coinbase: Address
@@ -49,7 +50,7 @@ class BlockEnvironment:
     prev_randao: Bytes32
     excess_blob_gas: U64
     parent_beacon_block_root: Hash32
-    state_changes: StateChanges
+    block_access_list_builder: BlockAccessListBuilder
 
 
 @dataclass
@@ -108,12 +109,11 @@ class TransactionEnvironment:
     gas: Uint
     access_list_addresses: Set[Address]
     access_list_storage_keys: Set[Tuple[Address, Bytes32]]
-    transient_storage: TransientStorage
+    state: TransactionState
     blob_versioned_hashes: Tuple[VersionedHash, ...]
     authorizations: Tuple[Authorization, ...]
     index_in_block: Optional[Uint]
     tx_hash: Optional[Hash32]
-    state_changes: "StateChanges" = field(default_factory=StateChanges)
 
 
 @dataclass
@@ -140,7 +140,6 @@ class Message:
     disable_precompiles: bool
     parent_evm: Optional["Evm"]
     is_create: bool
-    state_changes: "StateChanges" = field(default_factory=StateChanges)
 
 
 @dataclass
@@ -163,7 +162,6 @@ class Evm:
     error: Optional[EthereumException]
     accessed_addresses: Set[Address]
     accessed_storage_keys: Set[Tuple[Address, Bytes32]]
-    state_changes: StateChanges
 
 
 def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
@@ -185,8 +183,6 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
     evm.accessed_addresses.update(child_evm.accessed_addresses)
     evm.accessed_storage_keys.update(child_evm.accessed_storage_keys)
 
-    merge_on_success(child_evm.state_changes)
-
 
 def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
     """
@@ -201,5 +197,3 @@ def incorporate_child_on_error(evm: Evm, child_evm: Evm) -> None:
 
     """
     evm.gas_left += child_evm.gas_left
-
-    merge_on_failure(child_evm.state_changes)

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -10,19 +10,15 @@ from ethereum_types.numeric import U64, U256, Uint
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import keccak256
 from ethereum.exceptions import InvalidBlock, InvalidSignatureError
+from ethereum.state import Address
 
-from ..fork_types import Address, Authorization
-from ..state import (
+from ..fork_types import Authorization
+from ..state_tracker import (
     account_exists,
     get_account,
     increment_nonce,
     set_code,
-)
-from ..state_tracker import (
-    capture_pre_code,
     track_address,
-    track_code_change,
-    track_nonce_change,
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import GAS_COLD_ACCOUNT_ACCESS, GAS_WARM_ACCESS
@@ -143,10 +139,10 @@ def calculate_delegation_cost(
         The delegation address and access gas cost.
 
     """
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
 
-    code = get_account(state, address).code
-    track_address(evm.state_changes, address)
+    code = get_account(tx_state, address).code
+    track_address(tx_state, address)
 
     if not is_valid_delegation(code):
         return False, address, Uint(0)
@@ -176,7 +172,7 @@ def set_delegation(message: Message) -> U256:
         Refund from authority which already exists in state.
 
     """
-    state = message.block_env.state
+    tx_state = message.tx_env.state
     refund_counter = U256(0)
     for auth in message.tx_env.authorizations:
         if auth.chain_id not in (message.block_env.chain_id, U256(0)):
@@ -192,9 +188,9 @@ def set_delegation(message: Message) -> U256:
 
         message.accessed_addresses.add(authority)
 
-        authority_account = get_account(state, authority)
+        authority_account = get_account(tx_state, authority)
         authority_code = authority_account.code
-        track_address(message.tx_env.state_changes, authority)
+        track_address(tx_state, authority)
 
         if authority_code and not is_valid_delegation(authority_code):
             continue
@@ -203,7 +199,7 @@ def set_delegation(message: Message) -> U256:
         if authority_nonce != auth.nonce:
             continue
 
-        if account_exists(state, authority):
+        if account_exists(tx_state, authority):
             refund_counter += U256(PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST)
 
         if auth.address == NULL_ADDRESS:
@@ -211,23 +207,12 @@ def set_delegation(message: Message) -> U256:
         else:
             code_to_set = EOA_DELEGATION_MARKER + auth.address
 
-        tx_frame = message.tx_env.state_changes
-        # EIP-7928: Capture pre-code before any changes
-        capture_pre_code(tx_frame, authority, authority_code)
-
-        set_code(state, authority, code_to_set)
-
-        if authority_code != code_to_set:
-            # Track code change if different from current
-            track_code_change(tx_frame, authority, code_to_set)
-
-        increment_nonce(state, authority)
-        nonce_after = get_account(state, authority).nonce
-        track_nonce_change(tx_frame, authority, U64(nonce_after))
+        set_code(tx_state, authority, code_to_set)
+        increment_nonce(tx_state, authority)
 
     if message.code_address is None:
         raise InvalidBlock("Invalid type 4 transaction: no target")
 
-    message.code = get_account(state, message.code_address).code
+    message.code = get_account(tx_state, message.code_address).code
 
     return refund_counter

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -15,12 +15,10 @@ from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.crypto.hash import keccak256
+from ethereum.state import EMPTY_ACCOUNT
 from ethereum.utils.numeric import ceil32
 
-# track_address_access removed - now using state_changes.track_address()
-from ...fork_types import EMPTY_ACCOUNT
-from ...state import get_account
-from ...state_tracker import track_address
+from ...state_tracker import get_account, track_address
 from ...utils.address import to_address_masked
 from ...vm.memory import buffer_read, memory_write
 from .. import Evm
@@ -87,9 +85,9 @@ def balance(evm: Evm) -> None:
 
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
-    state = evm.message.block_env.state
-    balance = get_account(state, address).balance
-    track_address(evm.state_changes, address)
+    tx_state = evm.message.tx_env.state
+    balance = get_account(tx_state, address).balance
+    track_address(tx_state, address)
 
     push(evm.stack, balance)
 
@@ -356,9 +354,9 @@ def extcodesize(evm: Evm) -> None:
     charge_gas(evm, access_gas_cost)
 
     # OPERATION
-    state = evm.message.block_env.state
-    code = get_account(state, address).code
-    track_address(evm.state_changes, address)
+    tx_state = evm.message.tx_env.state
+    code = get_account(tx_state, address).code
+    track_address(tx_state, address)
 
     codesize = U256(len(code))
     push(evm.stack, codesize)
@@ -403,9 +401,9 @@ def extcodecopy(evm: Evm) -> None:
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
-    state = evm.message.block_env.state
-    code = get_account(state, address).code
-    track_address(evm.state_changes, address)
+    tx_state = evm.message.tx_env.state
+    code = get_account(tx_state, address).code
+    track_address(tx_state, address)
 
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -496,9 +494,9 @@ def extcodehash(evm: Evm) -> None:
     charge_gas(evm, access_gas_cost)
 
     # OPERATION
-    state = evm.message.block_env.state
-    account = get_account(state, address)
-    track_address(evm.state_changes, address)
+    tx_state = evm.message.tx_env.state
+    account = get_account(tx_state, address)
+    track_address(tx_state, address)
 
     if account == EMPTY_ACCOUNT:
         codehash = U256(0)
@@ -531,7 +529,7 @@ def self_balance(evm: Evm) -> None:
     # OPERATION
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     balance = get_account(
-        evm.message.block_env.state, evm.message.current_target
+        evm.message.tx_env.state, evm.message.current_target
     ).balance
 
     push(evm.stack, balance)

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -13,17 +13,13 @@ Implementations of the EVM storage related instructions.
 
 from ethereum_types.numeric import Uint
 
-from ...state import (
+from ...state_tracker import (
     get_storage,
     get_storage_original,
     get_transient_storage,
     set_storage,
     set_transient_storage,
-)
-from ...state_tracker import (
-    capture_pre_storage,
     track_storage_read,
-    track_storage_write,
 )
 from .. import Evm
 from ..exceptions import WriteInStaticContext
@@ -62,14 +58,9 @@ def sload(evm: Evm) -> None:
         charge_gas(evm, GAS_COLD_SLOAD)
 
     # OPERATION
-    value = get_storage(
-        evm.message.block_env.state, evm.message.current_target, key
-    )
-    track_storage_read(
-        evm.state_changes,
-        evm.message.current_target,
-        key,
-    )
+    tx_state = evm.message.tx_env.state
+    value = get_storage(tx_state, evm.message.current_target, key)
+    track_storage_read(tx_state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
@@ -97,11 +88,11 @@ def sstore(evm: Evm) -> None:
     # check we have at least the stipend gas
     check_gas(evm, GAS_CALL_STIPEND + Uint(1))
 
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     original_value = get_storage_original(
-        state, evm.message.current_target, key
+        tx_state, evm.message.current_target, key
     )
-    current_value = get_storage(state, evm.message.current_target, key)
+    current_value = get_storage(tx_state, evm.message.current_target, key)
 
     gas_cost = Uint(0)
 
@@ -109,17 +100,7 @@ def sstore(evm: Evm) -> None:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GAS_COLD_SLOAD
 
-    capture_pre_storage(
-        evm.message.tx_env.state_changes,
-        evm.message.current_target,
-        key,
-        current_value,
-    )
-    track_storage_read(
-        evm.state_changes,
-        evm.message.current_target,
-        key,
-    )
+    track_storage_read(tx_state, evm.message.current_target, key)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
@@ -151,13 +132,7 @@ def sstore(evm: Evm) -> None:
                 )
 
     charge_gas(evm, gas_cost)
-    set_storage(state, evm.message.current_target, key, new_value)
-    track_storage_write(
-        evm.state_changes,
-        evm.message.current_target,
-        key,
-        new_value,
-    )
+    set_storage(tx_state, evm.message.current_target, key, new_value)
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)
@@ -182,7 +157,7 @@ def tload(evm: Evm) -> None:
 
     # OPERATION
     value = get_transient_storage(
-        evm.message.tx_env.transient_storage, evm.message.current_target, key
+        evm.message.tx_env.state, evm.message.current_target, key
     )
     push(evm.stack, value)
 
@@ -210,7 +185,7 @@ def tstore(evm: Evm) -> None:
     # GAS
     charge_gas(evm, GAS_WARM_ACCESS)
     set_transient_storage(
-        evm.message.tx_env.transient_storage,
+        evm.message.tx_env.state,
         evm.message.current_target,
         key,
         new_value,

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -12,12 +12,12 @@ Implementations of the EVM system related instructions.
 """
 
 from ethereum_types.bytes import Bytes, Bytes0
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U256, Uint
 
+from ethereum.state import Address
 from ethereum.utils.numeric import ceil32
 
-from ...fork_types import Address
-from ...state import (
+from ...state_tracker import (
     account_has_code_or_nonce,
     account_has_storage,
     get_account,
@@ -25,13 +25,7 @@ from ...state import (
     is_account_alive,
     move_ether,
     set_account_balance,
-)
-from ...state_tracker import (
-    capture_pre_balance,
-    create_child_frame,
     track_address,
-    track_balance_change,
-    track_nonce_change,
 )
 from ...utils.address import (
     compute_contract_address,
@@ -95,7 +89,7 @@ def generic_create(
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
 
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
 
     call_data = memory_read_bytes(
         evm.memory, memory_start_position, memory_size
@@ -106,7 +100,7 @@ def generic_create(
     evm.return_data = b""
 
     sender_address = evm.message.current_target
-    sender = get_account(state, sender_address)
+    sender = get_account(tx_state, sender_address)
 
     if (
         sender.balance < endowment
@@ -119,31 +113,15 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    track_address(evm.state_changes, contract_address)
+    track_address(tx_state, contract_address)
     if account_has_code_or_nonce(
-        state, contract_address
-    ) or account_has_storage(state, contract_address):
-        increment_nonce(state, evm.message.current_target)
-        nonce_after = get_account(state, evm.message.current_target).nonce
-        track_nonce_change(
-            evm.state_changes,
-            evm.message.current_target,
-            U64(nonce_after),
-        )
+        tx_state, contract_address
+    ) or account_has_storage(tx_state, contract_address):
+        increment_nonce(tx_state, evm.message.current_target)
         push(evm.stack, U256(0))
         return
 
-    # Track nonce increment for CREATE
-    increment_nonce(state, evm.message.current_target)
-    nonce_after = get_account(state, evm.message.current_target).nonce
-    track_nonce_change(
-        evm.state_changes,
-        evm.message.current_target,
-        U64(nonce_after),
-    )
-
-    # Create call frame as child of parent EVM's frame
-    child_state_changes = create_child_frame(evm.state_changes)
+    increment_nonce(tx_state, evm.message.current_target)
 
     child_message = Message(
         block_env=evm.message.block_env,
@@ -164,7 +142,6 @@ def generic_create(
         disable_precompiles=False,
         parent_evm=evm,
         is_create=True,
-        state_changes=child_state_changes,
     )
     child_evm = process_create_message(child_message)
 
@@ -206,7 +183,7 @@ def create(evm: Evm) -> None:
     contract_address = compute_contract_address(
         evm.message.current_target,
         get_account(
-            evm.message.block_env.state, evm.message.current_target
+            evm.message.tx_env.state, evm.message.current_target
         ).nonce,
     )
 
@@ -340,9 +317,6 @@ def generic_call(
         evm.memory, memory_input_start_position, memory_input_size
     )
 
-    # Create call frame as child of parent EVM's frame
-    child_state_changes = create_child_frame(evm.state_changes)
-
     child_message = Message(
         block_env=evm.message.block_env,
         tx_env=evm.message.tx_env,
@@ -362,7 +336,6 @@ def generic_call(
         disable_precompiles=disable_precompiles,
         parent_evm=evm,
         is_create=False,
-        state_changes=child_state_changes,
     )
 
     child_evm = process_message(child_message)
@@ -430,12 +403,12 @@ def call(evm: Evm) -> None:
     )
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
     create_gas_cost = GAS_NEW_ACCOUNT
-    if value == 0 or is_account_alive(state, to):
+    if value == 0 or is_account_alive(tx_state, to):
         create_gas_cost = Uint(0)
 
     extra_gas = access_gas_cost + transfer_gas_cost + create_gas_cost
@@ -449,11 +422,11 @@ def call(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(evm.state_changes, code_address)
+        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code = get_account(state, code_address).code
+    code = get_account(tx_state, code_address).code
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -465,7 +438,7 @@ def call(evm: Evm) -> None:
     charge_gas(evm, message_call_gas.cost + extend_memory.cost)
 
     evm.memory += b"\x00" * extend_memory.expand_by
-    sender_balance = get_account(state, evm.message.current_target).balance
+    sender_balance = get_account(tx_state, evm.message.current_target).balance
     if sender_balance < value:
         push(evm.stack, U256(0))
         evm.return_data = b""
@@ -537,7 +510,7 @@ def callcode(evm: Evm) -> None:
     )
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -552,11 +525,11 @@ def callcode(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(evm.state_changes, code_address)
+        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code = get_account(state, code_address).code
+    code = get_account(tx_state, code_address).code
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -569,19 +542,7 @@ def callcode(evm: Evm) -> None:
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
-    sender_balance = get_account(
-        evm.message.block_env.state, evm.message.current_target
-    ).balance
-
-    # EIP-7928: For CALLCODE with value transfer, capture pre-balance
-    # in transaction frame. CALLCODE transfers value from/to current_target
-    # (same address), affecting current storage context, not child frame
-    if value != 0 and sender_balance >= value:
-        capture_pre_balance(
-            evm.message.tx_env.state_changes,
-            evm.message.current_target,
-            sender_balance,
-        )
+    sender_balance = get_account(tx_state, evm.message.current_target).balance
 
     if sender_balance < value:
         push(evm.stack, U256(0))
@@ -636,57 +597,34 @@ def selfdestruct(evm: Evm) -> None:
     check_gas(evm, gas_cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
-    track_address(evm.state_changes, beneficiary)
+    track_address(tx_state, beneficiary)
 
     if (
-        not is_account_alive(state, beneficiary)
-        and get_account(state, evm.message.current_target).balance != 0
+        not is_account_alive(tx_state, beneficiary)
+        and get_account(tx_state, evm.message.current_target).balance != 0
     ):
         gas_cost += GAS_SELF_DESTRUCT_NEW_ACCOUNT
 
     charge_gas(evm, gas_cost)
 
-    state = evm.message.block_env.state
     originator = evm.message.current_target
-    originator_balance = get_account(state, originator).balance
-    beneficiary_balance = get_account(state, beneficiary).balance
+    originator_balance = get_account(tx_state, originator).balance
 
-    # Get tracking context
-    tx_frame = evm.message.tx_env.state_changes
-
-    # Capture pre-balances for net-zero filtering
-    track_address(evm.state_changes, originator)
-    capture_pre_balance(tx_frame, originator, originator_balance)
-    capture_pre_balance(tx_frame, beneficiary, beneficiary_balance)
+    track_address(tx_state, originator)
 
     # Transfer balance
-    move_ether(state, originator, beneficiary, originator_balance)
-
-    # Track balance changes
-    originator_new_balance = get_account(state, originator).balance
-    beneficiary_new_balance = get_account(state, beneficiary).balance
-    track_balance_change(
-        evm.state_changes,
-        originator,
-        originator_new_balance,
-    )
-    track_balance_change(
-        evm.state_changes,
-        beneficiary,
-        beneficiary_new_balance,
-    )
+    move_ether(tx_state, originator, beneficiary, originator_balance)
 
     # register account for deletion only if it was created
     # in the same transaction
-    if originator in state.created_accounts:
+    if originator in tx_state.created_accounts:
         # If beneficiary is the same as originator, then
         # the ether is burnt.
-        set_account_balance(state, originator, U256(0))
-        track_balance_change(evm.state_changes, originator, U256(0))
+        set_account_balance(tx_state, originator, U256(0))
         evm.accounts_to_delete.add(originator)
 
     # HALT the execution
@@ -733,7 +671,7 @@ def delegatecall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(code_address)
 
@@ -748,11 +686,11 @@ def delegatecall(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(evm.state_changes, code_address)
+        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code = get_account(state, code_address).code
+    code = get_account(tx_state, code_address).code
 
     message_call_gas = calculate_message_call_gas(
         U256(0),
@@ -823,7 +761,7 @@ def staticcall(evm: Evm) -> None:
     check_gas(evm, access_gas_cost + extend_memory.cost)
 
     # STATE ACCESS
-    state = evm.message.block_env.state
+    tx_state = evm.message.tx_env.state
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
@@ -838,11 +776,11 @@ def staticcall(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(evm.state_changes, code_address)
+        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
-    code = get_account(state, code_address).code
+    code = get_account(tx_state, code_address).code
 
     message_call_gas = calculate_message_call_gas(
         U256(0),

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -15,9 +15,10 @@ from dataclasses import dataclass
 from typing import Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes0
-from ethereum_types.numeric import U64, U256, Uint, ulen
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.exceptions import EthereumException
+from ethereum.state import Address
 from ethereum.trace import (
     EvmStop,
     OpEnd,
@@ -30,29 +31,18 @@ from ethereum.trace import (
 )
 
 from ..blocks import Log
-from ..fork_types import Address
-from ..state import (
+from ..state_tracker import (
     account_has_code_or_nonce,
     account_has_storage,
-    begin_transaction,
-    commit_transaction,
+    copy_tx_state,
     destroy_storage,
     get_account,
     increment_nonce,
     mark_account_created,
     move_ether,
-    rollback_transaction,
+    restore_tx_state,
     set_code,
-)
-from ..state_tracker import (
-    capture_pre_balance,
-    capture_pre_code,
-    merge_on_failure,
-    merge_on_success,
     track_address,
-    track_balance_change,
-    track_code_change,
-    track_nonce_change,
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
@@ -115,13 +105,13 @@ def process_message_call(message: Message) -> MessageCallOutput:
         Output of the message call
 
     """
-    block_env = message.block_env
+    tx_state = message.tx_env.state
     refund_counter = U256(0)
     if message.target == Bytes0(b""):
         is_collision = account_has_code_or_nonce(
-            block_env.state, message.current_target
-        ) or account_has_storage(block_env.state, message.current_target)
-        track_address(message.tx_env.state_changes, message.current_target)
+            tx_state, message.current_target
+        ) or account_has_storage(tx_state, message.current_target)
+        track_address(tx_state, message.current_target)
         if is_collision:
             return MessageCallOutput(
                 Uint(0),
@@ -141,9 +131,9 @@ def process_message_call(message: Message) -> MessageCallOutput:
         if delegated_address is not None:
             message.disable_precompiles = True
             message.accessed_addresses.add(delegated_address)
-            message.code = get_account(block_env.state, delegated_address).code
+            message.code = get_account(tx_state, delegated_address).code
             message.code_address = delegated_address
-            track_address(message.block_env.state_changes, delegated_address)
+            track_address(tx_state, delegated_address)
 
         evm = process_message(message)
 
@@ -185,10 +175,9 @@ def process_create_message(message: Message) -> Evm:
         Items containing execution specific objects.
 
     """
-    state = message.block_env.state
-    transient_storage = message.tx_env.transient_storage
+    tx_state = message.tx_env.state
     # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
+    snapshot = copy_tx_state(tx_state)
 
     # If the address where the account is being created has storage, it is
     # destroyed. This can only happen in the following highly unlikely
@@ -197,23 +186,15 @@ def process_create_message(message: Message) -> Evm:
     #   `CREATE` or `CREATE2` call.
     # * The first `CREATE` happened before Spurious Dragon and left empty
     #   code.
-    destroy_storage(state, message.current_target)
+    destroy_storage(tx_state, message.current_target)
 
     # In the previously mentioned edge case the preexisting storage is ignored
     # for gas refund purposes. In order to do this we must track created
     # accounts. This tracking is also needed to respect the constraints
     # added to SELFDESTRUCT by EIP-6780.
-    mark_account_created(state, message.current_target)
+    mark_account_created(tx_state, message.current_target)
 
-    increment_nonce(state, message.current_target)
-    nonce_after = get_account(state, message.current_target).nonce
-    track_nonce_change(
-        message.state_changes,
-        message.current_target,
-        U64(nonce_after),
-    )
-
-    capture_pre_code(message.tx_env.state_changes, message.current_target, b"")
+    increment_nonce(tx_state, message.current_target)
 
     evm = process_message(message)
     if not evm.error:
@@ -227,25 +208,14 @@ def process_create_message(message: Message) -> Evm:
             if len(contract_code) > MAX_CODE_SIZE:
                 raise OutOfGasError
         except ExceptionalHalt as error:
-            rollback_transaction(state, transient_storage)
-            merge_on_failure(message.state_changes)
+            restore_tx_state(tx_state, snapshot)
             evm.gas_left = Uint(0)
             evm.output = b""
             evm.error = error
         else:
-            # Note: No need to capture pre code since it's always b"" here
-            set_code(state, message.current_target, contract_code)
-            if contract_code != b"":
-                track_code_change(
-                    message.state_changes,
-                    message.current_target,
-                    contract_code,
-                )
-            commit_transaction(state, transient_storage)
-            merge_on_success(message.state_changes)
+            set_code(tx_state, message.current_target, contract_code)
     else:
-        rollback_transaction(state, transient_storage)
-        merge_on_failure(message.state_changes)
+        restore_tx_state(tx_state, snapshot)
     return evm
 
 
@@ -264,8 +234,7 @@ def process_message(message: Message) -> Evm:
         Items containing execution specific objects
 
     """
-    state = message.block_env.state
-    transient_storage = message.tx_env.transient_storage
+    tx_state = message.tx_env.state
     if message.depth > STACK_DEPTH_LIMIT:
         raise StackDepthLimitError("Stack depth limit reached")
 
@@ -288,47 +257,21 @@ def process_message(message: Message) -> Evm:
         error=None,
         accessed_addresses=message.accessed_addresses,
         accessed_storage_keys=message.accessed_storage_keys,
-        state_changes=message.state_changes,
     )
 
     # take snapshot of state before processing the message
-    begin_transaction(state, transient_storage)
+    snapshot = copy_tx_state(tx_state)
 
-    track_address(message.state_changes, message.current_target)
+    track_address(tx_state, message.current_target)
 
     if message.should_transfer_value and message.value != 0:
-        # Track value transfer
-        sender_balance = get_account(state, message.caller).balance
-        recipient_balance = get_account(state, message.current_target).balance
-
-        track_address(message.state_changes, message.caller)
-        capture_pre_balance(
-            message.tx_env.state_changes, message.caller, sender_balance
-        )
-        capture_pre_balance(
-            message.tx_env.state_changes,
-            message.current_target,
-            recipient_balance,
-        )
+        track_address(tx_state, message.caller)
 
         move_ether(
-            state, message.caller, message.current_target, message.value
-        )
-
-        sender_new_balance = get_account(state, message.caller).balance
-        recipient_new_balance = get_account(
-            state, message.current_target
-        ).balance
-
-        track_balance_change(
-            message.state_changes,
+            tx_state,
             message.caller,
-            U256(sender_new_balance),
-        )
-        track_balance_change(
-            message.state_changes,
             message.current_target,
-            U256(recipient_new_balance),
+            message.value,
         )
 
     try:
@@ -360,11 +303,5 @@ def process_message(message: Message) -> Evm:
         evm.error = error
 
     if evm.error:
-        rollback_transaction(state, transient_storage)
-        if not message.is_create:
-            merge_on_failure(evm.state_changes)
-    else:
-        commit_transaction(state, transient_storage)
-        if not message.is_create:
-            merge_on_success(evm.state_changes)
+        restore_tx_state(tx_state, snapshot)
     return evm

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/mapping.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/mapping.py
@@ -13,7 +13,8 @@ Mapping of precompiled contracts to their implementations.
 
 from typing import Callable, Dict
 
-from ...fork_types import Address
+from ethereum.state import Address
+
 from . import (
     ALT_BN128_ADD_ADDRESS,
     ALT_BN128_MUL_ADDRESS,

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -1,0 +1,136 @@
+"""
+Shared state types and the `PreState` protocol used by the state transition
+function.
+
+The `PreState` protocol specifies the operations that any pre-execution state
+provider must support, allowing multiple backing implementations (in-memory
+`dict`, on-disk database, witness, etc.).
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Protocol, Tuple
+
+from ethereum_rlp import Extended
+from ethereum_types.bytes import Bytes, Bytes20, Bytes32
+from ethereum_types.frozen import slotted_freezable
+from ethereum_types.numeric import U256, Uint
+
+from ethereum.crypto.hash import Hash32
+
+Address = Bytes20
+Root = Hash32
+
+
+@slotted_freezable
+@dataclass
+class Account:
+    """
+    State associated with an address.
+    """
+
+    nonce: Uint
+    balance: U256
+    code: Bytes
+
+
+EMPTY_ACCOUNT = Account(
+    nonce=Uint(0),
+    balance=U256(0),
+    code=b"",
+)
+
+
+@slotted_freezable
+@dataclass
+class LeafNode:
+    """Leaf node in the Merkle Trie."""
+
+    rest_of_key: Bytes
+    value: Extended
+
+
+@slotted_freezable
+@dataclass
+class ExtensionNode:
+    """Extension node in the Merkle Trie."""
+
+    key_segment: Bytes
+    subnode: Extended
+
+
+BranchSubnodes = Tuple[
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+    Extended,
+]
+
+
+@slotted_freezable
+@dataclass
+class BranchNode:
+    """Branch node in the Merkle Trie."""
+
+    subnodes: BranchSubnodes
+    value: Extended
+
+
+InternalNode = LeafNode | ExtensionNode | BranchNode
+
+
+class PreState(Protocol):
+    """
+    Protocol for providing pre-execution state.
+
+    Specify the operations that any pre-state provider (dict, database,
+    witness, etc.) must support for the EELS state transition.
+    """
+
+    def get_account_optional(self, address: Address) -> Optional[Account]:
+        """
+        Get the account at an address.
+
+        Return ``None`` if there is no account at the address.
+        """
+        ...
+
+    def get_storage(self, address: Address, key: Bytes32) -> U256:
+        """
+        Get a storage value.
+
+        Return ``U256(0)`` if the key has not been set.
+        """
+        ...
+
+    def account_has_storage(self, address: Address) -> bool:
+        """
+        Check whether an account has any storage.
+
+        Only needed for EIP-7610.
+        """
+        ...
+
+    def compute_state_root_and_trie_changes(
+        self,
+        account_changes: Dict[Address, Optional[Account]],
+        storage_changes: Dict[Address, Dict[Bytes32, U256]],
+    ) -> Tuple[Root, List[InternalNode]]:
+        """
+        Compute the state root after applying changes to the pre-state.
+
+        Return the new state root together with the internal trie nodes
+        that were created or modified.
+        """
+        ...

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -5,6 +5,7 @@ Loader for code from the relevant fork.
 from inspect import signature
 from typing import Any, Final
 
+from ethereum.state import EMPTY_ACCOUNT
 from ethereum_spec_tools.forks import Hardfork
 
 
@@ -203,6 +204,8 @@ class ForkLoad:
     @property
     def EMPTY_ACCOUNT(self) -> Any:
         """EMPTY_ACCOUNT of the fork."""
+        if self.has_block_state:
+            return EMPTY_ACCOUNT
         return self._module("fork_types").EMPTY_ACCOUNT
 
     @property
@@ -277,6 +280,15 @@ class ForkLoad:
     def has_decode_transaction(self) -> bool:
         """Check if this fork has a `decode_transaction`."""
         return hasattr(self._module("transactions"), "decode_transaction")
+
+    @property
+    def has_block_state(self) -> bool:
+        """Check if the fork uses BlockState instead of State."""
+        try:
+            module = self._module("state_tracker")
+        except ModuleNotFoundError:
+            return False
+        return hasattr(module, "BlockState")
 
     @property
     def State(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -16,7 +16,15 @@ from typing_extensions import override
 from ethereum import trace
 from ethereum.exceptions import EthereumException, InvalidBlock
 from ethereum.fork_criteria import ByBlockNumber, ByTimestamp, Unscheduled
-from ethereum.forks.amsterdam.state_tracker import StateChanges
+
+# TODO: Make this not amsterdam specific once the state tracker has
+# been added to older forks.
+from ethereum.forks.amsterdam.block_access_lists.builder import (
+    BlockAccessListBuilder,
+)
+from ethereum.forks.amsterdam.block_access_lists.rlp_types import (
+    BlockAccessIndex,
+)
 from ethereum_spec_tools.forks import Hardfork, TemporaryHardfork
 
 from ..loaders.fixture_loader import Load
@@ -285,10 +293,20 @@ class T8N(Load):
             "coinbase": self.env.coinbase,
             "number": self.env.block_number,
             "time": self.env.block_timestamp,
-            "state": self.alloc.state,
             "block_gas_limit": self.env.block_gas_limit,
             "chain_id": self.chain_id,
         }
+
+        if self.fork.has_block_state:
+            from ethereum.forks.amsterdam.state_tracker import (
+                BlockState,
+            )
+
+            block_state = BlockState(pre_state=self.alloc.state)
+            kw_arguments["state"] = block_state
+            self._block_state = block_state
+        else:
+            kw_arguments["state"] = self.alloc.state
 
         block_environment = self.fork.BlockEnvironment
 
@@ -307,7 +325,9 @@ class T8N(Load):
             kw_arguments["excess_blob_gas"] = self.env.excess_blob_gas
 
         if self.fork.has_block_access_list_hash:
-            kw_arguments["state_changes"] = StateChanges()
+            kw_arguments["block_access_list_builder"] = (
+                BlockAccessListBuilder()
+            )
 
         return block_environment(**kw_arguments)
 
@@ -408,13 +428,12 @@ class T8N(Load):
                     f"Transaction {original_idx} failed: {e!r}"
                 )
 
-        # Post-execution operations use index N+1
+        # EIP-7928: Post-execution operations use index N+1
+        num_txs = len(self.txs.transactions)
         if self.fork.has_block_access_list_hash:
-            from ethereum.forks.amsterdam.state_tracker import (
-                increment_block_access_index,
+            block_env.block_access_list_builder.block_access_index = (
+                BlockAccessIndex(Uint(num_txs) + Uint(1))
             )
-
-            increment_block_access_index(block_env.state_changes)
 
         if not self.fork.proof_of_stake:
             if self.options.state_reward is None:
@@ -433,9 +452,8 @@ class T8N(Load):
             self.fork.process_general_purpose_requests(block_env, block_output)
 
         if self.fork.has_block_access_list_hash:
-            # Build block access list from block_env.state_changes
             block_output.block_access_list = self.fork.build_block_access_list(
-                block_env.state_changes
+                block_env.block_access_list_builder, block_env.state
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -307,7 +307,31 @@ class Result:
         self.receipt_root = t8n.fork.root(block_output.receipts_trie)
         self.bloom = t8n.fork.logs_bloom(block_output.block_logs)
         self.logs_hash = keccak256(rlp.encode(block_output.block_logs))
-        self.state_root = t8n.fork.state_root(block_env.state)
+        if t8n.fork.has_block_state:
+            # TODO: remove this once the state tracker is ported over
+            # to the older forks
+            from ethereum.forks.amsterdam.state import apply_changes_to_state
+            from ethereum.forks.amsterdam.state_tracker import (
+                extract_block_diffs,
+            )
+
+            account_changes, storage_changes = extract_block_diffs(
+                t8n._block_state
+            )
+            state_root_value, _ = (
+                t8n.alloc.state.compute_state_root_and_trie_changes(
+                    account_changes, storage_changes
+                )
+            )
+            self.state_root = state_root_value
+            # Apply diffs to pre-state for alloc output
+            apply_changes_to_state(
+                t8n.alloc.state,
+                account_changes,
+                storage_changes,
+            )
+        else:
+            self.state_root = t8n.fork.state_root(block_env.state)
         self.receipts = self.get_receipts_from_output(t8n, block_output)
 
         if hasattr(block_env, "base_fee_per_gas"):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
     pypy3
     json_infra
     static
-    optimized
     tests_pytest_py3
     tests_pytest_pypy3
     tests_benchmark_pytest_py3
@@ -134,21 +133,6 @@ commands =
         --until Amsterdam \
         {posargs} \
         tests
-
-[testenv:optimized]
-description = Run unit tests for optimized state and ethash
-passenv =
-    PYPY_GC_MAX
-    PYPY_GC_MIN
-commands =
-    pytest \
-        -m "not slow and not evm_tools" \
-        -n auto --maxprocesses 5 --dist=loadfile \
-        --ignore-glob='tests/test_t8n.py' \
-        --basetemp="{temp_dir}/pytest" \
-        --optimized \
-        {posargs} \
-        tests/json_infra
 
 [testenv:benchmark-gas-values]
 description = Run benchmark tests with `--gas-benchmark-values`


### PR DESCRIPTION
## 🗒️ Description

Note: This PR was originally aimed at #2155 which is in the context of the zkEVM project. However, this is a more elegant design of State for EELS (designed by Peter in #2063). Therefore, `forks/amsterdam` and the BALs implementation could also benefit from it

This PR is an implementation of the changes to state within EELS

1. Defines a PreState interface irrespective of implementation
2. Re-factors the current State as an implementation of the above interface
3. Creates state tracking classes which effectively track the state diffs as the block is processed
4. Incorporates the current BAL logic within the framework of this state tracker


### Next Steps (in separate PRs)

1. Code to be accessible only via codehash and codehash to be a part of the `Account`
2. For BALs tightly couple access and the corresponding access tracking (currently some access and its tracking are done separately which could lead to bugs)
3. Explore if the `Trie` implementation can be made fork agnostic
4. Make the testing framework and EELS share the `PreState` thus simplifying the `T8N` tool
5. Port changes to older forks

## 🔗 Related Issues or PRs
#2155
#2063


## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.


#### Cute Animal Picture

TBD
