### PR TITLE
chore(test-client-clis): update erigon exceptions mapping

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -99,6 +99,12 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"invalid block access list|block access list mismatch"
         ),
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"invalid block access list"
+        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (
+            r"invalid block access list"
+        ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             r"invalid block, txnIdx=\d+,.*gas limit too high"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -100,6 +100,9 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"invalid block access list|block access list mismatch"
         ),
+        BlockException.INVALID_BAL_MISSING_ACCOUNT: (
+            r"block access list mismatch"
+        ),
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
             r"invalid block access list"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -106,9 +106,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
             r"invalid block access list"
         ),
-        BlockException.INCORRECT_BLOCK_FORMAT: (
-            r"invalid block access list"
-        ),
+        BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list"),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
             r"invalid block, txnIdx=\d+,.*gas limit too high"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -94,6 +94,7 @@ class ErigonExceptionMapper(ExceptionMapper):
         BlockException.INVALID_STATE_ROOT: "invalid block: wrong trie root",
         BlockException.INVALID_RECEIPTS_ROOT: "receiptHash mismatch",
         BlockException.INVALID_LOG_BLOOM: "invalid bloom",
+        BlockException.GAS_USED_OVERFLOW: "block gas used overflow",
     }
     mapping_regex = {
         BlockException.INVALID_BLOCK_ACCESS_LIST: (


### PR DESCRIPTION
## 🗒️ Description
Update Erigon exceptions mapping

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.marylandzoo.org%2Fwp-content%2Fuploads%2F2017%2F10%2Friver_otter_web.jpg&f=1&nofb=1&ipt=c124d7ce8e67e770bae2b3f73f91be74dee7b37738c515df6e1083478d83f511)
