### PR TITLE
chore(specs): Move BAL types into `fork_types` module

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -18,52 +18,14 @@ from typing import Dict, List, Optional, Set, Tuple, TypeAlias
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U32, U64, U256, Uint, ulen
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from .exceptions import BlockAccessListGasLimitExceededError
+from .fork_types import BlockAccessIndex
 from .state_tracker import BlockState, TransactionState, get_code
-
-# TODO: Either remove or generalize these type aliases (#2260).
-
-StorageKey: TypeAlias = U256
-"""
-Slot within an [`Account`](ref:ethereum.state.Account)'s storage.
-"""
-
-StorageValue: TypeAlias = U256
-"""
-Value associated with a [`StorageKey`] within an [`Account`]'s storage.
-
-[`StorageKey`]: ref:ethereum.forks.amsterdam.block_access_lists.StorageKey
-[`Account`]: ref:ethereum.state.Account
-"""
-
-CodeData: TypeAlias = Bytes
-"""
-Bytecode associated with an [`Account`](ref:ethereum.state.Account).
-"""
-
-BlockAccessIndex: TypeAlias = U32
-"""
-Position within the set of all changes in a [`Block`].
-
-[`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
-"""
-
-Balance: TypeAlias = U256
-"""
-Balance associated with an [`Account`], in wei.
-
-[`Account`]: ref:ethereum.state.Account
-"""
-
-Nonce: TypeAlias = U64
-"""
-Nonce associated with an [`Account`](ref:ethereum.state.Account).
-"""
 
 
 @slotted_freezable
@@ -84,7 +46,7 @@ class StorageChange:
     [`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
     """
 
-    new_value: StorageValue
+    new_value: U256
     """
     Value of an [`Account`]'s storage slot after this change has been applied.
 
@@ -110,7 +72,7 @@ class BalanceChange:
     [`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
     """
 
-    post_balance: Balance
+    post_balance: U256
     """
     Balance of an [`Account`] after this change has been applied.
 
@@ -136,7 +98,7 @@ class NonceChange:
     [`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
     """
 
-    new_nonce: Nonce
+    new_nonce: U64
     """
     Nonce of an [`Account`] after this change has been applied.
 
@@ -162,7 +124,7 @@ class CodeChange:
     [`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
     """
 
-    new_code: CodeData
+    new_code: Bytes
     """
     Code of an [`Account`] after this change has been applied.
 
@@ -181,7 +143,7 @@ class SlotChanges:
     [`Account`]: ref:ethereum.state.Account
     """  # noqa: E501
 
-    slot: StorageKey
+    slot: U256
     """
     Location within an [`Account`]'s storage that has been modified.
 
@@ -215,7 +177,7 @@ class AccountChanges:
     [`Account`]: ref:ethereum.state.Account
     """
 
-    storage_reads: Tuple[StorageKey, ...]
+    storage_reads: Tuple[U256, ...]
     """
     Storage slots of the associated [`Account`] that have been read but not
     changed.

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -41,7 +41,6 @@ from ethereum.utils.byte import left_pad_zero_bytes
 
 from . import vm
 from .block_access_lists import (
-    BlockAccessIndex,
     BlockAccessListBuilder,
     build_block_access_list,
     hash_block_access_list,
@@ -60,7 +59,7 @@ from .exceptions import (
     PriorityFeeGreaterThanMaxFeeError,
     TransactionTypeContractCreationError,
 )
-from .fork_types import Authorization, VersionedHash
+from .fork_types import Authorization, BlockAccessIndex, VersionedHash
 from .requests import (
     CONSOLIDATION_REQUEST_TYPE,
     DEPOSIT_REQUEST_TYPE,

--- a/src/ethereum/forks/amsterdam/fork_types.py
+++ b/src/ethereum/forks/amsterdam/fork_types.py
@@ -16,10 +16,17 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes256
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U8, U64, U256
+from ethereum_types.numeric import U8, U32, U64, U256
 
 from ethereum.crypto.hash import Hash32
 from ethereum.state import Account, Address
+
+BlockAccessIndex = U32
+"""
+Position within the set of all changes in a [`Block`].
+
+[`Block`]: ref:ethereum.forks.amsterdam.blocks.Block
+"""
 
 VersionedHash = Hash32
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Related to #2260 -- I didn't create a NewType and instead just kept the type aliases to keep the diff less invasive and more straightforward.

These also don't change per fork, so most of them could also be a candidate for #2293

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
