### PR TITLE
chore(ci): Skip diffs if not on default branch

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -43,6 +43,8 @@ jobs:
         run: |
           tox -e spec-docs
           touch .tox/docs/.nojekyll
+        env:
+          DOCC_SKIP_DIFFS: ${{ (github.event_name != 'push' || github.ref_name != github.event.repository.default_branch) && '1' || '' }}
 
       - name: Upload Pages Artifact
         id: artifact

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -44,7 +44,7 @@ jobs:
           tox -e spec-docs
           touch .tox/docs/.nojekyll
         env:
-          DOCC_SKIP_DIFFS: ${{ (github.event_name != 'push' || github.ref_name != github.event.repository.default_branch) && '1' || '' }}
+          DOCC_SKIP_DIFFS: ${{ case(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch, '', '1') }}
 
       - name: Upload Pages Artifact
         id: artifact

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -44,7 +44,7 @@ jobs:
           tox -e spec-docs
           touch .tox/docs/.nojekyll
         env:
-          DOCC_SKIP_DIFFS: ${{ case(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch, '', '1') }}
+          DOCC_SKIP_DIFFS: ${{ (github.event_name != 'push' || github.ref_name != github.event.repository.default_branch) && '1' || '' }}
 
       - name: Upload Pages Artifact
         id: artifact

--- a/src/ethereum_spec_tools/docc.py
+++ b/src/ethereum_spec_tools/docc.py
@@ -19,6 +19,7 @@ Plugins for docc specific to the Ethereum execution specification.
 
 import dataclasses
 import logging
+import os
 from collections import defaultdict
 from itertools import tee, zip_longest
 from pathlib import PurePath
@@ -89,6 +90,10 @@ class EthereumDiscover(Discover):
         """
         Find sources.
         """
+        if os.environ.get("DOCC_SKIP_DIFFS"):
+            logging.info("Skipping diff discovery (DOCC_SKIP_DIFFS)")
+            return
+
         forks = {f.path: f for f in self.forks if f.path is not None}
 
         by_fork: Dict[Hardfork, Dict[PurePath, Source]] = defaultdict(dict)

--- a/tox.ini
+++ b/tox.ini
@@ -194,6 +194,7 @@ commands =
 [testenv:spec-docs]
 description = Generate documentation for the specification code using docc
 basepython = python3
+passenv = DOCC_SKIP_DIFFS
 commands =
     docc --output "{toxworkdir}/docs"
     python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs" / "index.html"))'


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Original reference here: https://github.com/ethereum/execution-specs/pull/2271#pullrequestreview-3843404008

For PR branches, we don't publish the diffs, so we can skip them and only run them on the default branch.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
