### PR TITLE
chore(ci): `json_infra` Put each fork on a separate github runner

### DIFF
--- a/.github/actions/check-fork-affected/action.yaml
+++ b/.github/actions/check-fork-affected/action.yaml
@@ -1,0 +1,46 @@
+name: Check Fork Affected
+description: Check if a fork is affected by changed files
+
+inputs:
+  fork:
+    description: The fork short name to check (e.g. gray_glacier)
+    required: true
+  file_list:
+    description: Path to file containing changed file paths
+    required: true
+
+outputs:
+  should_run:
+    description: Whether the fork's tests should run (true/false)
+    value: ${{ steps.check.outputs.should_run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check if fork is affected
+      id: check
+      shell: bash
+      run: |
+        FILE_LIST="${{ inputs.file_list }}"
+        FORK="${{ inputs.fork }}"
+        should_run=false
+        if [ ! -f "$FILE_LIST" ]; then
+          should_run=true
+        else
+          while IFS= read -r file || [ -n "$file" ]; do
+            case "$file" in
+              tests/json_infra/*)
+                should_run=true; break ;;
+              src/ethereum_spec_tools/evm_tools*)
+                should_run=true; break ;;
+              src/ethereum/forks/"$FORK"/*)
+                should_run=true; break ;;
+              src/ethereum/forks/*)
+                ;; # Different fork, skip
+              src/ethereum/*)
+                should_run=true; break ;;
+            esac
+          done < "$FILE_LIST"
+        fi
+        echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+        echo "Fork $FORK affected: $should_run"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,30 +110,30 @@ jobs:
       fail-fast: false
       matrix:
         fork:
-          - Frontier
-          - Homestead
-          - "Dao Fork"
-          - EIP150
-          - EIP158
-          - Byzantium
-          - ConstantinopleFix
-          - Istanbul
-          - "Muir Glacier"
-          - Berlin
-          - London
-          - "Arrow Glacier"
-          - "Gray Glacier"
-          - Paris
-          - Shanghai
-          - Cancun
-          - Prague
-          - Osaka
-          - BPO1
-          - BPO2
-          - BPO3
-          - BPO4
-          - BPO5
-          - Amsterdam
+          - frontier
+          - homestead
+          - dao_fork
+          - tangerine_whistle
+          - spurious_dragon
+          - byzantium
+          - constantinople
+          - istanbul
+          - muir_glacier
+          - berlin
+          - london
+          - arrow_glacier
+          - gray_glacier
+          - paris
+          - shanghai
+          - cancun
+          - prague
+          - osaka
+          - bpo1
+          - bpo2
+          - bpo3
+          - bpo4
+          - bpo5
+          - amsterdam
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: static
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         fork:
           - frontier

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -137,22 +137,33 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
-          submodules: recursive
           fetch-depth: 0
+      - uses: ./.github/actions/get-changed-files
+        id: get-changed-files
+      - uses: ./.github/actions/check-fork-affected
+        id: check-fork
+        with:
+          fork: ${{ matrix.fork }}
+          file_list: ${{ steps.get-changed-files.outputs.file_list }}
+      - name: Checkout submodules
+        if: steps.check-fork.outputs.should_run == 'true'
+        run: git submodule update --init --recursive
       - name: Setup Python
+        if: steps.check-fork.outputs.should_run == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
+        if: steps.check-fork.outputs.should_run == 'true'
       - name: Cache test fixtures
+        if: steps.check-fork.outputs.should_run == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: tests/json_infra/fixtures
           key: json-infra-fixtures-${{ hashFiles('tests/json_infra/__init__.py') }}
-      - uses: ./.github/actions/get-changed-files
-        id: get-changed-files
       - name: Run json infra tests (${{ matrix.fork }})
-        run: tox -e json_infra -- --fork="${{ matrix.fork }}" --file-list="${{ steps.get-changed-files.outputs.file_list }}"
+        if: steps.check-fork.outputs.should_run == 'true'
+        run: tox -e json_infra -- --fork="${{ matrix.fork }}"
 
   optimized:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,7 @@ jobs:
           PYPY_GC_MIN: "1G"
 
   json_infra:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     strategy:
       fail-fast: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Fetch full history for commit comparison
       - uses: ./.github/actions/get-changed-files
         id: get-changed-files
       - uses: ./.github/actions/check-fork-affected

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,6 @@ jobs:
           - bpo3
           - bpo4
           - bpo5
-          - amsterdam
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,7 @@ jobs:
           PYPY_GC_MIN: "1G"
 
   json_infra:
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     needs: static
     strategy:
       fail-fast: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,22 +104,55 @@ jobs:
           PYPY_GC_MIN: "1G"
 
   json_infra:
-    runs-on: [self-hosted-ghr, size-xl-x64]
+    runs-on: ubuntu-latest
     needs: static
+    strategy:
+      fail-fast: false
+      matrix:
+        fork:
+          - Frontier
+          - Homestead
+          - "Dao Fork"
+          - EIP150
+          - EIP158
+          - Byzantium
+          - ConstantinopleFix
+          - Istanbul
+          - "Muir Glacier"
+          - Berlin
+          - London
+          - "Arrow Glacier"
+          - "Gray Glacier"
+          - Paris
+          - Shanghai
+          - Cancun
+          - Prague
+          - Osaka
+          - BPO1
+          - BPO2
+          - BPO3
+          - BPO4
+          - BPO5
+          - Amsterdam
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           submodules: recursive
-          fetch-depth: 0  # Fetch full history for commit comparison
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
       - uses: ./.github/actions/setup-env
+      - name: Cache test fixtures
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: tests/json_infra/fixtures
+          key: json-infra-fixtures-${{ hashFiles('tests/json_infra/__init__.py') }}
       - uses: ./.github/actions/get-changed-files
         id: get-changed-files
-      - name: Run json infra tests
-        run: tox -e json_infra -- --file-list="${{ steps.get-changed-files.outputs.file_list }}"
+      - name: Run json infra tests (${{ matrix.fork }})
+        run: tox -e json_infra -- --fork="${{ matrix.fork }}" --file-list="${{ steps.get-changed-files.outputs.file_list }}"
 
   optimized:
     runs-on: [self-hosted-ghr, size-xl-x64]

--- a/tests/json_infra/conftest.py
+++ b/tests/json_infra/conftest.py
@@ -247,7 +247,8 @@ class _FixturesDownloader:
 
     def fetch_http(self, url: str, location: str) -> None:
         path = self.root.joinpath(location)
-        if path.exists() and any(path.iterdir()):
+        marker = path / ".source_url"
+        if marker.exists() and marker.read_text().strip() == url:
             print(f"{location} already available, skipping download.")
             return
         print(f"Downloading {location}...")
@@ -270,6 +271,7 @@ class _FixturesDownloader:
                 shutil.rmtree(path, ignore_errors=True)
                 print(f"Extracting {location}...")
                 tar.extractall(path)
+            marker.write_text(url + "\n")
 
     def fetch_git(self, url: str, location: str, commit_hash: str) -> None:
         path = self.root.joinpath(location)

--- a/tests/json_infra/conftest.py
+++ b/tests/json_infra/conftest.py
@@ -149,7 +149,16 @@ def pytest_configure(config: Config) -> None:
     if desired_fork:
         if desired_fork not in all_forks:
             raise ValueError(f"Unknown fork: {desired_fork}")
-        desired_forks.append(desired_fork)
+        # When --file-list is also set, only include the fork if it
+        # is among the affected forks determined from the changed files.
+        if file_list:
+            affected = extract_affected_forks(
+                config.rootpath, file_list, optimized
+            )
+            if desired_fork in affected:
+                desired_forks.append(desired_fork)
+        else:
+            desired_forks.append(desired_fork)
     elif forks_from or forks_until:
         # Determine start and end indices
         start_idx = 0

--- a/tests/json_infra/conftest.py
+++ b/tests/json_infra/conftest.py
@@ -247,6 +247,9 @@ class _FixturesDownloader:
 
     def fetch_http(self, url: str, location: str) -> None:
         path = self.root.joinpath(location)
+        if path.exists() and any(path.iterdir()):
+            print(f"{location} already available, skipping download.")
+            return
         print(f"Downloading {location}...")
 
         with self.session.get(url, stream=True) as response:

--- a/tests/json_infra/conftest.py
+++ b/tests/json_infra/conftest.py
@@ -146,7 +146,13 @@ def pytest_configure(config: Config) -> None:
 
     desired_forks = []
     all_forks = list(FORKS.keys())
+    # Build a lookup from short_name to json_test_name so that
+    # --fork accepts either format (e.g. "gray_glacier" or
+    # "Gray Glacier").
+    short_to_json = {f.short_name: name for name, f in FORKS.items()}
     if desired_fork:
+        if desired_fork in short_to_json:
+            desired_fork = short_to_json[desired_fork]
         if desired_fork not in all_forks:
             raise ValueError(f"Unknown fork: {desired_fork}")
         # When --file-list is also set, only include the fork if it


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Was initially curious to see what the workload distribution was across forks. If I haven't made a mistake then this PR:

- Removes the need for xl runners (switches back to the github free runners)
- Reduces CI time for json_infra from ~ 3 hours to ~20 minutes

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
