### PR TITLE
feat(test-execute): Batch RPC requests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/contracts.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/contracts.py
@@ -89,7 +89,7 @@ def deploy_deterministic_factory_contract(
             tx_index=tx_index,
         )
         tx_index += 1
-        eth_rpc.send_wait_transaction(fund_tx)
+        eth_rpc.send_wait_transactions([fund_tx])
         logger.info(f"Funding transaction mined: {fund_tx.hash}")
 
     # Add deployment transaction.
@@ -102,7 +102,7 @@ def deploy_deterministic_factory_contract(
         tx_index=tx_index,
     )
     tx_index += 1
-    eth_rpc.send_wait_transaction(deploy_tx)
+    eth_rpc.send_wait_transactions([deploy_tx])
     logger.info(f"Deployment transaction mined: {deploy_tx.hash}")
     deployment_contract_code = eth_rpc.get_code(DETERMINISTIC_FACTORY_ADDRESS)
     logger.info(f"Deployment contract code: {deployment_contract_code}")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Generator, List, Type
 import pytest
 from pytest_metadata.plugin import metadata_key
 
+from execution_testing.base_types import Account
+from execution_testing.base_types import Alloc as BaseAlloc
 from execution_testing.execution import BaseExecute
 from execution_testing.forks import Fork
 from execution_testing.logging import get_logger
@@ -716,21 +718,32 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 # send the funds to the required sender accounts
                 pre.send_pending_transactions()
 
-                for (
-                    deployed_contract,
-                    expected_code,
-                ) in pre._deployed_contracts:
-                    actual_code = eth_rpc.get_code(deployed_contract)
-                    if actual_code != expected_code:
-                        msg = (
-                            f"Deployed test contract didn't match expected "
-                            f"code at address {deployed_contract} "
-                            f"(not enough gas_limit?).\n"
-                            f"Expected: {expected_code}\n"
-                            f"Actual: {actual_code}"
-                        )
-                        logger.error(msg)
-                        raise Exception(msg)
+                if pre._deployed_contracts:
+                    contract_alloc = BaseAlloc(
+                        root={
+                            addr: Account()
+                            for addr, _ in pre._deployed_contracts
+                        }
+                    )
+                    actual_alloc = eth_rpc.get_alloc(contract_alloc)
+                    for (
+                        deployed_contract,
+                        expected_code,
+                    ) in pre._deployed_contracts:
+                        actual_account = actual_alloc.root[deployed_contract]
+                        assert actual_account is not None
+                        actual_code = actual_account.code
+                        if actual_code != expected_code:
+                            msg = (
+                                f"Deployed test contract didn't match "
+                                f"expected code at address "
+                                f"{deployed_contract} "
+                                f"(not enough gas_limit?).\n"
+                                f"Expected: {expected_code}\n"
+                                f"Actual: {actual_code}"
+                            )
+                            logger.error(msg)
+                            raise Exception(msg)
                 request.node.config.funded_accounts = ", ".join(
                     [str(eoa) for eoa in pre._funded_eoa]
                 )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -394,17 +394,8 @@ class Alloc(SharedAlloc):
 
             self._deployed_contracts.append((contract_address, deploy_code))
 
-        balance = self._eth_rpc.get_balance(contract_address)
-        nonce = self._eth_rpc.get_transaction_count(contract_address)
-        self.__internal_setitem__(
-            contract_address,
-            Account(
-                nonce=nonce,
-                balance=balance,
-                code=deploy_code,
-                storage={},
-            ),
-        )
+        account = self._eth_rpc.get_account(contract_address)
+        self.__internal_setitem__(contract_address, account)
 
         contract_address.label = label
         return contract_address
@@ -446,27 +437,20 @@ class Alloc(SharedAlloc):
                 f"Using address stub '{stub}' at {contract_address} "
                 f"(label={label})"
             )
-            code = self._eth_rpc.get_code(contract_address)
+            account = self._eth_rpc.get_account(contract_address)
+            code = account.code
             if code == b"":
                 raise ValueError(
                     f"Stub {stub} at {contract_address} has no code"
                 )
-            balance = self._eth_rpc.get_balance(contract_address)
-            nonce = self._eth_rpc.get_transaction_count(contract_address)
+            balance = account.balance
+            nonce = account.nonce
             bal_eth = balance / 10**18
             logger.debug(
                 f"Stub contract {contract_address}: balance={bal_eth:.18f} "
                 f"ETH, nonce={nonce}, code_size={len(code)} bytes"
             )
-            self.__internal_setitem__(
-                contract_address,
-                Account(
-                    nonce=nonce,
-                    balance=balance,
-                    code=code,
-                    storage={},
-                ),
-            )
+            self.__internal_setitem__(contract_address, account)
             return contract_address
 
         initcode_prefix = Bytecode()
@@ -827,36 +811,14 @@ class Alloc(SharedAlloc):
             f"(deployed_contracts={len(self._deployed_contracts)}, "
             f"funded_eoas={len(self._funded_eoa)})"
         )
-        transaction_batches: List[List[PendingTransaction]] = []
-        last_tx_batch: List[PendingTransaction] = []
-        max_txs_per_batch = 100
         for tx in self._pending_txs:
             assert tx.value is not None, (
                 "Transaction value must be set before sending them to the RPC."
             )
-            if len(last_tx_batch) >= max_txs_per_batch:
-                transaction_batches.append(last_tx_batch)
-                last_tx_batch = []
-            last_tx_batch.append(tx)
-        if last_tx_batch:
-            transaction_batches.append(last_tx_batch)
 
-        responses: List[TransactionByHashResponse] = []
-        for tx_batch in transaction_batches:
-            txs = [tx.with_signature_and_sender() for tx in tx_batch]
-            tx_hashes = self._eth_rpc.send_transactions(txs)
-            hash_strs = [str(h) for h in tx_hashes[:5]]
-            n_hashes = len(tx_hashes)
-            extra = f" and {n_hashes - 5} more" if n_hashes > 5 else ""
-            logger.info(f"Sent {n_hashes} transactions: {hash_strs}{extra}")
-            logger.info(
-                f"Waiting for {len(tx_batch)} transactions to be included "
-                "in blocks"
-            )
-            responses += self._eth_rpc.wait_for_transactions(tx_batch)
-            logger.info(
-                f"All {len(responses)} transactions confirmed in blocks"
-            )
+        txs = [tx.with_signature_and_sender() for tx in self._pending_txs]
+        responses = self._eth_rpc.send_wait_transactions(txs)
+
         for response in responses:
             logger.debug(f"Transaction response: {response.model_dump_json()}")
         return responses
@@ -928,22 +890,30 @@ def pre(
         return
 
     # Refund all EOAs (regardless of whether the test passed or failed)
+    funded_eoas = pre._funded_eoa
     logger.info(
-        f"Starting cleanup phase: refunding {len(pre._funded_eoa)} funded EOAs"
+        f"Starting cleanup phase: refunding {len(funded_eoas)} funded EOAs"
     )
-    refund_txs = []
+
+    if not funded_eoas:
+        logger.info("No funded EOAs to refund")
+        return
+
+    # Build refund transactions
+    refund_txs: List[Transaction] = []
     skipped_refunds = 0
-    error_refunds = 0
-    for idx, eoa in enumerate(pre._funded_eoa):
-        remaining_balance = eth_rpc.get_balance(eoa)
-        eoa.nonce = Number(eth_rpc.get_transaction_count(eoa))
-        refund_gas_limit = 21_000
-        tx_cost = refund_gas_limit * max_fee_per_gas
+    refund_gas_limit = 21_000
+    tx_cost = refund_gas_limit * max_fee_per_gas
+    for idx, eoa in enumerate(funded_eoas):
+        account = eth_rpc.get_account(eoa, skip_code=True)
+        remaining_balance = account.balance
+        eoa.nonce = Number(account.nonce)
         if remaining_balance < tx_cost:
             rem_eth = remaining_balance / 10**18
             cost_eth = tx_cost / 10**18
             logger.debug(
-                f"Skipping refund for EOA {eoa} (label={eoa.label}): "
+                f"Skipping refund for EOA {eoa} "
+                f"(label={eoa.label}): "
                 f"insufficient balance {rem_eth:.18f} ETH < "
                 f"transaction cost {cost_eth:.18f} ETH"
             )
@@ -954,14 +924,15 @@ def pre(
         rem_eth = remaining_balance / 10**18
         cost_eth = tx_cost / 10**18
         logger.debug(
-            f"Preparing refund transaction for EOA {eoa} (label={eoa.label}): "
+            f"Preparing refund transaction for EOA {eoa} "
+            f"(label={eoa.label}): "
             f"{ref_eth:.18f} ETH (remaining: {rem_eth:.18f} ETH, "
             f"cost: {cost_eth:.18f} ETH)"
         )
         refund_tx = Transaction(
             sender=eoa,
             to=worker_key,
-            gas_limit=21_000,
+            gas_limit=refund_gas_limit,
             max_fee_per_gas=max_fee_per_gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
             value=refund_value,
@@ -973,35 +944,18 @@ def pre(
             target=eoa.label,
             tx_index=idx,
         )
-        try:
-            logger.info(
-                f"Sending refund transaction for EOA {eoa}: {refund_tx.hash}"
-            )
-            refund_tx_hash = eth_rpc.send_transaction(refund_tx)
-            logger.info(f"Refund transaction sent: {refund_tx_hash}")
-            refund_txs.append(refund_tx)
-        except Exception as e:
-            eoa_key = eoa.key
-            logger.error(
-                f"Error sending refund transaction for EOA {eoa}: {e}."
-            )
-            if eoa_key is not None:
-                logger.info(
-                    f"Retrieve funds manually from EOA {eoa} "
-                    f"using private key {eoa_key.hex()}."
-                )
-            error_refunds += 1
-            continue
+        refund_txs.append(refund_tx)
+
     if refund_txs:
         logger.info(
-            f"Waiting for {len(refund_txs)} refund transactions "
-            f"({skipped_refunds} skipped due to insufficient balance, "
-            f"{error_refunds} errored)"
+            f"Sending {len(refund_txs)} refund transactions "
+            f"({skipped_refunds} skipped due to insufficient balance)"
         )
-        eth_rpc.wait_for_transactions(refund_txs)
+        eth_rpc.send_wait_transactions(refund_txs)
         logger.info(f"All {len(refund_txs)} refund transactions confirmed")
     else:
         logger.info(
-            f"No refund transactions to send ({skipped_refunds} EOAs skipped "
-            f"due to insufficient balance, {error_refunds} errored)"
+            f"No refund transactions to send "
+            f"({skipped_refunds} EOAs skipped "
+            f"due to insufficient balance)"
         )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/chain_builder_eth_rpc.py
@@ -4,181 +4,21 @@ submitted.
 """
 
 import time
+from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Sequence
+from typing import Any, List
 
 from filelock import FileLock
-from pydantic import RootModel
-from typing_extensions import Self
 
 from execution_testing.base_types import Address, Hash, HexNumber
 from execution_testing.forks import Fork
-from execution_testing.rpc import EngineRPC, TransactionProtocol
+from execution_testing.rpc import EngineRPC
 from execution_testing.rpc import EthRPC as BaseEthRPC
 from execution_testing.rpc.rpc_types import (
     ForkchoiceState,
     PayloadAttributes,
     PayloadStatusEnum,
-    TransactionByHashResponse,
 )
-from execution_testing.test_types.trie import keccak256
-
-
-class HashList(RootModel[List[Hash]]):
-    """Hash list class."""
-
-    root: List[Hash]
-
-    def append(self, item: Hash) -> None:
-        """Append an item to the list."""
-        self.root.append(item)
-
-    def clear(self) -> None:
-        """Clear the list."""
-        self.root.clear()
-
-    def remove(self, item: Hash) -> None:
-        """Remove an item from the list."""
-        self.root.remove(item)
-
-    def __contains__(self, item: Hash) -> bool:
-        """Check if an item is in the list."""
-        return item in self.root
-
-    def __len__(self) -> int:
-        """Get the length of the list."""
-        return len(self.root)
-
-    def __iter__(self) -> Iterator[Hash]:  # type: ignore
-        """Iterate over the list."""
-        return iter(self.root)
-
-
-class AddressList(RootModel[List[Address]]):
-    """Address list class."""
-
-    root: List[Address]
-
-    def append(self, item: Address) -> None:
-        """Append an item to the list."""
-        self.root.append(item)
-
-    def clear(self) -> None:
-        """Clear the list."""
-        self.root.clear()
-
-    def remove(self, item: Address) -> None:
-        """Remove an item from the list."""
-        self.root.remove(item)
-
-    def __contains__(self, item: Address) -> bool:
-        """Check if an item is in the list."""
-        return item in self.root
-
-    def __len__(self) -> int:
-        """Get the length of the list."""
-        return len(self.root)
-
-    def __iter__(self) -> Iterator[Address]:  # type: ignore
-        """Iterate over the list."""
-        return iter(self.root)
-
-
-class PendingTxHashes:
-    """
-    A class to manage the pending transaction hashes in a multi-process
-    environment.
-
-    It uses a lock file to ensure that only one process can access the pending
-    hashes file at a time.
-    """
-
-    pending_hashes_file: Path
-    pending_hashes_lock: Path
-    pending_tx_hashes: HashList | None
-    lock: FileLock | None
-
-    def __init__(self, temp_folder: Path):
-        """Initialize the pending transaction hashes manager."""
-        self.pending_hashes_file = temp_folder / "pending_tx_hashes"
-        self.pending_hashes_lock = temp_folder / "pending_tx_hashes.lock"
-        self.pending_tx_hashes = None
-        self.lock = None
-
-    def __enter__(self) -> Self:
-        """Lock the pending hashes file and load it."""
-        assert self.lock is None, "Lock already acquired"
-        self.lock = FileLock(self.pending_hashes_lock, timeout=-1)
-        self.lock.acquire()
-        assert self.pending_tx_hashes is None, (
-            "Pending transaction hashes already loaded"
-        )
-        if self.pending_hashes_file.exists():
-            with open(self.pending_hashes_file, "r") as f:
-                self.pending_tx_hashes = HashList.model_validate_json(f.read())
-        else:
-            self.pending_tx_hashes = HashList([])
-        return self
-
-    def __exit__(
-        self, exc_type: object, exc_value: object, traceback: object
-    ) -> None:
-        """Flush the pending hashes to the file and release the lock."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        with open(self.pending_hashes_file, "w") as f:
-            f.write(self.pending_tx_hashes.model_dump_json())
-        self.lock.release()
-        self.lock = None
-        self.pending_tx_hashes = None
-
-    def append(self, tx_hash: Hash) -> None:
-        """Add a transaction hash to the pending list."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        self.pending_tx_hashes.append(tx_hash)
-
-    def clear(self) -> None:
-        """Remove a transaction hash from the pending list."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None
-        self.pending_tx_hashes.clear()
-
-    def remove(self, tx_hash: Hash) -> None:
-        """Remove a transaction hash from the pending list."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        self.pending_tx_hashes.remove(tx_hash)
-
-    def __contains__(self, tx_hash: Hash) -> bool:
-        """Check if a transaction hash is in the pending list."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        return tx_hash in self.pending_tx_hashes
-
-    def __len__(self) -> int:
-        """Get the number of pending transaction hashes."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        return len(self.pending_tx_hashes)
-
-    def __iter__(self) -> Iterator[Hash]:
-        """Iterate over the pending transaction hashes."""
-        assert self.lock is not None, "Lock not acquired"
-        assert self.pending_tx_hashes is not None, (
-            "Pending transaction hashes not loaded"
-        )
-        return iter(self.pending_tx_hashes)
 
 
 class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
@@ -190,9 +30,8 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
 
     fork: Fork
     engine_rpc: EngineRPC
-    transactions_per_block: int
     get_payload_wait_time: float
-    pending_tx_hashes: PendingTxHashes
+    block_building_lock: FileLock
 
     def __init__(
         self,
@@ -200,7 +39,6 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         rpc_endpoint: str,
         fork: Fork,
         engine_rpc: EngineRPC,
-        transactions_per_block: int,
         session_temp_folder: Path,
         get_payload_wait_time: float,
         initial_forkchoice_update_retries: int = 5,
@@ -215,17 +53,17 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         )
         self.fork = fork
         self.engine_rpc = engine_rpc
-        self.transactions_per_block = transactions_per_block
-        self.pending_tx_hashes = PendingTxHashes(session_temp_folder)
+        self.block_building_lock = FileLock(
+            session_temp_folder / "chain_builder_fcu.lock"
+        )
         self.get_payload_wait_time = get_payload_wait_time
 
         # Send initial forkchoice updated only if we are the first worker
         base_name = "eth_rpc_forkchoice_updated"
         base_file = session_temp_folder / base_name
         base_error_file = session_temp_folder / f"{base_name}.err"
-        base_lock_file = session_temp_folder / f"{base_name}.lock"
 
-        with FileLock(base_lock_file):
+        with self.block_building_lock:
             if base_error_file.exists():
                 raise Exception(
                     "Error occurred during initial forkchoice_updated"
@@ -261,6 +99,17 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
                     raise Exception("Initial forkchoice_updated was invalid")
                 base_error_file.unlink()  # Success
                 base_file.touch()
+
+    @property
+    def transaction_polling_context(self) -> AbstractContextManager:
+        """
+        Return the block building lock as context manager so it's acquired
+        during transaction polling.
+
+        Reasoning is that the lock gets acquired once while all processes
+        wait for transactions, only one of them produces a new block.
+        """
+        return self.block_building_lock
 
     def generate_block(self: "ChainBuilderEthRPC") -> None:
         """Generate a block using the Engine API."""
@@ -358,162 +207,12 @@ class ChainBuilderEthRPC(BaseEthRPC, namespace="eth"):
         assert response.payload_status.status == PayloadStatusEnum.VALID, (
             "Payload was invalid"
         )
-        for tx in new_payload.execution_payload.transactions:
-            tx_hash = Hash(keccak256(tx))
-            if tx_hash in self.pending_tx_hashes:
-                self.pending_tx_hashes.remove(tx_hash)
 
-    def send_transaction(self, transaction: TransactionProtocol) -> Hash:
-        """`eth_sendRawTransaction`: Send a transaction to the client."""
-        returned_hash = super().send_transaction(transaction)
-        with self.pending_tx_hashes:
-            self.pending_tx_hashes.append(transaction.hash)
-            if len(self.pending_tx_hashes) >= self.transactions_per_block:
-                self.generate_block()
-        return returned_hash
-
-    def wait_for_transaction(
-        self, transaction: TransactionProtocol
-    ) -> TransactionByHashResponse:
+    def pending_transactions_handler(self) -> None:
         """
-        Wait for a specific transaction to be included in a block.
+        Called inside the transaction inclusion wait-loop.
 
-        Waits for a specific transaction to be included in a block by polling
-        `eth_getTransactionByHash` until it is confirmed or a timeout occurs.
-
-        Args:
-            transaction: The transaction to track.
-
-        Returns:
-            The transaction details after it is included in a block.
-
+        This class triggers the block building process if it's still waiting
+        for transactions to be included.
         """
-        return self.wait_for_transactions([transaction])[0]
-
-    def wait_for_transactions(
-        self, transactions: Sequence[TransactionProtocol]
-    ) -> List[TransactionByHashResponse]:
-        """
-        Wait for all transactions in the provided list to be included in a
-        block.
-
-        Waits for all transactions in the provided list to be included in a
-        block by polling `eth_getTransactionByHash` until they are confirmed or
-        a timeout occurs.
-
-        Args:
-            transactions: A list of transactions to track.
-
-        Returns:
-            A list of transaction details after they are included in a block.
-
-        Raises:
-            Exception: If one or more transactions are not included in a block
-                within the timeout period.
-
-        """
-        tx_hashes = [tx.hash for tx in transactions]
-        responses: List[TransactionByHashResponse] = []
-        pending_responses: Dict[Hash, TransactionByHashResponse] = {}
-
-        start_time = time.time()
-        pending_transactions_handler = PendingTransactionHandler(self)
-        while True:
-            tx_id = 0
-            pending_responses = {}
-            while tx_id < len(tx_hashes):
-                tx_hash = tx_hashes[tx_id]
-                tx = self.get_transaction_by_hash(tx_hash)
-                assert tx is not None, f"Transaction {tx_hash} not found"
-                if tx.block_number is not None:
-                    responses.append(tx)
-                    tx_hashes.pop(tx_id)
-                else:
-                    pending_responses[tx_hash] = tx
-                    tx_id += 1
-
-            if not tx_hashes:
-                return responses
-
-            pending_transactions_handler.handle()
-
-            if (time.time() - start_time) > self.transaction_wait_timeout:
-                break
-            time.sleep(0.1)
-
-        missing_txs_strings = [
-            f"{tx.hash} ({tx.model_dump_json()})"
-            for tx in transactions
-            if tx.hash in tx_hashes
-        ]
-
-        pending_tx_responses_string = "\n".join(
-            [
-                f"{tx_hash}: {tx.model_dump_json()}"
-                for tx_hash, tx in pending_responses.items()
-            ]
-        )
-        missing_str = ", ".join(missing_txs_strings)
-        raise Exception(
-            f"Transactions {missing_str} were not included in a block "
-            f"within {self.transaction_wait_timeout} seconds:\n"
-            f"{pending_tx_responses_string}"
-        )
-
-
-class PendingTransactionHandler:
-    """
-    Manages block generation based on the number of pending transactions or a
-    block generation interval.
-
-    Attributes:
-        block_generation_interval: The number of iterations after which a block
-            is generated if no new transactions are added (default: 10).
-
-    """
-
-    chain_builder_eth_rpc: ChainBuilderEthRPC
-    block_generation_interval: int
-    last_pending_tx_hashes_count: int | None = None
-    i: int = 0
-
-    def __init__(
-        self,
-        chain_builder_eth_rpc: ChainBuilderEthRPC,
-        block_generation_interval: int = 10,
-    ):
-        """Initialize the pending transaction handler."""
-        self.chain_builder_eth_rpc = chain_builder_eth_rpc
-        self.block_generation_interval = block_generation_interval
-
-    def handle(self) -> None:
-        """
-        Handle pending transactions and generate blocks if necessary.
-
-        If the number of pending transactions reaches the limit, a block is
-        generated.
-
-        If no new transactions have been added to the pending list and the
-        block generation interval has been reached, a block is generated to
-        avoid potential deadlock.
-        """
-        with self.chain_builder_eth_rpc.pending_tx_hashes:
-            if (
-                len(self.chain_builder_eth_rpc.pending_tx_hashes)
-                >= self.chain_builder_eth_rpc.transactions_per_block
-            ):
-                self.chain_builder_eth_rpc.generate_block()
-            else:
-                if (
-                    self.last_pending_tx_hashes_count is not None
-                    and len(self.chain_builder_eth_rpc.pending_tx_hashes)
-                    == self.last_pending_tx_hashes_count
-                    and self.i % self.block_generation_interval == 0
-                ):
-                    # If no new transactions have been added to the pending
-                    # list, generate a block to avoid potential deadlock.
-                    self.chain_builder_eth_rpc.generate_block()
-            self.last_pending_tx_hashes_count = len(
-                self.chain_builder_eth_rpc.pending_tx_hashes
-            )
-            self.i += 1
+        self.generate_block()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/hive.py
@@ -24,6 +24,8 @@ from execution_testing.fixtures.blockchain import FixtureHeader
 from execution_testing.forks import Fork
 from execution_testing.rpc import EngineRPC, EthRPC
 from execution_testing.test_types import (
+    DETERMINISTIC_FACTORY_ADDRESS,
+    DETERMINISTIC_FACTORY_BYTECODE,
     EOA,
     Alloc,
     ChainConfig,
@@ -104,7 +106,14 @@ def base_pre(
     seed_key_initial_balance = request.config.getoption(
         "seed_key_initial_balance"
     )
-    return Alloc({seed_key: Account(balance=seed_key_initial_balance)})
+    return Alloc(
+        {
+            seed_key: Account(balance=seed_key_initial_balance),
+            DETERMINISTIC_FACTORY_ADDRESS: Account(
+                nonce=1, code=DETERMINISTIC_FACTORY_BYTECODE
+            ),
+        }
+    )
 
 
 @pytest.fixture(scope="session")
@@ -387,7 +396,6 @@ def eth_rpc(
     client: Client,
     engine_rpc: EngineRPC,
     session_fork: Fork,
-    transactions_per_block: int,
     session_temp_folder: Path,
     max_transactions_per_batch: int | None,
 ) -> EthRPC:
@@ -398,7 +406,6 @@ def eth_rpc(
         rpc_endpoint=f"http://{client.ip}:8545",
         fork=session_fork,
         engine_rpc=engine_rpc,
-        transactions_per_block=transactions_per_block,
         session_temp_folder=session_temp_folder,
         get_payload_wait_time=get_payload_wait_time,
         transaction_wait_timeout=tx_wait_timeout,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote.py
@@ -177,7 +177,6 @@ def eth_rpc(
     rpc_endpoint: str,
     engine_rpc: EngineRPC | None,
     session_fork: Fork,
-    transactions_per_block: int,
     session_temp_folder: Path,
     max_transactions_per_batch: int | None,
 ) -> EthRPC:
@@ -194,7 +193,6 @@ def eth_rpc(
         rpc_endpoint=rpc_endpoint,
         fork=session_fork,
         engine_rpc=engine_rpc,
-        transactions_per_block=transactions_per_block,
         session_temp_folder=session_temp_folder,
         get_payload_wait_time=get_payload_wait_time,
         transaction_wait_timeout=tx_wait_timeout,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote_seed_sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/rpc/remote_seed_sender.py
@@ -54,10 +54,11 @@ def seed_key(
         )
     # check the nonce through the rpc client
     seed_key = EOA(key=rpc_seed_key)
-    seed_key.nonce = Number(eth_rpc.get_transaction_count(seed_key))
+    seed_account = eth_rpc.get_account(seed_key, skip_code=True)
+    seed_key.nonce = Number(seed_account.nonce)
 
     # Record the start balance of the worker key
-    start_balance = eth_rpc.get_balance(seed_key)
+    start_balance = seed_account.balance
 
     yield seed_key
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -68,8 +68,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         type=int,
         default=120,
         help=(
-            "Timeout in seconds for workers waiting to be funded. "
-            "Default=120"
+            "Timeout in seconds for workers waiting to be funded. Default=120"
         ),
     )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -61,6 +61,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         ),
     )
 
+    sender_group.addoption(
+        "--worker-funding-timeout",
+        action="store",
+        dest="worker_funding_timeout",
+        type=int,
+        default=120,
+        help=(
+            "Timeout in seconds for workers waiting to be funded. "
+            "Default=120"
+        ),
+    )
+
 
 @pytest.fixture(scope="session")
 def sender_funding_transactions_gas_price(
@@ -310,8 +322,18 @@ def session_worker_key(
             worker_funded_file.touch()
 
     if not is_last_worker:
-        logger.info("Waiting for all workers to be funded...")
+        funding_timeout = request.config.option.worker_funding_timeout
+        logger.info(
+            "Waiting for all workers to be funded "
+            f"(timeout={funding_timeout}s)..."
+        )
+        deadline = time.monotonic() + funding_timeout
         while not worker_funded_file.exists():
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"Timed out after {funding_timeout}s waiting "
+                    "for all workers to be funded"
+                )
             time.sleep(0.1)
         logger.info("All workers funded, proceeding")
 
@@ -391,7 +413,7 @@ def worker_key(
     """Prepare the worker key for the current test."""
     logger.debug(f"Preparing worker key {session_worker_key} for test")
     session_worker_account = eth_rpc.get_account(
-        session_worker_key, skip_code=True
+        session_worker_key, block_number="pending", skip_code=True
     )
     rpc_nonce = Number(session_worker_account.nonce)
     if rpc_nonce != session_worker_key.nonce:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -1,16 +1,22 @@
 """Sender mutex class that allows sending transactions one at a time."""
 
+import json
+import time
 from pathlib import Path
-from typing import Generator, Iterator
+from typing import Generator, Iterator, List
 
 import pytest
 from filelock import FileLock
 from pytest_metadata.plugin import metadata_key
 
-from execution_testing.base_types import Number, Wei
+from execution_testing.base_types import Address, Number, Wei
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
-from execution_testing.test_types import EOA, Transaction
+from execution_testing.test_types import (
+    EOA,
+    Transaction,
+    TransactionTestMetadata,
+)
 
 logger = get_logger(__name__)
 
@@ -256,55 +262,58 @@ def session_worker_key(
     assert worker_key_funding_amount is not None, (
         "`worker_key_funding_amount` is None"
     )
-    # For the seed sender we do need to keep track of the nonce because it is
-    # shared among different processes, and there might not be a new block
-    # produced between the transactions.
-    seed_sender_nonce_file_name = "seed_sender_nonce"
-    seed_sender_lock_file_name = f"{seed_sender_nonce_file_name}.lock"
-    seed_sender_nonce_file = session_temp_folder / seed_sender_nonce_file_name
-    seed_sender_lock_file = session_temp_folder / seed_sender_lock_file_name
+    worker_keys_file_name = "worker_keys.json"
+    worker_keys_lock_file_name = f"{worker_keys_file_name}.lock"
+    worker_keys_file = session_temp_folder / worker_keys_file_name
+    worker_keys_lock_file = session_temp_folder / worker_keys_lock_file_name
+    worker_funded_file = session_temp_folder / "worker_keys_funded"
 
     worker_key = next(eoa_iterator)
     logger.info(f"Allocated worker key: {worker_key}")
 
-    # Prepare funding transaction for this specific worker.
-    # Each worker locks the next nonce by using a file lock to coordinate.
-    with FileLock(seed_sender_lock_file):
-        if seed_sender_nonce_file.exists():
-            with seed_sender_nonce_file.open("r") as f:
-                seed_key.nonce = Number(f.read())
-                logger.debug(
-                    f"Loaded seed key nonce from file: {seed_key.nonce}"
-                )
+    # Each worker registers its key. The last worker to register builds
+    # and sends all funding transactions as a single batch.
+    is_last_worker = False
+    with FileLock(worker_keys_lock_file):
+        if worker_keys_file.exists():
+            registered_keys = json.loads(worker_keys_file.read_text())
         else:
-            logger.debug(
-                "No existing seed key nonce file, using current nonce"
-            )
-        fund_tx = Transaction(
-            sender=seed_key,
-            to=worker_key,
-            gas_limit=sender_fund_refund_gas_limit,
-            gas_price=sender_funding_transactions_gas_price,
-            value=worker_key_funding_amount,
-        ).with_signature_and_sender()
-        fund_eth = worker_key_funding_amount / 10**18
-        logger.info(
-            f"Preparing funding transaction: {fund_eth:.18f} ETH "
-            f"from {seed_key} to {worker_key} (nonce={seed_key.nonce})"
-        )
-        if not dry_run:
-            eth_rpc.send_transaction(fund_tx)
-            logger.info(f"Sent funding transaction: {fund_tx.hash}")
-        else:
-            logger.info("Dry run: skipping funding transaction send")
-        with seed_sender_nonce_file.open("w") as f:
-            f.write(str(seed_key.nonce))
-    if not dry_run:
-        logger.info(
-            f"Waiting for funding transaction to be mined: {fund_tx.hash}"
-        )
-        eth_rpc.wait_for_transaction(fund_tx)
-        logger.info(f"Funding transaction confirmed: {fund_tx.hash}")
+            registered_keys = []
+        registered_keys.append(str(worker_key))
+        worker_keys_file.write_text(json.dumps(registered_keys))
+
+        if len(registered_keys) == worker_count:
+            is_last_worker = True
+            fund_txs: List[Transaction] = []
+            for i, key_str in enumerate(registered_keys):
+                fund_tx = Transaction(
+                    sender=seed_key,
+                    to=Address(key_str),
+                    gas_limit=sender_fund_refund_gas_limit,
+                    gas_price=sender_funding_transactions_gas_price,
+                    value=worker_key_funding_amount,
+                    metadata=TransactionTestMetadata(
+                        test_id="global",
+                        phase="setup",
+                        action="fund_eoa",
+                        target="Session Worker Key",
+                        tx_index=i,
+                    ),
+                ).with_signature_and_sender()
+                fund_txs.append(fund_tx)
+
+            if not dry_run:
+                eth_rpc.send_wait_transactions(fund_txs)
+                logger.info("All worker funding transactions confirmed")
+            else:
+                logger.info("Dry run: skipping funding transaction send")
+            worker_funded_file.touch()
+
+    if not is_last_worker:
+        logger.info("Waiting for all workers to be funded...")
+        while not worker_funded_file.exists():
+            time.sleep(0.1)
+        logger.info("All workers funded, proceeding")
 
     # Run all tests for this worker.
     yield worker_key
@@ -313,8 +322,8 @@ def session_worker_key(
     logger.info(
         f"All tests completed for worker {worker_key}, preparing refund"
     )
-    remaining_balance = eth_rpc.get_balance(worker_key)
-    worker_key.nonce = Number(eth_rpc.get_transaction_count(worker_key))
+    worker_account = eth_rpc.get_account(worker_key, skip_code=True)
+    remaining_balance = worker_account.balance
     used_balance = worker_key_funding_amount - remaining_balance
     logger.info(
         f"Worker {worker_key} used balance: {used_balance / 10**18:.18f} ETH "
@@ -346,7 +355,7 @@ def session_worker_key(
 
     # Update the nonce of the sender in case one of the pre-alloc transactions
     # failed
-    worker_key.nonce = Number(eth_rpc.get_transaction_count(worker_key))
+    worker_key.nonce = worker_account.nonce
     refund_value = remaining_balance - tx_cost - 1
     logger.info(
         f"Preparing refund transaction: {refund_value / 10**18:.18f} ETH "
@@ -359,12 +368,19 @@ def session_worker_key(
         gas_limit=refund_gas_limit,
         gas_price=refund_gas_price,
         value=refund_value,
+        metadata=TransactionTestMetadata(
+            test_id="global",
+            phase="cleanup",
+            action="fund_eoa",
+            target="Session Worker Key Refund",
+            tx_index=worker_key.nonce,
+        ),
     ).with_signature_and_sender()
 
     logger.info(
         f"Sending and waiting for refund transaction: {refund_tx.hash}"
     )
-    eth_rpc.send_wait_transaction(refund_tx)
+    eth_rpc.send_wait_transactions([refund_tx])
     logger.info(f"Refund transaction confirmed: {refund_tx.hash}")
 
 
@@ -374,11 +390,10 @@ def worker_key(
 ) -> Generator[EOA, None, None]:
     """Prepare the worker key for the current test."""
     logger.debug(f"Preparing worker key {session_worker_key} for test")
-    rpc_nonce = Number(
-        eth_rpc.get_transaction_count(
-            session_worker_key, block_number="pending"
-        )
+    session_worker_account = eth_rpc.get_account(
+        session_worker_key, skip_code=True
     )
+    rpc_nonce = Number(session_worker_account.nonce)
     if rpc_nonce != session_worker_key.nonce:
         wk_nonce = session_worker_key.nonce
         logger.info(f"Worker key nonce mismatch: {wk_nonce} != {rpc_nonce}")
@@ -386,7 +401,7 @@ def worker_key(
         session_worker_key.nonce = rpc_nonce
 
     # Record the start balance of the worker key
-    worker_key_start_balance = eth_rpc.get_balance(session_worker_key)
+    worker_key_start_balance = session_worker_account.balance
     start_eth = worker_key_start_balance / 10**18
     logger.debug(f"Worker key start balance: {start_eth:.18f} ETH")
 

--- a/packages/testing/src/execution_testing/execution/transaction_post.py
+++ b/packages/testing/src/execution_testing/execution/transaction_post.py
@@ -113,11 +113,17 @@ class TransactionPost(BaseExecute):
                 signed_txs.append(tx)
             current_block_tx_hashes: List[Hash] = []
             if any(tx.error is not None for tx in signed_txs):
+                tx_queue: List[Transaction] = []
                 for transaction in signed_txs:
                     if transaction.error is None:
-                        eth_rpc.send_wait_transaction(transaction)
-                        current_block_tx_hashes.append(transaction.hash)
+                        tx_queue.append(transaction)
                     else:
+                        if tx_queue:
+                            eth_rpc.send_wait_transactions(tx_queue)
+                            current_block_tx_hashes.extend(
+                                tx.hash for tx in tx_queue
+                            )
+                            tx_queue = []
                         logger.info(
                             f"Sending transaction expecting rejection "
                             f"(expected error: {transaction.error})..."
@@ -130,6 +136,9 @@ class TransactionPost(BaseExecute):
                             "Transaction rejected as expected: "
                             f"{exc_info.value}"
                         )
+                if tx_queue:
+                    eth_rpc.send_wait_transactions(tx_queue)
+                    current_block_tx_hashes.extend(tx.hash for tx in tx_queue)
             else:
                 # Send transactions (batching is handled by eth_rpc internally)
                 eth_rpc.send_wait_transactions(signed_txs)
@@ -149,45 +158,24 @@ class TransactionPost(BaseExecute):
                 gas_used = int(receipt["gasUsed"], 16)
                 benchmark_gas_used += gas_used
 
-        for address, account in self.post.root.items():
-            balance = eth_rpc.get_balance(address)
-            code = eth_rpc.get_code(address)
-            nonce = eth_rpc.get_transaction_count(address)
-            if account is None:
-                assert balance == 0, (
-                    f"Balance of {address} is {balance}, expected 0."
+        actual_alloc = eth_rpc.get_alloc(self.post)
+        for address, expected_account in self.post.root.items():
+            actual_account = actual_alloc.root[address]
+            assert actual_account is not None
+            if expected_account is None:
+                assert actual_account.balance == 0, (
+                    f"Balance of {address} is "
+                    f"{actual_account.balance}, expected 0."
                 )
-                assert code == b"", (
-                    f"Code of {address} is {code}, expected 0x."
+                assert actual_account.code == b"", (
+                    f"Code of {address} is {actual_account.code}, expected 0x."
                 )
-                assert nonce == 0, (
-                    f"Nonce of {address} is {nonce}, expected 0."
+                assert actual_account.nonce == 0, (
+                    f"Nonce of {address} is "
+                    f"{actual_account.nonce}, expected 0."
                 )
             else:
-                if "balance" in account.model_fields_set:
-                    assert balance == account.balance, (
-                        f"Balance of {address} is {balance}, "
-                        f"expected {account.balance}."
-                    )
-                if "code" in account.model_fields_set:
-                    assert code == account.code, (
-                        f"Code of {address} is {code}, "
-                        f"expected {account.code}."
-                    )
-                if "nonce" in account.model_fields_set:
-                    assert nonce == account.nonce, (
-                        f"Nonce of {address} is {nonce}, "
-                        f"expected {account.nonce}."
-                    )
-                if "storage" in account.model_fields_set:
-                    for key, value in account.storage.items():
-                        storage_value = eth_rpc.get_storage_at(
-                            address, Hash(key)
-                        )
-                        assert storage_value == value, (
-                            f"Storage value at {key} of {address} is "
-                            f"{storage_value}, expected {value}."
-                        )
+                expected_account.check_alloc(address, actual_account)
 
         return ExecuteResult(
             benchmark_gas_used=benchmark_gas_used,

--- a/packages/testing/src/execution_testing/rpc/__init__.py
+++ b/packages/testing/src/execution_testing/rpc/__init__.py
@@ -20,6 +20,9 @@ from .rpc_types import (
     EthConfigResponse,
     ForkConfig,
     ForkConfigBlobSchedule,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    RPCCall,
     TransactionProtocol,
 )
 
@@ -36,7 +39,10 @@ __all__ = [
     "ForkConfig",
     "ForkConfigBlobSchedule",
     "ForkchoiceUpdateTimeoutError",
+    "JSONRPCRequest",
+    "JSONRPCResponse",
     "NetRPC",
+    "RPCCall",
     "PeerConnectionTimeoutError",
     "SendTransactionExceptionError",
     "TransactionProtocol",

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -770,7 +770,7 @@ class EthRPC(BaseRPC):
         responses = self.post_batch_request(calls=calls)
 
         results: List[Hash] = []
-        for tx, response in zip(transactions, responses, strict=False):
+        for tx, response in zip(transactions, responses, strict=True):
             try:
                 result_hash = Hash(response.result_or_raise())
                 assert result_hash == tx.hash

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -5,6 +5,7 @@ JSON-RPC methods and helper functions for EEST consume based hive simulators.
 import logging
 import os
 import time
+from contextlib import AbstractContextManager, nullcontext
 from itertools import count
 from pprint import pprint
 from typing import Any, Callable, ClassVar, Dict, List, Literal, Sequence
@@ -24,7 +25,14 @@ from tenacity import (
     wait_fixed as wait_fixed_tenacity,
 )
 
-from execution_testing.base_types import Address, Bytes, Hash, to_json
+from execution_testing.base_types import (
+    Account,
+    Address,
+    Alloc,
+    Bytes,
+    Hash,
+    to_json,
+)
 from execution_testing.logging import (
     get_logger,
 )
@@ -35,10 +43,12 @@ from .rpc_types import (
     ForkchoiceUpdateResponse,
     GetBlobsResponse,
     GetPayloadResponse,
-    JSONRPCError,
+    JSONRPCRequest,
+    JSONRPCResponse,
     PayloadAttributes,
     PayloadStatus,
     PayloadStatusEnum,
+    RPCCall,
     TransactionByHashResponse,
     TransactionProtocol,
 )
@@ -192,7 +202,7 @@ class BaseRPC:
     def _make_request(
         self,
         url: str,
-        json_payload: dict[str, Any],
+        json_payload: dict[str, Any] | list[dict[str, Any]],
         headers: dict[str, str],
         timeout: int | None,
     ) -> requests.Response:
@@ -212,36 +222,39 @@ class BaseRPC:
             url, json=json_payload, headers=headers, timeout=timeout
         )
 
+    def _build_json_rpc_request(
+        self,
+        call: RPCCall,
+    ) -> JSONRPCRequest:
+        """Build a JSON-RPC request object with namespace prefix."""
+        assert self.namespace, "RPC namespace not set"
+
+        next_request_id_counter = next(self.request_id_counter)
+        request_id = call.request_id
+        if request_id is None:
+            request_id = next_request_id_counter
+
+        return JSONRPCRequest(
+            method=f"{self.namespace}_{call.method}",
+            params=call.params,
+            id=request_id,
+        )
+
     def post_request(
         self,
         *,
-        method: str,
-        params: List[Any] | None = None,
+        request: RPCCall,
         extra_headers: Dict[str, str] | None = None,
-        request_id: int | str | None = None,
         timeout: int | None = None,
-    ) -> Any:
+    ) -> JSONRPCResponse:
         """
         Send JSON-RPC POST request to the client RPC server at port defined in
         the url.
         """
         if extra_headers is None:
             extra_headers = {}
-        if params is None:
-            params = []
 
-        assert self.namespace, "RPC namespace not set"
-
-        next_request_id_counter = next(self.request_id_counter)
-        if request_id is None:
-            request_id = next_request_id_counter
-
-        payload = {
-            "jsonrpc": "2.0",
-            "method": f"{self.namespace}_{method}",
-            "params": params,
-            "id": request_id,
-        }
+        json_rpc_request = self._build_json_rpc_request(request)
         base_header = {
             "Content-Type": "application/json",
         }
@@ -249,22 +262,68 @@ class BaseRPC:
 
         logger.debug(
             f"Sending RPC request to {self.url}, "
-            f"method={self.namespace}_{method}, timeout={timeout}..."
+            f"method={json_rpc_request.method}, timeout={timeout}..."
+        )
+
+        response = self._make_request(
+            self.url, json_rpc_request.model_dump(), headers, timeout
+        )
+        response.raise_for_status()
+
+        return JSONRPCResponse.model_validate(response.json())
+
+    def post_batch_request(
+        self,
+        *,
+        calls: Sequence[RPCCall],
+        extra_headers: Dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> List[JSONRPCResponse]:
+        """
+        Send a JSON-RPC batch POST request to the client RPC server at port
+        defined in the url.
+        """
+        if extra_headers is None:
+            extra_headers = {}
+
+        json_rpc_requests = [
+            self._build_json_rpc_request(call) for call in calls
+        ]
+        payload = [r.model_dump() for r in json_rpc_requests]
+        base_header = {
+            "Content-Type": "application/json",
+        }
+        headers = base_header | extra_headers
+
+        logger.debug(
+            f"Sending batch RPC request to {self.url}, "
+            f"{len(json_rpc_requests)} calls, timeout={timeout}..."
         )
 
         response = self._make_request(self.url, payload, headers, timeout)
         response.raise_for_status()
         response_json = response.json()
 
-        if "error" in response_json:
-            raise JSONRPCError(**response_json["error"])
-
-        assert "result" in response_json, (
-            "RPC response didn't contain a result field"
+        assert isinstance(response_json, list), (
+            "Batch RPC response is not a list"
         )
-        result = response_json["result"]
-        logger.info(f"RPC Result: {result}")
-        return result
+
+        response_map: dict[int | str, JSONRPCResponse] = {
+            r.id: r
+            for r in [
+                JSONRPCResponse.model_validate(item) for item in response_json
+            ]
+        }
+
+        results = []
+        for json_rpc_request in json_rpc_requests:
+            assert json_rpc_request.id in response_map, (
+                f"Missing response for request ID {json_rpc_request.id}"
+            )
+            results.append(response_map[json_rpc_request.id])
+
+        logger.info(f"Batch RPC: {len(results)} responses received")
+        return results
 
 
 class EthRPC(BaseRPC):
@@ -351,7 +410,9 @@ class EthRPC(BaseRPC):
         """
         try:
             logger.info("Requesting eth_config..")
-            response = self.post_request(method="config", timeout=timeout)
+            response = self.post_request(
+                request=RPCCall(method="config"), timeout=timeout
+            ).result_or_raise()
             if response is None:
                 logger.warning("eth_config request: failed to get response")
                 return None
@@ -370,7 +431,9 @@ class EthRPC(BaseRPC):
     def chain_id(self) -> int:
         """`eth_chainId`: Returns the current chain id."""
         logger.info("Requesting chainid of provided RPC endpoint..")
-        response = self.post_request(method="chainId", timeout=10)
+        response = self.post_request(
+            request=RPCCall(method="chainId"), timeout=10
+        ).result_or_raise()
         return int(response, 16)
 
     def get_block_by_number(
@@ -387,8 +450,9 @@ class EthRPC(BaseRPC):
         )
         logger.info(f"Requesting info about block {block}..")
         params = [block, full_txs]
-        response = self.post_request(method="getBlockByNumber", params=params)
-        return response
+        return self.post_request(
+            request=RPCCall(method="getBlockByNumber", params=params)
+        ).result_or_raise()
 
     def get_block_by_hash(
         self, block_hash: Hash, full_txs: bool = True
@@ -396,8 +460,9 @@ class EthRPC(BaseRPC):
         """`eth_getBlockByHash`: Returns information about a block by hash."""
         logger.info(f"Requesting block info of {block_hash}..")
         params = [f"{block_hash}", full_txs]
-        response = self.post_request(method="getBlockByHash", params=params)
-        return response
+        return self.post_request(
+            request=RPCCall(method="getBlockByHash", params=params)
+        ).result_or_raise()
 
     def get_block_by_hash_with_retry(
         self,
@@ -470,7 +535,9 @@ class EthRPC(BaseRPC):
         )
         logger.info(f"Requesting balance of {address} at block {block}")
         params = [f"{address}", block]
-        response = self.post_request(method="getBalance", params=params)
+        response = self.post_request(
+            request=RPCCall(method="getBalance", params=params)
+        ).result_or_raise()
         return int(response, 16)
 
     def get_code(
@@ -484,7 +551,9 @@ class EthRPC(BaseRPC):
         )
         logger.info(f"Requesting code of {address} at block {block}")
         params = [f"{address}", block]
-        response = self.post_request(method="getCode", params=params)
+        response = self.post_request(
+            request=RPCCall(method="getCode", params=params)
+        ).result_or_raise()
         return Bytes(response)
 
     def get_transaction_count(
@@ -502,8 +571,8 @@ class EthRPC(BaseRPC):
         logger.info(f"Requesting nonce of {address}")
         params = [f"{address}", block]
         response = self.post_request(
-            method="getTransactionCount", params=params
-        )
+            request=RPCCall(method="getTransactionCount", params=params)
+        ).result_or_raise()
         return int(response, 16)
 
     def get_transaction_by_hash(
@@ -513,8 +582,11 @@ class EthRPC(BaseRPC):
         try:
             logger.info(f"Requesting tx details of {transaction_hash}")
             response = self.post_request(
-                method="getTransactionByHash", params=[f"{transaction_hash}"]
-            )
+                request=RPCCall(
+                    method="getTransactionByHash",
+                    params=[f"{transaction_hash}"],
+                )
+            ).result_or_raise()
             if response is None:
                 return None
             return TransactionByHashResponse.model_validate(
@@ -523,6 +595,39 @@ class EthRPC(BaseRPC):
         except ValidationError as e:
             pprint(e.errors())
             raise e
+
+    def get_transactions_by_hash(
+        self, transaction_hashes: Sequence[Hash]
+    ) -> List[TransactionByHashResponse | None]:
+        """
+        Batch `eth_getTransactionByHash` for multiple hashes.
+
+        Return a list of responses in the same order as the input
+        hashes. Entries are `None` if the transaction was not found.
+        """
+        if not transaction_hashes:
+            return []
+        calls = [
+            RPCCall(
+                method="getTransactionByHash",
+                params=[f"{tx_hash}"],
+            )
+            for tx_hash in transaction_hashes
+        ]
+        responses = self.post_batch_request(calls=calls)
+        results: List[TransactionByHashResponse | None] = []
+        for response in responses:
+            result = response.result_or_raise()
+            if result is None:
+                results.append(None)
+            else:
+                results.append(
+                    TransactionByHashResponse.model_validate(
+                        result,
+                        context=self.response_validation_context,
+                    )
+                )
+        return results
 
     def get_transaction_receipt(
         self, transaction_hash: Hash
@@ -534,10 +639,12 @@ class EthRPC(BaseRPC):
         in benchmark tests.
         """
         logger.info(f"Requesting tx receipt of {transaction_hash}")
-        response = self.post_request(
-            method="getTransactionReceipt", params=[f"{transaction_hash}"]
-        )
-        return response
+        return self.post_request(
+            request=RPCCall(
+                method="getTransactionReceipt",
+                params=[f"{transaction_hash}"],
+            )
+        ).result_or_raise()
 
     def get_storage_at(
         self,
@@ -559,7 +666,9 @@ class EthRPC(BaseRPC):
             f"of contract {address}"
         )
         params = [f"{address}", f"{position}", block]
-        response = self.post_request(method="getStorageAt", params=params)
+        response = self.post_request(
+            request=RPCCall(method="getStorageAt", params=params)
+        ).result_or_raise()
         return Hash(response)
 
     def _get_gas_information(
@@ -572,7 +681,9 @@ class EthRPC(BaseRPC):
             time.time() - self._gas_information_cache_timestamp[method]
             > self.gas_information_stale_seconds
         ):
-            response = self.post_request(method=method)
+            response = self.post_request(
+                request=RPCCall(method=method)
+            ).result_or_raise()
             logger.info(f"Requesting stale {method}")
             self._gas_information_cache[method] = int(response, 16)
             self._gas_information_cache_timestamp[method] = time.time()
@@ -602,10 +713,12 @@ class EthRPC(BaseRPC):
         try:
             logger.info("Sending raw tx..")
             response = self.post_request(
-                method="sendRawTransaction",
-                params=[transaction_rlp.hex()],
-                request_id=request_id,
-            )
+                request=RPCCall(
+                    method="sendRawTransaction",
+                    params=[transaction_rlp.hex()],
+                    request_id=request_id,
+                )
+            ).result_or_raise()
             result_hash = Hash(response)
             assert result_hash is not None
             return result_hash
@@ -623,10 +736,12 @@ class EthRPC(BaseRPC):
         try:
             logger.info("Sending tx..")
             response = self.post_request(
-                method="sendRawTransaction",
-                params=[transaction.rlp().hex()],
-                request_id=transaction.metadata_string(),
-            )
+                request=RPCCall(
+                    method="sendRawTransaction",
+                    params=[transaction.rlp().hex()],
+                    request_id=transaction.metadata_string(),
+                )
+            ).result_or_raise()
             result_hash = Hash(response)
             assert result_hash == transaction.hash
             assert result_hash is not None
@@ -638,10 +753,32 @@ class EthRPC(BaseRPC):
         self, transactions: Sequence[TransactionProtocol]
     ) -> List[Hash]:
         """
-        Use `eth_sendRawTransaction` to send a list of transactions to the
+        Use `eth_sendRawTransaction` to send a batch of transactions to the
         client.
         """
-        return [self.send_transaction(tx) for tx in transactions]
+        if not transactions:
+            return []
+
+        calls = [
+            RPCCall(
+                method="sendRawTransaction",
+                params=[tx.rlp().hex()],
+                request_id=tx.metadata_string(),
+            )
+            for tx in transactions
+        ]
+        responses = self.post_batch_request(calls=calls)
+
+        results: List[Hash] = []
+        for tx, response in zip(transactions, responses, strict=False):
+            try:
+                result_hash = Hash(response.result_or_raise())
+                assert result_hash == tx.hash
+                assert result_hash is not None
+                results.append(tx.hash)
+            except Exception as e:
+                raise SendTransactionExceptionError(str(e), tx=tx) from e
+        return results
 
     def storage_at_keys(
         self,
@@ -659,6 +796,172 @@ class EthRPC(BaseRPC):
             results[key] = storage_value
         return results
 
+    def _build_get_account_calls(
+        self,
+        address: Address,
+        account: Account | None,
+        block: str,
+        skip_code: bool = False,
+    ) -> tuple[List[RPCCall], List[tuple[str, Any]]]:
+        """Build the RPC calls needed to fetch an account's state."""
+        calls: List[RPCCall] = []
+        # (field_name, storage_key)
+        call_info: List[tuple[str, Any]] = []
+
+        calls.append(
+            RPCCall(
+                method="getBalance",
+                params=[f"{address}", block],
+            )
+        )
+        call_info.append(("balance", None))
+        if not skip_code:
+            calls.append(
+                RPCCall(
+                    method="getCode",
+                    params=[f"{address}", block],
+                )
+            )
+            call_info.append(("code", None))
+        calls.append(
+            RPCCall(
+                method="getTransactionCount",
+                params=[f"{address}", block],
+            )
+        )
+        call_info.append(("nonce", None))
+
+        if account is not None and "storage" in account.model_fields_set:
+            for key in account.storage.root:
+                calls.append(
+                    RPCCall(
+                        method="getStorageAt",
+                        params=[
+                            f"{address}",
+                            f"{Hash(key)}",
+                            block,
+                        ],
+                    )
+                )
+                call_info.append(("storage", key))
+
+        return calls, call_info
+
+    @staticmethod
+    def _parse_account_responses(
+        call_info: List[tuple[str, Any]],
+        responses: List[JSONRPCResponse],
+    ) -> Account:
+        """Parse RPC responses into an Account."""
+        data: Dict[str, Any] = {}
+        for (field, key), response in zip(call_info, responses, strict=True):
+            result = response.result_or_raise()
+            if field == "balance":
+                data["balance"] = int(result, 16)
+            elif field == "code":
+                data["code"] = Bytes(result)
+            elif field == "nonce":
+                data["nonce"] = int(result, 16)
+            elif field == "storage":
+                if "storage" not in data:
+                    data["storage"] = {}
+                data["storage"][key] = Hash(result)
+        return Account(**data)
+
+    def get_account(
+        self,
+        address: Address,
+        account: Account | None = None,
+        block_number: BlockNumberType = "latest",
+        skip_code: bool = False,
+    ) -> Account:
+        """
+        Fetch account state from the chain for a single address using
+        a batch RPC request.
+
+        If `account` is provided, its storage keys are also fetched.
+        If `skip_code` is True, the code fetch is omitted.
+        """
+        block = (
+            hex(block_number)
+            if isinstance(block_number, int)
+            else block_number
+        )
+        calls, call_info = self._build_get_account_calls(
+            address, account, block, skip_code=skip_code
+        )
+        responses = self.post_batch_request(calls=calls)
+        return self._parse_account_responses(call_info, responses)
+
+    def get_alloc(
+        self,
+        alloc: Alloc,
+        block_number: BlockNumberType = "latest",
+        skip_code: bool = False,
+    ) -> Alloc:
+        """
+        Fetch account state from the chain for all addresses in the
+        given alloc using a batch RPC request.
+
+        If `skip_code` is True, the code fetch is omitted for all
+        accounts.
+        """
+        if not alloc.root:
+            return Alloc()
+
+        block = (
+            hex(block_number)
+            if isinstance(block_number, int)
+            else block_number
+        )
+
+        all_calls: List[RPCCall] = []
+        # (address, per-account call_info list, call count)
+        address_info: List[tuple[Address, List[tuple[str, Any]]]] = []
+
+        for address, account in alloc.root.items():
+            calls, call_info = self._build_get_account_calls(
+                address, account, block, skip_code=skip_code
+            )
+            all_calls.extend(calls)
+            address_info.append((address, call_info))
+
+        responses = self.post_batch_request(calls=all_calls)
+
+        result_alloc: Dict[Address, Account | None] = {}
+        offset = 0
+        for address, call_info in address_info:
+            n = len(call_info)
+            result_alloc[address] = self._parse_account_responses(
+                call_info, responses[offset : offset + n]
+            )
+            offset += n
+
+        return Alloc(root=result_alloc)
+
+    @property
+    def transaction_polling_context(self) -> AbstractContextManager:
+        """
+        Return a context manager acquired during transaction polling.
+
+        By default a no-op. Subclasses can override to synchronize
+        transaction querying with block building.
+        """
+        return nullcontext()
+
+    def pending_transactions_handler(self) -> None:
+        """
+        Called inside the transaction_polling_context context during the
+        transaction inclusion wait-loop.
+
+        Useful for subclasses to override to introduce logic to perform
+        between transaction waits, such as triggering the block building
+        process.
+
+        By default it only waits the `poll_interval`.
+        """
+        time.sleep(self.poll_interval)
+
     def wait_for_transaction(
         self, transaction: TransactionProtocol
     ) -> TransactionByHashResponse:
@@ -670,56 +973,76 @@ class EthRPC(BaseRPC):
         start_time = time.time()
         while True:
             logger.info(f"Waiting for inclusion of tx {tx_hash} in a block..")
-            tx = self.get_transaction_by_hash(tx_hash)
-            if tx is not None and tx.block_number is not None:
-                return tx
-            if (time.time() - start_time) > self.transaction_wait_timeout:
-                break
-            time.sleep(self.poll_interval)
+            with self.transaction_polling_context:
+                tx = self.get_transaction_by_hash(tx_hash)
+                if tx is not None and tx.block_number is not None:
+                    return tx
+                if (time.time() - start_time) > self.transaction_wait_timeout:
+                    break
+                self.pending_transactions_handler()
         raise Exception(
             f"Transaction {tx_hash} ({transaction.model_dump_json()}) "
-            f"not included in a block after {self.transaction_wait_timeout} "
-            "seconds"
+            f"not included in a block after "
+            f"{self.transaction_wait_timeout} seconds"
         )
 
     def wait_for_transactions(
         self, transactions: Sequence[TransactionProtocol]
     ) -> List[TransactionByHashResponse]:
         """
-        Use `eth_getTransactionByHash` to wait until all transactions in list
-        are included in a block.
+        Use `eth_getTransactionByHash` batch requests to wait until all
+        transactions in list are included in a block.
         """
-        tx_hashes = [tx.hash for tx in transactions]
-        responses: List[TransactionByHashResponse] = []
+        if not transactions:
+            return []
+
+        pending: dict[Hash, TransactionProtocol] = {
+            tx.hash: tx for tx in transactions
+        }
+        found: dict[Hash, TransactionByHashResponse] = {}
         start_time = time.time()
-        logger.info("Waiting for all transaction to be included in a block..")
-        while True:
-            i = 0
-            while i < len(tx_hashes):
-                tx_hash = tx_hashes[i]
-                tx = self.get_transaction_by_hash(tx_hash)
-                if tx is not None and tx.block_number is not None:
-                    responses.append(tx)
-                    logger.info(
-                        f"Tx {tx.hash} was included in block {tx.block_number}"
+        logger.info("Waiting for all transactions to be included in a block..")
+
+        while pending:
+            with self.transaction_polling_context:
+                pending_hashes = list(pending.keys())
+                tx_responses = self.get_transactions_by_hash(pending_hashes)
+
+                newly_found: List[Hash] = []
+                for tx_hash, tx_response in zip(
+                    pending_hashes, tx_responses, strict=True
+                ):
+                    if tx_response is None:
+                        continue
+                    if tx_response.block_number is not None:
+                        found[tx_hash] = tx_response
+                        newly_found.append(tx_hash)
+                        logger.info(
+                            f"Tx {tx_response.hash} was included "
+                            f"in block {tx_response.block_number}"
+                        )
+
+                for tx_hash in newly_found:
+                    del pending[tx_hash]
+
+                if not pending:
+                    break
+
+                if (time.time() - start_time) > self.transaction_wait_timeout:
+                    missing_txs_strings = [
+                        f"{tx.hash} ({tx.model_dump_json()})"
+                        for tx in transactions
+                        if tx.hash in pending
+                    ]
+                    raise Exception(
+                        f"Transactions "
+                        f"{', '.join(missing_txs_strings)} not "
+                        f"included in a block after "
+                        f"{self.transaction_wait_timeout} seconds"
                     )
-                    tx_hashes.pop(i)
-                else:
-                    i += 1
-            if not tx_hashes:
-                return responses
-            if (time.time() - start_time) > self.transaction_wait_timeout:
-                break
-            time.sleep(self.poll_interval)
-        missing_txs_strings = [
-            f"{tx.hash} ({tx.model_dump_json()})"
-            for tx in transactions
-            if tx.hash in tx_hashes
-        ]
-        raise Exception(
-            f"Transactions {', '.join(missing_txs_strings)} not included "
-            f"in a block after {self.transaction_wait_timeout} seconds"
-        )
+                self.pending_transactions_handler()
+
+        return [found[tx.hash] for tx in transactions]
 
     def send_wait_transaction(self, transaction: TransactionProtocol) -> Any:
         """Send transaction and waits until it is included in a block."""
@@ -761,7 +1084,9 @@ class DebugRPC(EthRPC):
     def trace_call(self, tr: dict[str, str], block_number: str) -> Any | None:
         """`debug_traceCall`: Returns pre state required for transaction."""
         params = [tr, block_number, {"tracer": "prestateTracer"}]
-        return self.post_request(method="traceCall", params=params)
+        return self.post_request(
+            request=RPCCall(method="traceCall", params=params)
+        ).result_or_raise()
 
 
 class EngineRPC(BaseRPC):
@@ -785,19 +1110,10 @@ class EngineRPC(BaseRPC):
         super().__init__(*args, **kwargs)
         self.jwt_secret = jwt_secret
 
-    def post_request(
-        self,
-        *,
-        method: str,
-        params: Any | None = None,
-        extra_headers: Dict[str, str] | None = None,
-        request_id: int | str | None = None,
-        timeout: int | None = None,
-    ) -> Any:
-        """
-        Send JSON-RPC POST request to the client RPC server at port defined in
-        the url.
-        """
+    def _jwt_extra_headers(
+        self, extra_headers: Dict[str, str] | None = None
+    ) -> Dict[str, str]:
+        """Build extra headers with JWT authentication."""
         if extra_headers is None:
             extra_headers = {}
         jwt_token = encode(
@@ -805,16 +1121,40 @@ class EngineRPC(BaseRPC):
             self.jwt_secret,
             algorithm="HS256",
         )
-        extra_headers = {
+        return {
             "Authorization": f"Bearer {jwt_token}",
         } | extra_headers
 
+    def post_request(
+        self,
+        *,
+        request: RPCCall,
+        extra_headers: Dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> JSONRPCResponse:
+        """
+        Send JSON-RPC POST request with Engine API JWT authentication.
+        """
         return super().post_request(
-            method=method,
-            params=params,
-            extra_headers=extra_headers,
+            request=request,
+            extra_headers=self._jwt_extra_headers(extra_headers),
             timeout=timeout,
-            request_id=request_id,
+        )
+
+    def post_batch_request(
+        self,
+        *,
+        calls: Sequence[RPCCall],
+        extra_headers: Dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> List[JSONRPCResponse]:
+        """
+        Send JSON-RPC batch POST request with Engine API JWT authentication.
+        """
+        return super().post_batch_request(
+            calls=calls,
+            extra_headers=self._jwt_extra_headers(extra_headers),
+            timeout=timeout,
         )
 
     def new_payload(self, *params: Any, version: int) -> PayloadStatus:
@@ -826,7 +1166,9 @@ class EngineRPC(BaseRPC):
         params_list = [to_json(param) for param in params]
 
         return PayloadStatus.model_validate(
-            self.post_request(method=method, params=params_list),
+            self.post_request(
+                request=RPCCall(method=method, params=params_list)
+            ).result_or_raise(),
             context=self.response_validation_context,
         )
 
@@ -850,9 +1192,8 @@ class EngineRPC(BaseRPC):
 
         return ForkchoiceUpdateResponse.model_validate(
             self.post_request(
-                method=method,
-                params=params,
-            ),
+                request=RPCCall(method=method, params=params),
+            ).result_or_raise(),
             context=self.response_validation_context,
         )
 
@@ -870,9 +1211,8 @@ class EngineRPC(BaseRPC):
 
         return GetPayloadResponse.model_validate(
             self.post_request(
-                method=method,
-                params=[f"{payload_id}"],
-            ),
+                request=RPCCall(method=method, params=[f"{payload_id}"]),
+            ).result_or_raise(),
             context=self.response_validation_context,
         )
 
@@ -889,9 +1229,8 @@ class EngineRPC(BaseRPC):
         params = [f"{h}" for h in versioned_hashes]
 
         response = self.post_request(
-            method=method,
-            params=[params],
-        )
+            request=RPCCall(method=method, params=[params]),
+        ).result_or_raise()
         if response is None:  # for tests that request non-existing blobs
             logger.debug("get_blobs response received but it has value: None")
             return None
@@ -984,7 +1323,9 @@ class NetRPC(BaseRPC):
 
     def peer_count(self) -> int:
         """`net_peerCount`: Get the number of peers connected to the client."""
-        response = self.post_request(method="peerCount")
+        response = self.post_request(
+            request=RPCCall(method="peerCount")
+        ).result_or_raise()
         return int(response, 16)  # hex -> int
 
     def wait_for_peer_connection(
@@ -1055,4 +1396,6 @@ class AdminRPC(BaseRPC):
 
     def add_peer(self, enode: str) -> bool:
         """`admin_addPeer`: Add a peer by enode URL."""
-        return self.post_request(method="addPeer", params=[enode])
+        return self.post_request(
+            request=RPCCall(method="addPeer", params=[enode])
+        ).result_or_raise()

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -780,22 +780,6 @@ class EthRPC(BaseRPC):
                 raise SendTransactionExceptionError(str(e), tx=tx) from e
         return results
 
-    def storage_at_keys(
-        self,
-        account: Address,
-        keys: List[Hash],
-        block_number: BlockNumberType = "latest",
-    ) -> Dict[Hash, Hash]:
-        """
-        Retrieve the storage values for the specified keys at a given address
-        and block number.
-        """
-        results: Dict[Hash, Hash] = {}
-        for key in keys:
-            storage_value = self.get_storage_at(account, key, block_number)
-            results[key] = storage_value
-        return results
-
     def _build_get_account_calls(
         self,
         address: Address,

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from hashlib import sha256
 from typing import Annotated, Any, Dict, List, Protocol, Self
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 from execution_testing.base_types import (
     Address,
@@ -55,6 +55,61 @@ class JSONRPCError(Exception):
             )
 
         return f"JSONRPCError(code={self.code}, message={self.message})"
+
+
+class RPCCall(BaseModel):
+    """Represent a JSON-RPC method call before namespace prefixing."""
+
+    method: str
+    params: List[Any] = []
+    request_id: int | str | None = None
+
+
+class JSONRPCRequest(BaseModel):
+    """Represent a JSON-RPC 2.0 request object."""
+
+    jsonrpc: str = "2.0"
+    method: str
+    params: List[Any] = []
+    id: int | str
+
+
+class JSONRPCErrorObject(BaseModel):
+    """Represent the error object in a JSON-RPC 2.0 response."""
+
+    code: int
+    message: str
+    data: str | None = None
+
+
+class JSONRPCResponse(BaseModel):
+    """Represent a JSON-RPC 2.0 response object."""
+
+    jsonrpc: str = "2.0"
+    id: int | str
+    result: Any = None
+    error: JSONRPCErrorObject | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_result_or_error(cls, data: Any) -> Any:
+        """Validate that the response contains 'result' or 'error'."""
+        if isinstance(data, dict):
+            if "result" not in data and "error" not in data:
+                raise ValueError(
+                    "RPC response must contain 'result' or 'error'"
+                )
+        return data
+
+    def result_or_raise(self) -> Any:
+        """Return the result or raise JSONRPCError."""
+        if self.error is not None:
+            raise JSONRPCError(
+                code=self.error.code,
+                message=self.error.message,
+                data=self.error.data,
+            )
+        return self.result
 
 
 class TransactionByHashResponse(Transaction):

--- a/tests/benchmark/compute/helpers.py
+++ b/tests/benchmark/compute/helpers.py
@@ -2,7 +2,7 @@
 
 import math
 from enum import Enum, auto
-from typing import Dict, Generator, Self, Sequence, cast
+from typing import Dict, Generator, List, Self, Sequence, cast
 
 from execution_testing import (
     EOA,
@@ -21,6 +21,7 @@ from execution_testing import (
     compute_create2_address,
     compute_deterministic_create2_address,
 )
+from pydantic import Field
 
 from tests.osaka.eip7951_p256verify_precompiles.spec import (
     FieldElement,
@@ -334,6 +335,12 @@ class CustomSizedContractInitcode(FixedIterationsBytecode):
         return self._cached_address
 
 
+class ContractDeploymentTransaction(TransactionWithCost):
+    """Transaction object that can include the expected gas to be consumed."""
+
+    deployed_contracts: List[Address] = Field(..., exclude=True)
+
+
 class CustomSizedContractFactory(IteratingBytecode):
     """
     Factory contract that creates contracts with a custom size.
@@ -439,7 +446,7 @@ class CustomSizedContractFactory(IteratingBytecode):
         sender: EOA,
         contract_count: int,
         contract_start_index: int = 0,
-    ) -> Generator[TransactionWithCost, None, None]:
+    ) -> Generator[ContractDeploymentTransaction, None, None]:
         """
         Create a list of transactions calling the factory to create the
         given number of contracts, each capped tx properly capped by the
@@ -485,12 +492,21 @@ class CustomSizedContractFactory(IteratingBytecode):
                     start_iteration=start_iteration,
                     calldata=calldata_max,
                 )
-            yield TransactionWithCost(
+            deployed_contracts = [
+                self.created_contract_address(
+                    salt=i,
+                )
+                for i in range(
+                    start_iteration, start_iteration + iteration_count
+                )
+            ]
+            yield ContractDeploymentTransaction(
                 to=to,
                 gas_limit=tx_gas_limit,
                 sender=sender,
                 gas_cost=tx_gas_cost,
                 data=calldata(iteration_count, start_iteration),
+                deployed_contracts=deployed_contracts,
             )
             start_iteration += iteration_count
             last_iteration_count = iteration_count

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -37,7 +37,7 @@ from execution_testing import (
     While,
 )
 
-from ..helpers import CustomSizedContractFactory
+from ..helpers import ContractDeploymentTransaction, CustomSizedContractFactory
 
 
 @pytest.mark.repricing(contract_balance=1)
@@ -616,15 +616,22 @@ def test_account_query(
         )
 
     # Deploy num_contracts via multiple txs (each capped by tx gas limit).
+    post = {}
     with TestPhaseManager.setup():
         setup_sender = pre.fund_eoa()
-        contracts_deployment_txs = list(
+        contracts_deployment_txs: List[ContractDeploymentTransaction] = []
+        for contract_creating_tx in (
             custom_sized_contract_factory.transactions_by_total_contract_count(
                 fork=fork,
                 sender=setup_sender,
                 contract_count=num_contracts,
             )
-        )
+        ):
+            contracts_deployment_txs.append(contract_creating_tx)
+            if custom_sized_contract_factory.contract_size > 0:
+                post[contract_creating_tx.deployed_contracts[-1]] = Account(
+                    nonce=1
+                )
 
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
@@ -651,14 +658,6 @@ def test_account_query(
                 )
             )
         total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
-
-    post = {}
-    if custom_sized_contract_factory.contract_size > 0:
-        for i in range(num_contracts):
-            deployed_contract_address = (
-                custom_sized_contract_factory.created_contract_address(salt=i)
-            )
-            post[deployed_contract_address] = Account(nonce=1)
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
+++ b/tests/benchmark/compute/scenario/test_unchunkified_bytecode.py
@@ -3,6 +3,8 @@ Benchmark operations that force the inclusion of max size bytecodes.
 This scenario is relevant in forks that have unchunkified bytecode.
 """
 
+from typing import List
+
 import pytest
 from execution_testing import (
     Account,
@@ -19,7 +21,7 @@ from execution_testing import (
     While,
 )
 
-from ..helpers import CustomSizedContractFactory
+from ..helpers import ContractDeploymentTransaction, CustomSizedContractFactory
 
 
 @pytest.mark.repricing
@@ -131,15 +133,22 @@ def test_unchunkified_bytecode(
         )
 
     # Deploy num_contracts via multiple txs (each capped by tx gas limit).
+    post = {}
     with TestPhaseManager.setup():
         setup_sender = pre.fund_eoa()
-        contracts_deployment_txs = list(
+        contracts_deployment_txs: List[ContractDeploymentTransaction] = []
+        for contract_creating_tx in (
             custom_sized_contract_factory.transactions_by_total_contract_count(
                 fork=fork,
                 sender=setup_sender,
                 contract_count=num_contracts,
             )
-        )
+        ):
+            contracts_deployment_txs.append(contract_creating_tx)
+            if custom_sized_contract_factory.contract_size > 0:
+                post[contract_creating_tx.deployed_contracts[-1]] = Account(
+                    nonce=1
+                )
 
     with TestPhaseManager.execution():
         attack_sender = pre.fund_eoa()
@@ -165,13 +174,6 @@ def test_unchunkified_bytecode(
                 )
             )
         total_gas_cost = sum(tx.gas_cost for tx in attack_txs)
-
-    post = {}
-    for i in range(num_contracts):
-        deployed_contract_address = (
-            custom_sized_contract_factory.created_contract_address(salt=i)
-        )
-        post[deployed_contract_address] = Account(nonce=1)
 
     benchmark_test(
         pre=pre,


### PR DESCRIPTION
## 🗒️ Description

Allow using [JSON-RPC batch requests](https://json-rpc.dev/learn/examples/batch-requests) in `execute` so all transactions that are contained within a single block in a test, are always requested in the same batch at the same time.

We also now batch nonce, balance, code and storage requests, which are meant to verify the test at the end of execution, all in a single batch request always.

Also a nice low-hanging fruit fix is that `execute hive` now sets the deterministic contract factory directly in the pre-allocation, so it does not need to be deployed before the tests start.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://preview.redd.it/this-cute-woodpecker-v0-t7vww30mucta1.jpg?width=640&crop=smart&auto=webp&s=1889a5756e56171901f9bc82e239cfb23f522c3f)
