### PR TITLE
feat(test): EIP-8024 update

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3461,9 +3461,9 @@ class Amsterdam(BPO2):
         )
         return {
             **base_map,
-            Opcodes.SWAPN: gas_costs.G_VERY_LOW,
-            Opcodes.DUPN: gas_costs.G_VERY_LOW,
-            Opcodes.EXCHANGE: gas_costs.G_VERY_LOW,
+            Opcodes.SWAPN: gas_costs.GAS_VERY_LOW,
+            Opcodes.DUPN: gas_costs.GAS_VERY_LOW,
+            Opcodes.EXCHANGE: gas_costs.GAS_VERY_LOW,
         }
 
     @classmethod

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -547,11 +547,11 @@ def _exchange_encoder(*args: int | bytes) -> bytes:
             )
 
         # encode_pair logic from EIP-8024
-        # n is first stack index (1-14), m is second (must be > n, up to 29)
-        if not (1 <= n <= 14 and n < m <= 29 and n + m <= 30):
+        # n is first stack index, m is second (n < m, n + m <= 30)
+        if not (1 <= n < m and n + m <= 30):
             raise ValueError(
-                f"EXCHANGE indices must satisfy: 1 <= n <= 14, "
-                f"n < m <= 29, n + m <= 30, got n={n}, m={m}"
+                f"EXCHANGE indices must satisfy: 1 <= n < m, "
+                f"n + m <= 30, got n={n}, m={m}"
             )
         if m <= 16:
             q, r = n - 1, m - 1

--- a/packages/testing/src/execution_testing/vm/opcodes.py
+++ b/packages/testing/src/execution_testing/vm/opcodes.py
@@ -547,10 +547,10 @@ def _exchange_encoder(*args: int | bytes) -> bytes:
             )
 
         # encode_pair logic from EIP-8024
-        # n is first stack index (1-13), m is second (must be > n, up to 29)
-        if not (1 <= n <= 13 and n < m <= 29 and n + m <= 30):
+        # n is first stack index (1-14), m is second (must be > n, up to 29)
+        if not (1 <= n <= 14 and n < m <= 29 and n + m <= 30):
             raise ValueError(
-                f"EXCHANGE indices must satisfy: 1 <= n <= 13, "
+                f"EXCHANGE indices must satisfy: 1 <= n <= 14, "
                 f"n < m <= 29, n + m <= 30, got n={n}, m={m}"
             )
         if m <= 16:
@@ -558,7 +558,7 @@ def _exchange_encoder(*args: int | bytes) -> bytes:
         else:
             q, r = 29 - m, n - 1
         k = 16 * q + r
-        imm = k if k <= 79 else k + 48
+        imm = k ^ 143
         return int.to_bytes(imm, 1, "big")
 
     raise ValueError(f"EXCHANGE requires 1 or 2 arguments, got {len(args)}")
@@ -601,10 +601,7 @@ def _dupn_swapn_encoder(*args: int | bytes) -> bytes:
             raise ValueError(
                 f"DUPN/SWAPN index must be in range [17, 235], got {arg}"
             )
-        if arg <= 107:
-            imm = arg - 17
-        else:
-            imm = arg + 20
+        imm = (arg + 111) % 256
         return int.to_bytes(imm, 1, "big")
 
     raise TypeError(
@@ -614,10 +611,8 @@ def _dupn_swapn_encoder(*args: int | bytes) -> bytes:
 
 def _swapn_stack_properties_modifier(data: bytes) -> tuple[int, int, int, int]:
     n = int.from_bytes(data, "big")
-    if n <= 90:
-        min_stack_height = n + 17
-    elif n >= 128:
-        min_stack_height = n - 20
+    if n <= 90 or n >= 128:
+        min_stack_height = (n + 145) % 256
     else:
         # Undefined behavior
         min_stack_height = 0
@@ -631,10 +626,8 @@ def _swapn_stack_properties_modifier(data: bytes) -> tuple[int, int, int, int]:
 
 def _dupn_stack_properties_modifier(data: bytes) -> tuple[int, int, int, int]:
     n = int.from_bytes(data, "big")
-    if n <= 90:
-        min_stack_height = n + 17
-    elif n >= 128:
-        min_stack_height = n - 20
+    if n <= 90 or n >= 128:
+        min_stack_height = (n + 145) % 256
     else:
         # Undefined behavior
         min_stack_height = 0
@@ -650,11 +643,11 @@ def _exchange_stack_properties_modifier(
     data: bytes,
 ) -> tuple[int, int, int, int]:
     n = int.from_bytes(data, "big")
-    if n > 79 and n < 128:
+    if n > 81 and n < 128:
         # Undefined behavior
         min_stack_height = 0
     else:
-        k = n if n <= 79 else n - 48
+        k = n ^ 143
         q, r = divmod(k, 16)
         if q < r:
             min_stack_height = max(q + 1, r + 1)

--- a/src/ethereum/forks/amsterdam/vm/runtime.py
+++ b/src/ethereum/forks/amsterdam/vm/runtime.py
@@ -65,19 +65,29 @@ def get_valid_jump_destinations(code: Bytes) -> Set[Uint]:
             # opcodes.
             push_data_size = current_opcode.value - Ops.PUSH1.value + 1
             pc += Uint(push_data_size)
-        elif current_opcode in (Ops.DUPN, Ops.SWAPN, Ops.EXCHANGE):
-            # EIP-8024: Handle immediate byte for DUPN, SWAPN, EXCHANGE
-            # If immediate is 0x5b (JUMPDEST), it's invalid and remains
-            # a valid jump target for backward compatibility.
-            # Only skip valid immediate values during analysis.
+        elif current_opcode in (Ops.DUPN, Ops.SWAPN):
+            # EIP-8024: DUPN/SWAPN invalid immediate range is
+            # 90 < x < 128, i.e. 0x5B (91) to 0x7F (127).
+            # Invalid immediates are not skipped so the byte
+            # remains at an instruction boundary.
             if (
                 pc + Uint(1) < ulen(code)
                 and 0x5B <= code[pc + Uint(1)] <= 0x7F
             ):
-                # 0x5b is invalid immediate, treat as JUMPDEST
                 pass
             else:
-                # Valid immediate, skip it
+                pc += Uint(1)
+        elif current_opcode == Ops.EXCHANGE:
+            # EIP-8024: EXCHANGE invalid immediate range is
+            # 81 < x < 128, i.e. 0x52 (82) to 0x7F (127).
+            # Invalid immediates are not skipped so the byte
+            # remains at an instruction boundary.
+            if (
+                pc + Uint(1) < ulen(code)
+                and 0x52 <= code[pc + Uint(1)] <= 0x7F
+            ):
+                pass
+            else:
                 pc += Uint(1)
 
         pc += Uint(1)

--- a/src/ethereum/forks/amsterdam/vm/stack.py
+++ b/src/ethereum/forks/amsterdam/vm/stack.py
@@ -48,10 +48,7 @@ def decode_single(x: U8) -> U8:
             "Valid range: 0 <= x <= 90 or 128 <= x <= 255"
         )
 
-    if x <= U8(90):
-        return x + U8(17)
-    else:
-        return x - U8(20)
+    return U8((int(x) + 145) % 256)
 
 
 def decode_pair(x: U8) -> Tuple[U8, U8]:
@@ -61,7 +58,7 @@ def decode_pair(x: U8) -> Tuple[U8, U8]:
     Parameters
     ----------
     x : int
-        The immediate byte value (0-79 or 128-255).
+        The immediate byte value (0-81 or 128-255).
 
     Returns
     -------
@@ -71,17 +68,17 @@ def decode_pair(x: U8) -> Tuple[U8, U8]:
     Raises
     ------
     InvalidParameter
-        If x is in the forbidden range (79 < x < 128 or x > 255).
+        If x is in the forbidden range (81 < x < 128 or x > 255).
 
     """
-    if not (U8(0) <= x <= U8(79) or U8(128) <= x <= U8(255)):
+    if not (U8(0) <= x <= U8(81) or U8(128) <= x <= U8(255)):
         raise InvalidParameter(
             f"EXCHANGE immediate byte {x} is in the forbidden "
-            "range 80 <= x <= 127\n"
-            "Valid range: 0 <= x <= 79 or 128 <= x <= 255"
+            "range 82 <= x <= 127\n"
+            "Valid range: 0 <= x <= 81 or 128 <= x <= 255"
         )
 
-    k = x if x <= U8(79) else x - U8(48)
+    k = U8(int(x) ^ 143)
     q, r = divmod(k, U8(16))
     if q < r:
         return q + U8(1), r + U8(1)

--- a/src/ethereum/forks/amsterdam/vm/stack.py
+++ b/src/ethereum/forks/amsterdam/vm/stack.py
@@ -26,6 +26,8 @@ def decode_single(x: U8) -> U8:
     """
     Decode the immediate byte for DUPN/SWAPN to get the stack index.
 
+    Return n with 17 <= n <= 235.
+
     Parameters
     ----------
     x : int
@@ -34,7 +36,7 @@ def decode_single(x: U8) -> U8:
     Returns
     -------
     int
-        The stack index (17-235).
+        The stack index n, where 17 <= n <= 235.
 
     Raises
     ------
@@ -55,6 +57,8 @@ def decode_pair(x: U8) -> Tuple[U8, U8]:
     """
     Decode the immediate byte for EXCHANGE to get two stack indices.
 
+    Return (n, m) with 1 <= n <= 14 and n < m <= 30 - n.
+
     Parameters
     ----------
     x : int
@@ -63,7 +67,8 @@ def decode_pair(x: U8) -> Tuple[U8, U8]:
     Returns
     -------
     Tuple[int, int]
-        The two stack indices (n, m).
+        The two stack indices (n, m), where
+        1 <= n <= 14 and n < m <= 30 - n.
 
     Raises
     ------

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
@@ -43,8 +43,8 @@ class Spec:
 
 def decode_pair(x: int) -> Tuple[int, int]:
     """Decode a pair with proper typing for tests."""
-    m, n = _decode_pair(U8(x))
-    return int(m), int(n)
+    n, m = _decode_pair(U8(x))
+    return int(n), int(m)
 
 
 def decode_single(x: int) -> int:

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
@@ -19,7 +19,7 @@ class ReferenceSpec:
 
 ref_spec_8024 = ReferenceSpec(
     git_path="EIPS/eip-8024.md",
-    version="b54accd182b0e2e040ce2ba1a8a61bff6ca9fa0e",
+    version="b9a5fa56ec91e4d82243e832d134c4f2984e1197",
 )
 
 
@@ -36,7 +36,7 @@ class Spec:
 
     # EXCHANGE constraints: 1 <= n < m <= 29, n + m <= 30
     EXCHANGE_MIN_N: int = 1
-    EXCHANGE_MAX_N: int = 13
+    EXCHANGE_MAX_N: int = 14
     EXCHANGE_MAX_M: int = 29
     EXCHANGE_MAX_SUM: int = 30
 

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/spec.py
@@ -19,7 +19,7 @@ class ReferenceSpec:
 
 ref_spec_8024 = ReferenceSpec(
     git_path="EIPS/eip-8024.md",
-    version="b9a5fa56ec91e4d82243e832d134c4f2984e1197",
+    version="380cb02832a6ed5310bfde51591e580ca6d1f3cd",
 )
 
 

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_dupn.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_dupn.py
@@ -150,31 +150,26 @@ def test_endofcode_behavior(
     Test DUPN when the immediate byte is beyond the end of code.
 
     Per EIP-8024, code[pc + 1] evaluates to 0 if beyond the end of the code,
-    matching PUSH behavior. With immediate = 0, decode_single(0) = 17, so
-    DUPN duplicates the 17th stack item.
+    matching PUSH behavior. With immediate = 0, decode_single(0) = 145, so
+    DUPN duplicates the 145th stack item.
 
     This test verifies the transaction succeeds (doesn't revert) when DUPN
     is the last byte of the code with no immediate byte following it.
     """
     sender = pre.fund_eoa()
 
-    # decode_single(0) = 17, which duplicates the 17th item from top
-    # We need 17 items on the stack for this to succeed
-    stack_height = 17
+    # decode_single(0) = 145, which duplicates the 145th item from top
+    # We need 145 items on the stack for this to succeed
+    stack_height = 145
     marker_value = 0x42
-    # The value at position 17 (first pushed) will be duplicated
-    dup_target_value = 0xBEEF
 
     # Build code: store marker, push enough items, then DUPN (no immediate)
     code = Bytecode()
     code += Op.SSTORE(0, marker_value)  # Store marker
 
-    # Push 17 items to stack so DUPN with implicit imm=0 succeeds
+    # Push 145 items to stack so DUPN with implicit imm=0 succeeds
     for i in range(stack_height):
-        if i == 0:
-            code += Op.PUSH2(dup_target_value)  # This will be at position 17
-        else:
-            code += Op.PUSH1(i)
+        code += Op.PUSH1(i % 256)
 
     # Add just the DUPN opcode without immediate byte
     # After DUPN, pc += 2 goes beyond code, causing implicit STOP
@@ -312,9 +307,9 @@ def test_dupn_with_dup1_sequence(
     """
     Test DUPN duplicating the bottom item after building stack with DUP1.
 
-    Stack layout: PUSH1(1) PUSH1(0) DUP1*15 DUPN[0]
-    Before DUPN: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] (17 items)
-    After DUPN[0] (decode_single(0)=17): [1, 0, 0, ..., 0, 1] (18 items)
+    Stack layout: PUSH1(1) PUSH1(0) DUP1*15 DUPN[0x80]
+    Before DUPN: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    After DUPN[0x80] (decode_single(0x80)=17): [1, 0, 0, ..., 0, 1]
     Result: 18 stack items, top=1, bottom=1, rest=0
     """
     sender = pre.fund_eoa()
@@ -328,9 +323,9 @@ def test_dupn_with_dup1_sequence(
 
     # Stack now has 17 items:
     # [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
-    # DUPN with immediate 0 (decode_single(0) = 17) duplicates position 17
+    # DUPN with immediate 0x80 (decode_single(0x80) = 17) duplicates pos 17
     # Pass as bytes (raw immediate byte for testing)
-    code += Op.DUPN[b"\x00"]
+    code += Op.DUPN[b"\x80"]
 
     # Store all stack values to verify
     for i in range(18):

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
@@ -647,6 +647,95 @@ def test_vector_exchange_valid_0x51(
     state_test(pre=pre, post=post, tx=tx)
 
 
+def test_eip_vector_exchange_end_of_code(
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    EIP test vector: 600260008080808080600160008080808080808080e8.
+
+    EXCHANGE at end of code, immediate = 0x00 (beyond code).
+    decode_pair(0) = (9, 16), swaps positions 10 and 17.
+    Results in 17 stack items, bottom=1, 10th from top=2, rest=0.
+    """
+    sender = pre.fund_eoa()
+
+    # Build exact bytecode from the EIP
+    code = (
+        Op.PUSH1[0x2]
+        + Op.PUSH1[0x0]
+        + Op.DUP1 * 5
+        + Op.PUSH1[0x1]
+        + Op.PUSH1[0x0]
+        + Op.DUP1 * 8
+        + Op.EXCHANGE
+    )
+    # 17 items on stack:
+    # pos 1-8: 0, pos 9: 0, pos 10: 1, pos 11-16: 0, pos 17: 2
+    # After EXCHANGE(9,16): swap pos 10 and 17 -> pos 10=2, pos 17=1
+
+    # Store marker before opcode to verify success
+    # Since EXCHANGE is at end of code, we verify by checking that the
+    # operation completed by storing the 10th and bottom items
+    contract_address = pre.deploy_contract(
+        code=Op.SSTORE(0, 0x42) + code + Op.STOP
+    )
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    # Verify marker was stored (tx succeeded)
+    post = {contract_address: Account(storage={0: 0x42})}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_eip_vector_exchange_30_items(
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    EIP test vector (30-item EXCHANGE).
+
+    Bytecode: 600080...(27x DUP1)...60016002e88f.
+    decode_pair(0x8f) = (1, 29), swaps positions 2 and 30.
+    Results in 30 stack items, top=2, bottom=1, rest=0.
+    """
+    sender = pre.fund_eoa()
+
+    code = (
+        Op.PUSH1[0x0]
+        + Op.DUP1 * 27
+        + Op.PUSH1[0x1]
+        + Op.PUSH1[0x2]
+        + Op.EXCHANGE[b"\x8f"]
+    )
+    # 30 items: pos 1=2, pos 2=1, rest=0
+    # After EXCHANGE(1,29): swap pos 2 and 30 -> pos 2=0, pos 30=1
+    # Result: top=2, bottom=1, rest=0
+
+    # Store top value
+    code += Op.PUSH1(0) + Op.SSTORE  # top = 2
+
+    # Pop to get to bottom
+    code += Op.POP * 28
+
+    # Store bottom value
+    code += Op.PUSH1(1) + Op.SSTORE  # bottom = 1
+    code += Op.STOP
+
+    contract_address = pre.deploy_contract(code=code)
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    post = {
+        contract_address: Account(
+            storage={
+                0: 2,  # top = 2 (unchanged)
+                1: 1,  # bottom = 1 (swapped from position 2)
+            }
+        )
+    }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
 def test_vector_exchange_invalid_0x52(
     pre: Alloc,
     state_test: StateTestFiller,

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
@@ -28,13 +28,13 @@ def test_eip_vector_dupn_duplicate_bottom(
     state_test: StateTestFiller,
 ) -> None:
     """
-    EIP test vector: 60016000808080808080808080808080808080e600.
+    EIP test vector: 60016000808080808080808080808080808080e680.
 
     Results in 18 stack items, top=1, bottom=1, rest=0.
 
-    PUSH1 1, PUSH1 0, 15x DUP1, DUPN[0]
+    PUSH1 1, PUSH1 0, 15x DUP1, DUPN[0x80]
     - After 15 DUP1s: 17 items [0,0,0,...,0,1]
-    - DUPN[0]: decode_single(0)=17, duplicate position 17 (value 1)
+    - DUPN[0x80]: decode_single(0x80)=17, duplicate position 17 (value 1)
     - Result: 18 items, top=1, bottom=1
     """
     sender = pre.fund_eoa()
@@ -74,13 +74,13 @@ def test_eip_vector_swapn_swap_with_bottom(
     state_test: StateTestFiller,
 ) -> None:
     """
-    EIP test vector: 600160008080808080808080808080808080806002e700.
+    EIP test vector: 600160008080808080808080808080808080806002e780.
 
     Results in 18 stack items, top=1, bottom=2, rest=0.
 
-    PUSH1 1, PUSH1 0, 15x DUP1, PUSH1 2, SWAPN[0]
+    PUSH1 1, PUSH1 0, 15x DUP1, PUSH1 2, SWAPN[0x80]
     - After PUSH1 2: 18 items with top=2, bottom=1
-    - SWAPN[0]: decode_single(0)=17, swap position 1 with position (17+1)=18
+    - SWAPN[0x80]: decode_single(0x80)=17, swap pos 1 with pos (17+1)=18
     - Result: 18 items, top=1, bottom=2
     """
     sender = pre.fund_eoa()
@@ -126,19 +126,19 @@ def test_eip_vector_exchange_swap_positions(
     state_test: StateTestFiller,
 ) -> None:
     """
-    EIP test vector: 600060016002e801.
+    EIP test vector: 600060016002e88e.
 
     Results in 3 stack items, from top to bottom: [2, 0, 1].
 
-    PUSH1 0, PUSH1 1, PUSH1 2, EXCHANGE[1]
+    PUSH1 0, PUSH1 1, PUSH1 2, EXCHANGE[0x8e]
     - After pushes: [2, 1, 0] (top to bottom)
-    - EXCHANGE[1]: decode_pair(1)=(1,2), swap positions 2 and 3
+    - EXCHANGE[0x8e]: decode_pair(0x8e)=(1,2), swap positions 2 and 3
     - Result: [2, 0, 1]
     """
     sender = pre.fund_eoa()
 
     # Build the exact bytecode from the EIP
-    code = Op.PUSH1[0x0] + Op.PUSH1[0x1] + Op.PUSH1[0x2] + Op.EXCHANGE[b"\x01"]
+    code = Op.PUSH1[0x0] + Op.PUSH1[0x1] + Op.PUSH1[0x2] + Op.EXCHANGE[b"\x8e"]
 
     # Store all 3 stack values
     code += Op.PUSH1(0) + Op.SSTORE  # Store position 1 / top (should be 2)
@@ -236,26 +236,20 @@ def test_eip_vector_exchange_with_iszero(
     state_test: StateTestFiller,
 ) -> None:
     """
-    EIP test vector: 600060006000e80115.
+    EIP test vector: 60008080e88e15.
 
     Results in 3 stack items, top=1, rest=0.
 
-    PUSH1 0, PUSH1 0, PUSH1 0, EXCHANGE[1], ISZERO
-    - After pushes: [0, 0, 0]
-    - EXCHANGE[1]: swap positions 2 and 3 (both 0, no visible change)
+    PUSH1 0, DUP1, DUP1, EXCHANGE[0x8e], ISZERO
+    - After DUP1s: [0, 0, 0]
+    - EXCHANGE[0x8e]: decode_pair(0x8e)=(1,2), swap pos 2 and 3
     - ISZERO: pop 0, push 1
     - Result: [1, 0, 0]
     """
     sender = pre.fund_eoa()
 
     # Build the exact bytecode from the EIP
-    code = (
-        Op.PUSH1[0x0]
-        + Op.PUSH1[0x0]
-        + Op.PUSH1[0x0]
-        + Op.EXCHANGE[b"\x01"]
-        + Op.ISZERO
-    )
+    code = Op.PUSH1[0x0] + Op.DUP1 + Op.DUP1 + Op.EXCHANGE[b"\x8e"] + Op.ISZERO
 
     # Store all 3 stack values
     code += Op.PUSH1(0) + Op.SSTORE  # Store top (should be 1)
@@ -284,19 +278,19 @@ def test_eip_vector_dupn_stack_underflow(
     state_test: StateTestFiller,
 ) -> None:
     """
-    EIP test vector: 6000808080808080808080808080808080e600.
+    EIP test vector: 6000808080808080808080808080808080e680.
 
     Results in exceptional halt (stack underflow).
 
-    PUSH1 0, 15x DUP1, DUPN[0]
+    PUSH1 0, 15x DUP1, DUPN[0x80]
     - After 15 DUP1s: 16 items
-    - DUPN[0]: decode_single(0)=17, needs position 17 but only 16 items
+    - DUPN[0x80]: decode_single(0x80)=17, needs position 17 but only 16 items
     - Result: exceptional halt
     """
     sender = pre.fund_eoa()
 
     # Build the exact bytecode from the EIP
-    code = Op.PUSH1[0x0] + Op.DUP1 * 15 + Op.DUPN[b"\x00"]
+    code = Op.PUSH1[0x0] + Op.DUP1 * 15 + Op.DUPN[b"\x80"]
 
     # This should not execute due to stack underflow
     code += Op.PUSH1(1) + Op.PUSH1(0) + Op.SSTORE
@@ -316,11 +310,11 @@ def test_vector_dupn_followed_by_jumpdest(
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test vector: e6005b [DUPN 17, JUMPDEST].
+    Test vector: e6805b [DUPN 17, JUMPDEST].
 
-    Verifies that DUPN with immediate 0x00 correctly consumes the immediate
+    Verifies that DUPN with immediate 0x80 correctly consumes the immediate
     byte. The 0x5b following the DUPN is a separate JUMPDEST instruction,
-    not part of DUPN. decode_single(0x00) = 17, so DUPN duplicates the 17th
+    not part of DUPN. decode_single(0x80) = 17, so DUPN duplicates the 17th
     stack item.
     """
     sender = pre.fund_eoa()
@@ -453,15 +447,15 @@ def test_vector_dupn_invalid_0x5f(
     state_test(pre=pre, post=post, tx=tx)
 
 
-def test_vector_exchange_0x12(
+def test_vector_exchange_0x9d(
     pre: Alloc,
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test vector: e812 [EXCHANGE 2 3].
+    Test vector: e89d [EXCHANGE 2 3].
 
-    EXCHANGE with immediate 0x12 (18 decimal).
-    decode_pair(18) = (2, 3), swaps positions 3 and 4.
+    EXCHANGE with immediate 0x9d (157 decimal).
+    decode_pair(0x9d) = (2, 3), swaps positions 3 and 4.
     """
     sender = pre.fund_eoa()
 
@@ -473,9 +467,9 @@ def test_vector_exchange_0x12(
     code += Op.PUSH2(0x2222)  # Position 2
     code += Op.PUSH2(0x1111)  # Position 1 (top)
 
-    # EXCHANGE with immediate 0x12 - swaps positions 3 and 4
-    # Hex: e8 12
-    code += Op.EXCHANGE[b"\x12"]
+    # EXCHANGE with immediate 0x9d - swaps positions 3 and 4
+    # Hex: e8 9d
+    code += Op.EXCHANGE[b"\x9d"]
 
     # Store all values to verify the swap
     code += Op.PUSH1(0) + Op.SSTORE  # Position 1 (top)
@@ -487,7 +481,7 @@ def test_vector_exchange_0x12(
     contract_address = pre.deploy_contract(code=code)
     tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
 
-    # After EXCHANGE[0x12]: positions 3 and 4 are swapped
+    # After EXCHANGE[0x9d]: positions 3 and 4 are swapped
     post = {
         contract_address: Account(
             storage={
@@ -502,15 +496,15 @@ def test_vector_exchange_0x12(
     state_test(pre=pre, post=post, tx=tx)
 
 
-def test_vector_exchange_0xd0(
+def test_vector_exchange_0x2f(
     pre: Alloc,
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test vector: e8d0 [EXCHANGE 1 19].
+    Test vector: e82f [EXCHANGE 1 19].
 
-    EXCHANGE with immediate 0xd0 (208 decimal).
-    decode_pair(208) = (1, 19), swaps positions 2 and 20.
+    EXCHANGE with immediate 0x2f (47 decimal).
+    decode_pair(0x2f) = (1, 19), swaps positions 2 and 20.
     """
     sender = pre.fund_eoa()
 
@@ -523,9 +517,9 @@ def test_vector_exchange_0xd0(
     code += Op.PUSH2(0xAAAA)  # Position 2 (will be swapped)
     code += Op.PUSH2(0x1111)  # Position 1 (top)
 
-    # EXCHANGE with immediate 0xd0 - swaps positions 2 and 20
-    # Hex: e8 d0
-    code += Op.EXCHANGE[b"\xd0"]
+    # EXCHANGE with immediate 0x2f - swaps positions 2 and 20
+    # Hex: e8 2f
+    code += Op.EXCHANGE[b"\x2f"]
 
     # Store position 1, 2, and 20 to verify
     code += Op.PUSH1(0) + Op.SSTORE  # Position 1 (top, unchanged)
@@ -541,7 +535,7 @@ def test_vector_exchange_0xd0(
     contract_address = pre.deploy_contract(code=code)
     tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
 
-    # After EXCHANGE[0xd0]: positions 2 and 20 are swapped
+    # After EXCHANGE[0x2f]: positions 2 and 20 are swapped
     post = {
         contract_address: Account(
             storage={
@@ -555,15 +549,113 @@ def test_vector_exchange_0xd0(
     state_test(pre=pre, post=post, tx=tx)
 
 
-def test_vector_exchange_invalid_0x50(
+def test_vector_exchange_valid_0x50(
     pre: Alloc,
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test vector: e850 [INVALID_EXCHANGE, POP].
+    Test vector: e850 [EXCHANGE 14 16].
 
-    EXCHANGE with immediate 0x50 (80 decimal) is in the invalid range (80-127).
-    Execution should abort with exceptional halt.
+    EXCHANGE with immediate 0x50 (80 decimal) is valid.
+    decode_pair(0x50) = (14, 16), swaps positions 15 and 17.
+    """
+    sender = pre.fund_eoa()
+
+    # Build stack with 17 items, with known values at positions 15 and 17
+    code = Bytecode()
+    for i in range(17):
+        stack_pos = 17 - i  # Position from top (1-indexed)
+        if stack_pos == 15:
+            code += Op.PUSH2(0xAAAA)
+        elif stack_pos == 17:
+            code += Op.PUSH2(0xBBBB)
+        else:
+            code += Op.PUSH2(0x1000 + i)
+
+    # EXCHANGE with immediate 0x50 - swaps positions 15 and 17
+    code += Op.EXCHANGE[b"\x50"]
+
+    # Store swapped positions to verify
+    # Pop to position 15 (pop 14 items)
+    for _ in range(14):
+        code += Op.POP
+    code += Op.PUSH1(0) + Op.SSTORE  # Position 15 (was 0xBBBB)
+    code += Op.POP  # Skip position 16
+    code += Op.PUSH1(1) + Op.SSTORE  # Position 17 (was 0xAAAA)
+    code += Op.STOP
+
+    contract_address = pre.deploy_contract(code=code)
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    post = {
+        contract_address: Account(
+            storage={
+                0: 0xBBBB,  # Position 15 now has value from 17
+                1: 0xAAAA,  # Position 17 now has value from 15
+            }
+        )
+    }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_vector_exchange_valid_0x51(
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Test vector: e851 [EXCHANGE 14 15].
+
+    EXCHANGE with immediate 0x51 (81 decimal) is valid.
+    decode_pair(0x51) = (14, 15), swaps positions 15 and 16.
+    """
+    sender = pre.fund_eoa()
+
+    # Build stack with 16 items, with known values at positions 15 and 16
+    code = Bytecode()
+    for i in range(16):
+        stack_pos = 16 - i
+        if stack_pos == 15:
+            code += Op.PUSH2(0xAAAA)
+        elif stack_pos == 16:
+            code += Op.PUSH2(0xBBBB)
+        else:
+            code += Op.PUSH2(0x1000 + i)
+
+    # EXCHANGE with immediate 0x51 - swaps positions 15 and 16
+    code += Op.EXCHANGE[b"\x51"]
+
+    # Pop to position 15 (pop 14 items)
+    for _ in range(14):
+        code += Op.POP
+    code += Op.PUSH1(0) + Op.SSTORE  # Position 15 (was 0xBBBB)
+    code += Op.PUSH1(1) + Op.SSTORE  # Position 16 (was 0xAAAA)
+    code += Op.STOP
+
+    contract_address = pre.deploy_contract(code=code)
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+
+    post = {
+        contract_address: Account(
+            storage={
+                0: 0xBBBB,  # Position 15 now has value from 16
+                1: 0xAAAA,  # Position 16 now has value from 15
+            }
+        )
+    }
+
+    state_test(pre=pre, post=post, tx=tx)
+
+
+def test_vector_exchange_invalid_0x52(
+    pre: Alloc,
+    state_test: StateTestFiller,
+) -> None:
+    """
+    Test vector: e852 [INVALID_EXCHANGE, MSTORE].
+
+    EXCHANGE with immediate 0x52 (82 decimal) is in the invalid
+    range (82-127). Execution should abort with exceptional halt.
     """
     sender = pre.fund_eoa()
 
@@ -572,12 +664,12 @@ def test_vector_exchange_invalid_0x50(
     for i in range(30):
         code += Op.PUSH1(i)
 
-    # EXCHANGE with invalid immediate 0x50 - should abort
-    # Hex: e8 50
-    code += Op.EXCHANGE[b"\x50"]
+    # EXCHANGE with invalid immediate 0x52 - should abort
+    # Hex: e8 52
+    code += Op.EXCHANGE[b"\x52"]
 
-    # This would be POP if we got here (0x50 = POP opcode)
-    code += Op.POP
+    # This would be MSTORE if we got here (0x52 = MSTORE opcode)
+    code += Op.MSTORE
     code += Op.PUSH1(0x42) + Op.PUSH1(0) + Op.SSTORE
     code += Op.STOP
 
@@ -593,9 +685,9 @@ def test_vector_exchange_invalid_0x50(
 @pytest.mark.parametrize(
     "eip8024_opcode,stack_items",
     [
-        pytest.param(Op.DUPN, 17, id="dupn"),
-        pytest.param(Op.SWAPN, 18, id="swapn"),
-        pytest.param(Op.EXCHANGE, 30, id="exchange"),
+        pytest.param(Op.DUPN, 145, id="dupn"),
+        pytest.param(Op.SWAPN, 146, id="swapn"),
+        pytest.param(Op.EXCHANGE, 17, id="exchange"),
     ],
 )
 def test_eip_vector_end_of_code(
@@ -608,9 +700,9 @@ def test_eip_vector_end_of_code(
     Test EIP-8024 opcodes at end of code (no immediate byte).
 
     When an opcode appears at end of code, code[pc+1] = 0 beyond end of code.
-    - DUPN: decode_single(0) = 17, needs 17 items on stack
-    - SWAPN: decode_single(0) = 17, needs 18 items on stack
-    - EXCHANGE: decode_pair(0) = (1, 29), needs 30 items on stack
+    - DUPN: decode_single(0) = 145, needs 145 items on stack
+    - SWAPN: decode_single(0) = 145, needs 146 items on stack
+    - EXCHANGE: decode_pair(0) = (9, 16), needs 17 items on stack
 
     Store a marker before the opcode to verify the transaction succeeded,
     since adding any opcode after would make that opcode byte the immediate.

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
@@ -312,22 +312,22 @@ def test_vector_dupn_followed_by_jumpdest(
     """
     Test vector: e6805b [DUPN 17, JUMPDEST].
 
-    Verifies that DUPN with immediate 0x80 correctly consumes the immediate
-    byte. The 0x5b following the DUPN is a separate JUMPDEST instruction,
-    not part of DUPN. decode_single(0x80) = 17, so DUPN duplicates the 17th
-    stack item.
+    Verify that DUPN with immediate 0x80 (128) correctly consumes the
+    immediate byte. The 0x5b following the DUPN is a separate JUMPDEST
+    instruction, not part of DUPN. decode_single(0x80) = 17, so DUPN
+    duplicates the 17th stack item.
     """
     sender = pre.fund_eoa()
 
-    # Push 17 items so DUPN[0x00] (which duplicates position 17) succeeds
+    # Push 17 items so DUPN[17] (immediate 0x80 / 128) succeeds
     marker_value = 0xBEEF
     code = Bytecode()
     code += Op.PUSH2(marker_value)  # This will be at position 17
     for i in range(16):
         code += Op.PUSH1(i)
 
-    # DUPN with immediate 0x00 followed by JUMPDEST
-    # Hex: e6 00 5b
+    # DUPN[17] encodes to immediate 0x80 (128), followed by JUMPDEST
+    # Bytecode: e6 80 5b
     code += Op.DUPN[17] + Op.JUMPDEST
 
     # Store the duplicated value (should be marker_value)
@@ -695,7 +695,7 @@ def test_eip_vector_exchange_30_items(
     EIP test vector (30-item EXCHANGE).
 
     Bytecode: 600080...(27x DUP1)...60016002e88f.
-    decode_pair(0x8f) = (1, 29), swaps positions 2 and 30.
+    decode_pair(0x8f / 143) = (1, 29), swaps positions 2 and 30.
     Results in 30 stack items, top=2, bottom=1, rest=0.
     """
     sender = pre.fund_eoa()

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_eip_vectors.py
@@ -41,9 +41,11 @@ def test_eip_vector_dupn_duplicate_bottom(
 
     # Build the exact bytecode from the EIP
     code = Op.PUSH1[0x1] + Op.PUSH1[0x0] + Op.DUP1 * 15 + Op.DUPN[17]
+    assert bytes(code) == bytes.fromhex(
+        "60016000808080808080808080808080808080e680"
+    )
 
-    # After DUPN: 18 items, top=1, bottom=1
-    # Verify by storing top value at key 0
+    # Verify by storing top and bottom values
     code += Op.PUSH1(0) + Op.SSTORE  # Store top (should be 1) at key 0
 
     # Pop 16 items to get to bottom 2 items
@@ -93,9 +95,11 @@ def test_eip_vector_swapn_swap_with_bottom(
         + Op.PUSH1[0x2]
         + Op.SWAPN[17]
     )
+    assert bytes(code) == bytes.fromhex(
+        "600160008080808080808080808080808080806002e780"
+    )
 
-    # After SWAPN: 18 items, top=1, bottom=2
-    # Verify by storing top value at key 0
+    # Verify by storing top and bottom values
     code += Op.PUSH1(0) + Op.SSTORE  # Store top (should be 1) at key 0
 
     # Pop 16 items to get to bottom 1 item
@@ -139,6 +143,7 @@ def test_eip_vector_exchange_swap_positions(
 
     # Build the exact bytecode from the EIP
     code = Op.PUSH1[0x0] + Op.PUSH1[0x1] + Op.PUSH1[0x2] + Op.EXCHANGE[b"\x8e"]
+    assert bytes(code) == bytes.fromhex("600060016002e88e")
 
     # Store all 3 stack values
     code += Op.PUSH1(0) + Op.SSTORE  # Store position 1 / top (should be 2)
@@ -182,6 +187,7 @@ def test_eip_vector_swapn_invalid_immediate_reverts(
         pushed_stack_items=0,
         terminating=True,
     )
+    assert bytes(code) == bytes.fromhex("e75b")
 
     contract_address = pre.deploy_contract(code=code)
     tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
@@ -217,6 +223,7 @@ def test_eip_vector_jump_over_invalid_dupn(
         popped_stack_items=0,
         pushed_stack_items=0,
     )
+    assert bytes(code) == bytes.fromhex("600456e65b")
 
     # After jumping to JUMPDEST, mark success
     code += Op.PUSH1(1) + Op.PUSH1(0) + Op.SSTORE
@@ -250,6 +257,7 @@ def test_eip_vector_exchange_with_iszero(
 
     # Build the exact bytecode from the EIP
     code = Op.PUSH1[0x0] + Op.DUP1 + Op.DUP1 + Op.EXCHANGE[b"\x8e"] + Op.ISZERO
+    assert bytes(code) == bytes.fromhex("60008080e88e15")
 
     # Store all 3 stack values
     code += Op.PUSH1(0) + Op.SSTORE  # Store top (should be 1)
@@ -291,6 +299,9 @@ def test_eip_vector_dupn_stack_underflow(
 
     # Build the exact bytecode from the EIP
     code = Op.PUSH1[0x0] + Op.DUP1 * 15 + Op.DUPN[b"\x80"]
+    assert bytes(code) == bytes.fromhex(
+        "6000808080808080808080808080808080e680"
+    )
 
     # This should not execute due to stack underflow
     code += Op.PUSH1(1) + Op.PUSH1(0) + Op.SSTORE
@@ -670,6 +681,9 @@ def test_eip_vector_exchange_end_of_code(
         + Op.DUP1 * 8
         + Op.EXCHANGE
     )
+    assert bytes(code) == bytes.fromhex(
+        "600260008080808080600160008080808080808080e8"
+    )
     # 17 items on stack:
     # pos 1-8: 0, pos 9: 0, pos 10: 1, pos 11-16: 0, pos 17: 2
     # After EXCHANGE(9,16): swap pos 10 and 17 -> pos 10=2, pos 17=1
@@ -707,6 +721,7 @@ def test_eip_vector_exchange_30_items(
         + Op.PUSH1[0x2]
         + Op.EXCHANGE[b"\x8f"]
     )
+    assert bytes(code) == bytes.fromhex("6000" + "80" * 27 + "60016002e88f")
     # 30 items: pos 1=2, pos 2=1, rest=0
     # After EXCHANGE(1,29): swap pos 2 and 30 -> pos 2=0, pos 30=1
     # Result: top=2, bottom=1, rest=0

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
@@ -289,21 +289,23 @@ def test_endofcode_behavior(
 @pytest.mark.parametrize(
     "immediate",
     [
-        # valid immediates: skipped, not a jump target
+        # valid immediates (0-81 / 128-255): skipped during JUMPDEST
+        # analysis, not reachable as jump targets
         0x00,
-        0x4F,
-        0x50,  # POP (now valid for EXCHANGE)
-        0x51,  # MLOAD (now valid for EXCHANGE)
-        # invalid immediates: not skipped, only 0x5B is JUMPDEST
-        0x52,  # MSTORE
-        0x5A,  # GAS
-        0x5B,  # JUMPDEST - only one where jump succeeds
-        0x5C,  # TLOAD
-        0x60,  # PUSH1
-        0x7F,  # PUSH32
-        # valid immediates again
-        0x80,
-        0xFF,
+        0x4F,  # 79
+        0x50,  # 80 — POP (valid for EXCHANGE)
+        0x51,  # 81 — MLOAD (valid for EXCHANGE)
+        # invalid immediates (82-127): not skipped during JUMPDEST
+        # analysis, only 0x5B (91) is a JUMPDEST
+        0x52,  # 82 — MSTORE (first invalid immediate)
+        0x5A,  # 90 — GAS (invalid immediate)
+        0x5B,  # 91 — JUMPDEST, only case where jump succeeds
+        0x5C,  # 92 — TLOAD (invalid immediate)
+        0x60,  # 96 — PUSH1 (invalid immediate)
+        0x7F,  # 127 — PUSH32 (last invalid immediate)
+        # valid immediates again (128-255)
+        0x80,  # 128
+        0xFF,  # 255
     ],
     ids=lambda x: f"imm_0x{x:02x}",
 )
@@ -347,15 +349,8 @@ def test_exchange_with_push_sequence(
     """
     Test EXCHANGE swapping positions 10 and 17 with a push sequence.
 
-    Stack layout: 15x PUSH1(0) PUSH1(1) PUSH1(2) EXCHANGE[0x8f]
-    Before EXCHANGE (17 items, top to bottom):
-    [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    After EXCHANGE[0x8f] (decode_pair(0x8f)=(1,29), swaps pos 2 and 30):
-    wait, decode_pair(0x8f) = k=0x8f^143=0, q=0, r=0 -> (1, 29).
-    Actually need 30 items for (1, 29). Use EXCHANGE[1, 2] instead.
-
-    Uses EXCHANGE to swap specific positions and verifies the result.
-    decode_pair(0) = (9, 16), swaps positions 10 and 17.
+    Build 17 stack items with markers at positions 10 and 17.
+    EXCHANGE[0x00]: decode_pair(0) = (9, 16), swaps positions 10 and 17.
     """
     sender = pre.fund_eoa()
 

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.valid_from("Amsterdam")
         (1, 29),  # Swap positions 2 and 30 (n + m = 30)
         (5, 10),  # Swap positions 6 and 11
         (13, 17),  # Swap positions 14 and 18 (n + m = 30)
+        (14, 16),  # Swap positions 15 and 17 (n + m = 30)
     ],
     ids=lambda x: f"{x}",
 )
@@ -93,7 +94,7 @@ def test_exchange_basic(
 
 @pytest.mark.parametrize(
     "immediate",
-    [0, 1, 15, 78, 79, 128, 129, 200, 255],
+    [0, 1, 15, 78, 79, 80, 81, 128, 129, 200, 255],
     ids=lambda x: f"exchange_imm_{x}",
 )
 def test_exchange_valid_immediates(
@@ -101,7 +102,7 @@ def test_exchange_valid_immediates(
     pre: Alloc,
     state_test: StateTestFiller,
 ) -> None:
-    """Test EXCHANGE with valid immediate values (0-79 and 128-255)."""
+    """Test EXCHANGE with valid immediate values (0-81 and 128-255)."""
     sender = pre.fund_eoa()
 
     # Decode the immediate to get the stack indices
@@ -206,8 +207,8 @@ def test_exchange_preserves_other_items(
 
 @pytest.mark.parametrize(
     "immediate",
-    # Boundaries of both valid ranges (0x00, 0x4F, 0x80, 0xFF)
-    [0, 78, 79, 128, 129, 255],
+    # Boundaries of both valid ranges (0x00, 0x51, 0x80, 0xFF)
+    [0, 78, 79, 80, 81, 128, 129, 255],
     ids=lambda x: f"underflow_imm_{x}",
 )
 def test_exchange_stack_underflow(
@@ -249,24 +250,24 @@ def test_endofcode_behavior(
     Test EXCHANGE when the immediate byte is beyond the end of code.
 
     Per EIP-8024, code[pc + 1] evaluates to 0 if beyond the end of the code,
-    matching PUSH behavior. With immediate = 0, decode_pair(0) = (1, 29), so
-    EXCHANGE swaps positions 2 and 30.
+    matching PUSH behavior. With immediate = 0, decode_pair(0) = (9, 16), so
+    EXCHANGE swaps positions 10 and 17.
 
     This test verifies the transaction succeeds (doesn't revert) when EXCHANGE
     is the last byte of the code with no immediate byte following it.
     """
     sender = pre.fund_eoa()
 
-    # decode_pair(0) = (1, 29), which swaps positions 2 and 30
-    # We need 30 items on the stack for this to succeed
-    stack_height = 30
+    # decode_pair(0) = (9, 16), which swaps positions 10 and 17
+    # We need 17 items on the stack for this to succeed
+    stack_height = 17
     marker_value = 0x42
 
     # Build code: store marker, push enough items, then EXCHANGE (no immediate)
     code = Bytecode()
     code += Op.PUSH1(marker_value) + Op.PUSH1(0) + Op.SSTORE  # Store marker
 
-    # Push 30 items to stack so EXCHANGE with implicit imm=0 succeeds
+    # Push 17 items to stack so EXCHANGE with implicit imm=0 succeeds
     for i in range(stack_height):
         code += Op.PUSH1(i)
 
@@ -291,8 +292,10 @@ def test_endofcode_behavior(
         # valid immediates: skipped, not a jump target
         0x00,
         0x4F,
+        0x50,  # POP (now valid for EXCHANGE)
+        0x51,  # MLOAD (now valid for EXCHANGE)
         # invalid immediates: not skipped, only 0x5B is JUMPDEST
-        0x50,  # POP
+        0x52,  # MSTORE
         0x5A,  # GAS
         0x5B,  # JUMPDEST - only one where jump succeeds
         0x5C,  # TLOAD
@@ -342,35 +345,37 @@ def test_exchange_with_push_sequence(
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test EXCHANGE swapping positions 2 and 30 with a push sequence.
+    Test EXCHANGE swapping positions 10 and 17 with a push sequence.
 
-    Stack layout: 28x PUSH1(0) PUSH1(1) PUSH1(2) EXCHANGE[0]
-    Before EXCHANGE (30 items, top to bottom):
-    [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-     0, 0, 0, 0, 0, 0, 0, 0]
-    After EXCHANGE[0] (decode_pair(0)=(1,29), swaps positions 2 and 30):
-    [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-     0, 0, 0, 0, 0, 0, 0, 1]
-    Result: 30 stack items, top=2, bottom=1, rest=0
+    Stack layout: 15x PUSH1(0) PUSH1(1) PUSH1(2) EXCHANGE[0x8f]
+    Before EXCHANGE (17 items, top to bottom):
+    [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    After EXCHANGE[0x8f] (decode_pair(0x8f)=(1,29), swaps pos 2 and 30):
+    wait, decode_pair(0x8f) = k=0x8f^143=0, q=0, r=0 -> (1, 29).
+    Actually need 30 items for (1, 29). Use EXCHANGE[1, 2] instead.
+
+    Uses EXCHANGE to swap specific positions and verifies the result.
+    decode_pair(0) = (9, 16), swaps positions 10 and 17.
     """
     sender = pre.fund_eoa()
 
-    # Build the stack: 28x PUSH1(0), PUSH1(1), PUSH1(2)
+    # Build 17 items with markers at positions 10 and 17
     code = Bytecode()
-    for _ in range(28):
-        code += Op.PUSH1(0)
-    code += Op.PUSH1(1)  # Position 2 from top after final push
-    code += Op.PUSH1(2)  # Position 1 (top)
+    for i in range(17):
+        stack_pos = 17 - i  # Position from top (1-indexed)
+        if stack_pos == 10:
+            code += Op.PUSH2(0xAAAA)
+        elif stack_pos == 17:
+            code += Op.PUSH2(0xBBBB)
+        else:
+            code += Op.PUSH1(0)
 
-    # Stack has 30 items:
-    # [2, 1, 0, 0, ..., 0, 0] (28 zeros in the middle)
-    # EXCHANGE with immediate 0 (decode_pair(0) = (1, 29))
-    # swaps pos 2 and 30
-    # Pass as bytes (raw immediate byte for testing)
+    # EXCHANGE with immediate 0 (decode_pair(0) = (9, 16))
+    # swaps pos 10 and 17
     code += Op.EXCHANGE[b"\x00"]
 
     # Store all stack values to verify
-    for i in range(30):
+    for i in range(17):
         code += Op.PUSH1(i) + Op.SSTORE
 
     code += Op.STOP
@@ -379,18 +384,17 @@ def test_exchange_with_push_sequence(
 
     tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
 
-    # Expected: top (position 0) = 2, position 1 = 0 (swapped from 30),
-    # bottom (position 29) = 1 (swapped from position 2), rest = 0
+    # Expected: position 9 has 0xBBBB (from pos 17), position 16 has
+    # 0xAAAA (from pos 10), rest = 0
     expected_storage = {}
-    for i in range(30):
-        if i == 0:
-            expected_storage[i] = 2  # Top unchanged
-        elif i == 1:
-            expected_storage[i] = 0  # Was at bottom (pos 30), now at pos 2
-        elif i == 29:
-            expected_storage[i] = 1  # Was at pos 2, now at bottom (pos 30)
+    for i in range(17):
+        stack_pos = i + 1  # 1-indexed position from top
+        if stack_pos == 10:
+            expected_storage[i] = 0xBBBB  # Swapped from position 17
+        elif stack_pos == 17:
+            expected_storage[i] = 0xAAAA  # Swapped from position 10
         else:
-            expected_storage[i] = 0  # All other values
+            expected_storage[i] = 0
 
     post = {contract_address: Account(storage=expected_storage)}
 
@@ -399,7 +403,7 @@ def test_exchange_with_push_sequence(
 
 @pytest.mark.parametrize(
     "immediate",
-    range(80, 128),  # Forbidden range: 0x50-0x7F
+    range(82, 128),  # Forbidden range: 0x52-0x7F
     ids=lambda x: f"imm_{x}",
 )
 def test_exchange_invalid_immediate_aborts(
@@ -408,7 +412,7 @@ def test_exchange_invalid_immediate_aborts(
     state_test: StateTestFiller,
 ) -> None:
     """
-    Test EXCHANGE aborts with invalid immediates (80-127).
+    Test EXCHANGE aborts with invalid immediates (82-127).
 
     This range is forbidden because it overlaps with JUMPDEST and PUSH opcodes.
     """

--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_swapn.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_swapn.py
@@ -194,14 +194,14 @@ def test_swapn_stack_underflow(
     """Test SWAPN causes transaction failure on stack underflow."""
     sender = pre.fund_eoa()
 
-    # SWAPN with immediate 0 (n=17) swaps position 1 with position 18
+    # SWAPN with immediate 0x80 (n=17) swaps position 1 with position 18
     # Need 18 items, so push only 17 to trigger underflow
     code = Bytecode()
     for i in range(17):
         code += Op.PUSH1(i)
     # Pass immediate as bytes (raw immediate byte for testing)
-    # decode_single(0) = 17, needs 18 items but only 17
-    code += Op.SWAPN[b"\x00"]
+    # decode_single(0x80) = 17, needs 18 items but only 17
+    code += Op.SWAPN[b"\x80"]
     code += Op.STOP
 
     contract_address = pre.deploy_contract(code=code)
@@ -222,26 +222,26 @@ def test_endofcode_behavior(
     Test SWAPN when the immediate byte is beyond the end of code.
 
     Per EIP-8024, code[pc + 1] evaluates to 0 if beyond the end of the code,
-    matching PUSH behavior. With immediate = 0, decode_single(0) = 17, so
-    SWAPN swaps position 1 with position 18.
+    matching PUSH behavior. With immediate = 0, decode_single(0) = 145, so
+    SWAPN swaps position 1 with position 146.
 
     This test verifies the transaction succeeds (doesn't revert) when SWAPN
     is the last byte of the code with no immediate byte following it.
     """
     sender = pre.fund_eoa()
 
-    # decode_single(0) = 17, which swaps position 1 with position 18
-    # We need 18 items on the stack for this to succeed
-    stack_height = 18
+    # decode_single(0) = 145, which swaps position 1 with position 146
+    # We need 146 items on the stack for this to succeed
+    stack_height = 146
     marker_value = 0x42
 
     # Build code: store marker, push enough items, then SWAPN (no immediate)
     code = Bytecode()
     code += Op.PUSH1(marker_value) + Op.PUSH1(0) + Op.SSTORE  # Store marker
 
-    # Push 18 items to stack so SWAPN with implicit imm=0 succeeds
+    # Push 146 items to stack so SWAPN with implicit imm=0 succeeds
     for i in range(stack_height):
-        code += Op.PUSH1(i)
+        code += Op.PUSH1(i % 256)
 
     # Add just the SWAPN opcode without immediate byte
     # After SWAPN, pc += 2 goes beyond code, causing implicit STOP
@@ -336,9 +336,9 @@ def test_swapn_with_dup1_and_push(
     """
     Test SWAPN swapping top and bottom after building stack with DUP1.
 
-    Stack layout: PUSH1(1) PUSH1(0) DUP1*15 PUSH1(2) SWAPN[0]
+    Stack layout: PUSH1(1) PUSH1(0) DUP1*15 PUSH1(2) SWAPN[0x80]
     Before SWAPN: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
-    After SWAPN[0] (decode_single(0)=17, swaps pos 1 and 18):
+    After SWAPN[0x80] (decode_single(0x80)=17, swaps pos 1 and 18):
     [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]
     Result: 18 stack items, top=1, bottom=2, rest=0
     """
@@ -353,9 +353,9 @@ def test_swapn_with_dup1_and_push(
     code += Op.PUSH1(2)  # Top of stack (position 1)
 
     # Stack: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
-    # SWAPN with immediate 0 (decode_single(0) = 17) swaps pos 1 and 18
+    # SWAPN with immediate 0x80 (decode_single(0x80)=17) swaps pos 1 and 18
     # Pass as bytes (raw immediate byte for testing)
-    code += Op.SWAPN[b"\x00"]
+    code += Op.SWAPN[b"\x80"]
 
     # Store all stack values to verify
     for i in range(18):

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -80,9 +80,17 @@ def test_all_opcodes(
     valid_opcodes = set(fork.valid_opcodes())
     all_opcodes = set(Opcode(i) for i in range(0xFF + 1))
     for opcode in sorted(valid_opcodes | all_opcodes):
+        test_opcode: Opcode | Bytecode = opcode
+        if opcode.has_data_portion():
+            if opcode in [Op.SWAPN, Op.DUPN]:
+                test_opcode = opcode[17]
+            elif opcode == Op.EXCHANGE:
+                test_opcode = opcode[1, 2]
+            else:
+                test_opcode = opcode[0]
         code_contract[opcode] = pre.deploy_contract(
             balance=10,
-            code=prepare_stack(opcode) + opcode + prepare_suffix(opcode),
+            code=prepare_stack(opcode) + test_opcode + prepare_suffix(opcode),
             storage={},
         )
 


### PR DESCRIPTION
## 🗒️ Description
[Spec is finna change](https://github.com/ethereum/EIPs/pull/11306), this adds the required changes.

## 🔗 Related Issues or PRs
Solves #2298 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
