### PR TITLE
refactor(spec-specs): use kwargs for message call output collision returns

### DIFF
--- a/src/ethereum/forks/arrow_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/arrow_glacier/vm/interpreter.py
@@ -112,7 +112,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/berlin/vm/interpreter.py
+++ b/src/ethereum/forks/berlin/vm/interpreter.py
@@ -111,7 +111,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/bpo1/vm/interpreter.py
+++ b/src/ethereum/forks/bpo1/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/bpo2/vm/interpreter.py
+++ b/src/ethereum/forks/bpo2/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/bpo3/vm/interpreter.py
+++ b/src/ethereum/forks/bpo3/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/bpo4/vm/interpreter.py
+++ b/src/ethereum/forks/bpo4/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/bpo5/vm/interpreter.py
+++ b/src/ethereum/forks/bpo5/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/byzantium/vm/interpreter.py
+++ b/src/ethereum/forks/byzantium/vm/interpreter.py
@@ -110,7 +110,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/cancun/vm/interpreter.py
+++ b/src/ethereum/forks/cancun/vm/interpreter.py
@@ -109,7 +109,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/constantinople/vm/interpreter.py
+++ b/src/ethereum/forks/constantinople/vm/interpreter.py
@@ -110,7 +110,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/dao_fork/vm/interpreter.py
+++ b/src/ethereum/forks/dao_fork/vm/interpreter.py
@@ -103,7 +103,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/frontier/vm/interpreter.py
+++ b/src/ethereum/forks/frontier/vm/interpreter.py
@@ -103,7 +103,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/gray_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/gray_glacier/vm/interpreter.py
@@ -112,7 +112,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/homestead/vm/interpreter.py
+++ b/src/ethereum/forks/homestead/vm/interpreter.py
@@ -103,7 +103,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/istanbul/vm/interpreter.py
+++ b/src/ethereum/forks/istanbul/vm/interpreter.py
@@ -111,7 +111,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/london/vm/interpreter.py
+++ b/src/ethereum/forks/london/vm/interpreter.py
@@ -112,7 +112,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/muir_glacier/vm/interpreter.py
+++ b/src/ethereum/forks/muir_glacier/vm/interpreter.py
@@ -111,7 +111,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/osaka/vm/interpreter.py
+++ b/src/ethereum/forks/osaka/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/paris/vm/interpreter.py
+++ b/src/ethereum/forks/paris/vm/interpreter.py
@@ -108,7 +108,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/prague/vm/interpreter.py
+++ b/src/ethereum/forks/prague/vm/interpreter.py
@@ -113,12 +113,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0),
-                U256(0),
-                tuple(),
-                set(),
-                AddressCollision(),
-                Bytes(b""),
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
+                return_data=Bytes(b""),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/shanghai/vm/interpreter.py
+++ b/src/ethereum/forks/shanghai/vm/interpreter.py
@@ -109,7 +109,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/spurious_dragon/vm/interpreter.py
+++ b/src/ethereum/forks/spurious_dragon/vm/interpreter.py
@@ -109,7 +109,12 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                touched_accounts=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)

--- a/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/interpreter.py
@@ -103,7 +103,11 @@ def process_message_call(message: Message) -> MessageCallOutput:
         ) or account_has_storage(block_env.state, message.current_target)
         if is_collision:
             return MessageCallOutput(
-                Uint(0), U256(0), tuple(), set(), AddressCollision()
+                gas_left=Uint(0),
+                refund_counter=U256(0),
+                logs=tuple(),
+                accounts_to_delete=set(),
+                error=AddressCollision(),
             )
         else:
             evm = process_create_message(message)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Backport required for EIP-8037.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Related specs PR: #2181
EIP Issue: #2040 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.tenor.com/n52WS-CO8tsAAAAm/cat-cats.webp)
