### PR TITLE
chore(specs): Track account and storage reads automatically for BALs

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -71,7 +71,6 @@ from .state_tracker import (
     incorporate_tx_into_block,
     increment_nonce,
     set_account_balance,
-    track_address,
 )
 from .transactions import (
     AccessListTransaction,
@@ -916,8 +915,6 @@ def process_transaction(
     )
     tx_state = TransactionState(parent=block_env.state)
 
-    track_address(tx_state, block_env.coinbase)
-
     trie_set(
         block_output.transactions_trie,
         rlp.encode(index),
@@ -950,7 +947,6 @@ def process_transaction(
     gas = tx.gas - intrinsic_gas
 
     increment_nonce(tx_state, sender)
-    track_address(tx_state, sender)
 
     sender_balance_after_gas_fee = (
         Uint(sender_account.balance) - effective_gas_fee - blob_gas_fee
@@ -1080,7 +1076,6 @@ def process_withdrawals(
             rlp.encode(wd),
         )
 
-        track_address(wd_state, wd.address)
         current_balance = get_account(wd_state, wd.address).balance
         new_balance = current_balance + wd.amount * GWEI_TO_WEI
         set_account_balance(wd_state, wd.address, new_balance)

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -611,6 +611,54 @@ def make_receipt(
     return encode_receipt(tx, receipt)
 
 
+def process_checked_system_transaction(
+    block_env: vm.BlockEnvironment,
+    target_address: Address,
+    data: Bytes,
+) -> MessageCallOutput:
+    """
+    Process a system transaction and raise an error if the contract does not
+    contain code or if the transaction fails.
+
+    Parameters
+    ----------
+    block_env :
+        The block scoped environment.
+    target_address :
+        Address of the contract to call.
+    data :
+        Data to pass to the contract.
+
+    Returns
+    -------
+    system_tx_output : `MessageCallOutput`
+        Output of processing the system transaction.
+
+    """
+    pre_state_account = block_env.state.pre_state.get_account_optional(
+        target_address
+    )
+    if pre_state_account is None or len(pre_state_account.code) == 0:
+        raise InvalidBlock(
+            f"System contract address {target_address.hex()} does not "
+            "contain code"
+        )
+
+    system_tx_output = process_unchecked_system_transaction(
+        block_env,
+        target_address,
+        data,
+    )
+
+    if system_tx_output.error:
+        raise InvalidBlock(
+            f"System contract ({target_address.hex()}) call failed: "
+            f"{system_tx_output.error}"
+        )
+
+    return system_tx_output
+
+
 def process_unchecked_system_transaction(
     block_env: vm.BlockEnvironment,
     target_address: Address,
@@ -677,54 +725,6 @@ def process_unchecked_system_transaction(
     incorporate_tx_into_block(
         system_tx_state, block_env.block_access_list_builder
     )
-
-    return system_tx_output
-
-
-def process_checked_system_transaction(
-    block_env: vm.BlockEnvironment,
-    target_address: Address,
-    data: Bytes,
-) -> MessageCallOutput:
-    """
-    Process a system transaction and raise an error if the contract does not
-    contain code or if the transaction fails.
-
-    Parameters
-    ----------
-    block_env :
-        The block scoped environment.
-    target_address :
-        Address of the contract to call.
-    data :
-        Data to pass to the contract.
-
-    Returns
-    -------
-    system_tx_output : `MessageCallOutput`
-        Output of processing the system transaction.
-
-    """
-    pre_state_account = block_env.state.pre_state.get_account_optional(
-        target_address
-    )
-    if pre_state_account is None or len(pre_state_account.code) == 0:
-        raise InvalidBlock(
-            f"System contract address {target_address.hex()} does not "
-            "contain code"
-        )
-
-    system_tx_output = process_unchecked_system_transaction(
-        block_env,
-        target_address,
-        data,
-    )
-
-    if system_tx_output.error:
-        raise InvalidBlock(
-            f"System contract ({target_address.hex()}) call failed: "
-            f"{system_tx_output.error}"
-        )
 
     return system_tx_output
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -614,11 +614,10 @@ def make_receipt(
 def process_system_transaction(
     block_env: vm.BlockEnvironment,
     target_address: Address,
-    system_contract_code: Bytes,
     data: Bytes,
 ) -> MessageCallOutput:
     """
-    Process a system transaction with the given code.
+    Process a system transaction.
 
     Prefer calling `process_checked_system_transaction` or
     `process_unchecked_system_transaction` depending on whether missing code or
@@ -630,8 +629,6 @@ def process_system_transaction(
         The block scoped environment.
     target_address :
         Address of the contract to call.
-    system_contract_code :
-        Code of the contract to call.
     data :
         Data to pass to the contract.
 
@@ -642,6 +639,7 @@ def process_system_transaction(
 
     """
     system_tx_state = TransactionState(parent=block_env.state)
+    system_contract_code = get_account(system_tx_state, target_address).code
 
     tx_env = vm.TransactionEnvironment(
         origin=SYSTEM_ADDRESS,
@@ -710,10 +708,10 @@ def process_checked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_tx_state = TransactionState(parent=block_env.state)
-    system_contract_code = get_account(system_tx_state, target_address).code
-
-    if len(system_contract_code) == 0:
+    pre_state_account = block_env.state.pre_state.get_account_optional(
+        target_address
+    )
+    if pre_state_account is None or len(pre_state_account.code) == 0:
         raise InvalidBlock(
             f"System contract address {target_address.hex()} does not "
             "contain code"
@@ -722,7 +720,6 @@ def process_checked_system_transaction(
     system_tx_output = process_system_transaction(
         block_env,
         target_address,
-        system_contract_code,
         data,
     )
 
@@ -759,12 +756,9 @@ def process_unchecked_system_transaction(
         Output of processing the system transaction.
 
     """
-    system_tx_state = TransactionState(parent=block_env.state)
-    system_contract_code = get_account(system_tx_state, target_address).code
     return process_system_transaction(
         block_env,
         target_address,
-        system_contract_code,
         data,
     )
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -635,10 +635,18 @@ def process_checked_system_transaction(
         Output of processing the system transaction.
 
     """
-    pre_state_account = block_env.state.pre_state.get_account_optional(
-        target_address
-    )
-    if pre_state_account is None or len(pre_state_account.code) == 0:
+    # Read through BlockState (not pre-state) so that a system contract
+    # deployed by an earlier transaction in the same block is visible.
+    # See EIP-7002 and EIP-7251 for this edge case.
+    #
+    # This read is not recorded in the state tracker.
+    # However, this is fine because `process_unchecked_system_transaction`
+    # does its own get_account on the TransactionState that we do incorporate
+    # into BlockState.
+    untracked_state = TransactionState(parent=block_env.state)
+    system_contract_code = get_account(untracked_state, target_address).code
+
+    if len(system_contract_code) == 0:
         raise InvalidBlock(
             f"System contract address {target_address.hex()} does not "
             "contain code"

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -611,17 +611,14 @@ def make_receipt(
     return encode_receipt(tx, receipt)
 
 
-def process_system_transaction(
+def process_unchecked_system_transaction(
     block_env: vm.BlockEnvironment,
     target_address: Address,
     data: Bytes,
 ) -> MessageCallOutput:
     """
-    Process a system transaction.
-
-    Prefer calling `process_checked_system_transaction` or
-    `process_unchecked_system_transaction` depending on whether missing code or
-    an execution error should cause the block to be rejected.
+    Process a system transaction without checking if the contract contains
+    code or if the transaction fails.
 
     Parameters
     ----------
@@ -717,7 +714,7 @@ def process_checked_system_transaction(
             "contain code"
         )
 
-    system_tx_output = process_system_transaction(
+    system_tx_output = process_unchecked_system_transaction(
         block_env,
         target_address,
         data,
@@ -730,37 +727,6 @@ def process_checked_system_transaction(
         )
 
     return system_tx_output
-
-
-def process_unchecked_system_transaction(
-    block_env: vm.BlockEnvironment,
-    target_address: Address,
-    data: Bytes,
-) -> MessageCallOutput:
-    """
-    Process a system transaction without checking if the contract contains code
-    or if the transaction fails.
-
-    Parameters
-    ----------
-    block_env :
-        The block scoped environment.
-    target_address :
-        Address of the contract to call.
-    data :
-        Data to pass to the contract.
-
-    Returns
-    -------
-    system_tx_output : `MessageCallOutput`
-        Output of processing the system transaction.
-
-    """
-    return process_system_transaction(
-        block_env,
-        target_address,
-        data,
-    )
 
 
 def apply_body(

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -100,6 +100,7 @@ def get_account_optional(
         Account at address.
 
     """
+    tx_state.account_reads.add(address)
     if address in tx_state.account_writes:
         return tx_state.account_writes[address]
     if address in tx_state.parent.account_writes:
@@ -157,6 +158,7 @@ def get_storage(
         Value at the key.
 
     """
+    tx_state.storage_reads.add((address, key))
     if address in tx_state.storage_writes:
         if key in tx_state.storage_writes[address]:
             return tx_state.storage_writes[address][key]
@@ -721,40 +723,3 @@ def extract_block_diffs(
 
     """
     return block_state.account_writes, block_state.storage_writes
-
-
-# -- BAL Tracking -----------------------------------------------------------
-
-
-def track_address(tx_state: TransactionState, address: Address) -> None:
-    """
-    Record that an address was accessed.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        The address that was accessed.
-
-    """
-    tx_state.account_reads.add(address)
-
-
-def track_storage_read(
-    tx_state: TransactionState, address: Address, key: Bytes32
-) -> None:
-    """
-    Record a storage read operation.
-
-    Parameters
-    ----------
-    tx_state :
-        The transaction state.
-    address :
-        The address whose storage was read.
-    key :
-        The storage key that was read.
-
-    """
-    tx_state.storage_reads.add((address, key))

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -18,7 +18,6 @@ from ..state_tracker import (
     get_account,
     increment_nonce,
     set_code,
-    track_address,
 )
 from ..utils.hexadecimal import hex_to_address
 from ..vm.gas import GAS_COLD_ACCOUNT_ACCESS, GAS_WARM_ACCESS
@@ -142,7 +141,6 @@ def calculate_delegation_cost(
     tx_state = evm.message.tx_env.state
 
     code = get_account(tx_state, address).code
-    track_address(tx_state, address)
 
     if not is_valid_delegation(code):
         return False, address, Uint(0)
@@ -190,7 +188,6 @@ def set_delegation(message: Message) -> U256:
 
         authority_account = get_account(tx_state, authority)
         authority_code = authority_account.code
-        track_address(tx_state, authority)
 
         if authority_code and not is_valid_delegation(authority_code):
             continue

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -18,7 +18,7 @@ from ethereum.crypto.hash import keccak256
 from ethereum.state import EMPTY_ACCOUNT
 from ethereum.utils.numeric import ceil32
 
-from ...state_tracker import get_account, track_address
+from ...state_tracker import get_account
 from ...utils.address import to_address_masked
 from ...vm.memory import buffer_read, memory_write
 from .. import Evm
@@ -87,7 +87,6 @@ def balance(evm: Evm) -> None:
     # Non-existent accounts default to EMPTY_ACCOUNT, which has balance 0.
     tx_state = evm.message.tx_env.state
     balance = get_account(tx_state, address).balance
-    track_address(tx_state, address)
 
     push(evm.stack, balance)
 
@@ -356,7 +355,6 @@ def extcodesize(evm: Evm) -> None:
     # OPERATION
     tx_state = evm.message.tx_env.state
     code = get_account(tx_state, address).code
-    track_address(tx_state, address)
 
     codesize = U256(len(code))
     push(evm.stack, codesize)
@@ -403,7 +401,6 @@ def extcodecopy(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     tx_state = evm.message.tx_env.state
     code = get_account(tx_state, address).code
-    track_address(tx_state, address)
 
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)
@@ -496,7 +493,6 @@ def extcodehash(evm: Evm) -> None:
     # OPERATION
     tx_state = evm.message.tx_env.state
     account = get_account(tx_state, address)
-    track_address(tx_state, address)
 
     if account == EMPTY_ACCOUNT:
         codehash = U256(0)

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -19,7 +19,6 @@ from ...state_tracker import (
     get_transient_storage,
     set_storage,
     set_transient_storage,
-    track_storage_read,
 )
 from .. import Evm
 from ..exceptions import WriteInStaticContext
@@ -60,7 +59,6 @@ def sload(evm: Evm) -> None:
     # OPERATION
     tx_state = evm.message.tx_env.state
     value = get_storage(tx_state, evm.message.current_target, key)
-    track_storage_read(tx_state, evm.message.current_target, key)
 
     push(evm.stack, value)
 
@@ -99,8 +97,6 @@ def sstore(evm: Evm) -> None:
     if (evm.message.current_target, key) not in evm.accessed_storage_keys:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GAS_COLD_SLOAD
-
-    track_storage_read(tx_state, evm.message.current_target, key)
 
     if original_value == current_value and current_value != new_value:
         if original_value == 0:

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -25,7 +25,6 @@ from ...state_tracker import (
     is_account_alive,
     move_ether,
     set_account_balance,
-    track_address,
 )
 from ...utils.address import (
     compute_contract_address,
@@ -113,7 +112,6 @@ def generic_create(
 
     evm.accessed_addresses.add(contract_address)
 
-    track_address(tx_state, contract_address)
     if account_has_code_or_nonce(
         tx_state, contract_address
     ) or account_has_storage(tx_state, contract_address):
@@ -422,7 +420,6 @@ def call(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
@@ -525,7 +522,6 @@ def callcode(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
@@ -601,8 +597,6 @@ def selfdestruct(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
-    track_address(tx_state, beneficiary)
-
     if (
         not is_account_alive(tx_state, beneficiary)
         and get_account(tx_state, evm.message.current_target).balance != 0
@@ -613,8 +607,6 @@ def selfdestruct(evm: Evm) -> None:
 
     originator = evm.message.current_target
     originator_balance = get_account(tx_state, originator).balance
-
-    track_address(tx_state, originator)
 
     # Transfer balance
     move_ether(tx_state, originator, beneficiary, originator_balance)
@@ -686,7 +678,6 @@ def delegatecall(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 
@@ -776,7 +767,6 @@ def staticcall(evm: Evm) -> None:
         # check enough gas for delegation access
         extra_gas += delegation_access_cost
         check_gas(evm, extra_gas + extend_memory.cost)
-        track_address(tx_state, code_address)
         if code_address not in evm.accessed_addresses:
             evm.accessed_addresses.add(code_address)
 

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -42,7 +42,6 @@ from ..state_tracker import (
     move_ether,
     restore_tx_state,
     set_code,
-    track_address,
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
@@ -111,7 +110,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
         is_collision = account_has_code_or_nonce(
             tx_state, message.current_target
         ) or account_has_storage(tx_state, message.current_target)
-        track_address(tx_state, message.current_target)
         if is_collision:
             return MessageCallOutput(
                 Uint(0),
@@ -133,7 +131,6 @@ def process_message_call(message: Message) -> MessageCallOutput:
             message.accessed_addresses.add(delegated_address)
             message.code = get_account(tx_state, delegated_address).code
             message.code_address = delegated_address
-            track_address(tx_state, delegated_address)
 
         evm = process_message(message)
 
@@ -262,11 +259,7 @@ def process_message(message: Message) -> Evm:
     # take snapshot of state before processing the message
     snapshot = copy_tx_state(tx_state)
 
-    track_address(tx_state, message.current_target)
-
     if message.should_transfer_value and message.value != 0:
-        track_address(tx_state, message.caller)
-
         move_ether(
             tx_state,
             message.caller,

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -37,7 +37,6 @@ from ..state_tracker import (
     copy_tx_state,
     destroy_storage,
     get_account,
-    get_account_optional,
     increment_nonce,
     mark_account_created,
     move_ether,
@@ -259,9 +258,6 @@ def process_message(message: Message) -> Evm:
 
     # take snapshot of state before processing the message
     snapshot = copy_tx_state(tx_state)
-
-    # Entering an account is a state access for BAL tracking.
-    get_account_optional(tx_state, message.current_target)
 
     if message.should_transfer_value and message.value != 0:
         move_ether(

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -37,6 +37,7 @@ from ..state_tracker import (
     copy_tx_state,
     destroy_storage,
     get_account,
+    get_account_optional,
     increment_nonce,
     mark_account_created,
     move_ether,
@@ -258,6 +259,9 @@ def process_message(message: Message) -> Evm:
 
     # take snapshot of state before processing the message
     snapshot = copy_tx_state(tx_state)
+
+    # Entering an account is a state access for BAL tracking.
+    get_account_optional(tx_state, message.current_target)
 
     if message.should_transfer_value and message.value != 0:
         move_ether(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Taken from bulletpoint 2 in https://github.com/ethereum/execution-specs/pull/2207

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
