### PR TITLE
feat(ci): auto-merge approved PRs via required workflow gates

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,14 +11,6 @@ on:
       - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/**"
       - ".github/workflows/benchmark.yaml"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "LICENSE*"
-      - ".gitignore"
-      - ".vscode/**"
-      - "whitelist.txt"
-      - "docs/**"                                                                                                                     
-      - "mkdocs.yml"
   workflow_dispatch:
 
 concurrency:
@@ -26,9 +18,38 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            relevant:
+              - "**"
+              - "!**/*.md"
+              - "!LICENSE*"
+              - "!.gitignore"
+              - "!.vscode/**"
+              - "!whitelist.txt"
+              - "!docs/**"
+              - "!mkdocs.yml"
+
   unit-tests:
     name: Benchmark Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -103,3 +124,20 @@ jobs:
       - uses: ./.github/actions/build-fixtures
         with:
           release_name: benchmark_fast
+
+  gate:
+    name: benchmark-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - unit-tests
+      - sanity-checks
+      - build-artifact
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -25,7 +25,7 @@ on:
     branches:
       - mainnet
       - forks/amsterdam
-    paths: &docs_paths
+    paths:
       - "src/ethereum/**"
       - "src/ethereum_spec_tools/docc.py"
       - "src/ethereum_spec_tools/forks.py"
@@ -41,7 +41,6 @@ on:
       - ".github/configs/docs-branches.yaml"
 
   pull_request:
-    paths: *docs_paths
 
   workflow_dispatch:
     inputs:
@@ -64,9 +63,42 @@ permissions:
   contents: read
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - "src/ethereum/**"
+              - "src/ethereum_spec_tools/docc.py"
+              - "src/ethereum_spec_tools/forks.py"
+              - "static/**"
+              - "docs/**"
+              - "packages/testing/**"
+              - "*.md"
+              - "mkdocs.yml"
+              - "uv.lock"
+              - "pyproject.toml"
+              - "Justfile"
+              - ".github/workflows/docs-build.yaml"
+              - ".github/configs/docs-branches.yaml"
+
   lint-md:
     name: "Lint Markdown"
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # TODO: Still on node20 — update when upstream releases a node22+ version
@@ -374,3 +406,23 @@ jobs:
           echo "  Branch: $BRANCH"
           echo "  SHA: ${{ github.sha }}"
           echo "  Run ID: ${{ github.run_id }}"
+
+  gate:
+    name: docs-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - lint-md
+      - check-should-publish
+      - html-docs
+      - spec-docs
+      - combine
+      - trigger-aggregator
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - mainnet
       - 'forks/**'
-    paths: &render_paths
+    paths:
       - 'src/ethereum/**'
       - 'static/**'
       - '.github/workflows/gh-pages.yaml'
@@ -14,16 +14,41 @@ on:
       - 'src/ethereum_spec_tools/forks.py'
   workflow_dispatch:
   pull_request:
-    paths: *render_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - 'src/ethereum/**'
+              - 'static/**'
+              - '.github/workflows/gh-pages.yaml'
+              - 'uv.lock'
+              - 'src/ethereum_spec_tools/docc.py'
+              - 'src/ethereum_spec_tools/forks.py'
+
   build:
     name: "Build Documentation"
     runs-on: "ubuntu-latest"
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,3 +91,19 @@ jobs:
         id: deployment
         # TODO: Still on node20 — update when upstream releases a node22+ version
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+  gate:
+    name: render-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - build
+      - deploy
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -13,19 +13,6 @@ on:
       - "docs/**"
       - "mkdocs.yml"
   pull_request:
-    paths:
-      - ".github/workflows/hive-consume.yaml"
-      - ".github/actions/start-hive-dev/**"
-      - ".github/actions/cache-docker-images/**"
-      - ".github/actions/load-docker-images/**"
-      - ".github/configs/hive/**"
-      - "packages/testing/src/execution_testing/cli/pytest_commands/consume.py"
-      - "packages/testing/src/execution_testing/cli/pytest_commands/build_block.py"
-      - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini"
-      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**"
-      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**"
-      - "packages/testing/src/execution_testing/fixtures/consume.py"
-      - "packages/testing/src/execution_testing/rpc/**"
   workflow_dispatch:
     inputs:
       docker_images:
@@ -67,9 +54,41 @@ env:
   FIXTURES_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - ".github/workflows/hive-consume.yaml"
+              - ".github/actions/start-hive-dev/**"
+              - ".github/actions/cache-docker-images/**"
+              - ".github/actions/load-docker-images/**"
+              - ".github/configs/hive/**"
+              - "packages/testing/src/execution_testing/cli/pytest_commands/consume.py"
+              - "packages/testing/src/execution_testing/cli/pytest_commands/build_block.py"
+              - "packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini"
+              - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/**"
+              - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/pytest_hive/**"
+              - "packages/testing/src/execution_testing/fixtures/consume.py"
+              - "packages/testing/src/execution_testing/rpc/**"
+
   cache-docker-images:
     name: Cache Docker Images
     runs-on: [self-hosted-ghr, size-l-x64]
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - name: Checkout execution-specs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -223,3 +242,19 @@ jobs:
           name: hive-logs-${{ matrix.name }}
           path: hive/workspace/
           retention-days: 7
+
+  gate:
+    name: hive-consume-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - cache-docker-images
+      - test-hive
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/hive-execute.yaml
+++ b/.github/workflows/hive-execute.yaml
@@ -10,11 +10,6 @@ on:
       - ".github/workflows/hive-execute.yaml"
       - ".github/actions/start-hive-dev/**"
   pull_request:
-    paths:
-      - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/**"
-      - "packages/testing/src/execution_testing/rpc/**"
-      - ".github/workflows/hive-execute.yaml"
-      - ".github/actions/start-hive-dev/**"
   workflow_dispatch:
 
 concurrency:
@@ -22,9 +17,33 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - "packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/**"
+              - "packages/testing/src/execution_testing/rpc/**"
+              - ".github/workflows/hive-execute.yaml"
+              - ".github/actions/start-hive-dev/**"
+
   cache-docker-images:
     name: Cache Docker Images
     runs-on: [self-hosted-ghr, size-l-x64]
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - name: Checkout execution-specs
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -103,3 +122,19 @@ jobs:
             -v \
             -p execution_testing.cli.pytest_commands.plugins.concurrency \
             src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute_remote.py
+
+  gate:
+    name: hive-execute-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - cache-docker-images
+      - test-execute-remote
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/test-checklist.yaml
+++ b/.github/workflows/test-checklist.yaml
@@ -5,14 +5,13 @@ on:
     branches:
       - master
       - mainnet
-    paths: &checklist_paths
+    paths:
       - "docs/writing_tests/checklist_templates/**"
       - "packages/testing/src/execution_testing/checklists/eip_checklist.py"
       - "packages/testing/src/execution_testing/checklists/eip_checklist.pyi"
       - "packages/testing/src/execution_testing/checklists/tests/test_checklist_template_consistency.py"
       - ".github/workflows/test-checklist.yaml"
   pull_request:
-    paths: *checklist_paths
   workflow_dispatch:
 
 concurrency:
@@ -20,12 +19,52 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            relevant:
+              - "docs/writing_tests/checklist_templates/**"
+              - "packages/testing/src/execution_testing/checklists/eip_checklist.py"
+              - "packages/testing/src/execution_testing/checklists/eip_checklist.pyi"
+              - "packages/testing/src/execution_testing/checklists/tests/test_checklist_template_consistency.py"
+              - ".github/workflows/test-checklist.yaml"
+
   checklist-consistency:
     name: Test checklist template consistency
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - name: Checkout ethereum/execution-specs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-uv
       - name: Run checklist consistency test
         run: just test-tests -k test_checklist_template_consistency
+
+  gate:
+    name: checklist-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - checklist-consistency
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,22 +16,43 @@ on:
       - "mkdocs.yml"
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "LICENSE*"
-      - ".gitignore"
-      - ".vscode/**"
-      - "whitelist.txt"
-      - "docs/**"
-      - "mkdocs.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  # Job-level path filter: the workflow must always run on PRs so its
+  # gate can be a required status check (skipped workflows never report).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant || 'true' }}
+    steps:
+      - name: Filter relevant paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          predicate-quantifier: "every"
+          filters: |
+            relevant:
+              - "**"
+              - "!**/*.md"
+              - "!LICENSE*"
+              - "!.gitignore"
+              - "!.vscode/**"
+              - "!whitelist.txt"
+              - "!docs/**"
+              - "!mkdocs.yml"
+
   static:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -186,3 +207,23 @@ jobs:
         env:
           PYPY_GC_MAX: "2G"
           PYPY_GC_MIN: "1G"
+
+  gate:
+    name: specs-gate
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - static
+      - fill
+      - fill-pypy
+      - json-loader
+      - test-tests
+      - test-tests-pypy
+    if: always()
+    steps:
+      - name: Check that all jobs passed or were skipped
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e \
+            '[.[].result] | all(. == "success" or . == "skipped")'

--- a/.github/workflows/yolo-merge.yaml
+++ b/.github/workflows/yolo-merge.yaml
@@ -1,0 +1,37 @@
+name: Yolo Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  yolo-merge:
+    name: yolo-merge
+    runs-on: ubuntu-latest
+    # Base prefixes must match the branches whose ruleset requires the
+    # gate checks; arming auto-merge on an unprotected base merges
+    # without CI.
+    if: >-
+      github.event.review.state == 'approved' &&
+      !github.event.pull_request.draft &&
+      (startsWith(github.event.pull_request.base.ref, 'forks/') ||
+       startsWith(github.event.pull_request.base.ref, 'devnets/') ||
+       startsWith(github.event.pull_request.base.ref, 'eips/'))
+    steps:
+      - name: Enable auto-merge
+        env:
+          # Prefer a PAT/App token: merges performed with github.token do
+          # not trigger push workflows (docs deploy, fixture builds) on the
+          # target branch.
+          GH_TOKEN: ${{ secrets.YOLO_MERGE_TOKEN || github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          gh pr merge "$PR_NUMBER" \
+            --squash --auto \
+            --subject "$PR_TITLE (#$PR_NUMBER)"


### PR DESCRIPTION
### Description

Enables GitHub native auto-merge on approval. Replaces the merge-gate/polling approach with Sam's suggestion from the review discussion: job-level path filtering, so every PR workflow always reports a check run and can be a required status check.

- Each PR workflow gets a `changes` job (`dorny/paths-filter`) carrying the old `on.pull_request` path filters; root jobs skip when no relevant files changed. Skipped jobs satisfy required checks — skipped *workflows* never report, which is why workflow-level PR filters had to go. Push-side filters are unchanged.
- Each PR workflow ends in an always-run gate job that fails if any job failed: `specs-gate`, `benchmark-gate`, `docs-gate`, `render-gate`, `hive-consume-gate`, `hive-execute-gate`, `checklist-gate`. These are the required checks; GitHub natively waits for them, so the old race (gate evaluating before slow workflows register) is gone.
- `yolo-merge.yaml` arms auto-merge (squash, PR title as subject) when a non-draft PR targeting `forks/`, `devnets/`, or `eips/` is approved; other bases are never armed.
- PRs touching only ignored files (e.g. `whitelist.txt`) now auto-merge too: workflows run, jobs skip, gates pass.

Repo settings required (admin):

1. Enable "Allow auto-merge" (currently off).
2. Add the 7 gate jobs above as required status checks on a ruleset targeting `forks/**`, `devnets/**`, and `eips/**` (must cover every base yolo-merge arms; devnet/eips branches currently have no pull_request rules at all).
3. Enable "Dismiss stale pull request approvals when new commits are pushed" (per discussion with @Carsons-Eels).
4. Optional but recommended: add a `YOLO_MERGE_TOKEN` secret (PAT/App token with contents+PR write). Merges armed with `github.token` are attributed to github-actions[bot], whose push does not trigger the push workflows (docs deploy, fixture builds).

### Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

### Checklist
<!-- Please check off all items before marking the PR ready for review. -->

- [x] Ran fast static checks to avoid CI fails, see [Code Standards](https://steel.ethereum.foundation/docs/execution-specs/getting_started/code_standards/) & [Verifying Changes](https://steel.ethereum.foundation/docs/execution-specs/getting_started/verifying_changes/): `just static`
- [x] PR title has the form `<type>(<area>):`, where `<type>` and `<area>` come from an appropriate `C-<type>`, respectively `A-<area>`, label. The title should match the target squash commit message.

### Cute Animal Picture

![yolo](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.nLfzzXz6p17jcjMyzjF4fwHaHa%3Fpid%3DApi&f=1&ipt=fe13ca9c01b8eeddd3ebef9f042d45e62ecdb036d3a470002b8e02d5ce4148f7)
