### PR TITLE
fix(test-specs): Exclude full post-state/setup-tx receipts on benchmarks

### DIFF
--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -290,6 +290,9 @@ class BenchmarkTest(BaseTest):
     fixed_opcode_count: float | None = None
     target_opcode: Op | None = None
     code_generator: BenchmarkCodeGenerator | None = None
+    # By default, benchmark tests require neither of these
+    include_full_post_state_in_output: bool = False
+    include_intermediate_block_tx_receipts: bool = False
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -491,6 +494,8 @@ class BenchmarkTest(BaseTest):
             pre=self.pre,
             post=self.post,
             blocks=self.blocks,
+            include_full_post_state_in_output=self.include_full_post_state_in_output,
+            include_intermediate_block_tx_receipts=self.include_intermediate_block_tx_receipts,
         )
 
     def _verify_target_opcode_count(

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -292,7 +292,7 @@ class BenchmarkTest(BaseTest):
     code_generator: BenchmarkCodeGenerator | None = None
     # By default, benchmark tests require neither of these
     include_full_post_state_in_output: bool = False
-    include_intermediate_block_tx_receipts: bool = False
+    include_tx_receipts_in_output: bool = False
 
     supported_fixture_formats: ClassVar[
         Sequence[FixtureFormat | LabeledFixtureFormat]
@@ -495,7 +495,7 @@ class BenchmarkTest(BaseTest):
             post=self.post,
             blocks=self.blocks,
             include_full_post_state_in_output=self.include_full_post_state_in_output,
-            include_intermediate_block_tx_receipts=self.include_intermediate_block_tx_receipts,
+            include_tx_receipts_in_output=self.include_tx_receipts_in_output,
         )
 
     def _verify_target_opcode_count(

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -378,7 +378,9 @@ class BuiltBlock(CamelModel):
     fork: Fork
     block_access_list: BlockAccessList | None
 
-    def get_fixture_block(self) -> FixtureBlock | InvalidFixtureBlock:
+    def get_fixture_block(
+        self, *, include_receipts: bool = True
+    ) -> FixtureBlock | InvalidFixtureBlock:
         """Get a FixtureBlockBase from the built block."""
         fixture_block = FixtureBlockBase(
             header=self.header,
@@ -398,7 +400,7 @@ class BuiltBlock(CamelModel):
                     )
                     for i, r in enumerate(self.result.receipts)
                 ]
-                if self.result.receipts
+                if self.result.receipts and include_receipts
                 else None
             ),
             block_access_list=self.block_access_list
@@ -499,10 +501,14 @@ class BlockchainTest(BaseTest):
     blocks: List[Block]
     genesis_environment: Environment = Field(default_factory=Environment)
     chain_id: int = 1
-    exclude_full_post_state_in_output: bool = False
+    include_full_post_state_in_output: bool = True
     """
-    Exclude the post state from the fixture output. In this case, the state
+    Include the post state in the fixture output. Otherwise, the state
     verification is only performed based on the state root.
+    """
+    include_intermediate_block_tx_receipts: bool = True
+    """
+    Include transaction receipts in blocks prior to the last block.
     """
 
     _benchmark_opcode_count: OpcodeCount | None = PrivateAttr(None)
@@ -875,14 +881,22 @@ class BlockchainTest(BaseTest):
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
             # Set the environment according to the block to execute.
+            is_last_block = i == len(self.blocks) - 1
             built_block = self.generate_block_data(
                 t8n=t8n,
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
-                last_block=i == len(self.blocks) - 1,
+                last_block=is_last_block,
             )
-            fixture_blocks.append(built_block.get_fixture_block())
+            include_receipts = (
+                is_last_block or self.include_intermediate_block_tx_receipts
+            )
+            fixture_blocks.append(
+                built_block.get_fixture_block(
+                    include_receipts=include_receipts
+                )
+            )
 
             # BAL verification already done in to_fixture_bal() if
             # expected_block_access_list set
@@ -918,10 +932,10 @@ class BlockchainTest(BaseTest):
             last_block_hash=head,
             pre=pre,
             post_state=alloc
-            if not self.exclude_full_post_state_in_output
+            if self.include_full_post_state_in_output
             else None,
             post_state_hash=state_root
-            if self.exclude_full_post_state_in_output
+            if not self.include_full_post_state_in_output
             else None,
             config=FixtureConfig(
                 fork=self.fork,
@@ -1004,7 +1018,7 @@ class BlockchainTest(BaseTest):
             "payloads": fixture_payloads,
             "last_block_hash": head_hash,
             "post_state_hash": state_root
-            if self.exclude_full_post_state_in_output
+            if not self.include_full_post_state_in_output
             else None,
             "config": FixtureConfig(
                 fork=self.fork,
@@ -1023,7 +1037,7 @@ class BlockchainTest(BaseTest):
             fixture_data.update(
                 {
                     "post_state": alloc
-                    if not self.exclude_full_post_state_in_output
+                    if self.include_full_post_state_in_output
                     else None,
                     "pre_hash": "",  # Will be set by BaseTestWrapper
                 }
@@ -1052,7 +1066,7 @@ class BlockchainTest(BaseTest):
                     ),
                     "pre": pre,
                     "post_state": alloc
-                    if not self.exclude_full_post_state_in_output
+                    if self.include_full_post_state_in_output
                     else None,
                 }
             )
@@ -1063,7 +1077,7 @@ class BlockchainTest(BaseTest):
                 {
                     "pre": pre,
                     "post_state": alloc
-                    if not self.exclude_full_post_state_in_output
+                    if self.include_full_post_state_in_output
                     else None,
                 }
             )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -279,6 +279,11 @@ class Block(Header):
     If set, the block is expected to produce an error response from the Engine
     API.
     """
+    include_receipts_in_output: bool | None = None
+    """
+    If set to `True`, the block’s output fixture representation will include
+    full transaction receipts. If unset, the test-level value is used.
+    """
     txs: List[Transaction] = Field(default_factory=list)
     """List of transactions included in the block."""
     ommers: List[Header] | None = None
@@ -506,9 +511,9 @@ class BlockchainTest(BaseTest):
     Include the post state in the fixture output. Otherwise, the state
     verification is only performed based on the state root.
     """
-    include_intermediate_block_tx_receipts: bool = True
+    include_tx_receipts_in_output: bool = True
     """
-    Include transaction receipts in blocks prior to the last block.
+    Include transaction receipts in the fixture output.
     """
 
     _benchmark_opcode_count: OpcodeCount | None = PrivateAttr(None)
@@ -878,10 +883,10 @@ class BlockchainTest(BaseTest):
         head = genesis.header.block_hash
         invalid_blocks = 0
         for i, block in enumerate(self.blocks):
+            is_last_block = i == len(self.blocks) - 1
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
             # Set the environment according to the block to execute.
-            is_last_block = i == len(self.blocks) - 1
             built_block = self.generate_block_data(
                 t8n=t8n,
                 block=block,
@@ -890,7 +895,9 @@ class BlockchainTest(BaseTest):
                 last_block=is_last_block,
             )
             include_receipts = (
-                is_last_block or self.include_intermediate_block_tx_receipts
+                block.include_receipts_in_output
+                if block.include_receipts_in_output is not None
+                else self.include_tx_receipts_in_output
             )
             fixture_blocks.append(
                 built_block.get_fixture_block(


### PR DESCRIPTION
## 🗒️ Description

Adds defaults to `BenchmarkTest` to exclude the full post state and the setup tx receipts in the output by default, in contrast to the `BlockchainTest` defaults which is to include them both.

Drops the size of the top two biggest fixtures:
- `account_query.json`: `16 GB` -> `2.0G`
- `unchunkified_bytecode.json`: `13 GB` -> `350M`

But of course the rest of the fixtures are also affected.

## 🔗 Related Issues or PRs
#2223

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t3.ftcdn.net/jpg/01/86/39/66/360_F_186396669_0rCCuHoL6BjOdqM2qQxZda0VKUktNOZE.jpg)
