### PR TITLE
chore(do not merge): Experiment with caching for "Build Doc" Job

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -39,6 +39,23 @@ jobs:
           version: ${{ vars.UV_VERSION }}
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
+      - uses: ./.github/actions/get-changed-files
+        if: github.event_name == 'pull_request'
+        id: get-changed-files
+
+      - name: Detect changed forks
+        if: github.event_name == 'pull_request'
+        run: |
+          FILE_LIST="${{ steps.get-changed-files.outputs.file_list }}"
+          FORKS=$(grep '^src/ethereum/forks/' "$FILE_LIST" | cut -d/ -f4 | sort -u | paste -sd, - || true)
+
+          if [ -n "$FORKS" ] && ! grep -qv '^src/ethereum/forks/' "$FILE_LIST"; then
+            echo "DOCC_DIFF_FORKS=$FORKS" >> "$GITHUB_ENV"
+            echo "Building diffs for changed forks only: $FORKS"
+          else
+            echo "Non-fork files changed, building all diffs"
+          fi
+
       - name: Build Documentation
         run: |
           uvx tox -e spec-docs

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -31,17 +31,17 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - name: Install uv ${{ vars.UV_VERSION }} and python ${{ vars.DEFAULT_PYTHON_VERSION }}
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
         with:
-          python-version: "3.11"
-
-      - name: Install Tox
-        run: pip install tox
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          version: ${{ vars.UV_VERSION }}
+          python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
 
       - name: Build Documentation
         run: |
-          tox -e spec-docs
+          uvx tox -e spec-docs
           touch .tox/docs/.nojekyll
 
       - name: Upload Pages Artifact

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -1116,11 +1116,9 @@ class MinimizeDiffsTransform(Transform):
     """
 
     _count: int
-    _total: int
 
-    def __init__(self, settings: PluginSettings) -> None:
+    def __init__(self, settings: PluginSettings) -> None:  # noqa: ARG002
         self._count = 0
-        self._total = 0
 
     def transform(self, context: Context) -> None:
         """

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -1134,9 +1134,8 @@ class MinimizeDiffsTransform(Transform):
             kind = "diff"
 
         logging.info(
-            "MinimizeDiffs [%d]: %s (%s)",
+            "MinimizeDiffs [%d] (%s)",
             self._count,
-            context[Source].output_path,
             kind,
         )
 

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -19,6 +19,7 @@ Plugins for docc specific to the Ethereum execution specification.
 
 import dataclasses
 import logging
+import os
 from collections import defaultdict
 from itertools import tee, zip_longest
 from pathlib import Path, PurePath
@@ -85,6 +86,25 @@ class EthereumDiscover(Discover):
         forks = base / "forks"
         self.forks = Hardfork.discover([str(forks)])
 
+    @staticmethod
+    def _diff_forks() -> Optional[FrozenSet[str]]:
+        """
+        Return fork short names to limit diffing to, or None for all.
+
+        Controlled by the DOCC_DIFF_FORKS environment variable (comma-
+        separated fork short names).  When set, only fork pairs where
+        at least one side is listed will be discovered.
+        """
+        env = os.environ.get("DOCC_DIFF_FORKS", "").strip()
+        if not env:
+            return None
+        names = frozenset(
+            name.strip() for name in env.split(",") if name.strip()
+        )
+        if names:
+            logging.info("Limiting diffs to forks: %s", ", ".join(names))
+        return names or None
+
     def discover(self, known: FrozenSet[T]) -> Iterator[Source]:
         """
         Find sources.
@@ -121,8 +141,17 @@ class EthereumDiscover(Discover):
 
             by_fork[fork][fork_relative_path] = source
 
+        diff_forks = self._diff_forks()
+
         diff_count = 0
         for before, after in pairwise(self.forks):
+            if diff_forks is not None:
+                if (
+                    before.short_name not in diff_forks
+                    and after.short_name not in diff_forks
+                ):
+                    continue
+
             paths = set(by_fork[before].keys()) | set(by_fork[after].keys())
 
             for path in paths:

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -315,6 +315,17 @@ class DiffNode(Node):
         )
 
 
+class IdenticalDiffNode(DiffNode):
+    """
+    A DiffNode where both sides have identical source content.
+
+    FixIndexTransform still rewrites identifiers, but
+    MinimizeDiffsTransform skips tree diffing entirely.
+    """
+
+    pass
+
+
 class EthereumBuilder(PythonBuilder):
     """
     A `PythonBuilder` that additionally builds `Document`s from `DiffSource`s.
@@ -407,15 +418,23 @@ class EthereumBuilder(PythonBuilder):
             document = Document(root)
             processed[diff_source] = document
 
-        # For identical pairs, use the after document directly.
-        # No DiffNode wrapper means MinimizeDiffsTransform has
-        # nothing to diff — the content passes through unchanged.
+        # For identical pairs, wrap in IdenticalDiffNode so that
+        # FixIndexTransform rewrites identifiers correctly, but
+        # MinimizeDiffsTransform can skip the expensive tree diff.
         for diff_source in identical:
+            after_node: Node = BlankNode()
             if diff_source.after:
-                document = after_processed[diff_source.after]
+                after_document = after_processed[diff_source.after]
                 del after_processed[diff_source.after]
-            else:
-                document = Document(BlankNode())
+                after_node = AfterNode(after_document.root)
+
+            root = IdenticalDiffNode(
+                diff_source.before_name,
+                BeforeNode(BlankNode()),
+                diff_source.after_name,
+                after_node,
+            )
+            document = Document(root)
             processed[diff_source] = document
 
 
@@ -1077,6 +1096,14 @@ class _MinimizeDiffsVisitor(Visitor):
         self._stack = []
         self.root = None
 
+    def _replace_node(self, node: Node, output: Node) -> None:
+        if 1 == len(self._stack):
+            self._stack[0] = output
+            self.root = output
+        else:
+            self._stack[-2].replace_child(node, output)
+            self._stack[-1] = output
+
     def enter(self, node: Node) -> Visit:
         self._stack.append(node)
         if self.root is None:
@@ -1084,6 +1111,15 @@ class _MinimizeDiffsVisitor(Visitor):
 
         if not isinstance(node, DiffNode):
             return Visit.TraverseChildren
+
+        # Identical files: skip tree diff, use after content directly.
+        if isinstance(node, IdenticalDiffNode):
+            after = node.after
+            if isinstance(after, AfterNode):
+                self._replace_node(node, after.child)
+            else:
+                self._replace_node(node, BlankNode())
+            return Visit.SkipChildren
 
         before = node.before
         after = node.after
@@ -1108,12 +1144,7 @@ class _MinimizeDiffsVisitor(Visitor):
         apply.root.visit(_HardenVisitor())
         output = apply.output()
 
-        if 1 == len(self._stack):
-            self._stack[0] = output
-            self.root = output
-        else:
-            self._stack[-2].replace_child(node, output)
-            self._stack[-1] = output
+        self._replace_node(node, output)
 
         return Visit.SkipChildren
 

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -21,7 +21,7 @@ import dataclasses
 import logging
 from collections import defaultdict
 from itertools import tee, zip_longest
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import (
     Dict,
     Final,
@@ -320,6 +320,28 @@ class EthereumBuilder(PythonBuilder):
     A `PythonBuilder` that additionally builds `Document`s from `DiffSource`s.
     """
 
+    @staticmethod
+    def _sources_identical(diff_source: "DiffSource[Source]") -> bool:
+        """
+        Return True if both sides of a diff have identical file content.
+
+        Avoid AST parsing and tree diffing when the source
+        files are byte-for-byte the same.
+        """
+        before = diff_source.before
+        after = diff_source.after
+
+        if before is None or after is None:
+            return False
+
+        before_path = getattr(before, "absolute_path", None)
+        after_path = getattr(after, "absolute_path", None)
+
+        if before_path is None or after_path is None:
+            return False
+
+        return Path(before_path).read_bytes() == Path(after_path).read_bytes()
+
     def build(
         self,
         unprocessed: Set[Source],
@@ -335,8 +357,29 @@ class EthereumBuilder(PythonBuilder):
         source_set = set(s for s in unprocessed if isinstance(s, DiffSource))
         unprocessed -= source_set
 
-        before_unprocessed = {s.before for s in source_set if s.before}
-        after_unprocessed = {s.after for s in source_set if s.after}
+        # Separate identical sources from changed sources to skip
+        # tree diffing for files that haven't changed.
+        changed: Set[DiffSource[Source]] = set()
+        identical: Set[DiffSource[Source]] = set()
+
+        for s in source_set:
+            if self._sources_identical(s):
+                identical.add(s)
+            else:
+                changed.add(s)
+
+        if identical:
+            logging.info(
+                "Skipping tree diff for %s identical file pair(s)",
+                len(identical),
+            )
+
+        before_unprocessed = {s.before for s in changed if s.before}
+        after_unprocessed = {s.after for s in changed if s.after}
+
+        # For identical pairs we only need the after tree.
+        after_identical = {s.after for s in identical if s.after}
+        after_unprocessed |= after_identical
 
         # Rebuild the sources so we get distinct tree objects.
         before_processed: Dict[Source, Document] = dict()
@@ -345,7 +388,7 @@ class EthereumBuilder(PythonBuilder):
         super().build(before_unprocessed, before_processed)
         super().build(after_unprocessed, after_processed)
 
-        for diff_source in source_set:
+        for diff_source in changed:
             before: Node = BlankNode()
             if diff_source.before:
                 before_document = before_processed[diff_source.before]
@@ -362,6 +405,17 @@ class EthereumBuilder(PythonBuilder):
                 diff_source.before_name, before, diff_source.after_name, after
             )
             document = Document(root)
+            processed[diff_source] = document
+
+        # For identical pairs, use the after document directly.
+        # No DiffNode wrapper means MinimizeDiffsTransform has
+        # nothing to diff — the content passes through unchanged.
+        for diff_source in identical:
+            if diff_source.after:
+                document = after_processed[diff_source.after]
+                del after_processed[diff_source.after]
+            else:
+                document = Document(BlankNode())
             processed[diff_source] = document
 
 

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -421,12 +421,23 @@ class EthereumBuilder(PythonBuilder):
         after_identical = {s.after for s in identical if s.after}
         after_unprocessed |= after_identical
 
+        logging.info(
+            "Building diff trees: %d changed, %d identical"
+            " (%d before + %d after sources)",
+            len(changed),
+            len(identical),
+            len(before_unprocessed),
+            len(after_unprocessed),
+        )
+
         # Rebuild the sources so we get distinct tree objects.
         before_processed: Dict[Source, Document] = dict()
         after_processed: Dict[Source, Document] = dict()
 
         super().build(before_unprocessed, before_processed)
+        logging.info("Built %d before trees", len(before_processed))
         super().build(after_unprocessed, after_processed)
+        logging.info("Built %d after trees", len(after_processed))
 
         for diff_source in changed:
             before: Node = BlankNode()
@@ -1104,15 +1115,35 @@ class MinimizeDiffsTransform(Transform):
     Move `DiffNode` nodes as far down the tree as reasonably possible.
     """
 
+    _count: int
+    _total: int
+
     def __init__(self, settings: PluginSettings) -> None:
-        pass
+        self._count = 0
+        self._total = 0
 
     def transform(self, context: Context) -> None:
         """
         Apply the transformation to the given document.
         """
+        self._count += 1
+        root = context[Document].root
+
+        kind = "skip"
+        if isinstance(root, IdenticalDiffNode):
+            kind = "identical"
+        elif isinstance(root, DiffNode):
+            kind = "diff"
+
+        logging.info(
+            "MinimizeDiffs [%d]: %s (%s)",
+            self._count,
+            context[Source].output_path,
+            kind,
+        )
+
         visitor = _MinimizeDiffsVisitor()
-        context[Document].root.visit(visitor)
+        root.visit(visitor)
         assert visitor.root is not None
         context[Document].root = visitor.root
 

--- a/tox.ini
+++ b/tox.ini
@@ -194,6 +194,9 @@ commands =
 [testenv:spec-docs]
 description = Generate documentation for the specification code using docc
 basepython = python3
+# TODO: remove DOCC_DIFF_FORKS — temporary for benchmarking
+setenv =
+    DOCC_DIFF_FORKS = amsterdam
 commands =
     docc --output "{toxworkdir}/docs"
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs" / "index.html"))'


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Was briefly looking into this to check why it takes so long.

Wrote some unorganized notes below for my own reference. (It could be wrong)

From my understanding, "Build Doc" is creating diffs across each fork so we can see how a file has changed over forks. 

If this is correct, then this jobs run time will increase if more forks are added.

I believe it does a pairwise diff, ie if we have the three forks:

- Frontier
- Homestead
- Amsterdam

Then it will create a diff for:

- Frontier -> Homestead
- Homestead -> Amsterdam

This is a file by file diff, so if frontier has 38 files and homestead has 38 files, then we would be diffing 38 file pairs.

-----

If we take the Frontier -> Homestead diff as an example. Lets say the code wants to check the diff between `frontier/vm/gas.py` and `homestead/vm/gas.py`.  It does the following:

- Parse both files into ASTs, so essentially converts the source code into a data structure
- Runs a TreeDiff algorithm, that compares the two ASTs to find differences.  (This is roughly O(n^2) in complexity
- Applies the result of the tree diff to generate the html rendering.(I'm a bit vague here as I didn't look too deep into this part)

Hypothesis: The tree diff algorithm is the expensive part. Noting that even if there is no change between Frontier and Homestead, I believe it still runs the algorithm, to then conclude that nothing has changed.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
