### PR TITLE
chore(deps,ci): bump action-lint version to support `case`

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -38,7 +38,7 @@ jobs:
           tox -e spec-docs
           touch .tox/docs/.nojekyll
         env:
-          DOCC_SKIP_DIFFS: ${{ (github.event_name != 'push' || github.ref_name != github.event.repository.default_branch) && '1' || '' }}
+          DOCC_SKIP_DIFFS: ${{ case(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch, '', '1') }}
 
       - name: Upload Pages Artifact
         id: artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ lint = [
     "types-requests>=2.31,<2.33",
 ]
 actionlint = [
-    "actionlint-py>=1.7",
+    "actionlint-py>=1.7.11,<2",
     "pyflakes>=3.0",
     "shellcheck-py>=0.10",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,9 +14,9 @@ members = [
 
 [[package]]
 name = "actionlint-py"
-version = "1.7.10.24"
+version = "1.7.11.24"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/01/790379bf4cab91a272421a39b3d80f4a0d1a1ed753c00176be28b7d6adc6/actionlint_py-1.7.10.24.tar.gz", hash = "sha256:bac4e74e944c692fc7c65661009caebf14621bb33d937127ee5df8ac0693736a", size = 12057, upload-time = "2026-01-01T17:06:36.282Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c7/9c673ac323c200d2e45579c15b78ddcdc140b1ad4918addcb0559ef7c90a/actionlint_py-1.7.11.24.tar.gz", hash = "sha256:5f6dffa97101d87f034e935c08eca6158cd46ed5b0d60c2fe65dcab3f6d4959e", size = 12055, upload-time = "2026-02-15T16:52:55.011Z" }
 
 [[package]]
 name = "annotated-types"

--- a/uv.lock
+++ b/uv.lock
@@ -956,12 +956,12 @@ provides-extras = ["optimized"]
 
 [package.metadata.requires-dev]
 actionlint = [
-    { name = "actionlint-py", specifier = ">=1.7" },
+    { name = "actionlint-py", specifier = ">=1.7.11,<2" },
     { name = "pyflakes", specifier = ">=3.0" },
     { name = "shellcheck-py", specifier = ">=0.10" },
 ]
 dev = [
-    { name = "actionlint-py", specifier = ">=1.7" },
+    { name = "actionlint-py", specifier = ">=1.7.11,<2" },
     { name = "cairosvg", specifier = ">=2.7.0,<3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Pretty low priority. Feel free to close if leaning against updating deps.

This is a small followup from https://github.com/ethereum/execution-specs/pull/2304#discussion_r2849276034

The current version of actionlint is 1.7.10 which does not support the `case` function. This updates it to [1.7.11](https://github.com/rhysd/actionlint/releases/tag/v1.7.11) where it was added.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:shell: 