### PR TITLE
chore(do not merge): Experiment with caching

### DIFF
--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -20,6 +20,7 @@ from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     Iterator,
     List,
@@ -72,14 +73,28 @@ class Hardfork:
     """
 
     mod: ModuleType
+    _discover_cache: ClassVar[Dict[type, List["Hardfork"]]] = {}
 
     @classmethod
     def discover(
-        cls: Type[H], submodule_search_locations: None | list[str] = None
+        cls: Type[H],
+        submodule_search_locations: None | list[str] = None,
+        *,
+        force: bool = False,
     ) -> List[H]:
         """
         Find packages which contain Ethereum hardfork specifications.
+
+        Results are cached when ``submodule_search_locations`` is ``None``.
+        Pass ``force=True`` to bypass the cache.
         """
+        if (
+            not force
+            and submodule_search_locations is None
+            and cls in cls._discover_cache
+        ):
+            return list(cls._discover_cache[cls])  # type: ignore
+
         if submodule_search_locations is None:
             ethereum_forks = importlib.import_module("ethereum.forks")
         else:
@@ -138,6 +153,9 @@ class Hardfork:
 
         # Timestamps are bigger than block numbers, so this always works.
         forks.sort(key=lambda fork: fork.criteria)
+
+        if submodule_search_locations is None:
+            cls._discover_cache[cls] = list(forks)
 
         return forks
 

--- a/tests/json_infra/helpers/load_state_tests.py
+++ b/tests/json_infra/helpers/load_state_tests.py
@@ -142,19 +142,20 @@ class StateTest(FixtureTestItem):
         ]
         t8n_options = parser.parse_args(t8n_args)
 
-        with ForkCache() as fork_cache:
-            try:
-                t8n = T8N(t8n_options, sys.stdout, in_stream, fork_cache)
-            except StateWithEmptyAccount as e:
-                pytest.xfail(str(e))
+        try:
+            t8n = T8N(
+                t8n_options, sys.stdout, in_stream, self.fork_cache
+            )
+        except StateWithEmptyAccount as e:
+            pytest.xfail(str(e))
 
-            t8n.run_state_test()
+        t8n.run_state_test()
 
-            if "expectException" in post:
-                assert 0 in t8n.txs.rejected_txs
-                return
+        if "expectException" in post:
+            assert 0 in t8n.txs.rejected_txs
+            return
 
-            assert hex_to_bytes(post_hash) == t8n.result.state_root
+        assert hex_to_bytes(post_hash) == t8n.result.state_root
 
 
 class StateTestFixture(Fixture, Collector):

--- a/tests/json_infra/helpers/load_state_tests.py
+++ b/tests/json_infra/helpers/load_state_tests.py
@@ -143,9 +143,7 @@ class StateTest(FixtureTestItem):
         t8n_options = parser.parse_args(t8n_args)
 
         try:
-            t8n = T8N(
-                t8n_options, sys.stdout, in_stream, self.fork_cache
-            )
+            t8n = T8N(t8n_options, sys.stdout, in_stream, self.fork_cache)
         except StateWithEmptyAccount as e:
             pytest.xfail(str(e))
 


### PR DESCRIPTION
## 🗒️ Description

Small caching experiment.

- Optimize ForkCache startup and teardown -- looks like it was being done per test.
- Optimize Hardfork.discover() -- was being called twice and was doing a lot of filesystem scans

<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
