### PR TITLE
feat(bench): parametrize SLOAD before SSTORE in ERC20 approve

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -32,6 +32,7 @@ from execution_testing import (
 )
 
 from tests.benchmark.stateful.helpers import (
+    ALLOWANCE_SELECTOR,
     APPROVE_SELECTOR,
     BALANCEOF_SELECTOR,
     CacheStrategy,
@@ -321,16 +322,20 @@ def test_sstore_erc20_approve(
     )
 
     if cache_strategy == CacheStrategy.CACHE_TX:
-        # Call balanceOf first to warm the storage slot, then
-        # restore the approve selector
+        # Call allowance(ADDRESS, spender) to warm the allowance
+        # storage slot that approve will later write to.
+        # Memory: save spender→[64], put ADDRESS→[32],
+        # set allowance selector, call, then restore.
         cache_warmup = (
-            Op.MSTORE(0, BALANCEOF_SELECTOR)
+            Op.MSTORE(64, Op.MLOAD(32))
+            + Op.MSTORE(32, Op.ADDRESS)
+            + Op.MSTORE(0, ALLOWANCE_SELECTOR)
             + Op.POP(
                 Op.CALL(
                     address=erc20_address,
                     value=0,
                     args_offset=28,
-                    args_size=36,
+                    args_size=68,
                     ret_offset=0,
                     ret_size=0,
                     # gas accounting
@@ -338,6 +343,7 @@ def test_sstore_erc20_approve(
                 )
             )
             + Op.MSTORE(0, APPROVE_SELECTOR)
+            + Op.MSTORE(32, Op.MLOAD(64))
         )
     else:
         cache_warmup = Bytecode()
@@ -407,6 +413,44 @@ def test_sstore_erc20_approve(
     )
 
     function_dispatch_cost = function_dispatch.gas_cost(fork)
+
+    if cache_strategy == CacheStrategy.CACHE_TX:
+        # Add allowance dispatch cost for the warmup call.
+        # allowance(owner, spender) computes the same double-
+        # keccak slot as approve but does SLOAD + RETURN.
+        function_dispatch_allowance = (
+            Op.PUSH4(ALLOWANCE_SELECTOR)
+            + Op.EQ
+            + Op.JUMPI
+            + Op.JUMPDEST
+            + Op.CALLDATALOAD(4)
+            + Op.CALLDATALOAD(36)
+            + Op.MSTORE(0, Op.CALLDATALOAD(4))
+            + Op.MSTORE(32, 1)
+            + Op.SHA3(
+                0,
+                64,
+                # gas accounting
+                data_size=64,
+                old_memory_size=0,
+                new_memory_size=64,
+            )
+            + Op.MSTORE(32)
+            + Op.MSTORE(0, Op.CALLDATALOAD(36))
+            + Op.SHA3(
+                0,
+                64,
+                # gas accounting
+                data_size=64,
+            )
+            + Op.SLOAD
+            + Op.PUSH0
+            + Op.MSTORE
+            + Op.RETURN(0, 32)
+        )
+        function_dispatch_cost += (
+            function_dispatch_allowance.gas_cost(fork)
+        )
 
     # Transaction Loops
     txs = []

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -34,12 +34,12 @@ from execution_testing import (
 from tests.benchmark.stateful.helpers import (
     APPROVE_SELECTOR,
     BALANCEOF_SELECTOR,
+    CacheStrategy,
     DECREMENT_COUNTER_CONDITION,
     MINT_SELECTOR,
     SLOAD_TOKENS,
     SSTORE_MINT_TOKENS,
     SSTORE_TOKENS,
-    CacheStrategy,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -266,6 +266,7 @@ def test_sload_erc20_balanceof(
     benchmark_test(pre=pre, blocks=blocks)
 
 
+@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
 def test_sstore_erc20_approve(
     benchmark_test: BenchmarkTestFiller,
@@ -274,6 +275,7 @@ def test_sstore_erc20_approve(
     gas_benchmark_value: int,
     tx_gas_limit: int,
     token_name: str,
+    cache_strategy: CacheStrategy,
 ) -> None:
     """Benchmark SSTORE using ERC20 approve on bloatnet."""
     # Stub Account
@@ -302,23 +304,48 @@ def test_sstore_erc20_approve(
         + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
-    loop = While(
-        body=(
-            Op.MSTORE(64, Op.MLOAD(32))
+    call_approve = (
+        Op.MSTORE(64, Op.MLOAD(32))
+        + Op.POP(
+            Op.CALL(
+                address=erc20_address,
+                value=0,
+                args_offset=28,
+                args_size=68,
+                ret_offset=0,
+                ret_size=0,
+                # gas accounting
+                address_warm=True,
+            )
+        )
+    )
+
+    if cache_strategy == CacheStrategy.CACHE_TX:
+        # Call balanceOf first to warm the storage slot, then
+        # restore the approve selector
+        cache_warmup = (
+            Op.MSTORE(0, BALANCEOF_SELECTOR)
             + Op.POP(
                 Op.CALL(
                     address=erc20_address,
                     value=0,
                     args_offset=28,
-                    args_size=68,
+                    args_size=36,
                     ret_offset=0,
                     ret_size=0,
                     # gas accounting
                     address_warm=True,
                 )
             )
-            + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1))
-        ),
+            + Op.MSTORE(0, APPROVE_SELECTOR)
+        )
+    else:
+        cache_warmup = Bytecode()
+
+    loop = While(
+        body=cache_warmup
+        + call_approve
+        + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
         condition=DECREMENT_COUNTER_CONDITION,
     )
 
@@ -366,10 +393,14 @@ def test_sstore_erc20_approve(
             # gas accounting
             data_size=64,
         )
-        + Op.DUP1
-        + Op.SLOAD.with_metadata(key_warm=False)
-        + Op.POP
-        + Op.SSTORE
+        + (
+            Op.DUP1
+            + Op.SLOAD.with_metadata(key_warm=False)
+            + Op.POP
+            + Op.SSTORE.with_metadata(key_warm=True)
+            if cache_strategy == CacheStrategy.CACHE_TX
+            else Op.SSTORE.with_metadata(key_warm=False)
+        )
         # Return true
         + Op.MSTORE(0, 1)
         + Op.RETURN(0, 32)
@@ -379,6 +410,7 @@ def test_sstore_erc20_approve(
 
     # Transaction Loops
     txs = []
+    cache_txs = []
     gas_remaining = gas_benchmark_value
     slot_offset = 0
 
@@ -397,23 +429,39 @@ def test_sstore_erc20_approve(
 
         calldata = Hash(num_calls) + Hash(slot_offset)
 
-        txs.append(
-            Transaction(
-                gas_limit=gas_available,
-                data=calldata,
-                to=attack_contract_address,
-                sender=pre.fund_eoa(),
-                access_list=access_list,
+        if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
+            with TestPhaseManager.setup():
+                cache_txs.append(
+                    Transaction(
+                        gas_limit=gas_available,
+                        data=calldata,
+                        to=attack_contract_address,
+                        sender=pre.fund_eoa(),
+                        access_list=access_list,
+                    )
+                )
+
+        with TestPhaseManager.execution():
+            txs.append(
+                Transaction(
+                    gas_limit=gas_available,
+                    data=calldata,
+                    to=attack_contract_address,
+                    sender=pre.fund_eoa(),
+                    access_list=access_list,
+                )
             )
-        )
 
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    benchmark_test(
-        pre=pre,
-        blocks=[Block(txs=txs)],
+    blocks = (
+        [Block(txs=txs)]
+        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
+        else [Block(txs=cache_txs), Block(txs=txs)]
     )
+
+    benchmark_test(pre=pre, blocks=blocks)
 
 
 @pytest.mark.parametrize("token_name", SSTORE_MINT_TOKENS)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -35,12 +35,12 @@ from tests.benchmark.stateful.helpers import (
     ALLOWANCE_SELECTOR,
     APPROVE_SELECTOR,
     BALANCEOF_SELECTOR,
-    CacheStrategy,
     DECREMENT_COUNTER_CONDITION,
     MINT_SELECTOR,
     SLOAD_TOKENS,
     SSTORE_MINT_TOKENS,
     SSTORE_TOKENS,
+    CacheStrategy,
     build_cache_strategy_blocks,
 )
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -41,6 +41,7 @@ from tests.benchmark.stateful.helpers import (
     SLOAD_TOKENS,
     SSTORE_MINT_TOKENS,
     SSTORE_TOKENS,
+    build_cache_strategy_blocks,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -258,10 +259,8 @@ def test_sload_erc20_balanceof(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = (
-        [Block(txs=txs)]
-        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
-        else [Block(txs=cache_txs), Block(txs=txs)]
+    blocks = build_cache_strategy_blocks(
+        cache_strategy, txs, cache_txs
     )
 
     benchmark_test(pre=pre, blocks=blocks)
@@ -499,10 +498,8 @@ def test_sstore_erc20_approve(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = (
-        [Block(txs=txs)]
-        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
-        else [Block(txs=cache_txs), Block(txs=txs)]
+    blocks = build_cache_strategy_blocks(
+        cache_strategy, txs, cache_txs
     )
 
     benchmark_test(pre=pre, blocks=blocks)
@@ -735,10 +732,8 @@ def test_sstore_erc20_mint(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = (
-        [Block(txs=txs)]
-        if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK
-        else [Block(txs=cache_txs), Block(txs=txs)]
+    blocks = build_cache_strategy_blocks(
+        cache_strategy, txs, cache_txs
     )
 
     benchmark_test(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -259,9 +259,7 @@ def test_sload_erc20_balanceof(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = build_cache_strategy_blocks(
-        cache_strategy, txs, cache_txs
-    )
+    blocks = build_cache_strategy_blocks(cache_strategy, txs, cache_txs)
 
     benchmark_test(pre=pre, blocks=blocks)
 
@@ -304,19 +302,16 @@ def test_sstore_erc20_approve(
         + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
-    call_approve = (
-        Op.MSTORE(64, Op.MLOAD(32))
-        + Op.POP(
-            Op.CALL(
-                address=erc20_address,
-                value=0,
-                args_offset=28,
-                args_size=68,
-                ret_offset=0,
-                ret_size=0,
-                # gas accounting
-                address_warm=True,
-            )
+    call_approve = Op.MSTORE(64, Op.MLOAD(32)) + Op.POP(
+        Op.CALL(
+            address=erc20_address,
+            value=0,
+            args_offset=28,
+            args_size=68,
+            ret_offset=0,
+            ret_size=0,
+            # gas accounting
+            address_warm=True,
         )
     )
 
@@ -447,9 +442,7 @@ def test_sstore_erc20_approve(
             + Op.MSTORE
             + Op.RETURN(0, 32)
         )
-        function_dispatch_cost += (
-            function_dispatch_allowance.gas_cost(fork)
-        )
+        function_dispatch_cost += function_dispatch_allowance.gas_cost(fork)
 
     # Transaction Loops
     txs = []
@@ -498,9 +491,7 @@ def test_sstore_erc20_approve(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = build_cache_strategy_blocks(
-        cache_strategy, txs, cache_txs
-    )
+    blocks = build_cache_strategy_blocks(cache_strategy, txs, cache_txs)
 
     benchmark_test(pre=pre, blocks=blocks)
 
@@ -732,9 +723,7 @@ def test_sstore_erc20_mint(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = build_cache_strategy_blocks(
-        cache_strategy, txs, cache_txs
-    )
+    blocks = build_cache_strategy_blocks(cache_strategy, txs, cache_txs)
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -9,6 +9,7 @@ from execution_testing import (
     AccessList,
     Address,
     Alloc,
+    Block,
     Fork,
     Hash,
     Op,
@@ -154,3 +155,20 @@ def build_benchmark_txs(
 
     assert txs, "Gas loop produced zero transactions"
     return txs, total_gas_consumed
+
+
+def build_cache_strategy_blocks(
+    cache_strategy: CacheStrategy,
+    txs: list[Transaction],
+    cache_txs: list[Transaction],
+) -> list[Block]:
+    """
+    Assemble benchmark blocks based on cache strategy.
+
+    For CACHE_PREVIOUS_BLOCK, prepend a warmup block before the
+    execution block so that client caches are hot but EVM state is
+    cold.  Otherwise return a single execution block.
+    """
+    if cache_strategy != CacheStrategy.CACHE_PREVIOUS_BLOCK:
+        return [Block(txs=txs)]
+    return [Block(txs=cache_txs), Block(txs=txs)]


### PR DESCRIPTION
## Summary
- Adds `sloads_before_sstore` parameter to `test_sstore_erc20_approve`, following the same pattern used by `test_sstore_variants`
- When `True` (existing behavior): SLOAD warms the slot, then SSTORE writes at warm cost (2,900 gas)
- When `False` (new variant): SSTORE hits a cold slot directly (5,000 gas), matching a vanilla Solidity `approve()` which does not SLOAD before writing

## Motivation
Standard ERC-20 `approve()` compiles to a bare SSTORE — there's no preceding SLOAD. The existing benchmark always included an SLOAD, which warmed the slot and changed the SSTORE gas profile. Parametrizing this lets us benchmark both patterns and decide which better represents the workload we want to measure.