### PR TITLE
feat(zkevm): fixe bytecode tracking and inclusion in the execution witness

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -682,7 +682,11 @@ def update_builder_from_tx(
             post_account.code_hash if post_account else EMPTY_CODE_HASH
         )
         if pre_code_hash != post_code_hash:
-            post_code = get_code(tx_state, post_code_hash)
+            post_code = get_code(
+                tx_state,
+                post_code_hash,
+                address,
+            )
             add_code_change(builder, address, idx, post_code)
 
     # Compare storage writes against block cumulative state

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -573,7 +573,11 @@ def check_transaction(
 
     if Uint(sender_account.balance) < max_gas_fee + Uint(tx.value):
         raise InsufficientBalanceError("insufficient sender balance")
-    sender_code = get_code(tx_state, sender_account.code_hash)
+    sender_code = get_code(
+        tx_state,
+        sender_account.code_hash,
+        sender_address,
+    )
     if sender_account.code_hash != EMPTY_CODE_HASH and not is_valid_delegation(
         sender_code
     ):
@@ -660,6 +664,7 @@ def process_checked_system_transaction(
     system_contract_code = get_code(
         untracked_state,
         get_account(untracked_state, target_address).code_hash,
+        target_address,
     )
 
     if len(system_contract_code) == 0:
@@ -711,6 +716,7 @@ def process_unchecked_system_transaction(
     system_contract_code = get_code(
         system_tx_state,
         get_account(system_tx_state, target_address).code_hash,
+        target_address,
     )
 
     tx_env = vm.TransactionEnvironment(

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
     from .block_access_lists import BlockAccessListBuilder
 
 
+CodeRead = Tuple[Address, Hash32]
+"""Code read keyed by account address and code hash."""
+
+
 @dataclass
 class BlockState:
     """
@@ -45,8 +49,9 @@ class BlockState:
 
     Read chain: block writes -> pre_state.
 
-    ``account_reads``, ``storage_reads``, and ``code_reads`` accumulate
-    across all transactions for BAL generation.
+    ``account_reads`` and ``storage_reads`` accumulate across all transactions
+    for BAL generation. ``code_reads`` accumulates code accesses used for
+    execution witness generation.
     """
 
     pre_state: PreState
@@ -58,7 +63,7 @@ class BlockState:
     storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
-    code_reads: Set[Hash32] = field(default_factory=set)
+    code_reads: Set[CodeRead] = field(default_factory=set)
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     oldest_ancestor_offset: Optional[Uint] = None
 
@@ -84,7 +89,7 @@ class TransactionState:
     storage_writes: Dict[Address, Dict[Bytes32, U256]] = field(
         default_factory=dict
     )
-    code_reads: Set[Hash32] = field(default_factory=set)
+    code_reads: Set[CodeRead] = field(default_factory=set)
     code_writes: Dict[Hash32, Bytes] = field(default_factory=dict)
     created_accounts: Set[Address] = field(default_factory=set)
     transient_storage: Dict[Tuple[Address, Bytes32], U256] = field(
@@ -148,7 +153,11 @@ def get_account(tx_state: TransactionState, address: Address) -> Account:
         return EMPTY_ACCOUNT
 
 
-def get_code(tx_state: TransactionState, code_hash: Hash32) -> Bytes:
+def get_code(
+    tx_state: TransactionState,
+    code_hash: Hash32,
+    address: Address,
+) -> Bytes:
     """
     Get the bytecode for a given code hash.
 
@@ -160,6 +169,8 @@ def get_code(tx_state: TransactionState, code_hash: Hash32) -> Bytes:
         The transaction state.
     code_hash :
         Hash of the code to look up.
+    address :
+        Address whose code is being accessed.
 
     Returns
     -------
@@ -169,7 +180,7 @@ def get_code(tx_state: TransactionState, code_hash: Hash32) -> Bytes:
     """
     if code_hash == EMPTY_CODE_HASH:
         return b""
-    tx_state.code_reads.add(code_hash)
+    tx_state.code_reads.add((address, code_hash))
     if code_hash in tx_state.code_writes:
         return tx_state.code_writes[code_hash]
     if code_hash in tx_state.parent.code_writes:

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -10,7 +10,7 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import Uint
 
 from ethereum.crypto.hash import Hash32
-from ethereum.state import PreState
+from ethereum.state import Address, PreState
 
 from .state_tracker import BlockState
 
@@ -74,26 +74,33 @@ def build_execution_witness(
 
 
 def get_witness_codes(
-    code_reads: Set[Hash32],
+    code_reads: Set[Tuple[Address, Hash32]],
     pre_state: PreState,
 ) -> List[Bytes]:
     """
-    Collect bytecodes from the pre-state for all code hashes read
-    during execution.
+    Collect bytecodes from the pre-state for all code reads during execution.
 
-    Skip hashes that do not exist in the pre-state (e.g. code deployed
-    within the same block).
+    Include a code hash only when the same address already had that code in the
+    pre-state. This avoids accidentally including bytecode created during the
+    current block when the same hash already exists elsewhere.
 
     Parameters
     ----------
     code_reads :
-        Code hashes accessed during block execution.
+        Code reads as ``(address, code_hash)`` during block execution.
     pre_state :
         The pre-execution state.
 
     """
+    witness_code_hashes: Set[Hash32] = set()
+    for address, code_hash in code_reads:
+        pre_account = pre_state.get_account_optional(address)
+        if pre_account is None or pre_account.code_hash != code_hash:
+            continue
+        witness_code_hashes.add(code_hash)
+
     codes: List[Bytes] = []
-    for code_hash in code_reads:
+    for code_hash in witness_code_hashes:
         try:
             codes.append(pre_state.get_code(code_hash))
         except KeyError:

--- a/src/ethereum/forks/amsterdam/utils/message.py
+++ b/src/ethereum/forks/amsterdam/utils/message.py
@@ -64,7 +64,9 @@ def prepare_message(
         current_target = tx.to
         msg_data = tx.data
         code = get_code(
-            tx_env.state, get_account(tx_env.state, tx.to).code_hash
+            tx_env.state,
+            get_account(tx_env.state, tx.to).code_hash,
+            tx.to,
         )
         code_address = tx.to
     else:

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -141,7 +141,11 @@ def calculate_delegation_cost(
     """
     tx_state = evm.message.tx_env.state
 
-    code = get_code(tx_state, get_account(tx_state, address).code_hash)
+    code = get_code(
+        tx_state,
+        get_account(tx_state, address).code_hash,
+        address,
+    )
 
     if not is_valid_delegation(code):
         return False, address, Uint(0)
@@ -188,7 +192,11 @@ def set_delegation(message: Message) -> U256:
         message.accessed_addresses.add(authority)
 
         authority_account = get_account(tx_state, authority)
-        authority_code = get_code(tx_state, authority_account.code_hash)
+        authority_code = get_code(
+            tx_state,
+            authority_account.code_hash,
+            authority,
+        )
 
         if authority_code and not is_valid_delegation(authority_code):
             continue
@@ -214,6 +222,7 @@ def set_delegation(message: Message) -> U256:
     message.code = get_code(
         tx_state,
         get_account(tx_state, message.code_address).code_hash,
+        message.code_address,
     )
 
     return refund_counter

--- a/src/ethereum/forks/amsterdam/vm/instructions/environment.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/environment.py
@@ -354,7 +354,7 @@ def extcodesize(evm: Evm) -> None:
     # OPERATION
     tx_state = evm.message.tx_env.state
     code_hash = get_account(tx_state, address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, address)
 
     codesize = U256(len(code))
     push(evm.stack, codesize)
@@ -401,7 +401,7 @@ def extcodecopy(evm: Evm) -> None:
     evm.memory += b"\x00" * extend_memory.expand_by
     tx_state = evm.message.tx_env.state
     code_hash = get_account(tx_state, address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, address)
 
     value = buffer_read(code, code_start_index, size)
     memory_write(evm.memory, memory_start_index, value)

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -425,7 +425,7 @@ def call(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, code_address)
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -528,7 +528,7 @@ def callcode(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, code_address)
 
     message_call_gas = calculate_message_call_gas(
         value,
@@ -685,7 +685,7 @@ def delegatecall(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, code_address)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),
@@ -775,7 +775,7 @@ def staticcall(evm: Evm) -> None:
             evm.accessed_addresses.add(code_address)
 
     code_hash = get_account(tx_state, code_address).code_hash
-    code = get_code(tx_state, code_hash)
+    code = get_code(tx_state, code_hash, code_address)
 
     message_call_gas = calculate_message_call_gas(
         U256(0),

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -133,6 +133,7 @@ def process_message_call(message: Message) -> MessageCallOutput:
             message.code = get_code(
                 tx_state,
                 get_account(tx_state, delegated_address).code_hash,
+                delegated_address,
             )
             message.code_address = delegated_address
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes.py
@@ -1,0 +1,100 @@
+"""Witness bytecode collection scenarios."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Initcode,
+    Op,
+    Transaction,
+    compute_create_address,
+)
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def test_witness_excludes_bytecode_created_in_same_block(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Create a contract in a block without reading its code first.
+
+    Manual witness check until execution witness assertions are supported:
+    - The deployed runtime code should not appear in
+      executionWitness.codes for this block.
+    """
+    runtime_code = bytes.fromhex("deadbeef")
+    creator = pre.fund_eoa()
+    created_contract = compute_create_address(address=creator, nonce=0)
+
+    create_tx = Transaction(
+        sender=creator,
+        to=None,
+        data=Initcode(deploy_code=runtime_code),
+        gas_limit=500_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[create_tx])],
+        post={
+            creator: Account(nonce=1),
+            created_contract: Account(
+                nonce=1,
+                code=runtime_code,
+            ),
+        },
+    )
+
+
+def test_witness_keeps_prestate_code_read_even_if_later_created_with_same_hash(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Tx1 reads pre-state code, tx2 later deploys the same runtime code hash.
+
+    Manual witness check until execution witness assertions are supported:
+    - 0x60006000F3 should appear in executionWitness.codes because
+      tx1 CALLs an existing pre-state contract with that code.
+    """
+    runtime_code = bytes(Op.PUSH1(0x00) + Op.PUSH1(0x00) + Op.RETURN)
+
+    existing_contract = pre.deploy_contract(code=runtime_code)
+
+    reader = pre.fund_eoa()
+    creator = pre.fund_eoa()
+    created_contract = compute_create_address(address=creator, nonce=0)
+
+    tx1_read_existing_code = Transaction(
+        sender=reader,
+        to=existing_contract,
+        gas_limit=200_000,
+    )
+    tx2_create_same_code_hash = Transaction(
+        sender=creator,
+        to=None,
+        data=Initcode(deploy_code=runtime_code),
+        gas_limit=500_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[tx1_read_existing_code, tx2_create_same_code_hash])
+        ],
+        post={
+            reader: Account(nonce=1),
+            creator: Account(nonce=1),
+            created_contract: Account(
+                nonce=1,
+                code=runtime_code,
+            ),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
This PR fix a bug in the bytecode tracking and witness inclusion. Before we only tracked a set of `code_hash`, and included them in the witness if the `code_hash` existed in the pre-state.

This is not correct because if a block contains a single transaction that creates a contract with `code_hash_1`, and another already-deployed contract with `code_hash_1` exists (e.g., not accessed during the block), then the bytecode would be included in the execution witness. Since this code is generated at runtime, it isn't required to be provided.

The way this is solved is to also track which account was the target of the `code_read`. This allows later to check if the tracked bytecode was created during runtime or not, compared with the previous `code_hash` for that account in the pre-state.

Additionally, I added two tests that covers two important cases:
- The simple case: a block that creates some bytecode. This bytecode must not appear in the generated execution witness.
- A more nuanced case: tx1 in the block access an existing contract with `code_hash_1`, and later a tx2 creates a new contract also with `code_hash_1`. The bytecode in this case must appear, since despite tx2 generated this bytecode at runtime, tx1 accessed it from an existing contract in the pre-state.

This was discovered by comparing our Amsterdam witness generation against my e2e working on from Osaka (for some tests -- I need to do a deeper comparison!).
