### PR TITLE
feat(zkevm): wire ExecutionWitness into the testing framework

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -25,10 +25,10 @@ from execution_testing.exceptions import (
     TransactionException,
     UndefinedException,
 )
+from execution_testing.fixtures.blockchain import ExecutionWitnessTemp
 from execution_testing.logging import (
     get_logger,
 )
-from execution_testing.fixtures.blockchain import ExecutionWitnessTemp
 from execution_testing.test_types import (
     Alloc,
     BlockAccessList,

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -25,7 +25,6 @@ from execution_testing.exceptions import (
     TransactionException,
     UndefinedException,
 )
-from execution_testing.fixtures.blockchain import ExecutionWitnessTemp
 from execution_testing.logging import (
     get_logger,
 )
@@ -33,6 +32,7 @@ from execution_testing.test_types import (
     Alloc,
     BlockAccessList,
     Environment,
+    ExecutionWitness,
     Transaction,
     TransactionReceipt,
 )
@@ -290,7 +290,7 @@ class Result(CamelModel):
     requests: List[Bytes] | None = None
     block_access_list: BlockAccessList | None = None
     block_access_list_hash: Hash | None = None
-    execution_witness_temp: ExecutionWitnessTemp | None = None
+    execution_witness: ExecutionWitness | None = None
     block_exception: Annotated[
         BlockExceptionWithMessage | UndefinedException | None,
         ExceptionMapperValidator,

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -28,6 +28,7 @@ from execution_testing.exceptions import (
 from execution_testing.logging import (
     get_logger,
 )
+from execution_testing.fixtures.blockchain import ExecutionWitnessTemp
 from execution_testing.test_types import (
     Alloc,
     BlockAccessList,
@@ -289,6 +290,7 @@ class Result(CamelModel):
     requests: List[Bytes] | None = None
     block_access_list: BlockAccessList | None = None
     block_access_list_hash: Hash | None = None
+    execution_witness_temp: ExecutionWitnessTemp | None = None
     block_exception: Annotated[
         BlockExceptionWithMessage | UndefinedException | None,
         ExceptionMapperValidator,

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -52,6 +52,7 @@ from execution_testing.forks import Fork, Paris
 from execution_testing.test_types import (
     BlockAccessList,
     Environment,
+    ExecutionWitness,
     Requests,
     Transaction,
     Withdrawal,
@@ -596,14 +597,6 @@ class FixtureWithdrawal(WithdrawalGeneric[ZeroPaddedHexNumber]):
         return cls(**w.model_dump())
 
 
-class ExecutionWitnessTemp(CamelModel):
-    """Execution witness for stateless validation."""
-
-    state: List[Bytes] = Field(default_factory=list)
-    codes: List[Bytes] = Field(default_factory=list)
-    headers: List[Bytes] = Field(default_factory=list)
-
-
 class FixtureBlockBase(CamelModel):
     """
     Representation of an Ethereum block within a test Fixture without RLP
@@ -632,7 +625,7 @@ class FixtureBlockBase(CamelModel):
     )
     withdrawals: List[FixtureWithdrawal] | None = None
     receipts: List[FixtureTransactionReceipt] | None = None
-    execution_witness_temp: ExecutionWitnessTemp | None = None
+    execution_witness: ExecutionWitness | None = None
     block_access_list: BlockAccessList | None = Field(
         None, description="EIP-7928 Block Access List"
     )

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -596,6 +596,14 @@ class FixtureWithdrawal(WithdrawalGeneric[ZeroPaddedHexNumber]):
         return cls(**w.model_dump())
 
 
+class ExecutionWitnessTemp(CamelModel):
+    """Execution witness for stateless validation."""
+
+    state: List[Bytes] = Field(default_factory=list)
+    codes: List[Bytes] = Field(default_factory=list)
+    headers: List[Bytes] = Field(default_factory=list)
+
+
 class FixtureBlockBase(CamelModel):
     """
     Representation of an Ethereum block within a test Fixture without RLP
@@ -624,6 +632,7 @@ class FixtureBlockBase(CamelModel):
     )
     withdrawals: List[FixtureWithdrawal] | None = None
     receipts: List[FixtureTransactionReceipt] | None = None
+    execution_witness_temp: ExecutionWitnessTemp | None = None
     block_access_list: BlockAccessList | None = Field(
         None, description="EIP-7928 Block Access List"
     )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -61,7 +61,7 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
 )
 from execution_testing.fixtures.blockchain import (
-    ExecutionWitnessTemp,
+    ExecutionWitness,
     FixtureBlock,
     FixtureBlockBase,
     FixtureConfig,
@@ -382,7 +382,7 @@ class BuiltBlock(CamelModel):
     engine_api_error_code: EngineAPIError | None = None
     fork: Fork
     block_access_list: BlockAccessList | None
-    execution_witness_temp: ExecutionWitnessTemp | None = None
+    execution_witness: ExecutionWitness | None = None
 
     def get_fixture_block(
         self, *, include_receipts: bool = True
@@ -412,8 +412,8 @@ class BuiltBlock(CamelModel):
             block_access_list=self.block_access_list
             if self.block_access_list
             else None,
-            execution_witness_temp=self.execution_witness_temp
-            if self.execution_witness_temp
+            execution_witness=self.execution_witness
+            if self.execution_witness
             else None,
             fork=self.fork,
         ).with_rlp(txs=self.txs)
@@ -778,8 +778,8 @@ class BlockchainTest(BaseTest):
             engine_api_error_code=block.engine_api_error_code,
             fork=self.fork,
             block_access_list=bal,
-            execution_witness_temp=(
-                transition_tool_output.result.execution_witness_temp
+            execution_witness=(
+                transition_tool_output.result.execution_witness
             ),
         )
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -61,6 +61,7 @@ from execution_testing.fixtures import (
     LabeledFixtureFormat,
 )
 from execution_testing.fixtures.blockchain import (
+    ExecutionWitnessTemp,
     FixtureBlock,
     FixtureBlockBase,
     FixtureConfig,
@@ -381,6 +382,7 @@ class BuiltBlock(CamelModel):
     engine_api_error_code: EngineAPIError | None = None
     fork: Fork
     block_access_list: BlockAccessList | None
+    execution_witness_temp: ExecutionWitnessTemp | None = None
 
     def get_fixture_block(
         self, *, include_receipts: bool = True
@@ -409,6 +411,9 @@ class BuiltBlock(CamelModel):
             ),
             block_access_list=self.block_access_list
             if self.block_access_list
+            else None,
+            execution_witness_temp=self.execution_witness_temp
+            if self.execution_witness_temp
             else None,
             fork=self.fork,
         ).with_rlp(txs=self.txs)
@@ -773,6 +778,9 @@ class BlockchainTest(BaseTest):
             engine_api_error_code=block.engine_api_error_code,
             fork=self.fork,
             block_access_list=bal,
+            execution_witness_temp=(
+                transition_tool_output.result.execution_witness_temp
+            ),
         )
 
         try:

--- a/packages/testing/src/execution_testing/test_types/__init__.py
+++ b/packages/testing/src/execution_testing/test_types/__init__.py
@@ -19,6 +19,7 @@ from .block_types import (
     Withdrawal,
 )
 from .chain_config_types import ChainConfig, ChainConfigDefaults
+from .execution_witness import ExecutionWitness
 from .helpers import (
     DETERMINISTIC_FACTORY_ADDRESS,
     DETERMINISTIC_FACTORY_BYTECODE,
@@ -68,9 +69,10 @@ __all__ = (
     "ChainConfigDefaults",
     "ConsolidationRequest",
     "DepositRequest",
+    "EOA",
     "Environment",
     "EnvironmentDefaults",
-    "EOA",
+    "ExecutionWitness",
     "NetworkWrappedTransaction",
     "Removable",
     "Requests",

--- a/packages/testing/src/execution_testing/test_types/execution_witness.py
+++ b/packages/testing/src/execution_testing/test_types/execution_witness.py
@@ -1,0 +1,18 @@
+"""Execution witness types."""
+
+from typing import List
+
+from pydantic import Field
+
+from execution_testing.base_types import (
+    Bytes,
+    CamelModel,
+)
+
+
+class ExecutionWitness(CamelModel):
+    """Execution witness for stateless validation."""
+
+    state: List[Bytes] = Field(default_factory=list)
+    codes: List[Bytes] = Field(default_factory=list)
+    headers: List[Bytes] = Field(default_factory=list)

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -74,6 +74,7 @@ from .state_tracker import (
     set_account_balance,
     track_address,
 )
+from .stateless_types import ExecutionWitnessBuilder, build_execution_witness
 from .transactions import (
     AccessListTransaction,
     BlobTransaction,

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -50,7 +50,6 @@ from .exceptions import (
     TransactionTypeContractCreationError,
 )
 from .fork_types import Authorization, VersionedHash
-from .stateless_types import ExecutionWitnessBuilder, build_execution_witness
 from .requests import (
     CONSOLIDATION_REQUEST_TYPE,
     DEPOSIT_REQUEST_TYPE,

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -50,6 +50,7 @@ from .exceptions import (
     TransactionTypeContractCreationError,
 )
 from .fork_types import Authorization, VersionedHash
+from .stateless_types import ExecutionWitnessBuilder, build_execution_witness
 from .requests import (
     CONSOLIDATION_REQUEST_TYPE,
     DEPOSIT_REQUEST_TYPE,
@@ -250,6 +251,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         excess_blob_gas=block.header.excess_blob_gas,
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
+        execution_witness=ExecutionWitnessBuilder(),
     )
 
     block_output = apply_body(
@@ -831,6 +833,10 @@ def apply_body(
 
     block_output.block_access_list = build_block_access_list(
         block_env.block_access_list_builder, block_env.state
+    )
+
+    block_output.execution_witness = build_execution_witness(
+        block_env.execution_witness
     )
 
     return block_output

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -15,6 +15,7 @@ from ethereum.state import Root
 from .blocks import Block
 from .execution_engine.types import NewPayloadRequest
 from .fork_types import VersionedHash
+from .stateless_types import ExecutionWitness
 
 # Amsterdam currently carries execution requests as raw bytes in order.
 ExecutionRequests = Tuple[Bytes, ...]
@@ -44,31 +45,6 @@ class NewPayloadRequestHeader:
     versioned_hashes: Sequence[VersionedHash]
     parent_beacon_block_root: Root
     execution_requests: ExecutionRequests
-
-
-@slotted_freezable
-@dataclass
-class ExecutionWitness:
-    """
-    Execution witness data for stateless validation.
-    """
-
-    state: Tuple[Bytes, ...]
-    """
-    Hashed trie-node preimages needed during execution and state-root
-    recomputation.
-    """
-
-    codes: Tuple[Bytes, ...]
-    """
-    Contract-code preimages (created or accessed) needed during execution.
-    """
-
-    headers: Tuple[Bytes, ...]
-    """
-    RLP-encoded block headers used for pre-state and ``BLOCKHASH`` correctness
-    proofs. This may trend toward empty with EIP-2935 and EIP-7709.
-    """
 
 
 @slotted_freezable

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -1,0 +1,67 @@
+"""
+Stateless validation types.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes
+from ethereum_types.frozen import slotted_freezable
+
+from .blocks import Header
+
+
+@slotted_freezable
+@dataclass
+class ExecutionWitness:
+    """
+    Execution witness data for stateless validation.
+    """
+
+    state: Tuple[Bytes, ...]
+    """
+    Hashed trie-node preimages needed during execution and state-root
+    recomputation.
+    """
+
+    codes: Tuple[Bytes, ...]
+    """
+    Contract-code preimages (created or accessed) needed during execution.
+    """
+
+    headers: Tuple[Bytes, ...]
+    """
+    RLP-encoded block headers used for pre-state and ``BLOCKHASH`` correctness
+    proofs. This may trend toward empty EIP-7709.
+    """
+
+
+@dataclass
+class ExecutionWitnessBuilder:
+    """
+    Mutable accumulator for execution witness data during block execution.
+    """
+
+    state: List[Bytes] = field(default_factory=list)
+    codes: List[Bytes] = field(default_factory=list)
+    headers: List[Header] = field(default_factory=list)
+
+
+def build_execution_witness(
+    builder: ExecutionWitnessBuilder,
+) -> ExecutionWitness:
+    """
+    Build the execution witness from the accumulated builder data.
+
+    Sort state and codes lexicographically, headers by block number
+    ascending.
+    """
+    return ExecutionWitness(
+        state=tuple(sorted(builder.state)),
+        codes=tuple(sorted(builder.codes)),
+        headers=tuple(
+            rlp.encode(h)
+            for h in sorted(builder.headers, key=lambda h: h.number)
+        ),
+    )

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -24,6 +24,7 @@ from ethereum.state import Address
 
 from ..block_access_lists.builder import BlockAccessListBuilder
 from ..block_access_lists.rlp_types import BlockAccessList
+from ..stateless_types import ExecutionWitness, ExecutionWitnessBuilder
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Authorization, VersionedHash
 from ..state_tracker import BlockState, TransactionState
@@ -51,6 +52,7 @@ class BlockEnvironment:
     excess_blob_gas: U64
     parent_beacon_block_root: Hash32
     block_access_list_builder: BlockAccessListBuilder
+    execution_witness: ExecutionWitnessBuilder
 
 
 @dataclass
@@ -79,6 +81,8 @@ class BlockOutput:
         Hash of all the requests in the block.
     block_access_list: `BlockAccessList`
         The block access list for the block.
+    execution_witness : `ExecutionWitness`
+        Execution witness data for stateless validation.
     """
 
     block_gas_used: Uint = Uint(0)
@@ -96,6 +100,7 @@ class BlockOutput:
     blob_gas_used: U64 = U64(0)
     requests: List[Bytes] = field(default_factory=list)
     block_access_list: BlockAccessList = field(default_factory=list)
+    execution_witness: Optional[ExecutionWitness] = None
 
 
 @dataclass

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -24,10 +24,10 @@ from ethereum.state import Address
 
 from ..block_access_lists.builder import BlockAccessListBuilder
 from ..block_access_lists.rlp_types import BlockAccessList
-from ..stateless_types import ExecutionWitness, ExecutionWitnessBuilder
 from ..blocks import Log, Receipt, Withdrawal
 from ..fork_types import Authorization, VersionedHash
 from ..state_tracker import BlockState, TransactionState
+from ..stateless_types import ExecutionWitness, ExecutionWitnessBuilder
 from ..transactions import LegacyTransaction
 from ..trie import Trie
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -143,6 +143,20 @@ class ForkLoad:
         return hasattr(module, "compute_block_access_list_hash")
 
     @property
+    def has_execution_witness(self) -> bool:
+        """Check if the fork has an `ExecutionWitness` type."""
+        try:
+            module = self._module("stateless_types")
+        except ModuleNotFoundError:
+            return False
+        return hasattr(module, "ExecutionWitness")
+
+    @property
+    def build_execution_witness(self) -> Any:
+        """Build function of the fork."""
+        return self._module("stateless_types").build_execution_witness
+
+    @property
     def signing_hash_2930(self) -> Any:
         """signing_hash_2930 function of the fork."""
         return self._module("transactions").signing_hash_2930

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -461,10 +461,8 @@ class T8N(Load):
             )
 
         if self.fork.has_execution_witness:
-            block_output.execution_witness = (
-                self.fork.build_execution_witness(
-                    block_env.execution_witness
-                )
+            block_output.execution_witness = self.fork.build_execution_witness(
+                block_env.execution_witness
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -25,6 +25,7 @@ from ethereum.forks.amsterdam.block_access_lists.builder import (
 from ethereum.forks.amsterdam.block_access_lists.rlp_types import (
     BlockAccessIndex,
 )
+from ethereum.forks.amsterdam.stateless_types import ExecutionWitnessBuilder
 from ethereum_spec_tools.forks import Hardfork, TemporaryHardfork
 
 from ..loaders.fixture_loader import Load
@@ -329,6 +330,9 @@ class T8N(Load):
                 BlockAccessListBuilder()
             )
 
+        if self.fork.has_execution_witness:
+            kw_arguments["execution_witness"] = ExecutionWitnessBuilder()
+
         return block_environment(**kw_arguments)
 
     def backup_state(self) -> None:
@@ -454,6 +458,13 @@ class T8N(Load):
         if self.fork.has_block_access_list_hash:
             block_output.block_access_list = self.fork.build_block_access_list(
                 block_env.block_access_list_builder, block_env.state
+            )
+
+        if self.fork.has_execution_witness:
+            block_output.execution_witness = (
+                self.fork.build_execution_witness(
+                    block_env.execution_witness
+                )
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -270,6 +270,7 @@ class Result:
     block_exception: Optional[str] = None
     block_access_list: Optional[Any] = None
     block_access_list_hash: Optional[Hash32] = None
+    execution_witness: Optional[Any] = None
 
     def get_receipts_from_output(
         self,
@@ -356,6 +357,9 @@ class Result:
                     block_output.block_access_list
                 )
             )
+
+        if hasattr(block_output, "execution_witness"):
+            self.execution_witness = block_output.execution_witness
 
     @staticmethod
     def _block_access_list_to_json(account_changes: Any) -> Any:
@@ -513,5 +517,19 @@ class Result:
             data["blockAccessListHash"] = encode_to_hex(
                 self.block_access_list_hash
             )
+
+        if self.execution_witness is not None:
+            ew = self.execution_witness
+            data["executionWitnessTemp"] = {
+                "state": [
+                    "0x" + s.hex() for s in ew.state
+                ],
+                "codes": [
+                    "0x" + c.hex() for c in ew.codes
+                ],
+                "headers": [
+                    "0x" + h.hex() for h in ew.headers
+                ],
+            }
 
         return data

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -521,15 +521,9 @@ class Result:
         if self.execution_witness is not None:
             ew = self.execution_witness
             data["executionWitnessTemp"] = {
-                "state": [
-                    "0x" + s.hex() for s in ew.state
-                ],
-                "codes": [
-                    "0x" + c.hex() for c in ew.codes
-                ],
-                "headers": [
-                    "0x" + h.hex() for h in ew.headers
-                ],
+                "state": ["0x" + s.hex() for s in ew.state],
+                "codes": ["0x" + c.hex() for c in ew.codes],
+                "headers": ["0x" + h.hex() for h in ew.headers],
             }
 
         return data

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -520,7 +520,7 @@ class Result:
 
         if self.execution_witness is not None:
             ew = self.execution_witness
-            data["executionWitnessTemp"] = {
+            data["executionWitness"] = {
                 "state": ["0x" + s.hex() for s in ew.state],
                 "codes": ["0x" + c.hex() for c in ew.codes],
                 "headers": ["0x" + h.hex() for h in ew.headers],


### PR DESCRIPTION
## 🗒️ Description
This PR adds the required wiring to include the `executionWitness` as part of filled test fixtures.

Example (you can run it):
```
$ uv run fill --clean -m "blockchain_test" --fork Amsterdam ./tests/tangerine_whistle -k test_selfdestruct_to_account
...
$ cat fixtures/blockchain_tests/tangerine_whistle/eip150_operation_gas_costs/eip150_selfdestruct/selfdestruct_to_account.json
...
 "receipts": [...],
 "executionWitness": {
     "state": [],
     "codes": [],
     "headers": []
  },
  "blockAccessList": [...],
...
```

The change is quite similar to how it is usually done in general (e.g. BALs):
- We add `ExecutionWitness` as part of the block output of the STF.
- The Amsterdam fork has a property to signal it supports execution witness generation.
- t8n now asks the fork if it has the property, and properly pulls the block output result to be returned.
- The testing framework detects this new potential output of t8n and adds it to the fixture output.

The goal of this PR is to already do all the wiring with the testing framework, so future PRs can focus only on generating the witness during execution, and we can already see the results in the filled fixtures.

I'll add some extra comments to help review.