### PR TITLE
feat(zkevm): track code_reads and wire them into ExecutionWitness

### DIFF
--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -45,8 +45,8 @@ class BlockState:
 
     Read chain: block writes -> pre_state.
 
-    ``account_reads`` and ``storage_reads`` accumulate across all
-    transactions for BAL generation.
+    ``account_reads``, ``storage_reads``, and ``code_reads`` accumulate
+    across all transactions for BAL generation.
     """
 
     pre_state: PreState
@@ -58,6 +58,7 @@ class BlockState:
     storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
+    code_reads: Set[Hash32] = field(default_factory=set)
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     oldest_ancestor_offset: Optional[Uint] = None
 
@@ -69,9 +70,9 @@ class TransactionState:
 
     Read chain: tx writes -> block writes -> pre_state.
 
-    ``storage_reads`` and ``account_reads`` are shared references
-    that survive rollback (reads from failed calls still appear in the
-    Block Access List).
+    ``storage_reads``, ``account_reads``, and ``code_reads`` are shared
+    references that survive rollback (reads from failed calls still
+    appear in the Block Access List).
     """
 
     parent: BlockState
@@ -83,6 +84,7 @@ class TransactionState:
     storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
+    code_reads: Set[Hash32] = field(default_factory=set)
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
@@ -167,6 +169,7 @@ def get_code(tx_state: TransactionState, code_hash: Hash32) -> Bytes:
     """
     if code_hash == EMPTY_CODE_HASH:
         return b""
+    tx_state.code_reads.add(code_hash)
     if code_hash in tx_state.code_writes:
         return tx_state.code_writes[code_hash]
     if code_hash in tx_state.parent.code_writes:
@@ -644,8 +647,8 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
     Create a snapshot of the transaction state for rollback.
 
     Deep-copy writes and transient storage.  The parent reference,
-    ``created_accounts``, ``storage_reads``, and ``account_reads``
-    are shared (not rolled back).
+    ``created_accounts``, ``storage_reads``, ``account_reads``, and
+    ``code_reads`` are shared (not rolled back).
 
     Parameters
     ----------
@@ -665,6 +668,7 @@ def copy_tx_state(tx_state: TransactionState) -> TransactionState:
             addr: dict(slots)
             for addr, slots in tx_state.storage_writes.items()
         },
+        code_reads=tx_state.code_reads,
         code_writes=dict(tx_state.code_writes),
         created_accounts=tx_state.created_accounts,
         transient_storage=dict(tx_state.transient_storage),
@@ -725,6 +729,7 @@ def incorporate_tx_into_block(
     # Merge reads and touches into block-level sets
     block.storage_reads.update(tx_state.storage_reads)
     block.account_reads.update(tx_state.account_reads)
+    block.code_reads.update(tx_state.code_reads)
 
     # Merge cumulative writes
     for address, account in tx_state.account_writes.items():
@@ -744,6 +749,7 @@ def incorporate_tx_into_block(
     tx_state.transient_storage.clear()
     tx_state.storage_reads = set()
     tx_state.account_reads = set()
+    tx_state.code_reads = set()
 
 
 def extract_block_diffs(

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -3,11 +3,14 @@ Stateless validation types.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List, Optional, Set, Tuple
 
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import Uint
+
+from ethereum.crypto.hash import Hash32
+from ethereum.state import PreState
 
 from .state_tracker import BlockState
 
@@ -45,7 +48,6 @@ class ExecutionWitnessBuilder:
 
     blockchain_headers: List[Bytes] = field(default_factory=list)
     state: List[Bytes] = field(default_factory=list)
-    codes: List[Bytes] = field(default_factory=list)
 
 
 def build_execution_witness(
@@ -62,11 +64,41 @@ def build_execution_witness(
         builder.blockchain_headers,
         block_state.oldest_ancestor_offset,
     )
+    codes = get_witness_codes(block_state.code_reads, block_state.pre_state)
+
     return ExecutionWitness(
         state=tuple(sorted(builder.state)),
-        codes=tuple(sorted(builder.codes)),
+        codes=tuple(codes),
         headers=tuple(ancestor_headers),
     )
+
+
+def get_witness_codes(
+    code_reads: Set[Hash32],
+    pre_state: PreState,
+) -> List[Bytes]:
+    """
+    Collect bytecodes from the pre-state for all code hashes read
+    during execution.
+
+    Skip hashes that do not exist in the pre-state (e.g. code deployed
+    within the same block).
+
+    Parameters
+    ----------
+    code_reads :
+        Code hashes accessed during block execution.
+    pre_state :
+        The pre-execution state.
+
+    """
+    codes: List[Bytes] = []
+    for code_hash in code_reads:
+        try:
+            codes.append(pre_state.get_code(code_hash))
+        except KeyError:
+            pass
+    return sorted(codes)
 
 
 def get_witness_ancestors(


### PR DESCRIPTION
## 🗒️ Description
This PR makes the state tracker have a `code_reads` which captures any `get_code` call.

This field is later used to fill the execution witness accordingly so it appears in the generated fixtures.

Example:
```
$ uv run fill --clean -m "blockchain_test" --fork Amsterdam ./tests/frontier/opcodes/test_blockhash.py -k "one_block_with_tx"
$ cat fixtures/blockchain_tests/frontier/opcodes/blockhash/genesis_hash_available.json 
...
"executionWitness": {
    "state": [],
    "codes": [
        "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500",
        "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
        "0x3373fffffffffffffffffffffffffffffffffffffffe1460cb5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f457600182026001905f5b5f82111560685781019083028483029004916001019190604d565b909390049250505036603814608857366101f457346101f4575f5260205ff35b34106101f457600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160df575060105b5f5b8181146101835782810160030260040181604c02815460601b8152601401816001015481526020019060020154807fffffffffffffffffffffffffffffffff00000000000000000000000000000000168252906010019060401c908160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160e1565b910180921461019557906002556101a0565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101cd57505f5b6001546002828201116101e25750505f6101e8565b01600290035b5f555f600155604c025ff35b5f5ffd",
        "0x3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd",
        "0x6000401560005560014015600155"
    ],
    "headers": [
        "0xf90278a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a014413270cd1509c3bc3194d1854cac72e031717b13f91dc9f14881fe2912e0efa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808407270e00808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
        "0xf90278a0c0a29049136e8c01b1cc7869f95905bef6959430e8dbfb2052420b053c27f6aea01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347942adc25665018aa1fe0e6bc666dac8fc2697ff9baa0c37001fcb398e2b2c23fc42c2c662854405c77054faa96dbaff7984a90cfab93a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080018407270e00800c80a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a0d19579646c765c8bd8958feabd54974d67214facc5b58ef1410a4b7fd50d1b5b"
    ]
},
...
```

## 🔗 Related Issues or PRs
Closes #2272
