### PR TITLE
chore(do not merge): Update `Unsigned` class to subclass `int`

### DIFF
--- a/packages/testing/pyproject.toml
+++ b/packages/testing/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pydantic>=2.12.3,<3",
     "rich>=13.7.0,<15",
     "filelock>=3.15.1,<4",
-    "ethereum-types>=0.3.0,<0.4",
+    "ethereum-types @ git+https://github.com/ethereum/ethereum-types.git@42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a",
     "pyyaml>=6.0.2,<7",
     "types-pyyaml>=6.0.12.20240917,<7",
     "pytest-json-report>=1.5.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "coincurve>=20,<21",
     "typing_extensions>=4.4",
     "py-ecc>=8.0.0b2,<9",
-    "ethereum-types>=0.3.0,<0.4",
+    "ethereum-types @ git+https://github.com/ethereum/ethereum-types.git@42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a",
     "ethereum-rlp>=0.1.5,<0.2",
     "cryptography>=45.0.1,<46",
     "platformdirs>=4.2,<5",

--- a/uv.lock
+++ b/uv.lock
@@ -944,7 +944,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.1,<46" },
     { name = "ethash", marker = "extra == 'optimized'", specifier = ">=1.1.0,<2" },
     { name = "ethereum-rlp", specifier = ">=0.1.5,<0.2" },
-    { name = "ethereum-types", specifier = ">=0.3.0,<0.4" },
+    { name = "ethereum-types", git = "https://github.com/ethereum/ethereum-types.git?rev=42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a" },
     { name = "libcst", specifier = ">=1.8,<2" },
     { name = "platformdirs", specifier = ">=4.2,<5" },
     { name = "py-ecc", specifier = ">=8.0.0b2,<9" },
@@ -1112,7 +1112,7 @@ requires-dist = [
     { name = "ethereum-execution", editable = "." },
     { name = "ethereum-hive", specifier = ">=0.1.0a1,<1.0.0" },
     { name = "ethereum-rlp", specifier = ">=0.1.5,<0.2" },
-    { name = "ethereum-types", specifier = ">=0.3.0,<0.4" },
+    { name = "ethereum-types", git = "https://github.com/ethereum/ethereum-types.git?rev=42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "gitpython", specifier = ">=3.1.31,<4" },
     { name = "jinja2", specifier = ">=3,<4" },
@@ -1181,13 +1181,9 @@ wheels = [
 [[package]]
 name = "ethereum-types"
 version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/ethereum/ethereum-types.git?rev=42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a#42ee6c1e9da3130f287a979c1f7f9ee0fab52e2a" }
 dependencies = [
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/90/32d9440ae5b2ac97d873862c9cbbacd28c82cf6d471efb54ef3051700739/ethereum_types-0.3.0.tar.gz", hash = "sha256:e5324efd269a0f66993163366543e39aae474a53f48031c31acec956867d8995", size = 15697, upload-time = "2026-02-20T03:47:40.169Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/3f/e9c35c2d879cd0084e9eb59e0e650e1688cc75ec3776291d92d4b7989fff/ethereum_types-0.3.0-py3-none-any.whl", hash = "sha256:ade1aae9df702067387b1e100f7b65fe96c87b1d7731fb7838cca79e84e51cca", size = 10685, upload-time = "2026-02-20T03:47:39.065Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

reopened #2333 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
