### PR TITLE
refactor(tests): Leftover manual gas calculation/hard-coded gas costs

### DIFF
--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -181,9 +181,7 @@ class CodeGasMeasure(Bytecode):
         stop: bool = True,
     ) -> Self:
         """Assemble the bytecode that measures gas usage."""
-        res = Bytecode()
-        # Get the gas of the code
-        res += Op.GAS + code + Op.GAS
+        res = Op.GAS + code + Op.GAS
         # We need to swap and pop for each extra stack item that remained from
         # the execution of the code
         res += (Op.SWAP1 + Op.POP) * extra_stack_items

--- a/packages/testing/src/execution_testing/tools/tools_code/generators.py
+++ b/packages/testing/src/execution_testing/tools/tools_code/generators.py
@@ -181,14 +181,21 @@ class CodeGasMeasure(Bytecode):
         stop: bool = True,
     ) -> Self:
         """Assemble the bytecode that measures gas usage."""
-        res = Op.GAS + code + Op.GAS
+        res = Bytecode()
+        # Get the gas of the code
+        res += Op.GAS + code + Op.GAS
         # We need to swap and pop for each extra stack item that remained from
         # the execution of the code
         res += (Op.SWAP1 + Op.POP) * extra_stack_items
         res += (
             Op.SWAP1
             + Op.SUB
-            + Op.PUSH1(overhead_cost + 2)
+            + Op.PUSH1[overhead_cost]
+            + Op.GAS
+            + Op.GAS
+            + Op.SWAP1
+            + Op.SUB
+            + Op.ADD
             + Op.SWAP1
             + Op.SSTORE(sstore_key, Op.SUB)
         )

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -416,13 +416,15 @@ class TestCreateInitcode:
         """
         Salt value used for CREATE2 contract creation.
         """
-        kwargs = {
-            "size": Op.CALLDATASIZE,
-            "init_code_size": len(initcode),
-        }
-        if opcode == Op.CREATE2:
-            kwargs["salt"] = create2_salt
-        return opcode(**kwargs)
+        return (
+            opcode(
+                size=Op.CALLDATASIZE,
+                salt=create2_salt,
+                init_code_size=len(initcode),
+            )
+            if opcode == Op.CREATE2
+            else opcode(size=Op.CALLDATASIZE, init_code_size=len(initcode))
+        )
 
     @pytest.fixture
     def creator_code(self, fork: Fork, create_code: Bytecode) -> Bytecode:

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -24,7 +24,6 @@ from execution_testing import (
     Transaction,
     TransactionException,
     TransactionReceipt,
-    ceiling_division,
     compute_create_address,
 )
 
@@ -141,11 +140,9 @@ def test_contract_creating_tx(
     )
 
     tx = Transaction(
-        nonce=0,
         to=None,
         data=initcode,
-        gas_limit=10000000,
-        gas_price=10,
+        gas_limit=10_000_000,
         sender=sender,
     )
 
@@ -320,12 +317,10 @@ class TestContractCreationGasUsage:
             pytest.fail("Invalid gas test case provided.")
 
         return Transaction(
-            nonce=0,
             to=None,
             access_list=tx_access_list,
             data=initcode,
             gas_limit=gas_limit,
-            gas_price=10,
             error=tx_error,
             sender=sender,
             # The entire gas limit is expected to be consumed.
@@ -415,29 +410,50 @@ class TestCreateInitcode:
         return 0xDEADBEEF
 
     @pytest.fixture
-    def creator_code(self, opcode: Op, create2_salt: int) -> Bytecode:
+    def create_code(
+        self, opcode: Op, create2_salt: int, initcode: Initcode
+    ) -> Bytecode:
+        """
+        Salt value used for CREATE2 contract creation.
+        """
+        kwargs = {
+            "size": Op.CALLDATASIZE,
+            "init_code_size": len(initcode),
+        }
+        if opcode == Op.CREATE2:
+            kwargs["salt"] = create2_salt
+        return opcode(**kwargs)
+
+    @pytest.fixture
+    def creator_code(self, fork: Fork, create_code: Bytecode) -> Bytecode:
         """
         Generate code for the creator contract which calls CREATE/CREATE2.
         """
         return (
             Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
             + Op.GAS
-            + (
-                opcode(size=Op.CALLDATASIZE, salt=create2_salt)
-                if opcode == Op.CREATE2
-                else opcode(size=Op.CALLDATASIZE)
-            )
+            + create_code
             + Op.GAS
             # stack: [Gas 2, Call Result, Gas 1]
             + Op.SWAP1
             # stack: [Call Result, Gas 2, Gas 1]
-            + Op.SSTORE(0, unchecked=True)
+            + Op.PUSH1[0]
+            # stack: [0, Call Result, Gas 2, Gas 1]
+            + Op.SSTORE
             # stack: [Gas 2, Gas 1]
             + Op.SWAP1
             # stack: [Gas 1, Gas 2]
             + Op.SUB
             # stack: [Gas 1 - Gas 2]
-            + Op.SSTORE(1, unchecked=True)
+            + Op.PUSH1[Op.GAS.gas_cost(fork)]
+            # stack: [Op.GAS cost, Gas 1 - Gas 2]
+            + Op.SWAP1
+            # stack: [Gas 1 - Gas 2, Op.GAS cost]
+            + Op.SUB
+            # stack: [Gas 1 - Gas 2 - Op.GAS cost]
+            + Op.PUSH1[1]
+            # stack: [1, Gas 1 - Gas 2 - Op.GAS cost]
+            + Op.SSTORE
         )
 
     @pytest.fixture
@@ -491,43 +507,10 @@ class TestCreateInitcode:
     ) -> Transaction:
         """Generate transaction that executes the caller contract."""
         return Transaction(
-            nonce=0,
             to=caller_contract_address,
             data=initcode,
-            gas_limit=10000000,
-            gas_price=10,
+            gas_limit=10_000_000,
             sender=sender,
-        )
-
-    @pytest.fixture
-    def contract_creation_gas_cost(
-        self, fork: Fork, opcode: Op, create2_salt: int
-    ) -> int:
-        """Calculate gas cost of the contract creation operation."""
-        create_code = (
-            opcode(size=Op.CALLDATASIZE, salt=create2_salt)
-            if opcode == Op.CREATE2
-            else opcode(size=Op.CALLDATASIZE)
-        )
-        return (create_code + Op.GAS).gas_cost(fork)
-
-    @pytest.fixture
-    def initcode_word_cost(self, fork: Fork, initcode: Initcode) -> int:
-        """Calculate gas cost charged for the initcode length."""
-        gas_costs = fork.gas_costs()
-        return ceiling_division(len(initcode), 32) * gas_costs.G_INITCODE_WORD
-
-    @pytest.fixture
-    def create2_word_cost(
-        self, opcode: Op, fork: Fork, initcode: Initcode
-    ) -> int:
-        """Calculate gas cost charged for the initcode length."""
-        if opcode == Op.CREATE:
-            return 0
-
-        gas_costs = fork.gas_costs()
-        return (
-            ceiling_division(len(initcode), 32) * gas_costs.G_KECCAK_256_WORD
         )
 
     @pytest.mark.xdist_group(name="bigmem")
@@ -543,9 +526,7 @@ class TestCreateInitcode:
         caller_contract_address: Address,
         creator_contract_address: Address,
         created_contract_address: Address,
-        contract_creation_gas_cost: int,
-        initcode_word_cost: int,
-        create2_word_cost: int,
+        create_code: Bytecode,
         fork: Fork,
     ) -> None:
         """
@@ -574,17 +555,9 @@ class TestCreateInitcode:
             )
 
         else:
-            expected_gas_usage = contract_creation_gas_cost
+            expected_gas_usage = create_code.gas_cost(fork)
             # The initcode is only executed if the length check succeeds
             expected_gas_usage += initcode.gas_cost(fork)
-
-            # CREATE2 hashing cost should only be deducted if the initcode
-            # does not exceed the max length
-            expected_gas_usage += create2_word_cost
-
-            # Initcode word cost is only deducted if the length check
-            # succeeds
-            expected_gas_usage += initcode_word_cost
 
             # Call returns 1 as valid initcode length s[0]==1 && s[1]==1
             post[caller_contract_address] = Account(

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -414,7 +414,7 @@ class TestCreateInitcode:
         self, opcode: Op, create2_salt: int, initcode: Initcode
     ) -> Bytecode:
         """
-        Salt value used for CREATE2 contract creation.
+        Generate the CREATE/CREATE2 bytecode.
         """
         return (
             opcode(


### PR DESCRIPTION
## 🗒️ Description

#### - `test_initcode.py`

Remove manual gas calculation of the `CREATE`/`CREATE2` opcodes.

#### - Remove hard-coded gas cost in `CodeGasMeasure`

`CodeGasMeasure` had a hard-coded gas cost of the `Op.GAS` opcode (`2`). This is now replaced with a dynamic calculation of the cost of the opcode.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.westonnurseries.com/wp-content/uploads/2019/06/Butterfly-Pollinator.jpeg)
