### PR TITLE
test: Add more invalid bal tests

### DIFF
--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -61,6 +61,10 @@ Conventions and patterns for writing consensus tests. Run this skill before writ
 - `@pytest.mark.parametrize("name", [pytest.param(val, id="label"), ...])` with descriptive `id=` strings
 - Stack parametrize decorators for multiple dimensions
 
+## After Writing Tests
+
+After writing or modifying tests, ask the user: "Would you like me to load the `/fill-tests` skill to verify the new tests fill correctly? (This loads an additional skill into context.)" If they agree, run `/fill-tests`, fill the new tests, then inspect the generated fixture JSON to verify the fixture contents match what the test intends.
+
 ## References
 
 See `docs/writing_tests/` and `docs/writing_tests/opcode_metadata.md` for detailed documentation.

--- a/packages/testing/src/execution_testing/test_types/block_access_list/modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/modifiers.py
@@ -500,6 +500,187 @@ def duplicate_account(
     return transform
 
 
+def _duplicate_in_field(
+    address: Address,
+    field_name: str,
+    match_fn: Callable[[Any], bool],
+    error_msg: str,
+    sub_field: Optional[str] = None,
+    sub_match_fn: Optional[Callable[[Any], bool]] = None,
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """
+    Duplicate the first matching entry in an account's field list.
+
+    When sub_field and sub_match_fn are provided, find the parent entry
+    via match_fn then duplicate within sub_field using sub_match_fn.
+    """
+    found = False
+
+    def _copy(entry: Any) -> Any:
+        if hasattr(entry, "model_copy"):
+            return entry.model_copy(deep=True)
+        return ZeroPaddedHexNumber(entry)
+
+    def transform(bal: BlockAccessList) -> BlockAccessList:
+        nonlocal found
+        new_root = []
+        for account_change in bal.root:
+            if account_change.address == address:
+                new_account = account_change.model_copy(deep=True)
+                entries = getattr(new_account, field_name)
+
+                if sub_field is not None and sub_match_fn is not None:
+                    for parent in entries:
+                        if match_fn(parent):
+                            children = getattr(parent, sub_field)
+                            new_children = []
+                            for child in children:
+                                new_children.append(child)
+                                if not found and sub_match_fn(child):
+                                    found = True
+                                    new_children.append(_copy(child))
+                            setattr(parent, sub_field, new_children)
+                            break
+                else:
+                    new_entries = []
+                    for entry in entries:
+                        new_entries.append(entry)
+                        if not found and match_fn(entry):
+                            found = True
+                            new_entries.append(_copy(entry))
+                    setattr(new_account, field_name, new_entries)
+
+                new_root.append(new_account)
+            else:
+                new_root.append(account_change)
+
+        if not found:
+            raise ValueError(error_msg)
+
+        return BlockAccessList(root=new_root)
+
+    return transform
+
+
+def duplicate_nonce_change(
+    address: Address, block_access_index: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a nonce change entry for a given block access index."""
+    return _duplicate_in_field(
+        address,
+        "nonce_changes",
+        match_fn=lambda c: c.block_access_index == block_access_index,
+        error_msg=(
+            f"Block access index {block_access_index} not found in "
+            f"nonce_changes of account {address}"
+        ),
+    )
+
+
+def duplicate_balance_change(
+    address: Address, block_access_index: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a balance change entry for a given block access index."""
+    return _duplicate_in_field(
+        address,
+        "balance_changes",
+        match_fn=lambda c: c.block_access_index == block_access_index,
+        error_msg=(
+            f"Block access index {block_access_index} not found in "
+            f"balance_changes of account {address}"
+        ),
+    )
+
+
+def duplicate_storage_slot(
+    address: Address, slot: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a storage slot entry in storage_changes."""
+    return _duplicate_in_field(
+        address,
+        "storage_changes",
+        match_fn=lambda s: s.slot == slot,
+        error_msg=(
+            f"Storage slot {slot} not found in storage_changes "
+            f"of account {address}"
+        ),
+    )
+
+
+def duplicate_storage_read(
+    address: Address, slot: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a storage read entry."""
+    return _duplicate_in_field(
+        address,
+        "storage_reads",
+        match_fn=lambda r: r == slot,
+        error_msg=(
+            f"Storage slot {slot} not found in storage_reads "
+            f"of account {address}"
+        ),
+    )
+
+
+def duplicate_slot_change(
+    address: Address, slot: int, block_access_index: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a slot change within a specific storage slot."""
+    return _duplicate_in_field(
+        address,
+        "storage_changes",
+        match_fn=lambda s: s.slot == slot,
+        error_msg=(
+            f"Block access index {block_access_index} not found "
+            f"in storage slot {slot} of account {address}"
+        ),
+        sub_field="slot_changes",
+        sub_match_fn=lambda c: c.block_access_index == block_access_index,
+    )
+
+
+def insert_storage_read(
+    address: Address, slot: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """
+    Insert a storage read at the correct sorted position.
+
+    Useful for testing that a key must not appear in both
+    storage_changes and storage_reads.
+    """
+    found_address = False
+
+    def transform(bal: BlockAccessList) -> BlockAccessList:
+        nonlocal found_address
+        new_root = []
+        for account_change in bal.root:
+            if account_change.address == address:
+                found_address = True
+                new_account = account_change.model_copy(deep=True)
+                reads = list(new_account.storage_reads)
+                new_slot = ZeroPaddedHexNumber(slot)
+                # Find insertion point to maintain sorted order
+                insert_idx = len(reads)
+                for i, existing in enumerate(reads):
+                    if existing >= new_slot:
+                        insert_idx = i
+                        break
+                reads.insert(insert_idx, new_slot)
+                new_account.storage_reads = reads
+                new_root.append(new_account)
+            else:
+                new_root.append(account_change)
+
+        if not found_address:
+            raise ValueError(
+                f"Address {address} not found in BAL to insert storage read"
+            )
+
+        return BlockAccessList(root=new_root)
+
+    return transform
+
+
 def reverse_accounts() -> Callable[[BlockAccessList], BlockAccessList]:
     """Reverse the order of accounts in the BAL."""
 
@@ -567,7 +748,6 @@ def keep_only(
 
 
 __all__ = [
-    # Core functions
     # Account-level modifiers
     "remove_accounts",
     "append_account",
@@ -589,4 +769,11 @@ __all__ = [
     "modify_code",
     # Block access index modifiers
     "swap_bal_indices",
+    # Duplicate entry modifiers (uniqueness constraint testing)
+    "duplicate_nonce_change",
+    "duplicate_balance_change",
+    "duplicate_storage_slot",
+    "duplicate_storage_read",
+    "duplicate_slot_change",
+    "insert_storage_read",
 ]

--- a/packages/testing/src/execution_testing/test_types/block_access_list/modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/block_access_list/modifiers.py
@@ -592,6 +592,21 @@ def duplicate_balance_change(
     )
 
 
+def duplicate_code_change(
+    address: Address, block_access_index: int
+) -> Callable[[BlockAccessList], BlockAccessList]:
+    """Duplicate a code change entry for a given block access index."""
+    return _duplicate_in_field(
+        address,
+        "code_changes",
+        match_fn=lambda c: c.block_access_index == block_access_index,
+        error_msg=(
+            f"Block access index {block_access_index} not found in "
+            f"code_changes of account {address}"
+        ),
+    )
+
+
 def duplicate_storage_slot(
     address: Address, slot: int
 ) -> Callable[[BlockAccessList], BlockAccessList]:
@@ -772,6 +787,7 @@ __all__ = [
     # Duplicate entry modifiers (uniqueness constraint testing)
     "duplicate_nonce_change",
     "duplicate_balance_change",
+    "duplicate_code_change",
     "duplicate_storage_slot",
     "duplicate_storage_read",
     "duplicate_slot_change",

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_modifiers.py
@@ -6,6 +6,7 @@ from execution_testing.base_types import Address
 from execution_testing.test_types.block_access_list import (
     BalAccountChange,
     BalBalanceChange,
+    BalCodeChange,
     BalNonceChange,
     BalStorageChange,
     BalStorageSlot,
@@ -14,6 +15,7 @@ from execution_testing.test_types.block_access_list import (
 from execution_testing.test_types.block_access_list.modifiers import (
     duplicate_account,
     duplicate_balance_change,
+    duplicate_code_change,
     duplicate_nonce_change,
     duplicate_slot_change,
     duplicate_storage_read,
@@ -37,6 +39,9 @@ def sample_bal() -> BlockAccessList:
                 ],
                 balance_changes=[
                     BalBalanceChange(block_access_index=1, post_balance=100),
+                ],
+                code_changes=[
+                    BalCodeChange(block_access_index=1, new_code=b"\x60"),
                 ],
             ),
             BalAccountChange(
@@ -101,6 +106,27 @@ def test_duplicate_balance_change_missing_index_raises(
     """Raise when the block_access_index is absent."""
     with pytest.raises(ValueError, match="not found"):
         duplicate_balance_change(ALICE, 99)(sample_bal)
+
+
+# --- duplicate_code_change ---
+
+
+def test_duplicate_code_change(sample_bal: BlockAccessList) -> None:
+    """Duplicate a code change by block_access_index."""
+    result = duplicate_code_change(ALICE, 1)(sample_bal)
+    assert len(result.root[0].code_changes) == 2
+    assert (
+        result.root[0].code_changes[0].block_access_index
+        == result.root[0].code_changes[1].block_access_index
+    )
+
+
+def test_duplicate_code_change_missing_index_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the block_access_index is absent."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_code_change(ALICE, 99)(sample_bal)
 
 
 def test_duplicate_storage_slot(sample_bal: BlockAccessList) -> None:

--- a/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_block_access_list_modifiers.py
@@ -1,0 +1,193 @@
+"""Unit tests for BAL modifier functions."""
+
+import pytest
+
+from execution_testing.base_types import Address
+from execution_testing.test_types.block_access_list import (
+    BalAccountChange,
+    BalBalanceChange,
+    BalNonceChange,
+    BalStorageChange,
+    BalStorageSlot,
+    BlockAccessList,
+)
+from execution_testing.test_types.block_access_list.modifiers import (
+    duplicate_account,
+    duplicate_balance_change,
+    duplicate_nonce_change,
+    duplicate_slot_change,
+    duplicate_storage_read,
+    duplicate_storage_slot,
+    insert_storage_read,
+)
+
+ALICE = Address(0xA)
+CONTRACT = Address(0xC)
+
+
+@pytest.fixture()
+def sample_bal() -> BlockAccessList:
+    """Build a minimal BAL with one flat account and one storage account."""
+    return BlockAccessList(
+        [
+            BalAccountChange(
+                address=ALICE,
+                nonce_changes=[
+                    BalNonceChange(block_access_index=1, post_nonce=1),
+                ],
+                balance_changes=[
+                    BalBalanceChange(block_access_index=1, post_balance=100),
+                ],
+            ),
+            BalAccountChange(
+                address=CONTRACT,
+                storage_changes=[
+                    BalStorageSlot(
+                        slot=1,
+                        slot_changes=[
+                            BalStorageChange(
+                                block_access_index=1, post_value=0x42
+                            ),
+                        ],
+                    ),
+                ],
+                storage_reads=[2, 5],
+            ),
+        ]
+    )
+
+
+def test_duplicate_account(sample_bal: BlockAccessList) -> None:
+    """Duplicate an account entry."""
+    result = duplicate_account(ALICE)(sample_bal)
+    alice_entries = [a for a in result.root if a.address == ALICE]
+    assert len(alice_entries) == 2
+
+
+def test_duplicate_account_missing_raises() -> None:
+    """Raise when the target address is absent."""
+    bal = BlockAccessList([BalAccountChange(address=ALICE, nonce_changes=[])])
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_account(CONTRACT)(bal)
+
+
+def test_duplicate_nonce_change(sample_bal: BlockAccessList) -> None:
+    """Duplicate a nonce change by block_access_index."""
+    result = duplicate_nonce_change(ALICE, 1)(sample_bal)
+    assert len(result.root[0].nonce_changes) == 2
+    assert (
+        result.root[0].nonce_changes[0].block_access_index
+        == result.root[0].nonce_changes[1].block_access_index
+    )
+
+
+def test_duplicate_nonce_change_missing_index_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the block_access_index is absent."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_nonce_change(ALICE, 99)(sample_bal)
+
+
+def test_duplicate_balance_change(sample_bal: BlockAccessList) -> None:
+    """Duplicate a balance change by block_access_index."""
+    result = duplicate_balance_change(ALICE, 1)(sample_bal)
+    assert len(result.root[0].balance_changes) == 2
+
+
+def test_duplicate_balance_change_missing_index_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the block_access_index is absent."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_balance_change(ALICE, 99)(sample_bal)
+
+
+def test_duplicate_storage_slot(sample_bal: BlockAccessList) -> None:
+    """Duplicate a storage slot entry."""
+    result = duplicate_storage_slot(CONTRACT, 1)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert len(contract.storage_changes) == 2
+    assert contract.storage_changes[0].slot == contract.storage_changes[1].slot
+
+
+def test_duplicate_storage_slot_missing_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the slot is absent."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_storage_slot(CONTRACT, 99)(sample_bal)
+
+
+def test_duplicate_storage_read(sample_bal: BlockAccessList) -> None:
+    """Duplicate a storage read entry."""
+    result = duplicate_storage_read(CONTRACT, 2)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert len(contract.storage_reads) == 3
+    assert contract.storage_reads[0] == contract.storage_reads[1] == 2
+
+
+def test_duplicate_storage_read_missing_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the slot is absent from storage_reads."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_storage_read(CONTRACT, 99)(sample_bal)
+
+
+def test_duplicate_slot_change(sample_bal: BlockAccessList) -> None:
+    """Duplicate a slot change within a storage slot."""
+    result = duplicate_slot_change(CONTRACT, 1, 1)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert len(contract.storage_changes[0].slot_changes) == 2
+    assert (
+        contract.storage_changes[0].slot_changes[0].block_access_index
+        == contract.storage_changes[0].slot_changes[1].block_access_index
+    )
+
+
+def test_duplicate_slot_change_missing_index_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the block_access_index is absent within the slot."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_slot_change(CONTRACT, 1, 99)(sample_bal)
+
+
+def test_duplicate_slot_change_missing_slot_raises(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Raise when the parent slot is absent."""
+    with pytest.raises(ValueError, match="not found"):
+        duplicate_slot_change(CONTRACT, 99, 1)(sample_bal)
+
+
+def test_insert_storage_read(sample_bal: BlockAccessList) -> None:
+    """Insert a storage read at the correct sorted position."""
+    result = insert_storage_read(CONTRACT, 3)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert len(contract.storage_reads) == 3
+    assert list(contract.storage_reads) == [2, 3, 5]
+
+
+def test_insert_storage_read_at_beginning(
+    sample_bal: BlockAccessList,
+) -> None:
+    """Insert before all existing reads."""
+    result = insert_storage_read(CONTRACT, 1)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert list(contract.storage_reads) == [1, 2, 5]
+
+
+def test_insert_storage_read_at_end(sample_bal: BlockAccessList) -> None:
+    """Insert after all existing reads."""
+    result = insert_storage_read(CONTRACT, 10)(sample_bal)
+    contract = [a for a in result.root if a.address == CONTRACT][0]
+    assert list(contract.storage_reads) == [2, 5, 10]
+
+
+def test_insert_storage_read_missing_address_raises() -> None:
+    """Raise when the address is absent."""
+    bal = BlockAccessList([BalAccountChange(address=ALICE, nonce_changes=[])])
+    with pytest.raises(ValueError, match="not found"):
+        insert_storage_read(CONTRACT, 1)(bal)

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
@@ -30,6 +30,12 @@ from execution_testing.test_types.block_access_list.modifiers import (
     append_change,
     append_storage,
     duplicate_account,
+    duplicate_balance_change,
+    duplicate_nonce_change,
+    duplicate_slot_change,
+    duplicate_storage_read,
+    duplicate_storage_slot,
+    insert_storage_read,
     modify_balance,
     modify_nonce,
     modify_storage,
@@ -833,6 +839,106 @@ def test_bal_invalid_extraneous_entries(
                         charlie=charlie,
                     )
                 ),
+            )
+        ],
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+@pytest.mark.exception_test
+@pytest.mark.parametrize(
+    "modifier",
+    [
+        pytest.param(
+            lambda alice, **_: duplicate_nonce_change(alice, 1),
+            id="duplicate_nonce_change",
+        ),
+        pytest.param(
+            lambda oracle, **_: duplicate_balance_change(oracle, 1),
+            id="duplicate_balance_change",
+        ),
+        pytest.param(
+            lambda oracle, **_: duplicate_storage_slot(oracle, 1),
+            id="duplicate_storage_slot",
+        ),
+        pytest.param(
+            lambda oracle, **_: duplicate_storage_read(oracle, 2),
+            id="duplicate_storage_read",
+        ),
+        pytest.param(
+            lambda oracle, **_: duplicate_slot_change(oracle, 1, 1),
+            id="duplicate_slot_change",
+        ),
+        pytest.param(
+            lambda oracle, **_: insert_storage_read(oracle, 1),
+            id="storage_key_in_both_changes_and_reads",
+        ),
+    ],
+)
+def test_bal_invalid_duplicate_entries(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    modifier: Callable,
+) -> None:
+    """
+    Test that clients reject blocks where BAL contains duplicate entries.
+
+    Verify the EIP-7928 uniqueness constraints: each block_access_index
+    must appear at most once per change list, each storage key at most
+    once in storage_changes and storage_reads, and no key in both.
+    """
+    alice = pre.fund_eoa()
+    oracle = pre.deploy_contract(
+        code=Op.SSTORE(1, 0x42) + Op.SLOAD(2),
+        storage={2: 0x84},
+    )
+
+    tx = Transaction(
+        sender=alice,
+        to=oracle,
+        value=100,
+        gas_limit=1_000_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        post=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                exception=BlockException.INCORRECT_BLOCK_FORMAT,
+                expected_block_access_list=BlockAccessListExpectation(
+                    account_expectations={
+                        alice: BalAccountExpectation(
+                            nonce_changes=[
+                                BalNonceChange(
+                                    block_access_index=1,
+                                    post_nonce=1,
+                                ),
+                            ],
+                        ),
+                        oracle: BalAccountExpectation(
+                            balance_changes=[
+                                BalBalanceChange(
+                                    block_access_index=1,
+                                    post_balance=100,
+                                ),
+                            ],
+                            storage_changes=[
+                                BalStorageSlot(
+                                    slot=1,
+                                    slot_changes=[
+                                        BalStorageChange(
+                                            block_access_index=1,
+                                            post_value=0x42,
+                                        ),
+                                    ],
+                                ),
+                            ],
+                            storage_reads=[2],
+                        ),
+                    }
+                ).modify(modifier(alice=alice, oracle=oracle)),
             )
         ],
     )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_invalid.py
@@ -21,9 +21,11 @@ from execution_testing import (
     BlockAccessListExpectation,
     BlockchainTestFiller,
     BlockException,
+    Initcode,
     Op,
     Storage,
     Transaction,
+    compute_create_address,
 )
 from execution_testing.test_types.block_access_list.modifiers import (
     append_account,
@@ -31,6 +33,7 @@ from execution_testing.test_types.block_access_list.modifiers import (
     append_storage,
     duplicate_account,
     duplicate_balance_change,
+    duplicate_code_change,
     duplicate_nonce_change,
     duplicate_slot_change,
     duplicate_storage_read,
@@ -858,6 +861,10 @@ def test_bal_invalid_extraneous_entries(
             id="duplicate_balance_change",
         ),
         pytest.param(
+            lambda created, **_: duplicate_code_change(created, 1),
+            id="duplicate_code_change",
+        ),
+        pytest.param(
             lambda oracle, **_: duplicate_storage_slot(oracle, 1),
             id="duplicate_storage_slot",
         ),
@@ -883,21 +890,32 @@ def test_bal_invalid_duplicate_entries(
     """
     Test that clients reject blocks where BAL contains duplicate entries.
 
+    Oracle writes storage, reads storage, and CREATEs a small contract.
     Verify the EIP-7928 uniqueness constraints: each block_access_index
-    must appear at most once per change list, each storage key at most
-    once in storage_changes and storage_reads, and no key in both.
+    must appear at most once per change list (nonce, balance, code,
+    slot), each storage key at most once in storage_changes and
+    storage_reads, and no key in both.
     """
     alice = pre.fund_eoa()
+    deploy_code = b"\x13\x37"
+    initcode = Initcode(deploy_code=deploy_code)
+    initcode_word = int.from_bytes(bytes(initcode).ljust(32, b"\x00"), "big")
     oracle = pre.deploy_contract(
-        code=Op.SSTORE(1, 0x42) + Op.SLOAD(2),
+        code=(
+            Op.SSTORE(1, 0x42)
+            + Op.SLOAD(2)
+            + Op.MSTORE(0, initcode_word)
+            + Op.CREATE(0, 0, len(initcode))
+        ),
         storage={2: 0x84},
     )
+    created = compute_create_address(address=oracle, nonce=1)
 
     tx = Transaction(
         sender=alice,
         to=oracle,
         value=100,
-        gas_limit=1_000_000,
+        gas_limit=2_000_000,
     )
 
     blockchain_test(
@@ -906,7 +924,7 @@ def test_bal_invalid_duplicate_entries(
         blocks=[
             Block(
                 txs=[tx],
-                exception=BlockException.INCORRECT_BLOCK_FORMAT,
+                exception=BlockException.INVALID_BLOCK_ACCESS_LIST,
                 expected_block_access_list=BlockAccessListExpectation(
                     account_expectations={
                         alice: BalAccountExpectation(
@@ -937,8 +955,22 @@ def test_bal_invalid_duplicate_entries(
                             ],
                             storage_reads=[2],
                         ),
+                        created: BalAccountExpectation(
+                            code_changes=[
+                                BalCodeChange(
+                                    block_access_index=1,
+                                    new_code=deploy_code,
+                                ),
+                            ],
+                        ),
                     }
-                ).modify(modifier(alice=alice, oracle=oracle)),
+                ).modify(
+                    modifier(
+                        alice=alice,
+                        oracle=oracle,
+                        created=created,
+                    )
+                ),
             )
         ],
     )


### PR DESCRIPTION
## 🗒️ Description

- Add invalid tests related to updates to EIP-7928 [here](https://github.com/ethereum/EIPs/pull/11338/changes) and conversation that lead to these changes in Eth R&D Discord [here](https://discord.com/channels/595666850260713488/1364000387195076608/1474242975109484672) (cc: @bhartnett)
    - Duplicate balance change
    - Duplicate nonce change
    - Duplicate code change
    - Duplicate storage change for a particular slot (just the change is duplicated)
    - Duplicate storage change _and_ slot (both slot and change are duplicated)
    - Duplicate storage read
    - Storage slot from storage change is also present in storage reads
- Add unit tests for BAL modifiers
- Update claude test-writing skill for better DevEx:
  - When writing new tests and invoking this skill, ask user if they want to `fill` tests to verify they can fill
  - Instruct the agent to review the generated JSON structure to ensure that this matches expectations for the new tests.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://a-z-animals.com/media/2022/10/iStock-1332372317-1024x614.jpg)
