### PR TITLE
feat(benchmarks): SLOAD/SSTORE tests for ERC20 bloated contracts cached/non-cached with existing/non-existing keys

### DIFF
--- a/tests/benchmark/stateful/bloatnet/stubs_bloatnet.json
+++ b/tests/benchmark/stateful/bloatnet/stubs_bloatnet.json
@@ -3,6 +3,7 @@
   "test_sload_empty_erc20_balanceof_XEN": "0x06450dEe7FD2Fb8E39061434BAbCFC05599a6Fb8",
   "test_sload_empty_erc20_balanceof_USDC": "0xA0b86991C6218B36c1d19D4a2E9Eb0CE3606EB48",
   "test_sload_empty_erc20_balanceof_IMT": "0x13119e34e140097a507b07a5564bde1bc375d9e6",
+  "test_sstore_erc20_mint_30GB_ERC20": "0x19fc17d87D946BBA47ca276f7b06Ee5737c4679C",
   "test_sstore_erc20_approve_30GB_ERC20": "0x19fc17d87D946BBA47ca276f7b06Ee5737c4679C",
   "test_sstore_erc20_approve_XEN": "0x06450dEe7FD2Fb8E39061434BAbCFC05599a6Fb8",
   "test_sstore_erc20_approve_USDC": "0xA0b86991C6218B36c1d19D4a2E9Eb0CE3606EB48",

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -187,8 +187,8 @@ def test_sload_erc20_balanceof(
         # Function body
         + Op.JUMPDEST
         + Op.CALLDATALOAD(4)
-        + Op.MSTORE(0)
-        + Op.MSTORE(32, 0)
+        + Op.MSTORE(0, 0)
+        + Op.MSTORE(32, Op.CALLDATALOAD(4))
         + Op.SHA3(
             0,
             64,
@@ -199,7 +199,8 @@ def test_sload_erc20_balanceof(
         )
         + Op.SLOAD
         # Return value
-        + Op.MSTORE(0)
+        + Op.PUSH0
+        + Op.MSTORE
         + Op.RETURN(0, 32)
     )
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -247,6 +247,10 @@ def test_sload_empty_erc20_balanceof(
                 cache_txs.append(tx)
 
         with TestPhaseManager.execution():
+            # TODO: CHECK IF THIS WORKS
+            # Does this actually create the tx in execution phase mode?
+            # Or is it depends on where the tx is created?
+            # (if thats the case then all txs are in the execution phase - right?)
             txs.append(tx)
 
         gas_remaining -= gas_available
@@ -419,7 +423,7 @@ def test_sstore_erc20_approve(
 
 @pytest.mark.parametrize("token_name", SSTORE_MINT_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
-@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 @pytest.mark.parametrize("no_change", [False, True])
 def test_sstore_erc20_mint(
     benchmark_test: BenchmarkTestFiller,
@@ -429,7 +433,7 @@ def test_sstore_erc20_mint(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
-    cached: bool,
+    cache_strategy: CacheStrategy,
     no_change: bool,
 ) -> None:
     """
@@ -552,7 +556,9 @@ def test_sstore_erc20_mint(
             new_memory_size=64,
         )
         + Op.DUP1
-        + Op.SLOAD.with_metadata(key_warm=cached)
+        + Op.SLOAD.with_metadata(
+            key_warm=cache_strategy == CacheStrategy.CACHE_TX
+        )
         + Op.CALLDATALOAD(36)
         + Op.ADD
         + Op.SSTORE
@@ -564,7 +570,7 @@ def test_sstore_erc20_mint(
 
     function_dispatch_cost = function_dispatch_mint.gas_cost(fork)
 
-    if cached:
+    if cache_strategy == CacheStrategy.CACHE_TX:
         # Add balanceOf dispatch cost for the warmup call
         function_dispatch_balanceof = (
             Op.PUSH4(BALANCEOF_SELECTOR)
@@ -590,6 +596,7 @@ def test_sstore_erc20_mint(
 
     # Transaction Loops
     txs = []
+    cache_txs = []
     gas_remaining = gas_benchmark_value
     # Start at 1 for existing balance slots,
     # or at keccak256("random") for non-existing slots
@@ -613,19 +620,30 @@ def test_sstore_erc20_mint(
             break
 
         calldata = Hash(num_calls) + Hash(slot_offset)
-
-        txs.append(
-            Transaction(
-                gas_limit=gas_available,
-                data=calldata,
-                to=attack_contract_address,
-                sender=pre.fund_eoa(),
-                access_list=access_list,
-            )
+        tx = Transaction(
+            gas_limit=gas_available,
+            data=calldata,
+            to=attack_contract_address,
+            sender=pre.fund_eoa(),
+            access_list=access_list,
         )
+        if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
+            with TestPhaseManager.setup():
+                cache_txs.append(tx)
+
+        with TestPhaseManager.execution():
+            # Same here, does this create tx is execution mode?
+            # And above setup mode?
+            txs.append(tx)
 
         gas_remaining -= gas_available
         slot_offset += num_calls
+
+    blocks = (
+        [Block(txs=txs)]
+        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
+        else [Block(txs=cache_txs), Block(txs=txs)]
+    )
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -36,8 +36,8 @@ from tests.benchmark.stateful.helpers import (
     BALANCEOF_SELECTOR,
     MINT_SELECTOR,
     SLOAD_TOKENS,
-    SSTORE_TOKENS,
     SSTORE_MINT_TOKENS,
+    SSTORE_TOKENS,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -415,12 +415,12 @@ def test_sstore_erc20_mint(
     cached: bool,
     no_change: bool,
 ) -> None:
-    """Benchmark SSTORE using ERC20 mint on bloatnet.
+    """
+    Benchmark SSTORE using ERC20 mint on bloatnet.
     This contract calls mint() on an ERC20 contract
     which supports the mint() function. It is intended
     to be used with ERC20 contracts bloated via bloatStorage.
     The mint will increase the total supply and the target account.
-
     """
     # Stub Account
     erc20_address = pre.deploy_contract(
@@ -481,7 +481,7 @@ def test_sstore_erc20_mint(
                     address=erc20_address,
                     value=0,
                     args_offset=28,
-                    args_size=36 + 32,
+                    args_size=36,
                     ret_offset=0,
                     ret_size=0,
                     # gas accounting

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -92,7 +92,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
-@pytest.mark.parametrize("cache_mode", list(CacheStrategy))
+@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 def test_sload_empty_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -34,6 +34,7 @@ from execution_testing import (
 from tests.benchmark.stateful.helpers import (
     APPROVE_SELECTOR,
     BALANCEOF_SELECTOR,
+    MINT_SELECTOR,
     SLOAD_TOKENS,
     SSTORE_TOKENS,
 )
@@ -359,6 +360,218 @@ def test_sstore_erc20_approve(
     txs = []
     gas_remaining = gas_benchmark_value
     slot_offset = 0
+
+    while gas_remaining > intrinsic_gas_with_access_list:
+        gas_available = min(gas_remaining, tx_gas_limit)
+
+        if gas_available < intrinsic_gas_with_access_list + setup_cost:
+            break
+
+        num_calls = (
+            gas_available - intrinsic_gas_with_access_list - setup_cost
+        ) // (function_dispatch_cost + loop_cost)
+
+        if num_calls == 0:
+            break
+
+        calldata = Hash(num_calls) + Hash(slot_offset)
+
+        txs.append(
+            Transaction(
+                gas_limit=gas_available,
+                data=calldata,
+                to=attack_contract_address,
+                sender=pre.fund_eoa(),
+                access_list=access_list,
+            )
+        )
+
+        gas_remaining -= gas_available
+        slot_offset += num_calls
+
+    benchmark_test(
+        pre=pre,
+        blocks=[Block(txs=txs)],
+    )
+
+
+@pytest.mark.parametrize("token_name", SSTORE_TOKENS)
+@pytest.mark.parametrize("existing_slots", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("no_change", [False, True])
+def test_sstore_erc20_mint(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+    existing_slots: bool,
+    cached: bool,
+    no_change: bool,
+) -> None:
+    """Benchmark SSTORE using ERC20 mint on bloatnet."""
+    # Stub Account
+    erc20_address = pre.deploy_contract(
+        code=Bytecode(),
+        stub=f"test_sstore_erc20_approve_{token_name}",
+    )
+
+    mint_amount = 0 if no_change else 1
+
+    # MEM[0] = function selector
+    # MEM[32] = target address
+    # MEM[64] = mint amount
+    setup = (
+        Op.MSTORE(
+            0,
+            MINT_SELECTOR,
+            # gas accounting
+            old_memory_size=0,
+            new_memory_size=32,
+        )
+        + Op.MSTORE(
+            32,
+            Op.CALLDATALOAD(32),  # Address Offset
+            # gas accounting
+            old_memory_size=32,
+            new_memory_size=64,
+        )
+        + Op.MSTORE(
+            64,
+            mint_amount,
+            # gas accounting
+            old_memory_size=64,
+            new_memory_size=96,
+        )
+        + Op.CALLDATALOAD(0)  # [num_calls]
+    )
+
+    call_mint = Op.POP(
+        Op.CALL(
+            address=erc20_address,
+            value=0,
+            args_offset=28,
+            args_size=68,
+            ret_offset=0,
+            ret_size=0,
+            # gas accounting
+            address_warm=True,
+        )
+    )
+
+    if cached:
+        # Call balanceOf first to warm the storage slot, then restore
+        # the mint selector
+        cache_warmup = (
+            Op.MSTORE(0, BALANCEOF_SELECTOR)
+            + Op.POP(
+                Op.CALL(
+                    address=erc20_address,
+                    value=0,
+                    args_offset=28,
+                    args_size=36+32,
+                    ret_offset=0,
+                    ret_size=0,
+                    # gas accounting
+                    address_warm=True,
+                )
+            )
+            + Op.MSTORE(0, MINT_SELECTOR)
+        )
+    else:
+        cache_warmup = Bytecode()
+
+    loop = While(
+        body=cache_warmup
+        + call_mint
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        condition=Op.PUSH1(1)  # [1, num_calls]
+        + Op.SWAP1  # [num_calls, 1]
+        + Op.SUB  # [num_calls-1]
+        + Op.DUP1  # [num_calls-1, num_calls-1]
+        + Op.ISZERO  # [num_calls-1==0, num_calls-1]
+        + Op.ISZERO,  # [num_calls-1!=0, num_calls-1]
+    )
+
+    # Contract Deployment
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    # Gas Accounting
+    setup_cost = setup.gas_cost(fork)
+    loop_cost = loop.gas_cost(fork)
+    access_list = [AccessList(address=erc20_address, storage_keys=[])]
+    intrinsic_gas_with_access_list = (
+        fork.transaction_intrinsic_cost_calculator()(
+            access_list=access_list,
+            calldata=b"\xff" * 64,
+        )
+    )
+
+    # Mint function dispatch: hash balance slot, SLOAD, ADD, SSTORE
+    function_dispatch_mint = (
+        Op.PUSH4(MINT_SELECTOR)
+        + Op.EQ
+        + Op.JUMPI
+        + Op.JUMPDEST
+        + Op.CALLDATALOAD(4)
+        + Op.MSTORE(0)
+        + Op.MSTORE(32, 0)
+        + Op.SHA3(
+            0,
+            64,
+            # gas accounting
+            data_size=64,
+            old_memory_size=0,
+            new_memory_size=64,
+        )
+        + Op.DUP1
+        + Op.SLOAD.with_metadata(access_warm=cached)
+        + Op.CALLDATALOAD(36)
+        + Op.ADD
+        + Op.SSTORE
+        + Op.PUSH1(1)
+        + Op.MSTORE(0)
+        + Op.RETURN(0, 32)
+    )
+
+    function_dispatch_cost = function_dispatch_mint.gas_cost(fork)
+
+    if cached:
+        # Add balanceOf dispatch cost for the warmup call
+        function_dispatch_balanceof = (
+            Op.PUSH4(BALANCEOF_SELECTOR)
+            + Op.EQ
+            + Op.JUMPI
+            + Op.JUMPDEST
+            + Op.CALLDATALOAD(4)
+            + Op.MSTORE(0)
+            + Op.MSTORE(32, 0)
+            + Op.SHA3(
+                0,
+                64,
+                # gas accounting
+                data_size=64,
+                old_memory_size=0,
+                new_memory_size=64,
+            )
+            + Op.SLOAD
+            + Op.MSTORE(0)
+            + Op.RETURN(0, 32)
+        )
+        function_dispatch_cost += function_dispatch_balanceof.gas_cost(fork)
+
+    # Transaction Loops
+    txs = []
+    gas_remaining = gas_benchmark_value
+    # Start at 1 for existing balance slots,
+    # or at keccak256("random") for non-existing slots
+    slot_offset = (
+        1
+        if existing_slots
+        else 0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
+    )
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -40,7 +40,6 @@ from tests.benchmark.stateful.helpers import (
     SSTORE_TOKENS,
     CacheStrategy,
 )
-from tests.cancun.eip4844_blobs.test_blob_txs_full import txs
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
 REFERENCE_SPEC_VERSION = "1.0"
@@ -243,14 +242,11 @@ def test_sload_empty_erc20_balanceof(
 
         if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
             with TestPhaseManager.setup():
-                # For block-level caching, we need to warm the slot in a separate transaction
+                # For block-level caching,
+                # we need to warm the slot in a separate transaction
                 cache_txs.append(tx)
 
         with TestPhaseManager.execution():
-            # TODO: CHECK IF THIS WORKS
-            # Does this actually create the tx in execution phase mode?
-            # Or is it depends on where the tx is created?
-            # (if thats the case then all txs are in the execution phase - right?)
             txs.append(tx)
 
         gas_remaining -= gas_available
@@ -647,7 +643,7 @@ def test_sstore_erc20_mint(
 
     benchmark_test(
         pre=pre,
-        blocks=[Block(txs=txs)],
+        blocks=blocks,
     )
 
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -93,7 +93,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
-def test_sload_empty_erc20_balanceof(
+def test_sload_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
     fork: Fork,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -88,6 +88,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 
 
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
+@pytest.mark.parametrize("existing_slots", [False, True])
 def test_sload_empty_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -95,6 +96,7 @@ def test_sload_empty_erc20_balanceof(
     gas_benchmark_value: int,
     tx_gas_limit: int,
     token_name: str,
+    existing_slots: bool,
 ) -> None:
     """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
     # Stub Account
@@ -191,7 +193,10 @@ def test_sload_empty_erc20_balanceof(
     # Transaction Loops
     txs = []
     gas_remaining = gas_benchmark_value
-    slot_offset = 0
+    # Start at 1 (ERC20 bloater writes the balance of address to the slot)
+    # or start at keccak256("random") for non-existing slots
+    slot_offset = (1 if existing_slots 
+        else 0xa4896a3f93bf4bf58378e579f3cf193bb4af1022af7d2089f37d8bae7157b85f) 
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -38,7 +38,9 @@ from tests.benchmark.stateful.helpers import (
     SLOAD_TOKENS,
     SSTORE_MINT_TOKENS,
     SSTORE_TOKENS,
+    CacheStrategy,
 )
+from tests.cancun.eip4844_blobs.test_blob_txs_full import txs
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
 REFERENCE_SPEC_VERSION = "1.0"
@@ -91,7 +93,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
-@pytest.mark.parametrize("cached", [False, True])
+@pytest.mark.parametrize("cache_mode", list(CacheStrategy))
 def test_sload_empty_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -100,7 +102,7 @@ def test_sload_empty_erc20_balanceof(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
-    cached: bool,
+    cache_strategy: CacheStrategy,
 ) -> None:
     """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
     # Stub Account
@@ -142,12 +144,17 @@ def test_sload_empty_erc20_balanceof(
         )
     )
 
+    cache_loop = (
+        call_balance_of
+        if cache_strategy == CacheStrategy.CACHE_TX
+        else Bytecode()
+    )
+
     loop = While(
         body=call_balance_of
         # Do the same call again for the cached variant
-        + Bytecode()
-        if not cached
-        else call_balance_of + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        + cache_loop
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         condition=Op.PUSH1(1)  # [1, num_calls]
         + Op.SWAP1  # [num_calls, 1]
         + Op.SUB  # [num_calls-1]
@@ -201,6 +208,7 @@ def test_sload_empty_erc20_balanceof(
 
     # Transaction Loops
     txs = []
+    cache_txs = []
     gas_remaining = gas_benchmark_value
     # Start at 1 (ERC20 bloater writes the balance of address to the slot)
     # or start at keccak256("random") for non-existing slots
@@ -225,23 +233,32 @@ def test_sload_empty_erc20_balanceof(
 
         calldata = Hash(num_calls) + Hash(slot_offset)
 
-        txs.append(
-            Transaction(
-                gas_limit=gas_available,
-                data=calldata,
-                to=attack_contract_address,
-                sender=pre.fund_eoa(),
-                access_list=access_list,
-            )
+        tx = Transaction(
+            gas_limit=gas_available,
+            data=calldata,
+            to=attack_contract_address,
+            sender=pre.fund_eoa(),
+            access_list=access_list,
         )
+
+        if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
+            with TestPhaseManager.setup():
+                # For block-level caching, we need to warm the slot in a separate transaction
+                cache_txs.append(tx)
+
+        with TestPhaseManager.execution():
+            txs.append(tx)
 
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    benchmark_test(
-        pre=pre,
-        blocks=[Block(txs=txs)],
+    blocks = (
+        [Block(txs=txs)]
+        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
+        else [Block(txs=cache_txs), Block(txs=txs)]
     )
+
+    benchmark_test(pre=pre, blocks=blocks)
 
 
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
@@ -471,7 +488,7 @@ def test_sstore_erc20_mint(
         )
     )
 
-    if cached:
+    if cache_strategy == CacheStrategy.CACHE_TX:
         # Call balanceOf first to warm the storage slot, then restore
         # the mint selector
         cache_warmup = (

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -37,6 +37,7 @@ from tests.benchmark.stateful.helpers import (
     MINT_SELECTOR,
     SLOAD_TOKENS,
     SSTORE_TOKENS,
+    SSTORE_MINT_TOKENS,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -99,7 +100,7 @@ def test_sload_empty_erc20_balanceof(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
-    cached: bool
+    cached: bool,
 ) -> None:
     """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
     # Stub Account
@@ -129,23 +130,24 @@ def test_sload_empty_erc20_balanceof(
     )
 
     call_balance_of = Op.POP(
-            Op.CALL(
-                address=erc20_address,
-                value=0,
-                args_offset=28,
-                args_size=36,
-                ret_offset=0,
-                ret_size=0,
-                # gas accounting
-                address_warm=True,
-            )
+        Op.CALL(
+            address=erc20_address,
+            value=0,
+            args_offset=28,
+            args_size=36,
+            ret_offset=0,
+            ret_size=0,
+            # gas accounting
+            address_warm=True,
         )
+    )
 
     loop = While(
         body=call_balance_of
         # Do the same call again for the cached variant
-        + Bytecode() if not cached else call_balance_of
-        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        + Bytecode()
+        if not cached
+        else call_balance_of + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         condition=Op.PUSH1(1)  # [1, num_calls]
         + Op.SWAP1  # [num_calls, 1]
         + Op.SUB  # [num_calls-1]
@@ -202,8 +204,11 @@ def test_sload_empty_erc20_balanceof(
     gas_remaining = gas_benchmark_value
     # Start at 1 (ERC20 bloater writes the balance of address to the slot)
     # or start at keccak256("random") for non-existing slots
-    slot_offset = (1 if existing_slots 
-        else 0xa4896a3f93bf4bf58378e579f3cf193bb4af1022af7d2089f37d8bae7157b85f) 
+    slot_offset = (
+        1
+        if existing_slots
+        else 0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
+    )
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
@@ -395,7 +400,7 @@ def test_sstore_erc20_approve(
     )
 
 
-@pytest.mark.parametrize("token_name", SSTORE_TOKENS)
+@pytest.mark.parametrize("token_name", SSTORE_MINT_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
 @pytest.mark.parametrize("cached", [False, True])
 @pytest.mark.parametrize("no_change", [False, True])
@@ -410,11 +415,17 @@ def test_sstore_erc20_mint(
     cached: bool,
     no_change: bool,
 ) -> None:
-    """Benchmark SSTORE using ERC20 mint on bloatnet."""
+    """Benchmark SSTORE using ERC20 mint on bloatnet.
+    This contract calls mint() on an ERC20 contract
+    which supports the mint() function. It is intended
+    to be used with ERC20 contracts bloated via bloatStorage.
+    The mint will increase the total supply and the target account.
+
+    """
     # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
-        stub=f"test_sstore_erc20_approve_{token_name}",
+        stub=f"test_sstore_erc20_mint_{token_name}",
     )
 
     mint_amount = 0 if no_change else 1
@@ -470,7 +481,7 @@ def test_sstore_erc20_mint(
                     address=erc20_address,
                     value=0,
                     args_offset=28,
-                    args_size=36+32,
+                    args_size=36 + 32,
                     ret_offset=0,
                     ret_size=0,
                     # gas accounting
@@ -483,9 +494,7 @@ def test_sstore_erc20_mint(
         cache_warmup = Bytecode()
 
     loop = While(
-        body=cache_warmup
-        + call_mint
-        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        body=cache_warmup + call_mint + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         condition=Op.PUSH1(1)  # [1, num_calls]
         + Op.SWAP1  # [num_calls, 1]
         + Op.SUB  # [num_calls-1]
@@ -515,24 +524,24 @@ def test_sstore_erc20_mint(
         + Op.EQ
         + Op.JUMPI
         + Op.JUMPDEST
-        + Op.CALLDATALOAD(4)
-        + Op.MSTORE(0)
+        + Op.MSTORE(0, Op.CALLDATALOAD(4))
         + Op.MSTORE(32, 0)
         + Op.SHA3(
             0,
             64,
             # gas accounting
             data_size=64,
-            old_memory_size=0,
+            old_memory_size=64,
             new_memory_size=64,
         )
         + Op.DUP1
-        + Op.SLOAD.with_metadata(access_warm=cached)
+        + Op.SLOAD.with_metadata(key_warm=cached)
         + Op.CALLDATALOAD(36)
         + Op.ADD
         + Op.SSTORE
-        + Op.PUSH1(1)
-        + Op.MSTORE(0)
+        # Increase total supply
+        + Op.SSTORE(0, Op.ADD(Op.SLOAD(0), Op.CALLDATALOAD(36)))
+        + Op.MSTORE(0, 1)
         + Op.RETURN(0, 32)
     )
 
@@ -545,19 +554,19 @@ def test_sstore_erc20_mint(
             + Op.EQ
             + Op.JUMPI
             + Op.JUMPDEST
-            + Op.CALLDATALOAD(4)
-            + Op.MSTORE(0)
+            + Op.MSTORE(0, Op.CALLDATALOAD(4))
             + Op.MSTORE(32, 0)
             + Op.SHA3(
                 0,
                 64,
                 # gas accounting
                 data_size=64,
-                old_memory_size=0,
+                old_memory_size=64,
                 new_memory_size=64,
             )
             + Op.SLOAD
-            + Op.MSTORE(0)
+            + Op.PUSH0
+            + Op.MSTORE
             + Op.RETURN(0, 32)
         )
         function_dispatch_cost += function_dispatch_balanceof.gas_cost(fork)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -134,8 +134,8 @@ def test_sload_empty_erc20_balanceof(
         Op.CALL(
             address=erc20_address,
             value=0,
-            args_offset=28,
-            args_size=36,
+            args_offset=32 - 4,
+            args_size=32 + 4,
             ret_offset=0,
             ret_size=0,
             # gas accounting
@@ -232,22 +232,30 @@ def test_sload_empty_erc20_balanceof(
 
         calldata = Hash(num_calls) + Hash(slot_offset)
 
-        tx = Transaction(
-            gas_limit=gas_available,
-            data=calldata,
-            to=attack_contract_address,
-            sender=pre.fund_eoa(),
-            access_list=access_list,
-        )
-
         if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
             with TestPhaseManager.setup():
                 # For block-level caching,
                 # we need to warm the slot in a separate transaction
-                cache_txs.append(tx)
+                cache_txs.append(
+                    Transaction(
+                        gas_limit=gas_available,
+                        data=calldata,
+                        to=attack_contract_address,
+                        sender=pre.fund_eoa(),
+                        access_list=access_list,
+                    )
+                )
 
         with TestPhaseManager.execution():
-            txs.append(tx)
+            txs.append(
+                Transaction(
+                    gas_limit=gas_available,
+                    data=calldata,
+                    to=attack_contract_address,
+                    sender=pre.fund_eoa(),
+                    access_list=access_list,
+                )
+            )
 
         gas_remaining -= gas_available
         slot_offset += num_calls
@@ -479,8 +487,8 @@ def test_sstore_erc20_mint(
         Op.CALL(
             address=erc20_address,
             value=0,
-            args_offset=28,
-            args_size=68,
+            args_offset=32 - 4,
+            args_size=32 + 32 + 4,
             ret_offset=0,
             ret_size=0,
             # gas accounting
@@ -497,8 +505,8 @@ def test_sstore_erc20_mint(
                 Op.CALL(
                     address=erc20_address,
                     value=0,
-                    args_offset=28,
-                    args_size=36,
+                    args_offset=32 - 4,
+                    args_size=32 + 4,
                     ret_offset=0,
                     ret_size=0,
                     # gas accounting
@@ -616,21 +624,30 @@ def test_sstore_erc20_mint(
             break
 
         calldata = Hash(num_calls) + Hash(slot_offset)
-        tx = Transaction(
-            gas_limit=gas_available,
-            data=calldata,
-            to=attack_contract_address,
-            sender=pre.fund_eoa(),
-            access_list=access_list,
-        )
         if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
             with TestPhaseManager.setup():
-                cache_txs.append(tx)
+                cache_txs.append(
+                    Transaction(
+                        gas_limit=gas_available,
+                        data=calldata,
+                        to=attack_contract_address,
+                        sender=pre.fund_eoa(),
+                        access_list=access_list,
+                    )
+                )
 
         with TestPhaseManager.execution():
             # Same here, does this create tx is execution mode?
             # And above setup mode?
-            txs.append(tx)
+            txs.append(
+                Transaction(
+                    gas_limit=gas_available,
+                    data=calldata,
+                    to=attack_contract_address,
+                    sender=pre.fund_eoa(),
+                    access_list=access_list,
+                )
+            )
 
         gas_remaining -= gas_available
         slot_offset += num_calls

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -89,6 +89,7 @@ REFERENCE_SPEC_VERSION = "1.0"
 
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
 def test_sload_empty_erc20_balanceof(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -97,6 +98,7 @@ def test_sload_empty_erc20_balanceof(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
+    cached: bool
 ) -> None:
     """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
     # Stub Account
@@ -125,8 +127,7 @@ def test_sload_empty_erc20_balanceof(
         + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
-    loop = While(
-        body=Op.POP(
+    call_balance_of = Op.POP(
             Op.CALL(
                 address=erc20_address,
                 value=0,
@@ -138,6 +139,11 @@ def test_sload_empty_erc20_balanceof(
                 address_warm=True,
             )
         )
+
+    loop = While(
+        body=call_balance_of
+        # Do the same call again for the cached variant
+        + Bytecode() if not cached else call_balance_of
         + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         condition=Op.PUSH1(1)  # [1, num_calls]
         + Op.SWAP1  # [num_calls, 1]

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,5 +1,6 @@
 """Shared constants and helpers for stateful benchmark tests."""
 
+from enum import Enum
 import json
 from pathlib import Path
 
@@ -35,3 +36,13 @@ MIXED_TOKENS = [
     for k in _STUBS.keys()
     if k.startswith("test_mixed_sload_sstore_")
 ]
+
+
+class CacheStrategy(str, Enum):
+    # No caching strategy: target state is cold in EVM and cache
+    NO_CACHE = "no_cache"
+    # Caching at tx level: target state is warm in EVM and cache
+    CACHE_TX = "cache_tx"
+    # Caching at previous block:
+    # Target state is cold in EVM but (assumed) to be cached
+    CACHE_PREVIOUS_BLOCK = "cache_previous_block"

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,7 +1,7 @@
 """Shared constants and helpers for stateful benchmark tests."""
 
-from enum import Enum
 import json
+from enum import Enum
 from pathlib import Path
 
 # ERC20 function selectors
@@ -39,6 +39,8 @@ MIXED_TOKENS = [
 
 
 class CacheStrategy(str, Enum):
+    """Defines cache assumptions for benchmarked state access."""
+
     # No caching strategy: target state is cold in EVM and cache
     NO_CACHE = "no_cache"
     # Caching at tx level: target state is warm in EVM and cache

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -25,6 +25,11 @@ SSTORE_TOKENS = [
     for k in _STUBS.keys()
     if k.startswith("test_sstore_erc20_approve_")
 ]
+SSTORE_MINT_TOKENS = [
+    k.replace("test_sstore_erc20_mint_", "")
+    for k in _STUBS.keys()
+    if k.startswith("test_sstore_erc20_mint_")
+]
 MIXED_TOKENS = [
     k.replace("test_mixed_sload_sstore_", "")
     for k in _STUBS.keys()

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -7,6 +7,7 @@ from pathlib import Path
 BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
 APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
 ALLOWANCE_SELECTOR = 0xDD62ED3E  # allowance(address,address)
+MINT_SELECTOR = 0x40C10F19  # mint(address,uint256)
 
 # Load token names from stubs_bloatnet.json for test parametrization
 _STUBS_FILE = Path(__file__).parent / "bloatnet" / "stubs_bloatnet.json"


### PR DESCRIPTION
## 🗒️ Description
Targets SLOAD/SSTORE variants for repricing. Note: the code for the mint SSTORE one is generated by Claude. I have checked this against a client to see if it runs correctly.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
