### PR TITLE
fix(test): Fix CI failure from 8024 specs update

### DIFF
--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -55,6 +55,11 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     """Prepare after opcode instructions."""
     if opcode == Op.JUMPI or opcode == Op.JUMP:
         return Op.JUMPDEST
+    if opcode in (Op.DUPN, Op.SWAPN):
+        # EIP-8024: The suffix byte serves as the implicit immediate.
+        # 0x80 decodes to stack index 17 via decode_single, which is
+        # within the 32 items pushed by prepare_stack.
+        return Bytecode(b"\x80", popped_stack_items=0, pushed_stack_items=0)
     return Op.STOP
 
 

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -55,11 +55,6 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     """Prepare after opcode instructions."""
     if opcode == Op.JUMPI or opcode == Op.JUMP:
         return Op.JUMPDEST
-    if opcode in (Op.DUPN, Op.SWAPN):
-        # EIP-8024: The suffix byte serves as the implicit immediate.
-        # 0x80 decodes to stack index 17 via decode_single, which is
-        # within the 32 items pushed by prepare_stack.
-        return Bytecode(b"\x80", popped_stack_items=0, pushed_stack_items=0)
     return Op.STOP
 
 
@@ -85,9 +80,17 @@ def test_all_opcodes(
     valid_opcodes = set(fork.valid_opcodes())
     all_opcodes = set(Opcode(i) for i in range(0xFF + 1))
     for opcode in sorted(valid_opcodes | all_opcodes):
+        test_opcode: Opcode | Bytecode = opcode
+        if opcode.has_data_portion():
+            if opcode in [Op.SWAPN, Op.DUPN]:
+                test_opcode = opcode[17]
+            elif opcode == Op.EXCHANGE:
+                test_opcode = opcode[1, 2]
+            else:
+                test_opcode = opcode[0]
         code_contract[opcode] = pre.deploy_contract(
             balance=10,
-            code=prepare_stack(opcode) + opcode + prepare_suffix(opcode),
+            code=prepare_stack(opcode) + test_opcode + prepare_suffix(opcode),
             storage={},
         )
 


### PR DESCRIPTION
## 🗒️ Description
`test_all_opcodes` constructs bytecode as `prepare_stack(op) + opcode_byte + STOP`. For `DUPN/SWAPN`, the `STOP` byte (0x00) gets consumed as the immediate operand. With the new branchless `decode_single`, `decode_single(0x00) = (0 + 145) % 256 = 145`, requiring 145/146 stack items. But `prepare_stack` only pushes 32 items, causing a stack underflow that makes the subcall fail when the test expects it to succeed.

Fix: In `prepare_suffix`, when the opcode is `DUPN` or `SWAPN`, return `0x80` instead of `STOP`. This byte serves as the implicit immediate and `decode_single(0x80) = (128 + 145) % 256 = 17`, which only needs 17-18 stack items (well within the 32 available). After consuming the immediate, PC advances past the end of code, causing an implicit stop.

`EXCHANGE` is unaffected because `decode_pair(0x00) = (9, 16)`, needing only 17 items.

## CI Failures this fixes

```
py3:
FAILED tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes[fork_Amsterdam-blockchain_test_engine_from_state_test]@t8n-cache-0694b8bd
FAILED tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes[fork_Amsterdam-blockchain_test_from_state_test]@t8n-cache-0694b8bd
FAILED tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes[fork_Amsterdam-state_test]@t8n-cache-0694b8bd

pypy3:
FAILED tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes[fork_Amsterdam-state_test]@t8n-cache-0694b8bd
```

## 🔗 Related Issues or PRs
#2301 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
