### PR TITLE
chore(tests): cache EIP-7934 calibration functions to fix py3 CI performance regression

### DIFF
--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -68,7 +68,21 @@ def block_errors() -> List[BlockException]:
     return [BlockException.RLP_BLOCK_LIMIT_EXCEEDED]
 
 
+@lru_cache(maxsize=128)
 def max_zero_calldata_bytes_for_gas(
+    fork: Fork,
+    gas_limit: int,
+    *,
+    max_len_hint: int,
+) -> int:
+    """Return the largest zero-calldata length whose intrinsic gas fits."""
+    calculator = fork.transaction_intrinsic_cost_calculator()
+    return _max_zero_calldata_bytes_for_gas(
+        calculator, gas_limit, max_len_hint=max_len_hint
+    )
+
+
+def _max_zero_calldata_bytes_for_gas(
     calculator: Callable[..., int],
     gas_limit: int,
     *,
@@ -116,6 +130,7 @@ def max_zero_calldata_bytes_for_gas(
     return lo
 
 
+@lru_cache(maxsize=128)
 def calibrated_block_gas_limit(
     fork: Fork,
     block_size_limit: int,
@@ -134,7 +149,7 @@ def calibrated_block_gas_limit(
 
     if tx_gas_limit_cap is not None:
         max_bytes_per_tx = max_zero_calldata_bytes_for_gas(
-            calculator,
+            fork,
             tx_gas_limit_cap,
             max_len_hint=estimated_calldata_bytes,
         )
@@ -431,7 +446,7 @@ def _exact_size_transactions_impl(
             authorization_count = len(
                 special_tx_dict.get("authorization_list", [])
             )
-            max_special_data_len = max_zero_calldata_bytes_for_gas(
+            max_special_data_len = _max_zero_calldata_bytes_for_gas(
                 calculator,
                 per_tx_gas_budget,
                 max_len_hint=200_000,
@@ -575,7 +590,7 @@ def _exact_size_transactions_impl(
         estimated_calldata = max(0, calldata_bytes_needed - 5)
 
         max_topoff_calldata = max_zero_calldata_bytes_for_gas(
-            calculator,
+            fork,
             topoff_gas_budget,
             max_len_hint=max(estimated_calldata, 1),
         )


### PR DESCRIPTION
## 🗒️ Description

Adds `@lru_cache` to `calibrated_block_gas_limit()` and `max_zero_calldata_bytes_for_gas()` in EIP-7934 tests to eliminate redundant computation across tests that share the same `(fork, block_size_limit)` parameters.

Closes #2314. Fixes the performance regression introduced in #2252.

### Motivation

The `calibrate_gas_limit` fixture is `autouse=True`, so every test invokes `calibrated_block_gas_limit()` which in turn calls `max_zero_calldata_bytes_for_gas()`, both expensive binary-search functions. Since each test passes the same `(fork, block_size_limit)` combination, every call after the first is pure redundant work.

### Approach

**`calibrated_block_gas_limit()`**: all parameters (`Fork`, `int`, `int`) are already hashable, so adding `@lru_cache(maxsize=128)` is sufficient with no signature changes.

**`max_zero_calldata_bytes_for_gas()`**: the original accepts an unhashable `calculator: Callable` and optional unhashable kwargs (`access_list`, `authorization_list_or_count`), so it can't be directly cached. Split into:
- A cached public wrapper `max_zero_calldata_bytes_for_gas(fork, gas_limit, *, max_len_hint)` that creates the calculator internally.
- A private uncached `_max_zero_calldata_bytes_for_gas(calculator, ...)` that retains the original signature for call sites needing unhashable kwargs.

Three call sites updated accordingly: two use the cached `fork`-based wrapper, one uses the private uncached function (because it passes `access_list` and `authorization_list_or_count`).

### Results

**With `--cov`** (matches CI `py3` environment):

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total wall clock (62 tests, `-n 6`) | 1171s (19:31) | 208s (3:28) | **5.6x faster** |

**Without `--cov`** (for comparison):

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total wall clock (62 tests, `-n 6`) | 286s (4:45) | 62s (1:02) | **4.6x faster** |
| Slowest test (call) | 5.83s | 2.30s | 2.5x faster |
| Setup overhead | up to 2.31s per test | ~0s (all cached) | eliminated |

Coverage instrumentation (`sys.settrace`) amplifies the uncached cost by 4.1x (286s to 1171s) because it traces every call in the binary search loops and RLP serialization. After caching, the amplification drops to 3.4x (62s to 208s) since the redundant calls are eliminated.

Fixture correctness verified via hasher.

## 🔗 Related Issues or PRs

Closes #2314.

## ✅ Checklist

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles).
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/1200px-Cat_November_2010-1a.jpg" width="512" />