### PR TITLE
feat(specs): Partially decouple `state_transition` from `BlockChain`

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -28,6 +28,7 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
+from ethereum.forks.bpo5.blocks import Header as PreviousHeader
 from ethereum.state import EMPTY_CODE_HASH, Address, BlockDiff, PreState
 
 from . import vm
@@ -144,7 +145,7 @@ class ChainContext:
     block_hashes: List[Hash32]
     """Recent ancestor hashes (up to 256) for the ``BLOCKHASH`` opcode."""
 
-    parent_header: Header
+    parent_header: Header | PreviousHeader
     """Parent header used for header validation and system contracts."""
 
 
@@ -418,7 +419,9 @@ def calculate_base_fee_per_gas(
     return Uint(expected_base_fee_per_gas)
 
 
-def validate_header(parent_header: Header, header: Header) -> None:
+def validate_header(
+    parent_header: Header | PreviousHeader, header: Header
+) -> None:
     """
     Verify a block header against its parent.
 

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -134,11 +134,18 @@ BLOB_COUNT_LIMIT = 6
 @slotted_freezable
 @dataclass
 class ChainContext:
-    """Chain context needed for block execution."""
+    """
+    Chain context needed for block execution.
+    """
 
     chain_id: U64
+    """Identify the chain for transaction signature recovery."""
+
     block_hashes: List[Hash32]
+    """Recent ancestor hashes (up to 256) for the ``BLOCKHASH`` opcode."""
+
     parent_header: Header
+    """Parent header used for header validation and system contracts."""
 
 
 @dataclass

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -12,10 +12,11 @@ Entry point for the Ethereum specification.
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes
+from ethereum_types.bytes import Bytes, Bytes32
+from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
@@ -27,7 +28,7 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
-from ethereum.state import EMPTY_CODE_HASH, Address
+from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
 
 from . import vm
 from .block_access_lists import (
@@ -130,6 +131,16 @@ MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
 BLOB_COUNT_LIMIT = 6
 
 
+@slotted_freezable
+@dataclass
+class ChainContext:
+    """Chain context needed for block execution."""
+
+    chain_id: U64
+    block_hashes: List[Hash32]
+    parent_header: Header
+
+
 @dataclass
 class BlockChain:
     """
@@ -228,20 +239,75 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         Block to apply to `chain`.
 
     """
+    chain_context = ChainContext(
+        chain_id=chain.chain_id,
+        block_hashes=get_last_256_block_hashes(chain),
+        parent_header=chain.blocks[-1].header,
+    )
+
+    account_changes, storage_changes, code_changes = execute_block(
+        block, chain.state, chain_context
+    )
+
+    apply_changes_to_state(
+        chain.state, account_changes, storage_changes, code_changes
+    )
+    chain.blocks.append(block)
+    if len(chain.blocks) > 255:
+        # Real clients have to store more blocks to deal with reorgs, but the
+        # protocol only requires the last 255
+        chain.blocks = chain.blocks[-255:]
+
+
+def execute_block(
+    block: Block,
+    pre_state: PreState,
+    chain_context: ChainContext,
+) -> Tuple[
+    Dict[Address, Optional[Account]],
+    Dict[Address, Dict[Bytes32, U256]],
+    Dict[Hash32, Bytes],
+]:
+    """
+    Execute a block and validate the resulting roots against the header.
+
+    This method is idempotent.
+
+    Parameters
+    ----------
+    block :
+        Block to validate and execute.
+    pre_state :
+        Pre-execution state provider.
+    chain_context :
+        Chain context that the block may need during execution.
+
+    Returns
+    -------
+    account_changes :
+        Per-address account diffs produced by execution.
+    storage_changes :
+        Per-address storage diffs produced by execution.
+    code_changes :
+        New bytecodes (keyed by code hash) introduced by execution.
+
+    """
     if len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE:
         raise InvalidBlock("Block rlp size exceeds MAX_RLP_BLOCK_SIZE")
 
-    validate_header(chain, block.header)
+    parent_header = chain_context.parent_header
+    validate_header(parent_header, block.header)
+
     if block.ommers != ():
         raise InvalidBlock
 
-    block_state = BlockState(pre_state=chain.state)
+    block_state = BlockState(pre_state=pre_state)
 
     block_env = vm.BlockEnvironment(
-        chain_id=chain.chain_id,
+        chain_id=chain_context.chain_id,
         state=block_state,
         block_gas_limit=block.header.gas_limit,
-        block_hashes=get_last_256_block_hashes(chain),
+        block_hashes=chain_context.block_hashes,
         coinbase=block.header.coinbase,
         number=block.header.number,
         base_fee_per_gas=block.header.base_fee_per_gas,
@@ -260,11 +326,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     account_changes, storage_changes, code_changes = extract_block_diffs(
         block_state
     )
-    block_state_root, _ = chain.state.compute_state_root_and_trie_changes(
+    block_state_root, _ = pre_state.compute_state_root_and_trie_changes(
         account_changes, storage_changes
-    )
-    apply_changes_to_state(
-        chain.state, account_changes, storage_changes, code_changes
     )
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
@@ -296,11 +359,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     if computed_block_access_list_hash != block.header.block_access_list_hash:
         raise InvalidBlock("Invalid block access list hash")
 
-    chain.blocks.append(block)
-    if len(chain.blocks) > 255:
-        # Real clients have to store more blocks to deal with reorgs, but the
-        # protocol only requires the last 255
-        chain.blocks = chain.blocks[-255:]
+    return account_changes, storage_changes, code_changes
 
 
 def calculate_base_fee_per_gas(
@@ -366,9 +425,9 @@ def calculate_base_fee_per_gas(
     return Uint(expected_base_fee_per_gas)
 
 
-def validate_header(chain: BlockChain, header: Header) -> None:
+def validate_header(parent_header: Header, header: Header) -> None:
     """
-    Verifies a block header.
+    Verify a block header against its parent.
 
     In order to consider a block's header valid, the logic for the
     quantities in the header should match the logic for the block itself.
@@ -379,16 +438,14 @@ def validate_header(chain: BlockChain, header: Header) -> None:
 
     Parameters
     ----------
-    chain :
-        History and current state.
+    parent_header :
+        Header of the parent block.
     header :
         Header to check for correctness.
 
     """
     if header.number < Uint(1):
         raise InvalidBlock
-
-    parent_header = chain.blocks[-1].header
 
     excess_blob_gas = calculate_excess_blob_gas(parent_header)
     if header.excess_blob_gas != excess_blob_gas:

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -12,10 +12,10 @@ Entry point for the Ethereum specification.
 """
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from ethereum_rlp import rlp
-from ethereum_types.bytes import Bytes, Bytes32
+from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
 from ethereum_types.numeric import U64, U256, Uint
 
@@ -28,7 +28,7 @@ from ethereum.exceptions import (
     InvalidSenderError,
     NonceMismatchError,
 )
-from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
+from ethereum.state import EMPTY_CODE_HASH, Address, BlockDiff, PreState
 
 from . import vm
 from .block_access_lists import (
@@ -67,7 +67,7 @@ from .state_tracker import (
     TransactionState,
     account_exists_and_is_empty,
     destroy_account,
-    extract_block_diffs,
+    extract_block_diff,
     get_account,
     get_code,
     incorporate_tx_into_block,
@@ -252,13 +252,9 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         parent_header=chain.blocks[-1].header,
     )
 
-    account_changes, storage_changes, code_changes = execute_block(
-        block, chain.state, chain_context
-    )
+    block_diff = execute_block(block, chain.state, chain_context)
 
-    apply_changes_to_state(
-        chain.state, account_changes, storage_changes, code_changes
-    )
+    apply_changes_to_state(chain.state, block_diff)
     chain.blocks.append(block)
     if len(chain.blocks) > 255:
         # Real clients have to store more blocks to deal with reorgs, but the
@@ -270,11 +266,7 @@ def execute_block(
     block: Block,
     pre_state: PreState,
     chain_context: ChainContext,
-) -> Tuple[
-    Dict[Address, Optional[Account]],
-    Dict[Address, Dict[Bytes32, U256]],
-    Dict[Hash32, Bytes],
-]:
+) -> BlockDiff:
     """
     Execute a block and validate the resulting roots against the header.
 
@@ -291,12 +283,8 @@ def execute_block(
 
     Returns
     -------
-    account_changes :
-        Per-address account diffs produced by execution.
-    storage_changes :
-        Per-address storage diffs produced by execution.
-    code_changes :
-        New bytecodes (keyed by code hash) introduced by execution.
+    block_diff : `BlockDiff`
+        Account, storage, and code changes produced by block execution.
 
     """
     if len(rlp.encode(block)) > MAX_RLP_BLOCK_SIZE:
@@ -330,11 +318,9 @@ def execute_block(
         transactions=block.transactions,
         withdrawals=block.withdrawals,
     )
-    account_changes, storage_changes, code_changes = extract_block_diffs(
-        block_state
-    )
+    block_diff = extract_block_diff(block_state)
     block_state_root, _ = pre_state.compute_state_root_and_trie_changes(
-        account_changes, storage_changes
+        block_diff.account_changes, block_diff.storage_changes
     )
     transactions_root = root(block_output.transactions_trie)
     receipt_root = root(block_output.receipts_trie)
@@ -366,7 +352,7 @@ def execute_block(
     if computed_block_access_list_hash != block.header.block_access_list_hash:
         raise InvalidBlock("Invalid block access list hash")
 
-    return account_changes, storage_changes, code_changes
+    return block_diff
 
 
 def calculate_base_fee_per_gas(

--- a/src/ethereum/forks/amsterdam/state.py
+++ b/src/ethereum/forks/amsterdam/state.py
@@ -27,6 +27,7 @@ from ethereum.state import (
     EMPTY_CODE_HASH,
     Account,
     Address,
+    BlockDiff,
     InternalNode,
     Root,
 )
@@ -140,31 +141,22 @@ def close_state(state: State) -> None:
     del state._code_store
 
 
-def apply_changes_to_state(
-    state: State,
-    account_changes: Dict[Address, Optional[Account]],
-    storage_changes: Dict[Address, Dict[Bytes32, U256]],
-    code_changes: Dict[Hash32, Bytes],
-) -> None:
+def apply_changes_to_state(state: State, diff: BlockDiff) -> None:
     """
-    Apply block-level diffs to the ``State`` for the next block.
+    Apply block-level diff to the ``State`` for the next block.
 
     Parameters
     ----------
     state :
         The state to update.
-    account_changes :
-        Account changes to apply.
-    storage_changes :
-        Storage changes to apply.
-    code_changes :
-        Code changes to apply.
+    diff :
+        Account, storage, and code changes to apply.
 
     """
-    for address, account in account_changes.items():
+    for address, account in diff.account_changes.items():
         trie_set(state._main_trie, address, account)
 
-    for address, slots in storage_changes.items():
+    for address, slots in diff.storage_changes.items():
         trie = state._storage_tries.get(address)
         if trie is None:
             trie = Trie(secured=True, default=U256(0))
@@ -174,7 +166,7 @@ def apply_changes_to_state(
         if trie._data == {}:
             del state._storage_tries[address]
 
-    state._code_store.update(code_changes)
+    state._code_store.update(diff.code_changes)
 
 
 def set_account(

--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -31,6 +31,7 @@ from ethereum.state import (
     EMPTY_CODE_HASH,
     Account,
     Address,
+    BlockDiff,
     PreState,
 )
 
@@ -745,15 +746,9 @@ def incorporate_tx_into_block(
     tx_state.account_reads = set()
 
 
-def extract_block_diffs(
-    block_state: BlockState,
-) -> Tuple[
-    Dict[Address, Optional[Account]],
-    Dict[Address, Dict[Bytes32, U256]],
-    Dict[Hash32, Bytes],
-]:
+def extract_block_diff(block_state: BlockState) -> BlockDiff:
     """
-    Extract account, storage, and code diffs from the block state.
+    Extract account, storage, and code diff from the block state.
 
     Parameters
     ----------
@@ -762,16 +757,12 @@ def extract_block_diffs(
 
     Returns
     -------
-    account_diffs :
-        Account changes to apply.
-    storage_diffs :
-        Storage changes to apply.
-    code_diffs :
-        Code changes to apply.
+    diff : `BlockDiff`
+        Account, storage, and code changes accumulated during block execution.
 
     """
-    return (
-        block_state.account_writes,
-        block_state.storage_writes,
-        block_state.code_writes,
+    return BlockDiff(
+        account_changes=block_state.account_writes,
+        storage_changes=block_state.storage_writes,
+        code_changes=block_state.code_writes,
     )

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -16,6 +16,7 @@ from typing import List, Tuple
 
 from ethereum_types.numeric import U64, U256, Uint
 
+from ethereum.forks.bpo5.blocks import Header as PreviousHeader
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
 
@@ -303,7 +304,9 @@ def init_code_cost(init_code_length: Uint) -> Uint:
     return GAS_CODE_INIT_PER_WORD * ceil32(init_code_length) // Uint(32)
 
 
-def calculate_excess_blob_gas(parent_header: Header) -> U64:
+def calculate_excess_blob_gas(
+    parent_header: Header | PreviousHeader,
+) -> U64:
     """
     Calculates the excess blob gas for the current block based
     on the gas used in the parent block.

--- a/src/ethereum/state.py
+++ b/src/ethereum/state.py
@@ -92,6 +92,22 @@ class BranchNode:
 InternalNode = LeafNode | ExtensionNode | BranchNode
 
 
+@dataclass
+class BlockDiff:
+    """
+    State changes produced by executing a block.
+    """
+
+    account_changes: Dict[Address, Optional[Account]]
+    """Per-address account diffs produced by execution."""
+
+    storage_changes: Dict[Address, Dict[Bytes32, U256]]
+    """Per-address storage diffs produced by execution."""
+
+    code_changes: Dict[Hash32, Bytes]
+    """New bytecodes (keyed by code hash) introduced by execution."""
+
+
 class PreState(Protocol):
     """
     Protocol for providing pre-execution state.

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -319,25 +319,18 @@ class Result:
             # to the older forks
             from ethereum.forks.amsterdam.state import apply_changes_to_state
             from ethereum.forks.amsterdam.state_tracker import (
-                extract_block_diffs,
+                extract_block_diff,
             )
 
-            account_changes, storage_changes, code_changes = (
-                extract_block_diffs(t8n._block_state)
-            )
+            block_diff = extract_block_diff(t8n._block_state)
             state_root_value, _ = (
                 t8n.alloc.state.compute_state_root_and_trie_changes(
-                    account_changes, storage_changes
+                    block_diff.account_changes, block_diff.storage_changes
                 )
             )
             self.state_root = state_root_value
             # Apply diffs to pre-state for alloc output
-            apply_changes_to_state(
-                t8n.alloc.state,
-                account_changes,
-                storage_changes,
-                code_changes,
-            )
+            apply_changes_to_state(t8n.alloc.state, block_diff)
         else:
             self.state_root = t8n.fork.state_root(block_env.state)
         self.receipts = self.get_receipts_from_output(t8n, block_output)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

**Goal**

The goal here is to decouple `BlockChain` from `state_transition` to make it easier for anyone with a given `PreState` to execute a block.

**What the PR does**

This PR creates a new method called `execute_block` which is effectively the code in `state_transition` that does not modify the `Blockchain` object.

The rough outline of what happens is:

```rust
fn state_transition(chain: BlockChain, block: Block) {
    // Convert `BlockChain` into `PreState` and `ChainContext`
    // This part will be different for stateful vs stateless.
   let pre_state = prestate_from_chain(chain);
   let chain_context = context_from(chain);
   
   // Call execute_block. This will be the same whether we are stateful or stateless.
   // No db changes are made here.
   let (account_changes, storage_changes, code_changes) = execute_block(block, pre_state, chain_context);
   
   // Apply all of the changes from block execution to the `BlockChain` object.
   // This is also specific to stateful, since stateless has no database.
   apply_state_changes(chain, account_changes, storage_changes, code_changes);
}
```


**Notable changes**

- `validate_header` previously was taking a `BlockChain` object in order to get the parent header. It now just takes the parent header as a parameter. This allows us to put it in `execute_block`
- `ChainContext` was introduced to group together the chain related items that don't fit into the `PreState` abstraction but are needed for block execution. This is the chain id, the last 256 block hashes and the parent header (for `validate_header`)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
