### PR TITLE
fix(benchmarks): mark specific benchmarks only valid from Prague

### DIFF
--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -208,7 +208,7 @@ def create_benchmark_executor(
 
     return IteratingBytecode(setup=prefix, iterating=loop, cleanup=suffix)
 
-
+@pytest.mark.valid_from("Prague") # EIP-7702 is used in this benchmark
 @pytest.mark.parametrize(
     "storage_action,tx_result",
     [

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -662,7 +662,7 @@ def build_delegated_storage_setup(
 
     return blocks
 
-
+@pytest.mark.valid_from("Prague") # EIP-7702 is used in this benchmark
 @pytest.mark.parametrize("access_warm", [True, False])
 @pytest.mark.parametrize("sloads_before_sstore", [True, False])
 @pytest.mark.parametrize(
@@ -820,7 +820,7 @@ def create_sload_executor(key_warm: bool) -> IteratingBytecode:
 
     return IteratingBytecode(setup=setup, iterating=loop, cleanup=cleanup)
 
-
+@pytest.mark.valid_from("Prague") # EIP-7702 is used in this benchmark
 @pytest.mark.parametrize("access_warm", [True, False])
 @pytest.mark.parametrize("storage_keys_pre_set", [True, False])
 def test_storage_sload_benchmark(


### PR DESCRIPTION
## 🗒️ Description
Draft PR to fix some stuff I found when checking the benchmarks. So far:

- Label benchs which use EIP-7702 to be valid from Prague.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
