### PR TITLE
feat(test-cli): Stack as callargs to`Op` for `evm_bytes`

### DIFF
--- a/packages/testing/src/execution_testing/cli/evm_bytes.py
+++ b/packages/testing/src/execution_testing/cli/evm_bytes.py
@@ -1,12 +1,12 @@
 """Define an entry point wrapper for pytest."""
 
-from dataclasses import dataclass, field
-from typing import Any, List
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List
 
 import click
 
-from execution_testing.base_types import ZeroPaddedHexNumber
-from execution_testing.vm import Bytecode, Macro, Op
+from execution_testing.base_types import HexNumber, ZeroPaddedHexNumber
+from execution_testing.vm import Op
 
 OPCODES_WITH_EMPTY_LINES_AFTER = {
     Op.STOP,
@@ -25,24 +25,60 @@ OPCODES_WITH_EMPTY_LINES_BEFORE = {
 class OpcodeWithOperands:
     """Simple opcode with its operands."""
 
-    opcode: Op | None
+    opcode: Op
     operands: List[int] = field(default_factory=list)
+    args: List["OpcodeWithOperands | HexNumber"] = field(default_factory=list)
+    kwargs: Dict[str, "OpcodeWithOperands | HexNumber"] = field(
+        default_factory=dict
+    )
 
-    def format(self, assembly: bool) -> str:
-        """Format the opcode with its operands."""
-        if self.opcode is None:
-            return ""
-        if assembly:
-            return self.format_assembly()
+    def __str__(self) -> str:
+        """Format into a string."""
+        output = ""
         if self.operands:
             operands = ", ".join(hex(operand) for operand in self.operands)
-            return f"Op.{self.opcode._name_}[{operands}]"
-        return f"Op.{self.opcode._name_}"
+            output = f"Op.{self.opcode._name_}[{operands}]"
+        else:
+            output = f"Op.{self.opcode._name_}"
+        if self.kwargs or self.args:
+            args: List[str] = []
+            if self.kwargs:
+                args = [f"{k}={v}" for k, v in self.kwargs.items()]
+            elif self.args:
+                args = [f"{arg}" for arg in self.args]
+            output = f"{output}({', '.join(args)})"
+        return output
 
-    def format_assembly(self) -> str:
+    def opcode_or_int(self) -> "OpcodeWithOperands | HexNumber":
+        """
+        Return self or an HexNumber if the opcode is a PUSH opcode and can be
+        seamlessly converted to int when used as a stack argument or keyword
+        argument.
+
+        Only return HexNumber if the PUSH opcode used is the minimum required
+        bytesize for the value. E.g. PUSH1[0xff] returns 0xff, but
+        PUSH2[0xff] returns the opcode itself because 0xff fits in PUSH1.
+        PUSH0 always returns itself.
+        """
+        if (
+            self.opcode is not None
+            and self.opcode._name_.startswith("PUSH")
+            and self.opcode.data_portion_length > 0
+            and len(self.operands) == 1
+        ):
+            value = self.operands[0]
+            min_bytes = max(1, (value.bit_length() + 7) // 8)
+            if self.opcode.data_portion_length == min_bytes:
+                return HexNumber(value)
+        return self
+
+
+@dataclass(kw_only=True)
+class OpcodeWithOperandsAssembly(OpcodeWithOperands):
+    """Simple opcode with its operands that formats into assembly."""
+
+    def __str__(self) -> str:
         """Format the opcode with its operands as assembly."""
-        if self.opcode is None:
-            return ""
         opcode_name = self.opcode._name_.lower()
         if self.opcode.data_portion_length == 0:
             return f"{opcode_name}"
@@ -52,27 +88,10 @@ class OpcodeWithOperands:
             )
             return f"{opcode_name} {operands}"
 
-    @property
-    def terminating(self) -> bool:
-        """Terminating opcode boolean."""
-        return self.opcode.terminating if self.opcode else False
 
-    @property
-    def bytecode(self) -> Bytecode:
-        """Opcode as bytecode with its operands if any."""
-        # opcode.opcode[*opcode.operands] crashes `black` formatter and doesn't
-        # work.
-        if self.opcode:
-            return (
-                self.opcode.__getitem__(*self.operands)
-                if self.operands
-                else self.opcode
-            )
-        else:
-            return Bytecode()
-
-
-def process_evm_bytes(evm_bytes: bytes) -> List[OpcodeWithOperands]:  # noqa: D103
+def process_evm_bytes(  # noqa: D103
+    evm_bytes: bytes, assembly: bool
+) -> List[OpcodeWithOperands]:
     evm_bytes_array = bytearray(evm_bytes)
 
     opcodes: List[OpcodeWithOperands] = []
@@ -82,27 +101,45 @@ def process_evm_bytes(evm_bytes: bytes) -> List[OpcodeWithOperands]:  # noqa: D1
 
         opcode: Op
         for op in Op:
-            if not isinstance(op, Macro) and op.int() == opcode_byte:
+            if op.int() == opcode_byte:
                 opcode = op
                 break
         else:
             raise ValueError(f"Unknown opcode: {opcode_byte}")
-
+        opcode_with_operands: OpcodeWithOperands
         if opcode.data_portion_length > 0:
-            opcodes.append(
-                OpcodeWithOperands(
-                    opcode=opcode,
-                    operands=[
-                        int.from_bytes(
-                            evm_bytes_array[: opcode.data_portion_length],
-                            "big",
-                        )
-                    ],
-                )
+            opcode_with_operands = OpcodeWithOperands(
+                opcode=opcode,
+                operands=[
+                    int.from_bytes(
+                        evm_bytes_array[: opcode.data_portion_length],
+                        "big",
+                    )
+                ],
             )
             evm_bytes_array = evm_bytes_array[opcode.data_portion_length :]
         else:
-            opcodes.append(OpcodeWithOperands(opcode=opcode))
+            opcode_with_operands = OpcodeWithOperands(opcode=opcode)
+        if (
+            opcode.popped_stack_items > 0
+            and len(opcodes) >= opcode.popped_stack_items
+            and not assembly
+        ):
+            # Check all args push items to the stack, else skip
+            args: List[OpcodeWithOperands] = list(
+                reversed(opcodes[-opcode.popped_stack_items :])
+            )
+            if all(arg.opcode.pushed_stack_items == 1 for arg in args):
+                args_with_int = [arg.opcode_or_int() for arg in args]
+                opcodes = opcodes[: -opcode.popped_stack_items]
+                if opcode.kwargs and len(opcode.kwargs) == len(args_with_int):
+                    opcode_with_operands.kwargs = dict(
+                        zip(opcode.kwargs, args_with_int, strict=True)
+                    )
+                else:
+                    opcode_with_operands.args = args_with_int
+
+        opcodes.append(opcode_with_operands)
 
     return opcodes
 
@@ -111,28 +148,24 @@ def format_opcodes(  # noqa: D103
     opcodes: List[OpcodeWithOperands], assembly: bool = False
 ) -> str:
     if assembly:
-        opcodes_with_empty_lines: List[OpcodeWithOperands] = []
+        opcodes_with_empty_lines: List[OpcodeWithOperandsAssembly | str] = []
         for i, op_with_operands in enumerate(opcodes):
             if (
                 op_with_operands.opcode in OPCODES_WITH_EMPTY_LINES_BEFORE
                 and len(opcodes_with_empty_lines) > 0
-                and opcodes_with_empty_lines[-1].opcode is not None
+                and opcodes_with_empty_lines[-1] != ""
             ):
-                opcodes_with_empty_lines.append(
-                    OpcodeWithOperands(opcode=None)
-                )
-            opcodes_with_empty_lines.append(op_with_operands)
+                opcodes_with_empty_lines.append("")
+            opcodes_with_empty_lines.append(
+                OpcodeWithOperandsAssembly(**asdict(op_with_operands))
+            )
             if (
                 op_with_operands.opcode in OPCODES_WITH_EMPTY_LINES_AFTER
                 and i < len(opcodes) - 1
             ):
-                opcodes_with_empty_lines.append(
-                    OpcodeWithOperands(opcode=None)
-                )
-        return "\n".join(
-            op.format(assembly) for op in opcodes_with_empty_lines
-        )
-    return " + ".join(op.format(assembly) for op in opcodes)
+                opcodes_with_empty_lines.append("")
+        return "\n".join(f"{op}" for op in opcodes_with_empty_lines)
+    return " + ".join(f"{op}" for op in opcodes)
 
 
 def process_evm_bytes_string(
@@ -143,7 +176,9 @@ def process_evm_bytes_string(
         evm_bytes_hex_string = evm_bytes_hex_string[2:]
 
     evm_bytes = bytes.fromhex(evm_bytes_hex_string)
-    return format_opcodes(process_evm_bytes(evm_bytes), assembly=assembly)
+    return format_opcodes(
+        process_evm_bytes(evm_bytes, assembly=assembly), assembly=assembly
+    )
 
 
 assembly_option = click.option(
@@ -240,6 +275,7 @@ def binary_file(binary_file: Any, assembly: bool) -> None:
 
     """  # noqa: D301
     processed_output = format_opcodes(
-        process_evm_bytes(binary_file.read()), assembly=assembly
+        process_evm_bytes(binary_file.read(), assembly=assembly),
+        assembly=assembly,
     )
     click.echo(processed_output)

--- a/packages/testing/src/execution_testing/cli/tests/test_evm_bytes.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_evm_bytes.py
@@ -8,13 +8,17 @@ from ..evm_bytes import process_evm_bytes_string
 
 basic_vector = [
     "0x60008080808061AAAA612d5ff1600055",
-    "Op.PUSH1[0x0] + Op.DUP1 + Op.DUP1 + Op.DUP1 + Op.DUP1 + "
-    "Op.PUSH2[0xaaaa] + Op.PUSH2[0x2d5f] + Op.CALL + Op.PUSH1[0x0] + "
-    "Op.SSTORE",
+    "Op.SSTORE(key=0x0, value=Op.CALL(gas=0x2d5f, "
+    "address=0xaaaa, value=Op.DUP1, args_offset=Op.DUP1, "
+    "args_size=Op.DUP1, ret_offset=Op.DUP1, ret_size=0x0))",
 ]
 complex_vector = [
     "0x7fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf5f527fc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf6020527fe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff60405260786040356020355f35608a565b5f515f55602051600155604051600255005b5e56",  # noqa: E501
-    "Op.PUSH32[0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf] + Op.PUSH0 + Op.MSTORE + Op.PUSH32[0xc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf] + Op.PUSH1[0x20] + Op.MSTORE + Op.PUSH32[0xe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff] + Op.PUSH1[0x40] + Op.MSTORE + Op.PUSH1[0x78] + Op.PUSH1[0x40] + Op.CALLDATALOAD + Op.PUSH1[0x20] + Op.CALLDATALOAD + Op.PUSH0 + Op.CALLDATALOAD + Op.PUSH1[0x8a] + Op.JUMP + Op.JUMPDEST + Op.PUSH0 + Op.MLOAD + Op.PUSH0 + Op.SSTORE + Op.PUSH1[0x20] + Op.MLOAD + Op.PUSH1[0x1] + Op.SSTORE + Op.PUSH1[0x40] + Op.MLOAD + Op.PUSH1[0x2] + Op.SSTORE + Op.STOP + Op.JUMPDEST + Op.MCOPY + Op.JUMP",  # noqa: E501
+    "Op.MSTORE(offset=Op.PUSH0, "
+    "value="
+    "0xa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+    ") + Op.MSTORE(offset=0x20, "
+    "value=0xc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf) + Op.MSTORE(offset=0x40, value=0xe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff) + Op.PUSH1[0x78] + Op.CALLDATALOAD(offset=0x40) + Op.CALLDATALOAD(offset=0x20) + Op.CALLDATALOAD(offset=Op.PUSH0) + Op.JUMP(pc=0x8a) + Op.JUMPDEST + Op.SSTORE(key=Op.PUSH0, value=Op.MLOAD(offset=Op.PUSH0)) + Op.SSTORE(key=0x1, value=Op.MLOAD(offset=0x20)) + Op.SSTORE(key=0x2, value=Op.MLOAD(offset=0x40)) + Op.STOP + Op.JUMPDEST + Op.MCOPY + Op.JUMP",  # noqa: E501
 ]
 
 


### PR DESCRIPTION
## 🗒️ Description

Improves the generated `Bytecode` by automatically passing previous opcodes as stack arguments for the next opcode.

Previous bytecode was:
```python
pre[contract] = Account(
        balance=0xde0b6b3a7640000,
        nonce=0,
        code=(
        Op.PUSH1[0x40] + Op.PUSH1[0x0] + Op.PUSH1[0x40] + Op.PUSH1[0x0]
        + Op.PUSH1[0x0] + Op.PUSH20[0xd0735f094c16e509e8d76999d9ee2e4fd5166c2e]
        + Op.PUSH2[0x1770] + Op.CALL + Op.STOP
    ),
    )
```

With this change, the bytecode is now:
```python
pre[contract] = Account(
        balance=0xDE0B6B3A7640000,
        nonce=0,
        code=(
            Op.CALL(
                gas=0x1770,
                address=0xD0735F094C16E509E8D76999D9EE2E4FD5166C2E,
                value=0x0,
                args_offset=0x0,
                args_size=0x40,
                ret_offset=0x0,
                ret_size=0x40,
            )
            + Op.STOP
        ),
    )
```

Required for #2321.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://photos.mongabay.com/j/DSC_0126.yemenchameleon.568.jpg)
