### PR TITLE
feat(zkevm): add zkevm feature for releases

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -20,3 +20,8 @@ bal:
   evm-type: develop
   fill-params: --fork=Amsterdam --fill-static-tests
   feature_only: true
+
+zkevm:
+  evm-type: develop
+  fill-params: -m "blockchain_test" --fork=Amsterdam ./tests/
+  feature_only: true


### PR DESCRIPTION
## 🗒️ Description
This PR adds a new `zkevm` config feature that automatically triggers a new release when a new tag is pushed, using the right command.

Pushing a tag with name `tests-zkevm@v0.1.0` should automatically create a corresponding release in the `execution-spec-tests` repo.