### PR TITLE
fix(zkevm): Fix linting errors

### DIFF
--- a/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/new_payload.py
@@ -8,9 +8,10 @@ from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 
 from ethereum.crypto.hash import keccak256
+from ethereum.state import Root
 
 from ..fork import state_transition
-from ..fork_types import Root, VersionedHash
+from ..fork_types import VersionedHash
 from ..transactions import BlobTransaction, decode_transaction
 from ..trie import copy_trie
 from .types import ExecutionEngine, ExecutionPayload, NewPayloadRequest
@@ -86,7 +87,6 @@ def notify_new_payload(
         address: copy_trie(storage_trie)
         for address, storage_trie in chain.state._storage_tries.items()
     }
-    created_accounts_snapshot = chain.state.created_accounts.copy()
     blocks_snapshot = list(chain.blocks)
 
     try:
@@ -108,7 +108,6 @@ def notify_new_payload(
         # payload; restore pre-execution snapshots.
         chain.state._main_trie = state_main_trie_snapshot
         chain.state._storage_tries = state_storage_tries_snapshot
-        chain.state.created_accounts = created_accounts_snapshot
         chain.blocks = blocks_snapshot
         return False
 

--- a/src/ethereum/forks/amsterdam/execution_engine/types.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/types.py
@@ -10,11 +10,11 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
-from ethereum.state import Root
+from ethereum.state import Address, Root
 
 from ..blocks import Withdrawal
 from ..fork import BlockChain
-from ..fork_types import Address, Bloom, VersionedHash
+from ..fork_types import Bloom, VersionedHash
 from ..transactions import LegacyTransaction
 
 # In this module, the execution engine is the chain/state container used by

--- a/src/ethereum/forks/amsterdam/execution_engine/types.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/types.py
@@ -10,10 +10,11 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32
+from ethereum.state import Root
 
 from ..blocks import Withdrawal
 from ..fork import BlockChain
-from ..fork_types import Address, Bloom, Root, VersionedHash
+from ..fork_types import Address, Bloom, VersionedHash
 from ..transactions import LegacyTransaction
 
 # In this module, the execution engine is the chain/state container used by

--- a/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py
+++ b/src/ethereum/forks/amsterdam/execution_engine/validation_helpers.py
@@ -9,10 +9,10 @@ from ethereum_types.bytes import Bytes, Bytes8
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.state import Root
 
 from ..blocks import Block, Header
 from ..fork import EMPTY_OMMER_HASH
-from ..fork_types import Root
 from ..requests import compute_requests_hash
 from ..transactions import LegacyTransaction
 from ..trie import Trie, root, trie_set

--- a/src/ethereum/forks/amsterdam/stateless.py
+++ b/src/ethereum/forks/amsterdam/stateless.py
@@ -10,10 +10,11 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64
 
 from ethereum.crypto.hash import Hash32
+from ethereum.state import Root
 
 from .blocks import Block
 from .execution_engine.types import NewPayloadRequest
-from .fork_types import Root, VersionedHash
+from .fork_types import VersionedHash
 
 # Amsterdam currently carries execution requests as raw bytes in order.
 ExecutionRequests = Tuple[Bytes, ...]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Fixes current linting error in #2268

`created_accounts` was moved into the state tracker. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
