### PR TITLE
chore(ci): add missing sudo to apt-get in setup-env action

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Install Tox and any other packages
       shell: bash
       run: |
-        DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config
         pip install 'tox>=4.11,<5' requests
 
     - name: Download Geth and add to $PATH


### PR DESCRIPTION
## 🗒️ Description

The second `apt-get install` step in `.github/actions/setup-env/action.yaml` was missing `sudo`, while the first step (Rust install) had it. This might be causing this intermittent CI failures on runners that don't run as root:

```
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```

The failure is intermittent because some self-hosted runners might now be executing as root (where `apt-get` works without `sudo`) and some don't (where it fails with a permission error). This might fix the intermittent CI failures reported in #2115.


## 🔗 Related Issues or PRs

- #2115. reported intermittent CI failure with this error
- #2280, came up here again hence the PR

## ✅ Checklist

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: Considered adding an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.6ls-1ViTlkvk5bOOn0BbgQHaJQ%3Fpid%3DApi&f=1&ipt=3a474806e3d67250b76a8765c04469e647041653a730128d3158fc1dbd5753fd&ipo=images)