### PR TITLE
chore(spec): remove duplicated set_authority_code; use set_code

### DIFF
--- a/src/ethereum/forks/amsterdam/state.py
+++ b/src/ethereum/forks/amsterdam/state.py
@@ -604,32 +604,6 @@ def set_code(state: State, address: Address, code: Bytes) -> None:
     modify_state(state, address, write_code)
 
 
-def set_authority_code(state: State, address: Address, code: Bytes) -> None:
-    """
-    Sets authority account code for EIP-7702 delegation.
-
-    This function is used specifically for setting authority code within
-    EIP-7702 Set Code Transactions.
-
-    Parameters
-    ----------
-    state:
-        The current state.
-
-    address:
-        Address of the authority account whose code needs to be set.
-
-    code:
-        The delegation designation bytecode to set.
-
-    """
-
-    def write_code(sender: Account) -> None:
-        sender.code = code
-
-    modify_state(state, address, write_code)
-
-
 def get_storage_original(state: State, address: Address, key: Bytes32) -> U256:
     """
     Get the original value in a storage slot i.e. the value before the current

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -16,7 +16,7 @@ from ..state import (
     account_exists,
     get_account,
     increment_nonce,
-    set_authority_code,
+    set_code,
 )
 from ..state_tracker import (
     capture_pre_code,
@@ -215,7 +215,7 @@ def set_delegation(message: Message) -> U256:
         # EIP-7928: Capture pre-code before any changes
         capture_pre_code(tx_frame, authority, authority_code)
 
-        set_authority_code(state, authority, code_to_set)
+        set_code(state, authority, code_to_set)
 
         if authority_code != code_to_set:
             # Track code change if different from current


### PR DESCRIPTION
## 🗒️ Description

closes #2246

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fstatic.boredpanda.com%2Fblog%2Fwp-content%2Fuploads%2F2017%2F04%2Fperfectly-round-animals-82-58eb95b19c61b__700.jpg&f=1&nofb=1&ipt=c22ae32c940933d3a874d3f8745ae555ca67194587c7214d5254d058d5aa1ae7)
