### PR TITLE
chore(test-benchmark): add repricing pytest marker to unchunkified test

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -290,7 +290,6 @@ class BenchmarkTest(BaseTest):
     fixed_opcode_count: float | None = None
     target_opcode: Op | None = None
     code_generator: BenchmarkCodeGenerator | None = None
-    fixed_opcode_count_without_code_generator: bool = False
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -345,10 +344,10 @@ class BenchmarkTest(BaseTest):
         blocks: List[Block] = self.setup_blocks
 
         if self.fixed_opcode_count is not None and self.code_generator is None:
-            if not self.fixed_opcode_count_without_code_generator:
+            if self.target_opcode is None:
                 pytest.skip(
                     "Cannot run fixed opcode count tests without a "
-                    "code generator"
+                    "code generator or a target opcode set"
                 )
 
         if self.code_generator is not None:

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -536,7 +536,9 @@ class BenchmarkTest(BaseTest):
                 self.target_opcode is not None
                 and self.fixed_opcode_count is not None
             ):
-                self._verify_target_opcode_count(blockchain_test._opcode_count)
+                self._verify_target_opcode_count(
+                    blockchain_test._benchmark_opcode_count
+                )
             return fixture
         else:
             raise Exception(f"Unsupported fixture format: {fixture_format}")

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -290,6 +290,7 @@ class BenchmarkTest(BaseTest):
     fixed_opcode_count: float | None = None
     target_opcode: Op | None = None
     code_generator: BenchmarkCodeGenerator | None = None
+    fixed_opcode_count_without_code_generator: bool = False
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -344,9 +345,11 @@ class BenchmarkTest(BaseTest):
         blocks: List[Block] = self.setup_blocks
 
         if self.fixed_opcode_count is not None and self.code_generator is None:
-            pytest.skip(
-                "Cannot run fixed opcode count tests without a code generator"
-            )
+            if not self.fixed_opcode_count_without_code_generator:
+                pytest.skip(
+                    "Cannot run fixed opcode count tests without a "
+                    "code generator"
+                )
 
         if self.code_generator is not None:
             # Inject fixed_opcode_count into the code generator if provided

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -343,12 +343,15 @@ class BenchmarkTest(BaseTest):
 
         blocks: List[Block] = self.setup_blocks
 
-        if self.fixed_opcode_count is not None and self.code_generator is None:
-            if self.target_opcode is None:
-                pytest.skip(
-                    "Cannot run fixed opcode count tests without a "
-                    "code generator or a target opcode set"
-                )
+        if (
+            self.fixed_opcode_count is not None
+            and self.code_generator is None
+            and self.target_opcode is None
+        ):
+            pytest.skip(
+                "Cannot run fixed opcode count tests without a "
+                "code generator or a target opcode set"
+            )
 
         if self.code_generator is not None:
             # Inject fixed_opcode_count into the code generator if provided

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -14,7 +14,13 @@ from typing import (
 )
 
 import pytest
-from pydantic import ConfigDict, Field, field_validator, model_serializer
+from pydantic import (
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_serializer,
+)
 
 from execution_testing.base_types import (
     Address,
@@ -32,6 +38,7 @@ from execution_testing.client_clis import (
     Result,
     TransitionTool,
 )
+from execution_testing.client_clis.cli_types import OpcodeCount
 from execution_testing.exceptions import (
     BlockException,
     EngineAPIError,
@@ -498,6 +505,8 @@ class BlockchainTest(BaseTest):
     verification is only performed based on the state root.
     """
 
+    _benchmark_opcode_count: OpcodeCount | None = PrivateAttr(None)
+
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
     ] = [
@@ -690,6 +699,10 @@ class BlockchainTest(BaseTest):
                     f"expected_benchmark_gas_used "
                     f"({expected_benchmark_gas_used}), difference: {diff}"
                 )
+
+            self._benchmark_opcode_count = (
+                transition_tool_output.result.opcode_count
+            )
 
         requests_list: List[Bytes] | None = None
         if self.fork.header_requests_required(

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -436,6 +436,7 @@ def test_account_query(
     code_size: int,
     value_sent: int,
     gas_benchmark_value: int,
+    fixed_opcode_count: int | None,
 ) -> None:
     """Benchmark scenario of accessing max-code size bytecode."""
     if opcode in (Op.EXTCODESIZE, Op.EXTCODEHASH, Op.BALANCE) and (
@@ -568,14 +569,19 @@ def test_account_query(
     attack_address = pre.deploy_contract(code=attack_code, balance=10**21)
 
     # Calculate the number of contracts to be targeted.
-    num_contracts = sum(
-        attack_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=attack_gas_limit,
-            calldata=calldata,
-            access_list=access_list_generator,
+    if fixed_opcode_count is not None:
+        # Fixed opcode count mode
+        num_contracts = int(fixed_opcode_count * 1000)
+    else:
+        # Gas limit mode
+        num_contracts = sum(
+            attack_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=attack_gas_limit,
+                calldata=calldata,
+                access_list=access_list_generator,
+            )
         )
-    )
 
     # Deploy num_contracts via multiple txs (each capped by tx gas limit).
     with TestPhaseManager.setup():
@@ -590,16 +596,28 @@ def test_account_query(
 
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
-        attack_txs = list(
-            attack_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=attack_gas_limit,
-                sender=attack_sender,
-                to=attack_address,
-                calldata=calldata,
-                access_list=access_list_generator,
+        if fixed_opcode_count is not None:
+            attack_txs = list(
+                attack_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=int(fixed_opcode_count * 1000),
+                    sender=attack_sender,
+                    to=attack_address,
+                    calldata=calldata,
+                    access_list=access_list_generator,
+                )
             )
-        )
+        else:
+            attack_txs = list(
+                attack_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=attack_gas_limit,
+                    sender=attack_sender,
+                    to=attack_address,
+                    calldata=calldata,
+                    access_list=access_list_generator,
+                )
+            )
         total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
 
     post = {}

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -404,6 +404,7 @@ def test_ext_account_query_cold(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -635,5 +635,7 @@ def test_account_query(
             Block(txs=contracts_deployment_txs),
             Block(txs=attack_txs),
         ],
+        target_opcode=opcode,
+        fixed_opcode_count_without_code_generator=True,
         expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -13,7 +13,7 @@ Supported Opcodes:
 """
 
 import math
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 from execution_testing import (
@@ -31,6 +31,7 @@ from execution_testing import (
     IteratingBytecode,
     JumpLoopGenerator,
     Op,
+    ParameterSet,
     TestPhaseManager,
     Transaction,
     While,
@@ -404,28 +405,73 @@ def test_ext_account_query_cold(
     )
 
 
+def generate_account_query_params() -> List[ParameterSet]:
+    """
+    Generate valid parameter combinations for test_account_query.
+
+    Returns tuples of: (opcode, access_warm, mem_size, code_size, value_sent)
+    """
+    all_mem_sizes = [0, 32, 256, 1024]
+    all_code_sizes = [0, 32, 256, 1024]
+    all_access_warm = [True, False]
+    all_value_sent = [0, 1]
+
+    params = []
+
+    # BALANCE, EXTCODESIZE, EXTCODEHASH:
+    # only mem_size=0, code_size=0, value_sent=0
+    for opcode in [Op.BALANCE, Op.EXTCODESIZE, Op.EXTCODEHASH]:
+        for access_warm in all_access_warm:
+            params.append(pytest.param(opcode, access_warm, 0, 0, 0))
+
+    # EXTCODECOPY: all mem_size, all code_size, value_sent=0
+    for access_warm in all_access_warm:
+        for mem_size in all_mem_sizes:
+            for code_size in all_code_sizes:
+                params.append(
+                    pytest.param(
+                        Op.EXTCODECOPY, access_warm, mem_size, code_size, 0
+                    )
+                )
+            # Add None (max_code_size) separately with custom ID
+            params.append(
+                pytest.param(
+                    Op.EXTCODECOPY,
+                    access_warm,
+                    mem_size,
+                    None,
+                    0,
+                    id=f"EXTCODECOPY-{access_warm}-{mem_size}-max_code_size-0",
+                )
+            )
+
+    # CALL, CALLCODE: all mem_size, code_size=0, all value_sent
+    for opcode in [Op.CALL, Op.CALLCODE]:
+        for access_warm in all_access_warm:
+            for mem_size in all_mem_sizes:
+                for value_sent in all_value_sent:
+                    params.append(
+                        pytest.param(
+                            opcode, access_warm, mem_size, 0, value_sent
+                        )
+                    )
+
+    # STATICCALL, DELEGATECALL: all mem_size, code_size=0, value_sent=0
+    for opcode in [Op.STATICCALL, Op.DELEGATECALL]:
+        for access_warm in all_access_warm:
+            for mem_size in all_mem_sizes:
+                params.append(
+                    pytest.param(opcode, access_warm, mem_size, 0, 0)
+                )
+
+    return params
+
+
 @pytest.mark.repricing
 @pytest.mark.parametrize(
-    "opcode",
-    [
-        Op.BALANCE,
-        # CALL*
-        Op.CALL,
-        Op.CALLCODE,
-        Op.DELEGATECALL,
-        Op.STATICCALL,
-        # EXTCODE*
-        Op.EXTCODESIZE,
-        Op.EXTCODEHASH,
-        Op.EXTCODECOPY,
-    ],
+    "opcode,access_warm,mem_size,code_size,value_sent",
+    generate_account_query_params(),
 )
-@pytest.mark.parametrize("access_warm", [True, False])
-@pytest.mark.parametrize("mem_size", [0, 32, 256, 1024])
-@pytest.mark.parametrize(
-    "code_size", [0, 32, 256, 1024, pytest.param(None, id="max_code_size")]
-)
-@pytest.mark.parametrize("value_sent", [0, 1])
 def test_account_query(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -439,20 +485,6 @@ def test_account_query(
     fixed_opcode_count: int | None,
 ) -> None:
     """Benchmark scenario of accessing max-code size bytecode."""
-    if opcode in (Op.EXTCODESIZE, Op.EXTCODEHASH, Op.BALANCE) and (
-        mem_size != 0 or code_size != 0
-    ):
-        pytest.skip(f"No memory size configuration for {opcode}")
-
-    if opcode not in (Op.CALL, Op.CALLCODE) and value_sent > 0:
-        pytest.skip(f"No value configuration for {opcode}")
-
-    if (
-        opcode in (Op.CALL, Op.CALLCODE, Op.STATICCALL, Op.DELEGATECALL)
-        and code_size != 0
-    ):
-        pytest.skip(f"No code size configuration for {opcode}")
-
     attack_gas_limit = gas_benchmark_value
 
     # Create the max-sized fork-dependent contract factory.

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -636,6 +636,5 @@ def test_account_query(
             Block(txs=attack_txs),
         ],
         target_opcode=opcode,
-        fixed_opcode_count_without_code_generator=True,
         expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -180,5 +180,7 @@ def test_unchunkified_bytecode(
             Block(txs=contracts_deployment_txs),
             Block(txs=attack_txs),
         ],
+        target_opcode=opcode,
+        fixed_opcode_count_without_code_generator=True,
         expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -41,6 +41,7 @@ def test_unchunkified_bytecode(
     fork: Fork,
     opcode: Op,
     gas_benchmark_value: int,
+    fixed_opcode_count: float | None,
 ) -> None:
     """Benchmark scenario of accessing max-code size bytecode."""
     # The attack gas limit represents the transaction gas limit cap or
@@ -116,13 +117,18 @@ def test_unchunkified_bytecode(
     attack_address = pre.deploy_contract(code=attack_code)
 
     # Calculate the number of contracts to be targeted.
-    num_contracts = sum(
-        attack_code.tx_iterations_by_gas_limit(
-            fork=fork,
-            gas_limit=attack_gas_limit,
-            calldata=calldata,
+    if fixed_opcode_count is not None:
+        # Fixed opcode count mode
+        num_contracts = int(fixed_opcode_count * 1000)
+    else:
+        # Gas limit mode
+        num_contracts = sum(
+            attack_code.tx_iterations_by_gas_limit(
+                fork=fork,
+                gas_limit=attack_gas_limit,
+                calldata=calldata,
+            )
         )
-    )
 
     # Deploy num_contracts via multiple txs (each capped by tx gas limit).
     with TestPhaseManager.setup():
@@ -137,15 +143,27 @@ def test_unchunkified_bytecode(
 
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
-        attack_txs = list(
-            attack_code.transactions_by_gas_limit(
-                fork=fork,
-                gas_limit=attack_gas_limit,
-                sender=attack_sender,
-                to=attack_address,
-                calldata=calldata,
+        if fixed_opcode_count is not None:
+            # Fixed opcode count mode.
+            attack_txs = list(
+                attack_code.transactions_by_total_iteration_count(
+                    fork=fork,
+                    total_iterations=int(fixed_opcode_count * 1000),
+                    sender=attack_sender,
+                    to=attack_address,
+                    calldata=calldata,
+                )
             )
-        )
+        else:
+            attack_txs = list(
+                attack_code.transactions_by_gas_limit(
+                    fork=fork,
+                    gas_limit=attack_gas_limit,
+                    sender=attack_sender,
+                    to=attack_address,
+                    calldata=calldata,
+                )
+            )
         total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
 
     post = {}

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -181,6 +181,5 @@ def test_unchunkified_bytecode(
             Block(txs=attack_txs),
         ],
         target_opcode=opcode,
-        fixed_opcode_count_without_code_generator=True,
         expected_benchmark_gas_used=total_gas_cost,
     )

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -22,6 +22,7 @@ from execution_testing import (
 from ..helpers import CustomSizedContractFactory
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode",
     [


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
