### PR TITLE
fix(tests): Failing initcode test

### DIFF
--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -237,7 +237,7 @@ class TestContractCreationGasUsage:
         """
         return [
             AccessList(address=Address(i), storage_keys=[])
-            for i in range(1, 478)
+            for i in range(1, 642)
         ]
 
     @pytest.fixture


### PR DESCRIPTION
## 🗒️ Description

Fixes initcode tests by increasing the number of access-list items so that the datafloor cost does not exceed the intrinsic transaction cost and invalidates the test.

I did a (manual) binary search to find this value, but this can definitely be automated in the python method, even in `forks/amsterdam`.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/d/dc/Vulpes_lagopus_in_Iceland_%28cropped_3%29.jpg)
