### PR TITLE
feat(tests): port EXTCODEHASH codeless account with storage test

### DIFF
--- a/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
+++ b/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
@@ -347,3 +347,58 @@ def test_extcodehash_empty_contract_creation(
         },
         tx=tx,
     )
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/ethereum/tests/blob/v13.3/src/GeneralStateTestsFiller/stExtCodeHash/dynamicAccountOverwriteEmpty_ParisFiller.yml",  # noqa: E501
+    ],
+    pr=[],
+)
+@pytest.mark.pre_alloc_mutable
+@pytest.mark.parametrize(
+    "balance, nonce",
+    [
+        pytest.param(1, 0, id="balance"),
+        pytest.param(0, 1, id="nonce"),
+        pytest.param(1, 1, id="balance_and_nonce"),
+    ],
+)
+def test_extcodehash_codeless_with_storage(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    balance: int,
+    nonce: int,
+) -> None:
+    """
+    Test EXTCODEHASH/EXTCODESIZE of a codeless account that has storage.
+
+    All three variants are non-empty per EIP-161 (non-zero balance or nonce),
+    so EXTCODEHASH returns keccak256("") and EXTCODESIZE returns 0.
+    Storage is not part of the EIP-161 emptiness check.
+    """
+    target_address = pre.empty_account()
+    pre[target_address] = Account(balance=balance, nonce=nonce, storage={1: 1})
+
+    storage = Storage()
+    code = Op.SSTORE(
+        storage.store_next(keccak256(b"")),
+        Op.EXTCODEHASH(target_address),
+    ) + Op.SSTORE(
+        storage.store_next(0),
+        Op.EXTCODESIZE(target_address),
+    )
+
+    code_address = pre.deploy_contract(code)
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=code_address,
+        gas_limit=100_000,
+    )
+
+    state_test(
+        pre=pre,
+        post={code_address: Account(storage=storage)},
+        tx=tx,
+    )


### PR DESCRIPTION
## 🗒️ Description
Port sub-case from dynamicAccountOverwriteEmpty_ParisFiller.yml: a codeless account with storage returns keccak256("") for EXTCODEHASH and 0 for EXTCODESIZE. Parametrized over three non-empty variants (balance only, nonce only, both).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
