### PR TITLE
chore(ci): Investigate possible flaky test

### DIFF
--- a/packages/testing/src/execution_testing/test_types/blob_types.py
+++ b/packages/testing/src/execution_testing/test_types/blob_types.py
@@ -86,6 +86,8 @@ class Blob(CamelModel):
         )
         return (
             "blob_"
+            + fork.name()
+            + "_"
             + str(seed)
             + "_cell_proofs_"
             + str(amount_cell_proofs)

--- a/packages/testing/src/execution_testing/test_types/tests/test_blob_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_blob_types.py
@@ -97,7 +97,13 @@ def test_blob_creation_and_writing_and_reading(
     #       determine what filename would be
     cell_proof_amount = str(fork.get_blob_constant("AMOUNT_CELL_PROOFS"))
     file_name = (
-        "blob_" + str(seed) + "_cell_proofs_" + cell_proof_amount + ".json"
+        "blob_"
+        + fork.name()
+        + "_"
+        + str(seed)
+        + "_cell_proofs_"
+        + cell_proof_amount
+        + ".json"
     )
     #       read
     restored = Blob.from_file(file_name)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

See comment here: https://github.com/ethereum/execution-specs/pull/2307#issuecomment-3955373758

Expectedly, I haven't been able to reproduce this locally, but looking at the code, the only thing that is the same between cancun and prage is the blob filename, since it is `blob_0_cell_proofs_0.json`. 

If there is a race condition, then they would both use the same file. However, the file has the fork name in it, so if the Cancun run reads the Prague file because it was not deleted for some reason, then we get the error seen in the CI, since the file contents include the fork name.



## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
