### PR TITLE
fix(ci): resolve package dependency

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -10,6 +10,9 @@ runs:
     - uses: ./.github/actions/setup-uv
       with:
         enable-cache: "false"
+    - name: Install system dependencies for coincurve
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y pkg-config libsecp256k1-dev
     - name: Install EEST
       shell: bash
       run: uv sync --no-progress


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

When i am testing PR #2346 , the CI workflow breaks [here](https://github.com/ethereum/execution-specs/actions/runs/22486691872/job/65137995332).

```python
  "/data/gh-home/.cache/uv/builds-v0/.tmpcPRebN/lib/python3.14/site-packages/scikit_build_core/builder/builder.py",
  line 297, in configure
      self.config.configure(
      ~~~~~~~~~~~~~~~~~~~~~^
          defines=cmake_defines,
          ^^^^^^^^^^^^^^^^^^^^^^
          cmake_args=[*self.get_cmake_args(), *configure_args],
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          toolchain=self.settings.cmake.toolchain_file,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )
      ^
    File
  "/data/gh-home/.cache/uv/builds-v0/.tmpcPRebN/lib/python3.14/site-packages/scikit_build_core/cmake.py",
  line 282, in configure
      raise FailedLiveProcessError(msg) from None
  scikit_build_core.errors.FailedLiveProcessError: CMake configuration
  failed

  hint: This usually indicates a problem with the package or the build
  environment.
help: `coincurve` (v20.0.0) was included because `ethereum-execution`
    depends on `coincurve`
```

It seems there is a package dependency issue, i add the missing dependency and the updated version [workflow](https://github.com/ethereum/execution-specs/actions/runs/22487180598) is successful at the building stage.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
