### PR TITLE
chore(test-tests): Fix EIP-7934 and EIP-7623 for Amsterdam

### DIFF
--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -44,6 +44,7 @@ EXTRA_DATA_AT_LIMIT = b"\x00" * 15
 # reserves 1 byte so delta=-1 tests stay valid
 EXTRA_DATA_TOLERANCE = len(EXTRA_DATA_AT_LIMIT) - 1
 BLOCK_GAS_LIMIT = 100_000_000
+BLOCK_GAS_LIMIT_MARGIN = 1_000_000
 
 
 @pytest.fixture
@@ -67,9 +68,107 @@ def block_errors() -> List[BlockException]:
     return [BlockException.RLP_BLOCK_LIMIT_EXCEEDED]
 
 
+def max_zero_calldata_bytes_for_gas(
+    calculator,
+    gas_limit: int,
+    *,
+    max_len_hint: int,
+    access_list=None,
+    authorization_list_or_count=None,
+) -> int:
+    """Return the largest zero-calldata length whose intrinsic gas fits."""
+    if gas_limit <= 0:
+        return 0
+
+    kwargs = {}
+    if access_list is not None:
+        kwargs["access_list"] = access_list
+    if authorization_list_or_count is not None:
+        kwargs["authorization_list_or_count"] = authorization_list_or_count
+
+    if calculator(calldata=b"", **kwargs) > gas_limit:
+        return 0
+
+    upper_bound = max(1, max_len_hint)
+    lo = 0
+    hi = 1
+
+    while (
+        hi < upper_bound
+        and calculator(calldata=b"\x00" * hi, **kwargs) <= gas_limit
+    ):
+        lo = hi
+        hi = min(hi * 2, upper_bound)
+
+    if (
+        hi == upper_bound
+        and calculator(calldata=b"\x00" * hi, **kwargs) <= gas_limit
+    ):
+        return hi
+
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        if calculator(calldata=b"\x00" * mid, **kwargs) <= gas_limit:
+            lo = mid
+        else:
+            hi = mid
+
+    return lo
+
+
+def calibrated_block_gas_limit(
+    fork: Fork,
+    block_size_limit: int,
+    requested_gas_limit: int,
+) -> int:
+    """
+    Return a block gas limit that can support building a block near the target
+    RLP size under the fork's calldata pricing.
+    """
+    calculator = fork.transaction_intrinsic_cost_calculator()
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+
+    # Estimate calldata bytes required to approach the RLP limit and reserve a
+    # small margin for RLP overhead variability.
+    estimated_calldata_bytes = block_size_limit + 1024
+
+    if tx_gas_limit_cap is not None:
+        max_bytes_per_tx = max_zero_calldata_bytes_for_gas(
+            calculator,
+            tx_gas_limit_cap,
+            max_len_hint=estimated_calldata_bytes,
+        )
+        if max_bytes_per_tx > 0:
+            max_tx_gas = calculator(calldata=b"\x00" * max_bytes_per_tx)
+            tx_count = (
+                estimated_calldata_bytes + max_bytes_per_tx - 1
+            ) // max_bytes_per_tx
+            estimated_required_gas = (
+                tx_count * max_tx_gas + BLOCK_GAS_LIMIT_MARGIN
+            )
+        else:
+            estimated_required_gas = BLOCK_GAS_LIMIT
+    else:
+        empty_calldata_cost = calculator(calldata=b"")
+        one_zero_byte_cost = calculator(calldata=b"\x00")
+        per_zero_byte_cost = max(one_zero_byte_cost - empty_calldata_cost, 1)
+        estimated_required_gas = (
+            empty_calldata_cost
+            + estimated_calldata_bytes * per_zero_byte_cost
+            + BLOCK_GAS_LIMIT_MARGIN
+        )
+
+    return max(
+        requested_gas_limit,
+        BLOCK_GAS_LIMIT,
+        estimated_required_gas,
+    )
+
+
 def get_block_rlp_size(
     fork: Fork,
     transactions: List[Transaction],
+    block_gas_limit: int,
     withdrawals: List[Withdrawal] | None = None,
 ) -> int:
     """
@@ -80,7 +179,7 @@ def get_block_rlp_size(
         block_number=1,
         timestamp=HEADER_TIMESTAMP,
     )
-    header.gas_limit = ZeroPaddedHexNumber(BLOCK_GAS_LIMIT)
+    header.gas_limit = ZeroPaddedHexNumber(block_gas_limit)
     header.extra_data = Bytes(EXTRA_DATA_AT_LIMIT)
 
     total_gas = sum((tx.gas_limit or 21000) for tx in transactions)
@@ -148,6 +247,12 @@ def exact_size_transactions(
         block size.
 
     """
+    effective_block_gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=gas_limit,
+    )
+
     log_contract = None
     if emit_logs:
         if pre is None:
@@ -178,7 +283,7 @@ def exact_size_transactions(
         transactions, extra_data_len = _exact_size_transactions_cached(
             block_size_limit,
             fork,
-            gas_limit,
+            effective_block_gas_limit,
             sender,
             emit_logs_contract=log_contract,
         )
@@ -188,7 +293,7 @@ def exact_size_transactions(
         transactions, extra_data_len = _exact_size_transactions_impl(
             block_size_limit,
             fork,
-            gas_limit,
+            effective_block_gas_limit,
             sender,
             specific_transaction_to_include=specific_transaction_to_include,
             emit_logs_contract=log_contract,
@@ -245,20 +350,134 @@ def _exact_size_transactions_impl(
     total_gas_used = 0
 
     calculator = fork.transaction_intrinsic_cost_calculator()
+    tx_gas_limit_cap = fork.transaction_gas_limit_cap()
+    per_tx_gas_budget = (
+        block_gas_limit
+        if tx_gas_limit_cap is None
+        else min(tx_gas_limit_cap, block_gas_limit)
+    )
 
-    data_large = Bytes(b"\x00" * 500_000)
+    max_generic_data_len = max_zero_calldata_bytes_for_gas(
+        calculator,
+        per_tx_gas_budget,
+        max_len_hint=500_000,
+    )
+    if max_generic_data_len == 0:
+        raise ValueError(
+            "Unable to build calldata transaction within gas limits"
+        )
+
+    data_large = Bytes(b"\x00" * max_generic_data_len)
     gas_limit_large = calculator(calldata=data_large)
+    empty_tx_gas_limit = calculator(calldata=b"")
 
-    # block with 16 transactions + large calldata remains safely below the
-    # limit add 15 generic transactions to fill the block and one typed
-    # transaction if tx_type is specified, otherwise just add 16 generic
-    # transactions
     not_all_generic_txs = any(
         kwarg is not None
         for kwarg in [specific_transaction_to_include, emit_logs_contract]
     )
 
-    generic_tx_num = 15 if not_all_generic_txs else 16
+    sample_base_size = get_block_rlp_size(
+        fork,
+        [],
+        block_gas_limit=block_gas_limit,
+        withdrawals=withdrawals,
+    )
+    sample_generic_tx = Transaction(
+        sender=sender,
+        nonce=0,
+        max_fee_per_gas=10**11,
+        max_priority_fee_per_gas=10**11,
+        gas_limit=gas_limit_large,
+        data=data_large,
+    )
+    generic_tx_contribution = (
+        get_block_rlp_size(
+            fork,
+            [sample_generic_tx],
+            block_gas_limit=block_gas_limit,
+            withdrawals=withdrawals,
+        )
+        - sample_base_size
+    )
+
+    special_tx_contribution = 0
+    special_tx_gas_limit = 0
+    special_tx_dict = None
+    special_tx_data = None
+
+    if not_all_generic_txs:
+        if specific_transaction_to_include is not None:
+            special_tx_dict = specific_transaction_to_include.model_dump(
+                exclude_unset=True
+            )
+            authorization_count = len(
+                special_tx_dict.get("authorization_list", [])
+            )
+            max_special_data_len = max_zero_calldata_bytes_for_gas(
+                calculator,
+                per_tx_gas_budget,
+                max_len_hint=200_000,
+                access_list=specific_transaction_to_include.access_list,
+                authorization_list_or_count=authorization_count,
+            )
+            special_tx_data = Bytes(b"\x00" * max_special_data_len)
+            special_tx_gas_limit = int(
+                calculator(
+                    calldata=special_tx_data,
+                    access_list=specific_transaction_to_include.access_list,
+                    authorization_list_or_count=authorization_count,
+                )
+            )
+            sample_special_tx = Transaction(
+                **{
+                    **special_tx_dict,
+                    "sender": sender,
+                    "nonce": 0,
+                    "data": special_tx_data,
+                    "gas_limit": HexNumber(special_tx_gas_limit),
+                }
+            )
+        elif emit_logs_contract is not None:
+            special_tx_gas_limit = empty_tx_gas_limit
+            sample_special_tx = Transaction(
+                sender=sender,
+                nonce=0,
+                max_fee_per_gas=10**11,
+                max_priority_fee_per_gas=10**11,
+                gas_limit=special_tx_gas_limit,
+                to=emit_logs_contract,
+            )
+        else:
+            raise ValueError(
+                "Either specific_transaction_to_include or "
+                "emit_logs_contract must be provided."
+            )
+
+        special_tx_contribution = (
+            get_block_rlp_size(
+                fork,
+                [sample_special_tx],
+                block_gas_limit=block_gas_limit,
+                withdrawals=withdrawals,
+            )
+            - sample_base_size
+        )
+
+    gas_for_generics = max(
+        block_gas_limit - special_tx_gas_limit - empty_tx_gas_limit,
+        0,
+    )
+    max_generic_by_gas = gas_for_generics // gas_limit_large
+    size_for_generics = max(
+        block_size_limit
+        - EXTRA_DATA_TOLERANCE
+        - sample_base_size
+        - special_tx_contribution,
+        0,
+    )
+    max_generic_by_size = size_for_generics // max(generic_tx_contribution, 1)
+    generic_tx_num = min(max_generic_by_gas, max_generic_by_size)
+
     for _ in range(generic_tx_num):
         tx = Transaction(
             sender=sender,
@@ -272,26 +491,15 @@ def _exact_size_transactions_impl(
         total_gas_used += gas_limit_large
         nonce += 1
 
-    # append a typed transaction to fill the block
     if not_all_generic_txs:
         if specific_transaction_to_include is not None:
-            tx_dict = specific_transaction_to_include.model_dump(
-                exclude_unset=True
-            )
-            data = Bytes(b"\x00" * 200_000)
-            gas_limit = HexNumber(
-                calculator(
-                    calldata=data,
-                    access_list=specific_transaction_to_include.access_list,
-                    authorization_list_or_count=len(
-                        tx_dict.get("authorization_list", [])
-                    ),
-                )
-            )
+            assert special_tx_dict is not None
+            assert special_tx_data is not None
+            tx_dict = dict(special_tx_dict)
             tx_dict["sender"] = sender
             tx_dict["nonce"] = nonce
-            tx_dict["data"] = data
-            tx_dict["gas_limit"] = gas_limit
+            tx_dict["data"] = special_tx_data
+            tx_dict["gas_limit"] = HexNumber(special_tx_gas_limit)
             last_tx = Transaction(**tx_dict)
         elif emit_logs_contract is not None:
             last_tx = Transaction(
@@ -299,7 +507,7 @@ def _exact_size_transactions_impl(
                 nonce=nonce,
                 max_fee_per_gas=10**11,
                 max_priority_fee_per_gas=10**11,
-                gas_limit=calculator(calldata=b""),
+                gas_limit=special_tx_gas_limit,
                 to=emit_logs_contract,
             )
         else:
@@ -313,25 +521,34 @@ def _exact_size_transactions_impl(
         total_gas_used += last_tx.gas_limit
 
     current_size = get_block_rlp_size(
-        fork, transactions, withdrawals=withdrawals
+        fork,
+        transactions,
+        block_gas_limit=block_gas_limit,
+        withdrawals=withdrawals,
     )
     remaining_bytes = block_size_limit - current_size
     remaining_gas = block_gas_limit - total_gas_used
 
-    if remaining_bytes > 0 and remaining_gas > 50_000:
+    topoff_gas_budget = (
+        remaining_gas
+        if tx_gas_limit_cap is None
+        else min(remaining_gas, tx_gas_limit_cap)
+    )
+    if remaining_bytes > 0 and topoff_gas_budget > 50_000:
         # create an empty transaction to measure base contribution
         empty_tx = Transaction(
             sender=sender,
             nonce=nonce,
             max_fee_per_gas=10**11,
             max_priority_fee_per_gas=10**11,
-            gas_limit=calculator(calldata=b""),
+            gas_limit=empty_tx_gas_limit,
             data=b"",
         )
 
         empty_block_size = get_block_rlp_size(
             fork,
             transactions + [empty_tx],
+            block_gas_limit=block_gas_limit,
             withdrawals=withdrawals,
         )
         empty_contribution = empty_block_size - current_size
@@ -339,10 +556,17 @@ def _exact_size_transactions_impl(
         calldata_bytes_needed = remaining_bytes - empty_contribution
         estimated_calldata = max(0, calldata_bytes_needed - 5)
 
-        target_calldata = b"\x00" * estimated_calldata
+        max_topoff_calldata = max_zero_calldata_bytes_for_gas(
+            calculator,
+            topoff_gas_budget,
+            max_len_hint=max(estimated_calldata, 1),
+        )
+        target_calldata = b"\x00" * min(
+            estimated_calldata, max_topoff_calldata
+        )
         target_gas = calculator(calldata=target_calldata)
 
-        if target_gas <= remaining_gas:
+        if target_gas <= topoff_gas_budget:
             test_tx = Transaction(
                 sender=sender,
                 nonce=nonce,
@@ -358,6 +582,7 @@ def _exact_size_transactions_impl(
     final_size = get_block_rlp_size(
         fork,
         transactions,
+        block_gas_limit=block_gas_limit,
         withdrawals=withdrawals,
     )
     # Compute the extra_data length that compensates for any size gap.
@@ -404,6 +629,12 @@ def test_block_at_rlp_size_limit_boundary(
     - At the limit, the block is valid
     - At the limit + 1 byte, the block is invalid
     """
+    env.gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=env.gas_limit,
+    )
+
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -446,6 +677,12 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     typed_transaction: Transaction,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
+    env.gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=env.gas_limit,
+    )
+
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -483,6 +720,12 @@ def test_block_at_rlp_limit_with_logs(
     Test that a block at the RLP size limit is valid even when transactions
     emit logs.
     """
+    env.gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=env.gas_limit,
+    )
+
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -520,6 +763,12 @@ def test_block_at_rlp_limit_with_withdrawals(
     Test that a block at the RLP size limit is valid even when the block
     contains withdrawals.
     """
+    env.gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=env.gas_limit,
+    )
+
     withdrawals = [
         Withdrawal(
             index=0,
@@ -587,6 +836,12 @@ def test_fork_transition_block_rlp_limit(
     - At fork (timestamp 15000): Block at limit should be accepted
     - At fork (timestamp 15000): Block at limit +1 should be rejected
     """
+    env.gas_limit = calibrated_block_gas_limit(
+        fork=fork,
+        block_size_limit=block_size_limit,
+        requested_gas_limit=env.gas_limit,
+    )
+
     sender_before_fork = pre.fund_eoa()
     sender_at_fork = pre.fund_eoa()
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -165,6 +165,22 @@ def calibrated_block_gas_limit(
     )
 
 
+@pytest.fixture(autouse=True)
+def calibrate_gas_limit(
+    env: Environment,
+    fork: Fork,
+    block_size_limit: int,
+) -> None:
+    """Calibrate block gas limit for fork-specific calldata pricing."""
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
+    )
+
+
 def get_block_rlp_size(
     fork: Fork,
     transactions: List[Transaction],
@@ -357,18 +373,20 @@ def _exact_size_transactions_impl(
         else min(tx_gas_limit_cap, block_gas_limit)
     )
 
-    max_generic_data_len = max_zero_calldata_bytes_for_gas(
-        calculator,
-        per_tx_gas_budget,
-        max_len_hint=500_000,
-    )
-    if max_generic_data_len == 0:
+    max_data_len = 500_000
+    if tx_gas_limit_cap is not None:
+        while (
+            max_data_len > 0
+            and calculator(calldata=b"\x00" * max_data_len) > tx_gas_limit_cap
+        ):
+            max_data_len //= 2
+
+    data_large = Bytes(b"\x00" * max_data_len)
+    gas_limit_large = calculator(calldata=data_large)
+    if gas_limit_large > per_tx_gas_budget:
         raise ValueError(
             "Unable to build calldata transaction within gas limits"
         )
-
-    data_large = Bytes(b"\x00" * max_generic_data_len)
-    gas_limit_large = calculator(calldata=data_large)
     empty_tx_gas_limit = calculator(calldata=b"")
 
     not_all_generic_txs = any(
@@ -629,14 +647,6 @@ def test_block_at_rlp_size_limit_boundary(
     - At the limit, the block is valid
     - At the limit + 1 byte, the block is invalid
     """
-    env.gas_limit = ZeroPaddedHexNumber(
-        calibrated_block_gas_limit(
-            fork=fork,
-            block_size_limit=block_size_limit,
-            requested_gas_limit=env.gas_limit,
-        )
-    )
-
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -679,14 +689,6 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     typed_transaction: Transaction,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
-    env.gas_limit = ZeroPaddedHexNumber(
-        calibrated_block_gas_limit(
-            fork=fork,
-            block_size_limit=block_size_limit,
-            requested_gas_limit=env.gas_limit,
-        )
-    )
-
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -724,14 +726,6 @@ def test_block_at_rlp_limit_with_logs(
     Test that a block at the RLP size limit is valid even when transactions
     emit logs.
     """
-    env.gas_limit = ZeroPaddedHexNumber(
-        calibrated_block_gas_limit(
-            fork=fork,
-            block_size_limit=block_size_limit,
-            requested_gas_limit=env.gas_limit,
-        )
-    )
-
     transactions, extra_data_len = exact_size_transactions(
         sender,
         block_size_limit,
@@ -769,14 +763,6 @@ def test_block_at_rlp_limit_with_withdrawals(
     Test that a block at the RLP size limit is valid even when the block
     contains withdrawals.
     """
-    env.gas_limit = ZeroPaddedHexNumber(
-        calibrated_block_gas_limit(
-            fork=fork,
-            block_size_limit=block_size_limit,
-            requested_gas_limit=env.gas_limit,
-        )
-    )
-
     withdrawals = [
         Withdrawal(
             index=0,
@@ -844,14 +830,6 @@ def test_fork_transition_block_rlp_limit(
     - At fork (timestamp 15000): Block at limit should be accepted
     - At fork (timestamp 15000): Block at limit +1 should be rejected
     """
-    env.gas_limit = ZeroPaddedHexNumber(
-        calibrated_block_gas_limit(
-            fork=fork,
-            block_size_limit=block_size_limit,
-            requested_gas_limit=env.gas_limit,
-        )
-    )
-
     sender_before_fork = pre.fund_eoa()
     sender_at_fork = pre.fund_eoa()
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -3,7 +3,7 @@ Tests for [EIP-7934: RLP Execution Block Size Limit](https://eips.ethereum.org/E
 """
 
 from functools import lru_cache
-from typing import List, Tuple
+from typing import Any, Callable, List, Sized, Tuple
 
 import pytest
 from execution_testing import (
@@ -69,18 +69,18 @@ def block_errors() -> List[BlockException]:
 
 
 def max_zero_calldata_bytes_for_gas(
-    calculator,
+    calculator: Callable[..., int],
     gas_limit: int,
     *,
     max_len_hint: int,
-    access_list=None,
-    authorization_list_or_count=None,
+    access_list: Any | None = None,
+    authorization_list_or_count: Sized | int | None = None,
 ) -> int:
     """Return the largest zero-calldata length whose intrinsic gas fits."""
     if gas_limit <= 0:
         return 0
 
-    kwargs = {}
+    kwargs: dict[str, object] = {}
     if access_list is not None:
         kwargs["access_list"] = access_list
     if authorization_list_or_count is not None:
@@ -629,10 +629,12 @@ def test_block_at_rlp_size_limit_boundary(
     - At the limit, the block is valid
     - At the limit + 1 byte, the block is invalid
     """
-    env.gas_limit = calibrated_block_gas_limit(
-        fork=fork,
-        block_size_limit=block_size_limit,
-        requested_gas_limit=env.gas_limit,
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
     )
 
     transactions, extra_data_len = exact_size_transactions(
@@ -677,10 +679,12 @@ def test_block_rlp_size_at_limit_with_all_typed_transactions(
     typed_transaction: Transaction,
 ) -> None:
     """Test the block RLP size limit with all transaction types."""
-    env.gas_limit = calibrated_block_gas_limit(
-        fork=fork,
-        block_size_limit=block_size_limit,
-        requested_gas_limit=env.gas_limit,
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
     )
 
     transactions, extra_data_len = exact_size_transactions(
@@ -720,10 +724,12 @@ def test_block_at_rlp_limit_with_logs(
     Test that a block at the RLP size limit is valid even when transactions
     emit logs.
     """
-    env.gas_limit = calibrated_block_gas_limit(
-        fork=fork,
-        block_size_limit=block_size_limit,
-        requested_gas_limit=env.gas_limit,
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
     )
 
     transactions, extra_data_len = exact_size_transactions(
@@ -763,10 +769,12 @@ def test_block_at_rlp_limit_with_withdrawals(
     Test that a block at the RLP size limit is valid even when the block
     contains withdrawals.
     """
-    env.gas_limit = calibrated_block_gas_limit(
-        fork=fork,
-        block_size_limit=block_size_limit,
-        requested_gas_limit=env.gas_limit,
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
     )
 
     withdrawals = [
@@ -836,10 +844,12 @@ def test_fork_transition_block_rlp_limit(
     - At fork (timestamp 15000): Block at limit should be accepted
     - At fork (timestamp 15000): Block at limit +1 should be rejected
     """
-    env.gas_limit = calibrated_block_gas_limit(
-        fork=fork,
-        block_size_limit=block_size_limit,
-        requested_gas_limit=env.gas_limit,
+    env.gas_limit = ZeroPaddedHexNumber(
+        calibrated_block_gas_limit(
+            fork=fork,
+            block_size_limit=block_size_limit,
+            requested_gas_limit=env.gas_limit,
+        )
     )
 
     sender_before_fork = pre.fund_eoa()

--- a/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
+++ b/tests/prague/eip7623_increase_calldata_cost/test_refunds.py
@@ -212,7 +212,11 @@ def execution_gas_used(
         refund_test_type
         == RefundTestType.EXECUTION_GAS_MINUS_REFUND_GREATER_THAN_DATA_FLOOR
     ):
-        return execution_gas + 1
+        # Keep incrementing until we actually get gas_used > tx_floor_data_cost
+        # (adding just 1 may not be enough due to refund cap boundary effects)
+        while execution_gas_cost(execution_gas) <= tx_floor_data_cost:
+            execution_gas += 1
+        return execution_gas
     elif (
         refund_test_type
         == RefundTestType.EXECUTION_GAS_MINUS_REFUND_LESS_THAN_DATA_FLOOR


### PR DESCRIPTION
## 🗒️ Description
When you fill this with `--until=amsterdam` after having implemented eip7976 then py3 CI for it fails with `AssertionError: Size mismatch` and `AssertionError: Correct intrinsic cost should be less than or equal to the tx gas limit cap`. These test adjustments fix that for Amsterdam and later. After this PR is merged i can rebase eip7976 and hopefully CI will pass then

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
