### PR TITLE
chore(test-client-clis): map geth "bal validation failure" to GAS_USED_OVERFLOW

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -128,6 +128,7 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_RECEIPTS_ROOT: "invalid receipt root hash",
         BlockException.INVALID_LOG_BLOOM: "invalid bloom",
         BlockException.INVALID_STATE_ROOT: "invalid merkle root",
+        BlockException.GAS_USED_OVERFLOW: "bal validation failure",
     }
     mapping_regex: ClassVar[Dict[ExceptionBase, str]] = {
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED: (


### PR DESCRIPTION
## 🗒️ Description

Map geth's `"bal validation failure"` error string to `BlockException.GAS_USED_OVERFLOW` in `GethExceptionMapper`.

In Amsterdam (with BAL / EIP-7928), when a block's gas used exceeds its gas limit, geth rejects the block during BAL validation — the state diff mismatches the declared BAL — before it reaches the gas-used check. This causes geth to return `"bal validation failure"` instead of a gas-specific error, which was previously unmapped.

[Hive failure](https://hive.ethpandaops.io/#/test/bal-quick/1772113676-07f747fb12c7b71e90950c83dcd5c2ba?testnumber=202):

```
2026-02-26 13:44:56 [INFO] ./src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py:110: Payload response status: PayloadStatusEnum.INVALID
2026-02-26 13:44:56 [FAIL] ./src/execution_testing/logging/logger.py:69: Undefined exception message: expected exception: "BlockException.GAS_USED_OVERFLOW", returned exception: "bal validation failure" (mapper: "GethExceptionMapper")
```

> [!NOTE]
> If geth returns additional error strings that should also map to `GAS_USED_OVERFLOW` in the future, move the mapping from `mapping_substring` to `mapping_regex` using alternation, e.g., `r"bal validation failure|other error string"`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.

#### Cute Animal Picture

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/481px-Cat_November_2010-1a.jpg" width="480" alt="cute cat" />