### PR TITLE
feat(zkevm): capture pre-state and post-state MPT nodes into the execution witness

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -253,9 +253,11 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
         execution_witness=ExecutionWitnessBuilder(
-            pre_state_accounts_data = chain.state._main_trie,
-            pre_state_storages_data = chain.state._storage_tries,
-            blockchain_headers=[rlp.encode(blk.header) for blk in chain.blocks]
+            pre_state_accounts_data=chain.state._main_trie,
+            pre_state_storages_data=chain.state._storage_tries,
+            blockchain_headers=[
+                rlp.encode(blk.header) for blk in chain.blocks
+            ],
         ),
     )
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -253,6 +253,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         parent_beacon_block_root=block.header.parent_beacon_block_root,
         block_access_list_builder=BlockAccessListBuilder(),
         execution_witness=ExecutionWitnessBuilder(
+            pre_state_accounts_data = chain.state._main_trie,
+            pre_state_storages_data = chain.state._storage_tries,
             blockchain_headers=[rlp.encode(blk.header) for blk in chain.blocks]
         ),
     )

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -270,6 +270,11 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     block_state_root, _ = chain.state.compute_state_root_and_trie_changes(
         account_changes, storage_changes
     )
+    block_output.execution_witness = build_execution_witness(
+        block_env.execution_witness,
+        block_env.state,
+        expected_post_state_root=block_state_root,
+    )
     apply_changes_to_state(
         chain.state, account_changes, storage_changes, code_changes
     )
@@ -829,10 +834,6 @@ def apply_body(
 
     block_output.block_access_list = build_block_access_list(
         block_env.block_access_list_builder, block_env.state
-    )
-
-    block_output.execution_witness = build_execution_witness(
-        block_env.execution_witness, block_env.state
     )
 
     return block_output

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -10,8 +10,14 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
-from ethereum.forks.amsterdam.incremental_mpt import IncrementalMPT, build_mpt, mpt_get, mpt_root, mpt_set
-from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT, Trie, trie_get
+from ethereum.forks.amsterdam.incremental_mpt import (
+    IncrementalMPT,
+    build_mpt,
+    mpt_get,
+    mpt_root,
+    mpt_set,
+)
+from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT, Trie
 from ethereum.state import Account, Address, PreState, Root
 
 from .state_tracker import BlockState
@@ -53,100 +59,117 @@ class ExecutionWitnessBuilder:
     blockchain_headers: List[Bytes] = field(default_factory=list)
 
 
-def build_execution_witness(
-    builder: ExecutionWitnessBuilder,
-    block_state: BlockState,
-) -> ExecutionWitness:
-    """
-    Build the execution witness from the accumulated builder data.
-
-    Sort state and codes lexicographically, headers by block number
-    ascending.
-    """
-    ancestor_headers = get_witness_ancestors(
-        builder.blockchain_headers,
-        block_state.oldest_ancestor_offset,
-    )
-    codes = get_witness_codes(block_state.code_reads, block_state.pre_state)
-
-    # Build account and storages IncrementalMPTs from pre-state flat data.
+def _build_pre_state_storage_mpts(
+    pre_state_storages_data: Dict[Address, Trie[Bytes32, U256]],
+) -> Dict[Address, IncrementalMPT[Bytes32, U256]]:
+    """Build incremental storage MPTs from pre-state flat storage data."""
     incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]] = {}
-    for address, data in builder.pre_state_storages_data.items():
+    for address, data in pre_state_storages_data.items():
         incr_storage_mpts[address] = build_mpt(
             data._data, secured=True, default=U256(0)
         )
+    return incr_storage_mpts
+
+
+def _build_pre_state_account_mpt(
+    pre_state_accounts_data: Trie[Address, Optional[Account]],
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]],
+) -> IncrementalMPT[Address, Optional[Account]]:
+    """Build the incremental account MPT from pre-state flat account data."""
 
     def get_pre_storage_root(address: Address) -> Root:
         if address in incr_storage_mpts:
             return mpt_root(incr_storage_mpts[address])
         return EMPTY_TRIE_ROOT
 
-    incr_account_mpt = build_mpt(
-        builder.pre_state_accounts_data._data,
+    return build_mpt(
+        pre_state_accounts_data._data,
         secured=True,
         default=None,
         get_storage_root=get_pre_storage_root,
     )
 
-    # 1. Traverse all accessed and dirty storage keys on the pre-state
-    # MPTs to capture pre-state trie nodes in the witness. This must
-    # happen before any writes since writes mutate the tree in-place.
+
+def _collect_storage_accesses(
+    block_state: BlockState,
+) -> Dict[Address, Set[Bytes32]]:
+    """
+    Collect all storage keys that must be traversed on pre-state tries.
+
+    Includes both reads and writes so all needed pre-state nodes are captured
+    before in-place mutation.
+    """
     all_storage_accesses: Dict[Address, Set[Bytes32]] = {}
     for address, key in block_state.storage_reads:
         all_storage_accesses.setdefault(address, set()).add(key)
     for address, slots in block_state.storage_writes.items():
         all_storage_accesses.setdefault(address, set()).update(slots)
+    return all_storage_accesses
 
+
+def _capture_pre_state_storage_nodes(
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]],
+    all_storage_accesses: Dict[Address, Set[Bytes32]],
+) -> None:
+    """Traverse pre-state storage tries to record witness nodes."""
     for address, keys in all_storage_accesses.items():
         if address not in incr_storage_mpts:
             continue
         for key in keys:
             mpt_get(incr_storage_mpts[address], key)
 
-    # 2. Apply dirty storage to storages (writes)
-    for address, dirty_keys in block_state.storage_writes.items():
+
+def _apply_storage_writes(
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]],
+    storage_writes: Dict[Address, Dict[Bytes32, U256]],
+) -> None:
+    """Apply block storage writes to incremental storage MPTs."""
+    for address, dirty_keys in storage_writes.items():
         if address not in incr_storage_mpts:
-            # New storage created during block
+            # New storage created during block.
             incr_storage_mpts[address] = build_mpt(
                 {}, secured=True, default=U256(0)
             )
 
-        # We do two passes to ensure deletions are processed after
-        # inserts/updates to minimize the number of nodes touched
-        # in the MPT.
-        # First pass: inserts and updates
+        # Two passes: insert/update first, deletions second.
         for key, value in dirty_keys.items():
             if value != 0:
                 mpt_set(incr_storage_mpts[address], key, value)
-        # Second pass: deletions
         for key, value in dirty_keys.items():
             if value == 0:
                 mpt_set(incr_storage_mpts[address], key, value)
 
-    # Accounts are "dirty" if:
-    # - Account fields changed (nonce/balance/code) - tracked in dirty_accounts
-    # - Storage changed (storage root changed) - tracked in dirty_storage
-    all_dirty_accounts = (
-        set(block_state.account_writes.keys())
-        | set(block_state.storage_writes.keys())
+
+def _get_all_dirty_accounts(block_state: BlockState) -> Set[Address]:
+    """Return addresses whose account leaf may change in the state trie."""
+    return set(block_state.account_writes.keys()) | set(
+        block_state.storage_writes.keys()
     )
 
-    # 3. Traverse all accessed and dirty accounts on the pre-state MPT
-    # to capture pre-state trie nodes before writes mutate the tree.
-    for address in block_state.account_reads | all_dirty_accounts:
+
+def _capture_pre_state_account_nodes(
+    incr_account_mpt: IncrementalMPT[Address, Optional[Account]],
+    account_reads: Set[Address],
+    all_dirty_accounts: Set[Address],
+) -> None:
+    """Traverse pre-state account trie to record witness nodes."""
+    for address in account_reads | all_dirty_accounts:
         mpt_get(incr_account_mpt, address)
 
-    # 4. Apply dirty accounts
+
+def _apply_account_writes(
+    incr_account_mpt: IncrementalMPT[Address, Optional[Account]],
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]],
+    block_state: BlockState,
+    all_dirty_accounts: Set[Address],
+) -> None:
+    """Apply final account values and post-storage roots to account trie."""
     for address in all_dirty_accounts:
-        # Get post-state account data
         if address in block_state.account_writes:
             account = block_state.account_writes[address]
         else:
-            account = (
-                block_state.pre_state.get_account_optional(address)
-            )
+            account = block_state.pre_state.get_account_optional(address)
 
-        # Get storage root for this account
         if address in incr_storage_mpts:
             addr_storage_root = mpt_root(incr_storage_mpts[address])
         else:
@@ -164,10 +187,81 @@ def build_execution_witness(
             get_storage_root=get_storage_root_fn,
         )
 
-    # Collect witness from all MPTs
-    accessed_nodes=dict(incr_account_mpt.witness.accessed_nodes)
+
+def _collect_accessed_nodes(
+    incr_account_mpt: IncrementalMPT[Address, Optional[Account]],
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]],
+) -> Dict[Bytes, Bytes]:
+    """Merge accessed trie nodes from account and storage witnesses."""
+    accessed_nodes = dict(incr_account_mpt.witness.accessed_nodes)
     for mpt in incr_storage_mpts.values():
-       accessed_nodes.update(mpt.witness.accessed_nodes)
+        accessed_nodes.update(mpt.witness.accessed_nodes)
+    return accessed_nodes
+
+
+def build_execution_witness(
+    builder: ExecutionWitnessBuilder,
+    block_state: BlockState,
+    expected_post_state_root: Root,
+) -> ExecutionWitness:
+    """
+    Build the execution witness from the accumulated builder data.
+
+    Sort state and codes lexicographically, headers by block number
+    ascending.
+    """
+    ancestor_headers = get_witness_ancestors(
+        builder.blockchain_headers,
+        block_state.oldest_ancestor_offset,
+    )
+    codes = get_witness_codes(block_state.code_reads, block_state.pre_state)
+
+    # Build account and storage IncrementalMPTs from pre-state flat data.
+    incr_storage_mpts = _build_pre_state_storage_mpts(
+        builder.pre_state_storages_data
+    )
+    incr_account_mpt = _build_pre_state_account_mpt(
+        builder.pre_state_accounts_data, incr_storage_mpts
+    )
+
+    # 1. Traverse all accessed and dirty storage keys on the pre-state
+    # MPTs to capture pre-state trie nodes in the witness. This must
+    # happen before any writes since writes mutate the tree in-place.
+    all_storage_accesses = _collect_storage_accesses(block_state)
+    _capture_pre_state_storage_nodes(incr_storage_mpts, all_storage_accesses)
+
+    # 2. Apply dirty storage to storages (writes)
+    _apply_storage_writes(incr_storage_mpts, block_state.storage_writes)
+
+    # Accounts are "dirty" if:
+    # - Account fields changed (nonce/balance/code) - tracked in dirty_accounts
+    # - Storage changed (storage root changed) - tracked in dirty_storage
+    all_dirty_accounts = _get_all_dirty_accounts(block_state)
+
+    # 3. Traverse all accessed and dirty accounts on the pre-state MPT
+    # to capture pre-state trie nodes before writes mutate the tree.
+    _capture_pre_state_account_nodes(
+        incr_account_mpt,
+        block_state.account_reads,
+        all_dirty_accounts,
+    )
+
+    # 4. Apply dirty accounts
+    _apply_account_writes(
+        incr_account_mpt,
+        incr_storage_mpts,
+        block_state,
+        all_dirty_accounts,
+    )
+
+    # Safety check: the post-state root implied by the witness construction
+    # must match the canonical state-root calculation.
+    assert mpt_root(incr_account_mpt) == expected_post_state_root
+
+    # Collect witness from all MPTs
+    accessed_nodes = _collect_accessed_nodes(
+        incr_account_mpt, incr_storage_mpts
+    )
 
     return ExecutionWitness(
         state=tuple(sorted(accessed_nodes.values())),

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -3,14 +3,16 @@ Stateless validation types.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
-from ethereum.state import Address, PreState
+from ethereum.forks.amsterdam.incremental_mpt import IncrementalMPT, build_mpt, mpt_get, mpt_root, mpt_set
+from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT, Trie, trie_get
+from ethereum.state import Account, Address, PreState, Root
 
 from .state_tracker import BlockState
 
@@ -46,8 +48,9 @@ class ExecutionWitnessBuilder:
     Mutable accumulator for execution witness data during block execution.
     """
 
+    pre_state_accounts_data: Trie[Address, Optional[Account]]
+    pre_state_storages_data: Dict[Address, Trie[Bytes32, U256]]
     blockchain_headers: List[Bytes] = field(default_factory=list)
-    state: List[Bytes] = field(default_factory=list)
 
 
 def build_execution_witness(
@@ -66,8 +69,108 @@ def build_execution_witness(
     )
     codes = get_witness_codes(block_state.code_reads, block_state.pre_state)
 
+    # Build account and storages IncrementalMPTs from pre-state flat data.
+    incr_storage_mpts: Dict[Address, IncrementalMPT[Bytes32, U256]] = {}
+    for address, data in builder.pre_state_storages_data.items():
+        incr_storage_mpts[address] = build_mpt(
+            data._data, secured=True, default=U256(0)
+        )
+
+    def get_pre_storage_root(address: Address) -> Root:
+        if address in incr_storage_mpts:
+            return mpt_root(incr_storage_mpts[address])
+        return EMPTY_TRIE_ROOT
+
+    incr_account_mpt = build_mpt(
+        builder.pre_state_accounts_data._data,
+        secured=True,
+        default=None,
+        get_storage_root=get_pre_storage_root,
+    )
+
+    # 1. Traverse all accessed and dirty storage keys on the pre-state
+    # MPTs to capture pre-state trie nodes in the witness. This must
+    # happen before any writes since writes mutate the tree in-place.
+    all_storage_accesses: Dict[Address, Set[Bytes32]] = {}
+    for address, key in block_state.storage_reads:
+        all_storage_accesses.setdefault(address, set()).add(key)
+    for address, slots in block_state.storage_writes.items():
+        all_storage_accesses.setdefault(address, set()).update(slots)
+
+    for address, keys in all_storage_accesses.items():
+        if address not in incr_storage_mpts:
+            continue
+        for key in keys:
+            mpt_get(incr_storage_mpts[address], key)
+
+    # 2. Apply dirty storage to storages (writes)
+    for address, dirty_keys in block_state.storage_writes.items():
+        if address not in incr_storage_mpts:
+            # New storage created during block
+            incr_storage_mpts[address] = build_mpt(
+                {}, secured=True, default=U256(0)
+            )
+
+        # We do two passes to ensure deletions are processed after
+        # inserts/updates to minimize the number of nodes touched
+        # in the MPT.
+        # First pass: inserts and updates
+        for key, value in dirty_keys.items():
+            if value != 0:
+                mpt_set(incr_storage_mpts[address], key, value)
+        # Second pass: deletions
+        for key, value in dirty_keys.items():
+            if value == 0:
+                mpt_set(incr_storage_mpts[address], key, value)
+
+    # Accounts are "dirty" if:
+    # - Account fields changed (nonce/balance/code) - tracked in dirty_accounts
+    # - Storage changed (storage root changed) - tracked in dirty_storage
+    all_dirty_accounts = (
+        set(block_state.account_writes.keys())
+        | set(block_state.storage_writes.keys())
+    )
+
+    # 3. Traverse all accessed and dirty accounts on the pre-state MPT
+    # to capture pre-state trie nodes before writes mutate the tree.
+    for address in block_state.account_reads | all_dirty_accounts:
+        mpt_get(incr_account_mpt, address)
+
+    # 4. Apply dirty accounts
+    for address in all_dirty_accounts:
+        # Get post-state account data
+        if address in block_state.account_writes:
+            account = block_state.account_writes[address]
+        else:
+            account = (
+                block_state.pre_state.get_account_optional(address)
+            )
+
+        # Get storage root for this account
+        if address in incr_storage_mpts:
+            addr_storage_root = mpt_root(incr_storage_mpts[address])
+        else:
+            addr_storage_root = EMPTY_TRIE_ROOT
+
+        def get_storage_root_fn(
+            _: Address, sr: Root = addr_storage_root
+        ) -> Root:
+            return sr
+
+        mpt_set(
+            incr_account_mpt,
+            address,
+            account,
+            get_storage_root=get_storage_root_fn,
+        )
+
+    # Collect witness from all MPTs
+    accessed_nodes=dict(incr_account_mpt.witness.accessed_nodes)
+    for mpt in incr_storage_mpts.values():
+       accessed_nodes.update(mpt.witness.accessed_nodes)
+
     return ExecutionWitness(
-        state=tuple(sorted(builder.state)),
+        state=tuple(sorted(accessed_nodes.values())),
         codes=tuple(codes),
         headers=tuple(ancestor_headers),
     )

--- a/src/ethereum/forks/amsterdam/stateless_types.py
+++ b/src/ethereum/forks/amsterdam/stateless_types.py
@@ -10,17 +10,17 @@ from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32
-from ethereum.forks.amsterdam.incremental_mpt import (
+from ethereum.state import Account, Address, PreState, Root
+
+from .incremental_mpt import (
     IncrementalMPT,
     build_mpt,
     mpt_get,
     mpt_root,
     mpt_set,
 )
-from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT, Trie
-from ethereum.state import Account, Address, PreState, Root
-
 from .state_tracker import BlockState
+from .trie import EMPTY_TRIE_ROOT, Trie
 
 
 @slotted_freezable

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -479,9 +479,26 @@ class T8N(Load):
             )
 
         if self.fork.has_execution_witness:
-            block_output.execution_witness = self.fork.build_execution_witness(
-                block_env.execution_witness,
-                block_env.state,
+            assert self.fork.has_block_state
+            # TODO(zkevm): since IncrementalMPT isn't the authoritative way to 
+            # do post-state root calculation, we calculate the post-state root
+            # here with patricialize. Note this work will happen again later in
+            # t8n to provide the expected output. Although we could cache it,
+            # it might be too invasive and not worth it. Note also this is safe 
+            # since `compute_state_root_and_trie_changes` does not mutate anything
+            # in state (i.e. it does transient copies of MPTs to do its work).
+            expected_post_state_root, _ = (
+                self.alloc.state.compute_state_root_and_trie_changes(
+                    block_env.state.account_writes,
+                    block_env.state.storage_writes,
+                )
+            )
+            block_output.execution_witness = (
+                self.fork.build_execution_witness(
+                    block_env.execution_witness,
+                    block_env.state,
+                    expected_post_state_root=expected_post_state_root,
+                )
             )
 
     def run_blockchain_test(self) -> None:

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -330,7 +330,9 @@ class T8N(Load):
 
         if self.fork.has_execution_witness:
             kw_arguments["execution_witness"] = ExecutionWitnessBuilder(
-                blockchain_headers=self.env.block_headers
+                pre_state_accounts_data=self.alloc.state._main_trie,
+                pre_state_storages_data=self.alloc.state._storage_tries,
+                blockchain_headers=self.env.block_headers,
             )
 
         return block_environment(**kw_arguments)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -480,25 +480,24 @@ class T8N(Load):
 
         if self.fork.has_execution_witness:
             assert self.fork.has_block_state
-            # TODO(zkevm): since IncrementalMPT isn't the authoritative way to 
-            # do post-state root calculation, we calculate the post-state root
-            # here with patricialize. Note this work will happen again later in
-            # t8n to provide the expected output. Although we could cache it,
-            # it might be too invasive and not worth it. Note also this is safe 
-            # since `compute_state_root_and_trie_changes` does not mutate anything
-            # in state (i.e. it does transient copies of MPTs to do its work).
+            # TODO(zkevm): since IncrementalMPT isn't the authoritative way
+            # to do post-state root calculation, we calculate the post-state
+            # root here with patricialize. Note this work will happen again
+            # later in t8n to provide the expected output. Although we could
+            # cache it, it might be too invasive and not worth it. Note also
+            # this is safe since `compute_state_root_and_trie_changes` does
+            # not mutate anything in state (i.e. it does transient copies of
+            # MPTs to do its work).
             expected_post_state_root, _ = (
                 self.alloc.state.compute_state_root_and_trie_changes(
                     block_env.state.account_writes,
                     block_env.state.storage_writes,
                 )
             )
-            block_output.execution_witness = (
-                self.fork.build_execution_witness(
-                    block_env.execution_witness,
-                    block_env.state,
-                    expected_post_state_root=expected_post_state_root,
-                )
+            block_output.execution_witness = self.fork.build_execution_witness(
+                block_env.execution_witness,
+                block_env.state,
+                expected_post_state_root=expected_post_state_root,
             )
 
     def run_blockchain_test(self) -> None:


### PR DESCRIPTION
## 🗒️ Description
This PR adds the feature of using the state tracker's capture from the STF execution and properly generating and recording the MPT nodes for the execution witness output.

This involves MPT nodes from two "buckets":
- Pre-state MPT nodes from the account and storage tries -- basically constructing an MPT proof, all required state accessed in the STF.
- Post-state root extra MPT nodes required due to branch compressions during deletions. e.g. a branch node is collapsed, thus a sibling node is "lifted up" thus required to understand how the branch should be compressed. Note only sibilings that weren't created nor edited during post-state root calculation should be included.

As an extra safety check, for all filled tests we do a post-state root calculation check between the "official" `patricialize` calculation and the post-`IncrementalMPT` state (which was required to calculate for latter bullet). This is just a sanity check that the `IncrementalMPT` is working as expected. Doing this was a bit of a quirk trying hard not to pollute much the general design/architecture of things -- mainly because "block outputs" are calculated before the official post-state root. In any case, I think the current solution is okay. Eventually, if `IncrementalMPT` gains enough confidence to be the "official" way to calculate post-state roots, we can probably do something a bit more elegant/efficient. For now, prioritising correctness.


Example run (see new filled `state` field):
```
$ uv run fill --clean -m "blockchain_test" --fork Amsterdam ./tests/frontier/opcodes/test_blockhash.py -k "one_block_with_tx"
$ cat fixtures/blockchain_tests/frontier/opcodes/blockhash/genesis_hash_available.json
...
  "withdrawals": [...],
  "executionWitness": {
      "state": [
          "0xf851808080808080808080808080a031357c4a138624e300159fc631211a29d8373db4bdf59b80dad6e816593d0bcb8080a0b5790ff14363bee5d40c4a9fd9d6a515fc44683cc4d46666b4d9c775dded101780",
          "0xf869a0209d57be05dd69371c4dd2e871bce6e9f4124236825bb612ee18a45e5675be51b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a06e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d",
          "0xf869a037d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c",
          "0xf869a03d6aea581b220579a2b99819299dd32c7c28a420018ecb0bde93af007ad89a31b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a078c6cb5202685228bbcbfb992b1c4e116c7ec5ef11e25b8e92716cfc628ddd60",
          "0xf869a03f86c581c7d7b44eecbb92fd9e5867945ec1acdc0ea5bbabda21d17dddf06473b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00345a365d2f4c5975b9f1599abe0a2ee76b7a3a731bc68781bd04c84e4858f50",
          "0xf8d1a09e5ad71f774e0d0dd63f978cc6021e09acb8fbcecdbfff2975d362926c4f9ace80a0b5b019eac3ef7c2d4afafb62220bef8661aebbb166638c4e09a745c57168fa7aa066a64e47bae97c0fccdc260c76b1c987c89560cb40e86ea17a1d5fd49e35bebea0bb39564b6e52e9597d80db3ab98d34c4ddb4baace92877af682b80901d2435c980a039e4714d1eb6e1d5b21ca2bffd56333a7cd697596ff64317d1ae21ffd048e6ca808080808080a008be39f7c15cc06a7d863615397887281eadcbdb7907665d0683ca3c6383e6b0808080"
      ],
      "codes": [
          "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500",
          "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
          "0x3373fffffffffffffffffffffffffffffffffffffffe1460cb5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f457600182026001905f5b5f82111560685781019083028483029004916001019190604d565b909390049250505036603814608857366101f457346101f4575f5260205ff35b34106101f457600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160df575060105b5f5b8181146101835782810160030260040181604c02815460601b8152601401816001015481526020019060020154807fffffffffffffffffffffffffffffffff00000000000000000000000000000000168252906010019060401c908160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160e1565b910180921461019557906002556101a0565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101cd57505f5b6001546002828201116101e25750505f6101e8565b01600290035b5f555f600155604c025ff35b5f5ffd",
          "0x3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd"
      ],
      "headers": [
          "0xf90278a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a014413270cd1509c3bc3194d1854cac72e031717b13f91dc9f14881fe2912e0efa056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808407270e00808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
      ]
  },
  "blockAccessList": [...],
...
```