### PR TITLE
feat(zkevm): add ancestor header tracking

### DIFF
--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -106,6 +106,7 @@ def environment_from_parent_header(parent: "FixtureHeader") -> "Environment":
         parent_gas_limit=parent.gas_limit,
         parent_ommers_hash=parent.ommers_hash,
         block_hashes={parent.number: parent.block_hash},
+        block_headers={parent.number: parent.rlp},
     )
 
 
@@ -124,7 +125,10 @@ def apply_new_parent(
     updated["parent_ommers_hash"] = new_parent.ommers_hash
     block_hashes = env.block_hashes.copy()
     block_hashes[new_parent.number] = new_parent.block_hash
+    block_headers = env.block_headers.copy()
+    block_headers[new_parent.number] = new_parent.rlp
     updated["block_hashes"] = block_hashes
+    updated["block_headers"] = block_headers
     return env.copy(**updated)
 
 

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -137,7 +137,9 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     parent_beacon_block_root: Hash | None = Field(None)
 
     block_hashes: Dict[ZeroPaddedHexNumber, Hash] = Field(default_factory=dict)
-    block_headers: Dict[ZeroPaddedHexNumber, Bytes] = Field(default_factory=dict)
+    block_headers: Dict[ZeroPaddedHexNumber, Bytes] = Field(
+        default_factory=dict
+    )
     ommers: List[Hash] = Field(default_factory=list)
     withdrawals: List[Withdrawal] | None = Field(None)
     extra_data: Bytes = Field(Bytes(b"\x00"), exclude=True)

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -137,6 +137,7 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     parent_beacon_block_root: Hash | None = Field(None)
 
     block_hashes: Dict[ZeroPaddedHexNumber, Hash] = Field(default_factory=dict)
+    block_headers: Dict[ZeroPaddedHexNumber, Bytes] = Field(default_factory=dict)
     ommers: List[Hash] = Field(default_factory=list)
     withdrawals: List[Withdrawal] | None = Field(None)
     extra_data: Bytes = Field(Bytes(b"\x00"), exclude=True)

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -475,6 +475,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                 "currentNumber": "0x01",
                 "currentTimestamp": "0x03e8",
                 "blockHashes": {},
+                "blockHeaders": {},
                 "ommers": [],
                 "parentUncleHash": (
                     "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
@@ -540,6 +541,7 @@ CHECKSUM_ADDRESS = "0x8a0A19589531694250d570040a0c4B74576919B8"
                     "0x01": "0x0000000000000000000000000000000000000000000000000000000000000002",  # noqa: E501
                     "0x03": "0x0000000000000000000000000000000000000000000000000000000000000004",  # noqa: E501
                 },
+                "blockHeaders": {},
                 "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000004",  # noqa: E501
                 "ommers": [],
             },

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -68,7 +68,6 @@ from .state_tracker import (
     destroy_account,
     extract_block_diffs,
     get_account,
-    get_witness_ancestors,
     incorporate_tx_into_block,
     increment_nonce,
     set_account_balance,
@@ -843,15 +842,8 @@ def apply_body(
     )
 
     block_output.execution_witness = build_execution_witness(
-        block_env.execution_witness
-    )
-    # TODO(zkevm): whenever PR #2259 is merged, rebase on
-    # top of it and make the following code add the ancestor
-    # in the block_output.execution_witness
-    ancestor_headers = get_witness_ancestors(  # noqa: F841
-        block_env.block_headers,
-        block_env.state.oldest_ancestor_offset,
-    )
+        block_env.execution_witness, block_env.state, block_env.block_headers
+    ) 
 
     return block_output
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -254,9 +254,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
         execution_witness=ExecutionWitnessBuilder(),
-        block_headers=[
-            rlp.encode(blk.header) for blk in chain.blocks
-        ],
+        block_headers=[rlp.encode(blk.header) for blk in chain.blocks],
     )
 
     block_output = apply_body(

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -68,10 +68,10 @@ from .state_tracker import (
     destroy_account,
     extract_block_diffs,
     get_account,
+    get_witness_ancestors,
     incorporate_tx_into_block,
     increment_nonce,
     set_account_balance,
-    get_witness_ancestors,
     track_address,
     track_ancestor_access,
 )
@@ -847,10 +847,10 @@ def apply_body(
     block_output.execution_witness = build_execution_witness(
         block_env.execution_witness
     )
-    # TODO(zkevm): whenever https://github.com/ethereum/execution-specs/pull/2259 is merged,
-    # rebase on top of it and make the following code add the ancestor in the
-    # block_output.execution_witness
-    ancestor_headers = get_witness_ancestors(
+    # TODO(zkevm): whenever PR #2259 is merged, rebase on
+    # top of it and make the following code add the ancestor
+    # in the block_output.execution_witness
+    ancestor_headers = get_witness_ancestors(  # noqa: F841
         block_env.block_headers,
         block_env.state.oldest_ancestor_offset,
     )

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -252,8 +252,9 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         excess_blob_gas=block.header.excess_blob_gas,
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
-        execution_witness=ExecutionWitnessBuilder(),
-        block_headers=[rlp.encode(blk.header) for blk in chain.blocks],
+        execution_witness=ExecutionWitnessBuilder(
+            blockchain_headers=[rlp.encode(blk.header) for blk in chain.blocks]
+        ),
     )
 
     block_output = apply_body(
@@ -842,7 +843,7 @@ def apply_body(
     )
 
     block_output.execution_witness = build_execution_witness(
-        block_env.execution_witness, block_env.state, block_env.block_headers
+        block_env.execution_witness, block_env.state
     )
 
     return block_output

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -71,7 +71,9 @@ from .state_tracker import (
     incorporate_tx_into_block,
     increment_nonce,
     set_account_balance,
+    get_witness_ancestors,
     track_address,
+    track_ancestor_access,
 )
 from .stateless_types import ExecutionWitnessBuilder, build_execution_witness
 from .transactions import (
@@ -252,6 +254,9 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
         execution_witness=ExecutionWitnessBuilder(),
+        block_headers=[
+            rlp.encode(blk.header) for blk in chain.blocks
+        ],
     )
 
     block_output = apply_body(
@@ -815,6 +820,10 @@ def apply_body(
         target_address=HISTORY_STORAGE_ADDRESS,
         data=block_env.block_hashes[-1],  # The parent hash
     )
+    track_ancestor_access(
+        block_env.state,
+        Uint(1),
+    )
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
         process_transaction(block_env, block_output, tx, Uint(i))
@@ -837,6 +846,13 @@ def apply_body(
 
     block_output.execution_witness = build_execution_witness(
         block_env.execution_witness
+    )
+    # TODO(zkevm): whenever https://github.com/ethereum/execution-specs/pull/2259 is merged,
+    # rebase on top of it and make the following code add the ancestor in the
+    # block_output.execution_witness
+    ancestor_headers = get_witness_ancestors(
+        block_env.block_headers,
+        block_env.state.oldest_ancestor_offset,
     )
 
     return block_output

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -843,7 +843,7 @@ def apply_body(
 
     block_output.execution_witness = build_execution_witness(
         block_env.execution_witness, block_env.state, block_env.block_headers
-    ) 
+    )
 
     return block_output
 

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -19,7 +19,7 @@ within a single transaction and supports copy-on-write rollback.
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
@@ -51,6 +51,7 @@ class BlockState:
     storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
+    oldest_ancestor_offset: Optional[Uint] = None
 
 
 @dataclass
@@ -758,3 +759,51 @@ def track_storage_read(
 
     """
     tx_state.storage_reads.add((address, key))
+
+
+def get_witness_ancestors(
+    block_headers: List[Bytes],
+    oldest_ancestor_offset: Optional[Uint],
+) -> List[Bytes]:
+    """
+    Collect RLP-encoded ancestor headers from ``oldest_ancestor_offset``
+    blocks back onward.
+
+    Parameters
+    ----------
+    block_headers :
+        RLP-encoded headers.
+    oldest_ancestor_offset :
+        Offset from the current block to the oldest ancestor accessed
+        during execution, or ``None`` if no ancestor was accessed.
+
+    """
+    if oldest_ancestor_offset is None:
+        return []
+    return list(block_headers[-int(oldest_ancestor_offset) :])
+
+
+def track_ancestor_access(
+    block_state: BlockState, offset: Uint
+) -> None:
+    """
+    Record that an ancestor block was accessed.
+
+    Update ``oldest_ancestor_offset`` if ``offset`` is further back (larger)
+    than the current value.  Called by the BLOCKHASH opcode (when
+    returning a valid hash) and the EIP-2935 system contract call.
+
+    Parameters
+    ----------
+    block_state :
+        The block state.
+    offset :
+        Offset from the current block to the ancestor that was
+        accessed.
+
+    """
+    if (
+        block_state.oldest_ancestor_offset is None
+        or offset > block_state.oldest_ancestor_offset
+    ):
+        block_state.oldest_ancestor_offset = offset

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -19,7 +19,7 @@ within a single transaction and supports copy-on-write rollback.
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import modify
@@ -759,6 +759,7 @@ def track_storage_read(
 
     """
     tx_state.storage_reads.add((address, key))
+
 
 def track_ancestor_access(block_state: BlockState, offset: Uint) -> None:
     """

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -783,9 +783,7 @@ def get_witness_ancestors(
     return list(block_headers[-int(oldest_ancestor_offset) :])
 
 
-def track_ancestor_access(
-    block_state: BlockState, offset: Uint
-) -> None:
+def track_ancestor_access(block_state: BlockState, offset: Uint) -> None:
     """
     Record that an ancestor block was accessed.
 

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -760,29 +760,6 @@ def track_storage_read(
     """
     tx_state.storage_reads.add((address, key))
 
-
-def get_witness_ancestors(
-    block_headers: List[Bytes],
-    oldest_ancestor_offset: Optional[Uint],
-) -> List[Bytes]:
-    """
-    Collect RLP-encoded ancestor headers from ``oldest_ancestor_offset``
-    blocks back onward.
-
-    Parameters
-    ----------
-    block_headers :
-        RLP-encoded headers.
-    oldest_ancestor_offset :
-        Offset from the current block to the oldest ancestor accessed
-        during execution, or ``None`` if no ancestor was accessed.
-
-    """
-    if oldest_ancestor_offset is None:
-        return []
-    return list(block_headers[-int(oldest_ancestor_offset) :])
-
-
 def track_ancestor_access(block_state: BlockState, offset: Uint) -> None:
     """
     Record that an ancestor block was accessed.

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -9,7 +9,6 @@ from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import Uint
 
-from .blocks import Header
 from .state_tracker import BlockState
 
 
@@ -44,15 +43,14 @@ class ExecutionWitnessBuilder:
     Mutable accumulator for execution witness data during block execution.
     """
 
+    blockchain_headers: List[Bytes] = field(default_factory=list)
     state: List[Bytes] = field(default_factory=list)
     codes: List[Bytes] = field(default_factory=list)
-    headers: List[Header] = field(default_factory=list)
 
 
 def build_execution_witness(
     builder: ExecutionWitnessBuilder,
     block_state: BlockState,
-    block_headers: List[Bytes],
 ) -> ExecutionWitness:
     """
     Build the execution witness from the accumulated builder data.
@@ -61,7 +59,7 @@ def build_execution_witness(
     ascending.
     """
     ancestor_headers = get_witness_ancestors(
-        block_headers,
+        builder.blockchain_headers,
         block_state.oldest_ancestor_offset,
     )
     return ExecutionWitness(

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -5,14 +5,12 @@ Stateless validation types.
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import Uint
 
-from ethereum.forks.amsterdam.state_tracker import BlockState
-
 from .blocks import Header
+from .state_tracker import BlockState
 
 
 @slotted_freezable
@@ -53,7 +51,7 @@ class ExecutionWitnessBuilder:
 
 def build_execution_witness(
     builder: ExecutionWitnessBuilder,
-    block_state : BlockState,
+    block_state: BlockState,
     block_headers: List[Bytes],
 ) -> ExecutionWitness:
     """
@@ -62,15 +60,16 @@ def build_execution_witness(
     Sort state and codes lexicographically, headers by block number
     ascending.
     """
-    ancestor_headers = get_witness_ancestors(  
+    ancestor_headers = get_witness_ancestors(
         block_headers,
         block_state.oldest_ancestor_offset,
     )
     return ExecutionWitness(
         state=tuple(sorted(builder.state)),
         codes=tuple(sorted(builder.codes)),
-        headers=ancestor_headers,
+        headers=tuple(ancestor_headers),
     )
+
 
 def get_witness_ancestors(
     block_headers: List[Bytes],

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -3,11 +3,14 @@ Stateless validation types.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
+from ethereum_types.numeric import Uint
+
+from ethereum.forks.amsterdam.state_tracker import BlockState
 
 from .blocks import Header
 
@@ -50,6 +53,8 @@ class ExecutionWitnessBuilder:
 
 def build_execution_witness(
     builder: ExecutionWitnessBuilder,
+    block_state : BlockState,
+    block_headers: List[Bytes],
 ) -> ExecutionWitness:
     """
     Build the execution witness from the accumulated builder data.
@@ -57,11 +62,33 @@ def build_execution_witness(
     Sort state and codes lexicographically, headers by block number
     ascending.
     """
+    ancestor_headers = get_witness_ancestors(  
+        block_headers,
+        block_state.oldest_ancestor_offset,
+    )
     return ExecutionWitness(
         state=tuple(sorted(builder.state)),
         codes=tuple(sorted(builder.codes)),
-        headers=tuple(
-            rlp.encode(h)
-            for h in sorted(builder.headers, key=lambda h: h.number)
-        ),
+        headers=ancestor_headers,
     )
+
+def get_witness_ancestors(
+    block_headers: List[Bytes],
+    oldest_ancestor_offset: Optional[Uint],
+) -> List[Bytes]:
+    """
+    Collect RLP-encoded ancestor headers from ``oldest_ancestor_offset``
+    blocks back onward.
+
+    Parameters
+    ----------
+    block_headers :
+        RLP-encoded headers.
+    oldest_ancestor_offset :
+        Offset from the current block to the oldest ancestor accessed
+        during execution, or ``None`` if no ancestor was accessed.
+
+    """
+    if oldest_ancestor_offset is None:
+        return []
+    return list(block_headers[-int(oldest_ancestor_offset) :])

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -53,7 +53,6 @@ class BlockEnvironment:
     parent_beacon_block_root: Hash32
     block_access_list_builder: BlockAccessListBuilder
     execution_witness: ExecutionWitnessBuilder
-    block_headers: List[Bytes]
 
 
 @dataclass

--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -53,6 +53,7 @@ class BlockEnvironment:
     parent_beacon_block_root: Hash32
     block_access_list_builder: BlockAccessListBuilder
     execution_witness: ExecutionWitnessBuilder
+    block_headers: List[Bytes]
 
 
 @dataclass

--- a/src/ethereum/forks/amsterdam/vm/instructions/block.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/block.py
@@ -13,6 +13,7 @@ Implementations of the EVM block instructions.
 
 from ethereum_types.numeric import U256, Uint
 
+from ...state_tracker import track_ancestor_access
 from .. import Evm
 from ..gas import GAS_BASE, GAS_BLOCK_HASH, charge_gas
 from ..stack import pop, push
@@ -57,6 +58,10 @@ def block_hash(evm: Evm) -> None:
         current_block_hash = evm.message.block_env.block_hashes[
             -(current_block_number - block_number)
         ]
+        track_ancestor_access(
+            evm.message.block_env.state,
+            current_block_number - block_number,
+        )
 
     push(evm.stack, U256.from_be_bytes(current_block_hash))
 

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -305,6 +305,25 @@ class ForkLoad:
         return hasattr(module, "BlockState")
 
     @property
+    def has_track_ancestor_access(self) -> bool:
+        """Check if the fork has ancestor tracking."""
+        try:
+            module = self._module("state_tracker")
+        except ModuleNotFoundError:
+            return False
+        return hasattr(module, "track_ancestor_access")
+
+    @property
+    def track_ancestor_access(self) -> Any:
+        """track_ancestor_access function of the fork."""
+        return self._module("state_tracker").track_ancestor_access
+
+    @property
+    def get_witness_ancestors(self) -> Any:
+        """get_witness_ancestors function of the fork."""
+        return self._module("state_tracker").get_witness_ancestors
+
+    @property
     def State(self) -> Any:
         """State class of the fork."""
         return self._module("state").State

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -318,7 +318,6 @@ class ForkLoad:
         """track_ancestor_access function of the fork."""
         return self._module("state_tracker").track_ancestor_access
 
-
     @property
     def State(self) -> Any:
         """State class of the fork."""

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -318,10 +318,6 @@ class ForkLoad:
         """track_ancestor_access function of the fork."""
         return self._module("state_tracker").track_ancestor_access
 
-    @property
-    def get_witness_ancestors(self) -> Any:
-        """get_witness_ancestors function of the fork."""
-        return self._module("state_tracker").get_witness_ancestors
 
     @property
     def State(self) -> Any:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -331,9 +331,9 @@ class T8N(Load):
             )
 
         if self.fork.has_execution_witness:
-            kw_arguments["execution_witness"] = ExecutionWitnessBuilder()
-        if self.fork.has_track_ancestor_access:
-            kw_arguments["block_headers"] = self.env.block_headers
+            kw_arguments["execution_witness"] = ExecutionWitnessBuilder(
+                blockchain_headers=self.env.block_headers
+            )
 
         return block_environment(**kw_arguments)
 
@@ -471,7 +471,6 @@ class T8N(Load):
             block_output.execution_witness = self.fork.build_execution_witness(
                 block_env.execution_witness,
                 block_env.state,
-                block_env.block_headers,
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -333,9 +333,7 @@ class T8N(Load):
         if self.fork.has_execution_witness:
             kw_arguments["execution_witness"] = ExecutionWitnessBuilder()
         if self.fork.has_track_ancestor_access:
-            kw_arguments["block_headers"] = (
-                self.env.block_headers
-            )
+            kw_arguments["block_headers"] = self.env.block_headers
 
         return block_environment(**kw_arguments)
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -469,12 +469,9 @@ class T8N(Load):
 
         if self.fork.has_execution_witness:
             block_output.execution_witness = self.fork.build_execution_witness(
-                block_env.execution_witness
-            )
-        if self.fork.has_track_ancestor_access:
-            ancestor_headers = self.fork.get_witness_ancestors(  # noqa: F841
+                block_env.execution_witness,
+                block_env.state,
                 block_env.block_headers,
-                block_env.state.oldest_ancestor_offset,
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -332,6 +332,10 @@ class T8N(Load):
 
         if self.fork.has_execution_witness:
             kw_arguments["execution_witness"] = ExecutionWitnessBuilder()
+        if self.fork.has_track_ancestor_access:
+            kw_arguments["block_headers"] = (
+                self.env.block_headers
+            )
 
         return block_environment(**kw_arguments)
 
@@ -403,6 +407,11 @@ class T8N(Load):
                 target_address=self.fork.HISTORY_STORAGE_ADDRESS,
                 data=block_env.block_hashes[-1],  # The parent hash
             )
+            if self.fork.has_track_ancestor_access:
+                self.fork.track_ancestor_access(
+                    block_env.state,
+                    Uint(1),
+                )
 
         if self.fork.has_beacon_roots_address:
             self.fork.process_unchecked_system_transaction(
@@ -463,6 +472,11 @@ class T8N(Load):
         if self.fork.has_execution_witness:
             block_output.execution_witness = self.fork.build_execution_witness(
                 block_env.execution_witness
+            )
+        if self.fork.has_track_ancestor_access:
+            ancestor_headers = self.fork.get_witness_ancestors(
+                block_env.block_headers,
+                block_env.state.oldest_ancestor_offset,
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -474,7 +474,7 @@ class T8N(Load):
                 block_env.execution_witness
             )
         if self.fork.has_track_ancestor_access:
-            ancestor_headers = self.fork.get_witness_ancestors(
+            ancestor_headers = self.fork.get_witness_ancestors(  # noqa: F841
                 block_env.block_headers,
                 block_env.state.oldest_ancestor_offset,
             )

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -73,7 +73,7 @@ class Env:
         self.read_base_fee_per_gas(data, t8n)
         self.read_randao(data, t8n)
         self.read_block_hashes(data)
-        self.read_block_headers(data)
+        self.read_block_headers(data, t8n)
         self.read_ommers(data, t8n)
         self.read_withdrawals(data, t8n)
 
@@ -303,22 +303,31 @@ class Env:
 
         self.block_hashes = block_hashes
 
-    def read_block_headers(self, data: Any) -> None:
+    def read_block_headers(self, data: Any, t8n: "T8N") -> None:
         """
         Read RLP-encoded block headers as an ordered list without gaps.
         """
-        if "blockHeaders" not in data:
-            self.block_headers = []
+        self.block_headers = []
+
+        if not t8n.fork.has_track_ancestor_access:
             return
 
-        block_headers = [hex_to_bytes(value) for value in data["blockHeaders"]]
+        if not data.get("blockHeaders"):
+            return
 
-        expected_count = min(Uint(256), self.block_number)
-        if len(block_headers) != expected_count:
-            raise ValueError(
-                f"expected {expected_count} block headers,"
-                f" got {len(block_headers)}"
-            )
+        raw = data["blockHeaders"]
+
+        # blockHeaders is a dict mapping hex block number to hex RLP.
+        clean: Dict[int, bytes] = {}
+        for key, value in raw.items():
+            clean[int(key, 16)] = hex_to_bytes(value)
+
+        max_count = min(Uint(256), self.block_number)
+        block_headers: List[Any] = []
+        for number in range(self.block_number - max_count, self.block_number):
+            if number not in clean:
+                raise ValueError(f"missing block header for block {number}")
+            block_headers.append(clean[number])
 
         self.block_headers = block_headers
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -312,9 +312,8 @@ class Env:
         if not t8n.fork.has_track_ancestor_access:
             return
 
-        assert data.get("blockHeaders"), (
-            "blockHeaders is required for track ancestor access"
-        )
+        if not data.get("blockHeaders"):
+            return
         # blockHeaders is a dict mapping hex block number to hex RLP.
         dic_block_headers = data["blockHeaders"]
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -312,22 +312,22 @@ class Env:
         if not t8n.fork.has_track_ancestor_access:
             return
 
-        if not data.get("blockHeaders"):
-            return
-
-        raw = data["blockHeaders"]
-
+        assert data.get("blockHeaders"), (
+            "blockHeaders is required for track ancestor access"
+        )
         # blockHeaders is a dict mapping hex block number to hex RLP.
-        clean: Dict[int, bytes] = {}
-        for key, value in raw.items():
-            clean[int(key, 16)] = hex_to_bytes(value)
+        dic_block_headers = data["blockHeaders"]
+
+        headers_by_number: Dict[int, bytes] = {}
+        for key, value in dic_block_headers.items():
+            headers_by_number[int(key, 16)] = hex_to_bytes(value)
 
         max_count = min(Uint(256), self.block_number)
         block_headers: List[Any] = []
         for number in range(self.block_number - max_count, self.block_number):
-            if number not in clean:
+            if number not in headers_by_number:
                 raise ValueError(f"missing block header for block {number}")
-            block_headers.append(clean[number])
+            block_headers.append(headers_by_number[number])
 
         self.block_headers = block_headers
 

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -47,6 +47,7 @@ class Env:
     parent_gas_limit: Optional[Uint]
     parent_base_fee_per_gas: Optional[Uint]
     block_hashes: Optional[List[Any]]
+    block_headers: List[Any]
     parent_ommers_hash: Optional[Hash32]
     ommers: Any
     parent_beacon_block_root: Optional[Hash32]
@@ -72,6 +73,7 @@ class Env:
         self.read_base_fee_per_gas(data, t8n)
         self.read_randao(data, t8n)
         self.read_block_hashes(data)
+        self.read_block_headers(data)
         self.read_ommers(data, t8n)
         self.read_withdrawals(data, t8n)
 
@@ -300,6 +302,28 @@ class Env:
                 block_hashes.append(None)
 
         self.block_hashes = block_hashes
+
+    def read_block_headers(self, data: Any) -> None:
+        """
+        Read RLP-encoded block headers as an ordered list without gaps.
+        """
+        if "blockHeaders" not in data:
+            self.block_headers = []
+            return
+
+        block_headers = [
+            hex_to_bytes(value)
+            for value in data["blockHeaders"]
+        ]
+
+        expected_count = min(Uint(256), self.block_number)
+        if len(block_headers) != expected_count:
+            raise ValueError(
+                f"expected {expected_count} block headers,"
+                f" got {len(block_headers)}"
+            )
+
+        self.block_headers = block_headers
 
     def read_ommers(self, data: Any, t8n: "T8N") -> None:
         """

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -311,10 +311,7 @@ class Env:
             self.block_headers = []
             return
 
-        block_headers = [
-            hex_to_bytes(value)
-            for value in data["blockHeaders"]
-        ]
+        block_headers = [hex_to_bytes(value) for value in data["blockHeaders"]]
 
         expected_count = min(Uint(256), self.block_number)
         if len(block_headers) != expected_count:


### PR DESCRIPTION
## 🗒️ Description
This PR adds support for tracking ancestor headers in the `ExecutionWitness`.

The tracking is done mostly as one would expect -- the only quirk is that t8n should now also receive the block headers, not just the hashes. This is added as a new field in the input for all forks, but only Amsterdam uses it.

The block hashes input is still kept, since even if we could derive it from block headers, that would mean changing all forks' behaviour in their BLOCKHASH.

You can test this is working by running this example test that uses `BLOCKHASH`:
```
$ uv run fill --clean -m "blockchain_test" --fork Amsterdam ./tests/frontier/opcodes/test_blockhash.py -k "one_block_with_tx"
```

And if you see the output of the fixture:
```
...
                "receipts": [...],
                "executionWitness": {
                    "state": [],
                    "codes": [],
                    "headers": [
                        "0xf90278a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a014413270cd1509c3bc3194d1854cac72e031717b13f91dc9f14881fe2912e0efa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808407270e00808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                        "0xf90278a0c0a29049136e8c01b1cc7869f95905bef6959430e8dbfb2052420b053c27f6aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0c37001fcb398e2b2c23fc42c2c662854405c77054faa96dbaff7984a90cfab93a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018407270e00800c80a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a0d19579646c765c8bd8958feabd54974d67214facc5b58ef1410a4b7fd50d1b5b"
                    ]
                },
                "blockAccessList": [...],
...
```