### PR TITLE
refactor(test-benchmarks): ensure `SSTORE` N->N writes nonzero key/value

### DIFF
--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -501,8 +501,8 @@ def test_storage_access_warm_benchmark(
     """
     match storage_action:
         case StorageAction.WRITE_SAME_VALUE:
-            # Timestamp is nonzero (no txs run in Genesis block), so this always writes
-            # to the zero key a nonzero, constant value
+            # Timestamp is nonzero (no txs run in Genesis block),
+            # Always writes to the zero key a nonzero, constant value
             attack_block = Op.SSTORE(Op.PUSH0, Op.TIMESTAMP)
         case StorageAction.WRITE_NEW_VALUE:
             attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)

--- a/tests/benchmark/compute/instruction/test_storage.py
+++ b/tests/benchmark/compute/instruction/test_storage.py
@@ -501,7 +501,9 @@ def test_storage_access_warm_benchmark(
     """
     match storage_action:
         case StorageAction.WRITE_SAME_VALUE:
-            attack_block = Op.SSTORE(Op.PUSH0, Op.PUSH0)
+            # Timestamp is nonzero (no txs run in Genesis block), so this always writes
+            # to the zero key a nonzero, constant value
+            attack_block = Op.SSTORE(Op.PUSH0, Op.TIMESTAMP)
         case StorageAction.WRITE_NEW_VALUE:
             attack_block = Op.SSTORE(Op.PUSH0, Op.GAS)
         case StorageAction.READ:


### PR DESCRIPTION
## 🗒️ Description
Tweaks benchmarks to fix expectations in repricings. CC @misilva73
Draft, will push more tweaks if more are found after analysis

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
