### PR TITLE
feat(ci): dual-publish fixture releases to EELS and EEST

### DIFF
--- a/.github/workflows/release_fixture_feature.yaml
+++ b/.github/workflows/release_fixture_feature.yaml
@@ -66,10 +66,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/tests-')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Download all artifacts
         run: |
@@ -77,17 +80,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Draft Pre-release to EEST Repository
+      - name: Draft pre-release on EELS (canonical)
         run: |
-          # Strip "tests-" prefix from tag for EEST
-          TAG_NAME="${{ github.ref_name }}"
-          RELEASE_TAG="${TAG_NAME#tests-}"
+          # Find previous tag scoped to this feature (e.g., tests-bal@v*)
+          FEATURE_PREFIX="${TAG_NAME%%@*}"
+          PREV_TAG=$(
+            git tag --list "${FEATURE_PREFIX}@v*" --sort=-v:refname \
+              | grep -v "^${TAG_NAME}$" \
+              | head -n 1 \
+            || true
+          )
+          NOTES_ARGS=""
+          if [ -n "$PREV_TAG" ]; then
+            NOTES_ARGS="--notes-start-tag $PREV_TAG"
+          fi
+          gh release create "$TAG_NAME" --draft --prerelease --generate-notes $NOTES_ARGS ./artifacts/**/*
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
 
-          gh release create "$RELEASE_TAG" \
+      - name: Draft pre-release on EEST (mirror)
+        run: |
+          EEST_TAG="${TAG_NAME#tests-}"
+          gh release create "$EEST_TAG" \
             --repo ethereum/execution-spec-tests \
             --draft \
             --prerelease \
-            --generate-notes \
+            --notes "This release is mirrored from [ethereum/execution-specs ${TAG_NAME}](https://github.com/ethereum/execution-specs/releases/tag/${TAG_NAME})." \
             ./artifacts/**/*
         env:
+          TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.EEST_RELEASE_TOKEN }}

--- a/.github/workflows/release_fixture_feature.yaml
+++ b/.github/workflows/release_fixture_feature.yaml
@@ -90,11 +90,11 @@ jobs:
               | head -n 1 \
             || true
           )
-          NOTES_ARGS=""
+          NOTES_ARGS=()
           if [ -n "$PREV_TAG" ]; then
-            NOTES_ARGS="--notes-start-tag $PREV_TAG"
+            NOTES_ARGS=(--notes-start-tag "$PREV_TAG")
           fi
-          gh release create "$TAG_NAME" --draft --prerelease --generate-notes $NOTES_ARGS ./artifacts/**/*
+          gh release create "$TAG_NAME" --draft --prerelease --generate-notes "${NOTES_ARGS[@]}" ./artifacts/**/*
         env:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_fixture_full.yaml
+++ b/.github/workflows/release_fixture_full.yaml
@@ -87,11 +87,11 @@ jobs:
               | head -n 1 \
             || true
           )
-          NOTES_ARGS=""
+          NOTES_ARGS=()
           if [ -n "$PREV_TAG" ]; then
-            NOTES_ARGS="--notes-start-tag $PREV_TAG"
+            NOTES_ARGS=(--notes-start-tag "$PREV_TAG")
           fi
-          gh release create "$TAG_NAME" --draft --generate-notes $NOTES_ARGS ./artifacts/**/*
+          gh release create "$TAG_NAME" --draft --generate-notes "${NOTES_ARGS[@]}" ./artifacts/**/*
         env:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_fixture_full.yaml
+++ b/.github/workflows/release_fixture_full.yaml
@@ -65,10 +65,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/tests-')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Download all artifacts
         run: |
@@ -76,16 +79,31 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Create Release
+      - name: Draft release on EELS (canonical)
         run: |
-          # Strip "tests-" prefix from tag for EEST
-          TAG_NAME="${{ github.ref_name }}"
-          RELEASE_TAG="${TAG_NAME#tests-}"
+          PREV_TAG=$(
+            git tag --list 'tests-v[0-9]*' --sort=-v:refname \
+              | grep -v "^${TAG_NAME}$" \
+              | head -n 1 \
+            || true
+          )
+          NOTES_ARGS=""
+          if [ -n "$PREV_TAG" ]; then
+            NOTES_ARGS="--notes-start-tag $PREV_TAG"
+          fi
+          gh release create "$TAG_NAME" --draft --generate-notes $NOTES_ARGS ./artifacts/**/*
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
 
-          gh release create "$RELEASE_TAG" \
+      - name: Draft release on EEST (mirror)
+        run: |
+          EEST_TAG="${TAG_NAME#tests-}"
+          gh release create "$EEST_TAG" \
             --repo ethereum/execution-spec-tests \
             --draft \
-            --generate-notes \
+            --notes "This release is mirrored from [ethereum/execution-specs ${TAG_NAME}](https://github.com/ethereum/execution-specs/releases/tag/${TAG_NAME})." \
             ./artifacts/**/*
         env:
+          TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.EEST_RELEASE_TOKEN }}


### PR DESCRIPTION
## 🗒️ Description

Fixture releases are built on EELS (`ethereum/execution-specs`) but currently published only on EEST (`ethereum/execution-spec-tests`). This PR makes EELS the canonical release origin and mirrors to EEST for backwards compatibility.

#### How a release flows

```
push tag tests-v5.5.0 to EELS
  → workflow triggers
    → build fixtures
    → create draft release on EELS   (tag: tests-v5.5.0, token: github.token)
    → create draft release on EEST   (tag: v5.5.0,       token: EEST_RELEASE_TOKEN)
```

#### Tag mapping

| Release type | Tag pushed to EELS | EELS release tag | EEST mirror tag |
|---|---|---|---|
| Full | `tests-v5.5.0` | `tests-v5.5.0` | `v5.5.0` |
| Feature | `tests-bal@v5.1.0` | `tests-bal@v5.1.0` | `bal@v5.1.0` |

The `tests-` prefix is stripped for EEST so existing EEST consumers see no change.

#### Atomicity

EELS release is created first. If it fails, the job fails and the EEST step is skipped (default sequential step behavior).

### Changes

**Both `release_fixture_full.yaml` and `release_fixture_feature.yaml`:**

- `permissions: contents: write` on release job (required for
  `github.token` to create releases on EELS).
- `fetch-depth: 0` on checkout to access previous fixture tags.
- **Draft release on EELS** (new step): finds the previous fixture tag
  (`tests-v*` for full, `tests-{feature}@v*` for feature) and passes it
  as `--notes-start-tag` to scope auto-generated notes to fixture
  releases only (EELS also has Python package tags). Creates canonical
  release using `github.token`.
- **Draft release on EEST** (updated step): strips `tests-` prefix from
  tag, uses provenance banner as body linking back to the EELS release.
- Script injection hardening: `github.ref_name` passed via `env:`
  bindings instead of direct `${{ }}` interpolation in `run:` blocks.
- Feature workflow adds `--prerelease` to both `gh release create`
  calls.

## 🔗 Related Issues or PRs

Closes #2337.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails.
- [x] All: PR title adheres to the repo standard.
- [ ] All: Considered updating the online docs in the `./docs/` directory.
- [x] All: Set appropriate labels for the changes.

### Test plan

- [ ] Trigger `release_fixture_full.yaml` via `workflow_dispatch` on a
  test tag (`tests-v0.0.1-test`). Verify:
    - Draft release on EELS with `tests-` prefixed tag.
    - Draft release on EEST with prefix stripped.
    - EEST body contains provenance banner.
    - Both releases have matching assets.
- [ ] Trigger `release_fixture_feature.yaml` with a feature tag
  (`tests-testfeat@v0.0.1-test`). Verify same plus `--prerelease`.
- [ ] First-release edge case: no previous tag, workflow succeeds
  without `--notes-start-tag`.

#### Cute Animal Picture

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/1200px-Cat_November_2010-1a.jpg" width="512" />