### PR TITLE
refactor(test-cli): optimize execute remote with pooling

### DIFF
--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -178,6 +178,7 @@ class BaseRPC:
         self.url = url
         self.request_id_counter = count(1)
         self.response_validation_context = response_validation_context
+        self.session = requests.Session()
 
     def __init_subclass__(cls, namespace: str | None = None) -> None:
         """
@@ -218,7 +219,7 @@ class BaseRPC:
           application-level issues rather than transient network problems
         """
         logger.debug(f"Making HTTP request to {url}, timeout={timeout}")
-        return requests.post(
+        return self.session.post(
             url, json=json_payload, headers=headers, timeout=timeout
         )
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Replace per-request `requests.post()` calls with a persistent `requests.Session` in `BaseRPC`, enabling HTTP connection pooling (keep-alive) across RPC calls to the same host.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Issue #1949

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![adam-berkecz-K6kZKJOmZrk-unsplash](https://github.com/user-attachments/assets/b9406e4f-49f5-4043-9181-8bc8e9213428)


Photo by <a href="https://unsplash.com/@aberkecz?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">[Ádám Berkecz](https://unsplash.com/@aberkecz?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)</a> on <a href="https://unsplash.com/photos/dolphin-K6kZKJOmZrk?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText">[Unsplash](https://unsplash.com/photos/dolphin-K6kZKJOmZrk?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)</a>