### PR TITLE
chore(tests): EIP-7825 test fix to avoid 3 failures on EIP-7976 ci run

### DIFF
--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -346,7 +346,6 @@ def test_tx_gas_limit_cap_full_calldata(
     state_test: StateTestFiller,
     pre: Alloc,
     zero_byte: bool,
-    total_cost_floor_per_token: int,
     exceed_tx_gas_limit: bool,
     correct_intrinsic_cost_in_transaction_gas_limit: bool,
     fork: Fork,
@@ -357,26 +356,14 @@ def test_tx_gas_limit_cap_full_calldata(
     assert tx_gas_limit_cap is not None, (
         "Fork does not have a transaction gas limit cap"
     )
-    gas_available = tx_gas_limit_cap - intrinsic_cost()
-
-    max_tokens_in_calldata = gas_available // total_cost_floor_per_token
-    num_of_bytes = (
-        max_tokens_in_calldata if zero_byte else max_tokens_in_calldata // 4
-    )
-
-    num_of_bytes += int(exceed_tx_gas_limit)
-
-    # Gas cost calculation based on EIP-7623:
-    # (https://eips.ethereum.org/EIPS/eip-7623)
-    #
-    # Simplified in this test case:
-    # - No execution gas used (no opcodes are executed)
-    # - Not a contract creation (no initcode)
-    #
-    # Token accounting:
-    #   tokens_in_calldata = zero_bytes + 4 * non_zero_bytes
-
     byte_data = b"\x00" if zero_byte else b"\xff"
+    max_num_of_bytes = max_count_with_intrinsic_cost_at_most(
+        lambda calldata_size: intrinsic_cost(
+            calldata=byte_data * calldata_size
+        ),
+        tx_gas_limit_cap,
+    )
+    num_of_bytes = max_num_of_bytes + int(exceed_tx_gas_limit)
 
     correct_intrinsic_cost = intrinsic_cost(calldata=byte_data * num_of_bytes)
     if exceed_tx_gas_limit:


### PR DESCRIPTION
## 🗒️ Description
`uv run fill --until Amsterdam -v -s --clean -k "fork_Amsterdam and zero_byte_True and exceed_tx_gas_limit_False and correct_intrinsic_cost_in_transaction_gas_limit_True"`

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
