### PR TITLE
fix(clients): extend ethrex mapper to cover all BAL ordering error messages

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -42,14 +42,14 @@ class EthrexExceptionMapper(ExceptionMapper):
             "the header after executing"
         ),
         BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
-            "Block access list accounts not in strictly ascending order"
+            "not in strictly ascending order"
         ),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             "Block access list hash does not match the one in "
             "the header after executing"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
-            "Block access list accounts not in strictly ascending order"
+            "not in strictly ascending order"
         ),
         BlockException.INVALID_GAS_USED: (
             "Gas used doesn't match value in header"
@@ -170,7 +170,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"Block access list contains index \d+ "
             r"exceeding max valid index \d+|"
             r"Failed to RLP decode BAL|"
-            r"Block access list accounts not in strictly ascending order.*"
+            r"Block access list .+ not in strictly ascending order.*"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"Block access list hash does not match "


### PR DESCRIPTION
## Summary

- `INVALID_BAL_EXTRA_ACCOUNT` and `INCORRECT_BLOCK_FORMAT` substring matches: generalized from `"Block access list accounts not in strictly ascending order"` to `"not in strictly ascending order"` to cover all field types (`balance_changes`, `nonce_changes`, `code_changes`, etc.)
- `INVALID_BLOCK_ACCESS_LIST` regex: generalized from `accounts not in strictly ascending order.*` to `.+ not in strictly ascending order.*` for the same reason

Needed because ethrex now validates ordering for `balance_changes`, `nonce_changes`, and `code_changes` (not just accounts), so error messages include those field names rather than `accounts`.
