### PR TITLE
bug(tests): fix failing test in ci for 7981

### DIFF
--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -685,10 +685,8 @@ def test_tx_gas_limit_cap_authorized_tx(
 
     auth_address = pre.deploy_contract(code=Op.STOP)
 
+    access_list = make_access_list(auth_list_length)
     auth_signers = [pre.fund_eoa() for _ in range(auth_list_length)]
-    access_list = [
-        AccessList(address=addr, storage_keys=[]) for addr in auth_signers
-    ]
 
     auth_tuples = [
         AuthorizationTuple(


### PR DESCRIPTION
## 🗒️ Description
In CI of 7981 I can see:

```
py3:
FAILED tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_authorized_tx[fork_Amsterdam-blockchain_test_engine_from_state_test-exceed_tx_gas_limit_False-correct_intrinsic_cost_in_transaction_gas_limit_True]@t8n-cache-687483f0
FAILED tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_authorized_tx[fork_Amsterdam-blockchain_test_from_state_test-exceed_tx_gas_limit_False-correct_intrinsic_cost_in_transaction_gas_limit_True]@t8n-cache-687483f0
FAILED tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_authorized_tx[fork_Amsterdam-state_test-exceed_tx_gas_limit_False-correct_intrinsic_cost_in_transaction_gas_limit_True]@t8n-cache-687483f0

pypy3:
FAILED tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_limit_cap_authorized_tx[fork_Amsterdam-state_test-exceed_tx_gas_limit_False-correct_intrinsic_cost_in_transaction_gas_limit_True]@t8n-cache-687483f0
```

this PR is supposed to fix it.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
