### PR TITLE
fix(ci): don't cancel in-progress runs on the default branch

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,7 +23,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
   unit-tests:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,8 +22,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   unit-tests:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   build:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
   build:

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -41,7 +41,7 @@ on:
 
 concurrency:
   group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 env:
   # Use direct URL instead of release spec (e.g., develop@v5.3.0) to avoid GitHub API rate limits

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -41,7 +41,7 @@ on:
 
 concurrency:
   group: hive-consume-${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 env:
   # Use direct URL instead of release spec (e.g., develop@v5.3.0) to avoid GitHub API rate limits

--- a/.github/workflows/test-checklist.yaml
+++ b/.github/workflows/test-checklist.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   checklist-consistency:

--- a/.github/workflows/test-checklist.yaml
+++ b/.github/workflows/test-checklist.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
   checklist-consistency:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 jobs:
   static:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
   static:


### PR DESCRIPTION
## 🗒️ Description

When multiple PRs get merged to the default branch in quick succession, `cancel-in-progress: true` causes earlier CI runs to be cancelled before completing. This means some merge commits never get a full CI run.

This is annoying as the majority of runs get cancelled. This strongly devalues this CI step:
- It's noisy, I never check fails.
- Binary search to detect a genuine fail doesn't work; there is incomplete information.
- Benchmark artifacts only get built if certain paths change; if a benchmark flow gets triggered, it can get killed by a merge commit to a non-benchmark PR, the new actions generated by this PR will not trigger the benchmark flow, so no benchmark artifact will get generated.

This will create more load on our runners, but it's in the right place imo.

What pushed me other the edge: 
- I manually re-triggered the Benchmark flow to check whether the test fail in the previous run was flaky.
- I merged PR while waiting; manually triggered flow got cancelled.
- I got frustrated.

---

This PR makes `cancel-in-progress` conditional: it remains `true` for PR and feature branch runs, but is set to `false` when the ref matches the default branch. Uses `github.event.repository.default_branch` so the expression adapts automatically if the default branch changes.

Also adds a `github.run_id` fallback to the benchmark workflow's concurrency group for robustness (consistent with the other workflows).

---

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/0214c872-4270-460b-982d-488102cb7f47" />

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg)