### PR TITLE
chore(ci): make codecov project check informational

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,16 @@
+# The project check compares overall repo coverage against the base branch.
+# When the base branch moves ahead (new merges), the comparison becomes stale
+# and causes false failures on PRs — this is why we've been seeing codecov/project
+# failures across multiple PRs despite all modified lines being fully covered.
+#
+# Tradeoff: making project informational means we won't block on indirect coverage
+# loss (e.g. control flow changes that make existing covered lines unreachable).
+# The patch check still enforces that all new/modified lines are covered.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
## 🗒️ Description

The `codecov/project` check compares overall repo coverage against the base branch. When the base branch moves ahead (new merges), the comparison becomes stale and causes false failures on PRs, this is why we've been seeing `codecov/project` failures across multiple PRs despite all modified lines being fully covered (e.g. #2250).

This adds a `codecov.yaml` that makes the `codecov/project` check informational (non-blocking) while keeping the `codecov/patch` check enforced to ensure all new/modified lines are covered.

**Tradeoff:** making project informational means we won't block on indirect coverage loss (e.g. control flow changes that make existing covered lines unreachable). The patch check still enforces that all new/modified lines are covered.

## 🔗 Related Issues or PRs

#2250, example of a PR blocked by a stale `codecov/project` check

## ✅ Checklist

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.1oBnLZ16e009qMAuONz9yAHaHe%3Fpid%3DApi&f=1&ipt=58e226b895cdb8d25c5f40df2d29e94d62513603d6927644257a9d0523a0953e&ipo=images)