### PR TITLE
fix: return False instead of raising AssertionError in FixedSizeBytes…

### DIFF
--- a/packages/testing/src/execution_testing/base_types/base_types.py
+++ b/packages/testing/src/execution_testing/base_types/base_types.py
@@ -375,12 +375,13 @@ class FixedSizeBytes(Bytes):
         if other is None:
             return False
         if not isinstance(other, FixedSizeBytes):
-            assert (
+            if not (
                 isinstance(other, str)
                 or isinstance(other, int)
                 or isinstance(other, bytes)
                 or isinstance(other, SupportsBytes)
-            )
+            ):
+                return False
             other = self._sized_(other)
         return super().__eq__(other)
 


### PR DESCRIPTION
## 🗒️ Description

The FixedSizeBytes.__eq__ method was using assert to check type compatibility, which raises AssertionError when comparing with unsupported types like None or dict. This replaces the assert with a conditional that returns False for unsupported types, following Python's equality semantics.
## 🔗 Related Issues or PRs
Fixes #2290

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails
- [x] All: PR title adheres to the repo standard

#### Cute Animal Picture

![Cute cat](https://placekittens.com/200/300)