### PR TITLE
chore(ci,deps): remove `setup-env` from jobs that don't need it

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,6 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
-      - uses: ./.github/actions/setup-env
       - name: Run py3 tests
         run: tox -e py3
         env:
@@ -85,7 +84,6 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
-      - uses: ./.github/actions/setup-env
       - name: Run pypy3 tests
         run: tox -e pypy3
         env:
@@ -117,7 +115,6 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
-      - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/build-evmone
       - name: Run py3 tests
         run: tox -e tests_pytest_py3
@@ -134,7 +131,6 @@ jobs:
       - uses: ./.github/actions/setup-uv
         with:
           python-version: "pypy3.11"
-      - uses: ./.github/actions/setup-env
       - uses: ./.github/actions/build-evmone
       - name: Run pypy3 tests
         run: tox -e tests_pytest_pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,9 @@ commands =
 
 [testenv:tests_pytest_py3]
 description = Run the testing package unit tests (with Python)
+dependency_groups =
+    test
+    lint  # TODO: add ruff for gentest; remove as part of ethereum/execution-specs#1715
 changedir = {toxinidir}/packages/testing
 package = editable
 commands =
@@ -88,6 +91,8 @@ commands =
 
 [testenv:py3]
 description = Fill the tests using EELS (with Python)
+dependency_groups =
+    test
 commands =
     fill \
         -m "not slow and not benchmark" \
@@ -136,6 +141,8 @@ commands =
 
 [testenv:benchmark-gas-values]
 description = Run benchmark tests with `--gas-benchmark-values`
+dependency_groups =
+    test
 passenv =
     EVM_BIN
 commands =
@@ -154,6 +161,8 @@ commands =
 
 [testenv:benchmark-fixed-opcode-cli]
 description = Run benchmark tests with `--fixed-opcode-count 1`
+dependency_groups =
+    test
 passenv =
     EVM_BIN
 commands =
@@ -173,6 +182,8 @@ commands =
 
 [testenv:benchmark-fixed-opcode-config]
 description = Run `benchmark_parser` and the benchmark tests using the generated file
+dependency_groups =
+    test
 passenv =
     EVM_BIN
 commands =


### PR DESCRIPTION
## Description

Remove the `setup-env` step from CI jobs that don't need Rust, `build-essential`, or Geth. Noticed while working on #2310 and #2283.

`setup-env` installs the native build toolchain and Geth. After #2310, `setup-uv` already handles Python, uv, and tox -- so `setup-env` is only needed by jobs that compile `ethereum-execution[optimized]` (Rust) or run Geth.

Four jobs don't need either:

- `py3` / `pypy3`: run `fill` using EELS (no Geth), don't use `optimized`.
- `tests_pytest_py3` / `tests_pytest_pypy3`: run testing package unit tests with evmone. `build-evmone` is self-contained. No Geth needed.

`py3` and `pypy3` are on the critical path -- removing `setup-env` saves ~2 min per CI run.

### tox.ini

Override `dependency_groups` in `py3` and `tests_pytest_py3` to exclude `ethereum-execution[optimized]`, matching `pypy3` and `tests_pytest_pypy3` which already do this. Also applied the same override to the three benchmark envs (`benchmark-gas-values`, `benchmark-fixed-opcode-cli`, `benchmark-fixed-opcode-config`) for consistency -- they run on `ubuntu-latest` (which has Rust pre-installed) so they happen to work today, but explicitly excluding `optimized` makes the intent clear and avoids a future footgun if runners change.

### test.yaml

Delete `- uses: ./.github/actions/setup-env` from `py3`, `pypy3`, `tests_pytest_py3`, `tests_pytest_pypy3`. `json_infra` is left as-is (may need Geth).

### Single Datapoint Comparison

#### Before
https://github.com/ethereum/execution-specs/actions/runs/22436513783?pr=2310
<img width="799" height="599" alt="image" src="https://github.com/user-attachments/assets/e174e1d9-c915-40ed-a93b-506bd0af7ba2" />

#### After
https://github.com/ethereum/execution-specs/actions/runs/22441413436?pr=2335
<img width="786" height="600" alt="image" src="https://github.com/user-attachments/assets/6ced5a2f-23b7-49ec-b2ba-98cd3a6a82bd" />


## Related Issues or PRs

- #2310
- #2283

## Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails:
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the repo standard.