### PR TITLE
feat(ci): allow phase1 not fail if collected tests are empty

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/base.py
@@ -35,6 +35,11 @@ class PytestExecution:
     description: Optional[str] = None
     """Optional description for this execution phase."""
 
+    allowed_exit_codes: List[pytest.ExitCode] = field(
+        default_factory=lambda: [pytest.ExitCode.OK]
+    )
+    """Exit codes treated as successful for this execution."""
+
 
 class ArgumentProcessor(ABC):
     """Base class for processing command-line arguments."""
@@ -99,7 +104,7 @@ class PytestRunner:
                 sys.stderr.flush()
 
             result = self.run_single(execution)
-            if result != 0:
+            if result not in execution.allowed_exit_codes:
                 return result
 
         return 0

--- a/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
@@ -3,6 +3,7 @@
 from typing import Any, List
 
 import click
+import pytest
 
 from .base import PytestCommand, PytestExecution, common_pytest_options
 from .processors import (
@@ -80,6 +81,10 @@ class FillCommand(PytestCommand):
                 config_file=self.config_path,
                 args=phase1_args,
                 description="generating pre-allocation groups",
+                allowed_exit_codes=[
+                    pytest.ExitCode.OK,
+                    pytest.ExitCode.NO_TESTS_COLLECTED,
+                ],
             ),
             PytestExecution(
                 config_file=self.config_path,


### PR DESCRIPTION
## 🗒️ Description
This is a fix for creating `project/zkevm` releases. See [previous failure logs](https://github.com/ethereum/execution-specs/actions/runs/22466695171/job/65074210468).

The problem is that the filling configuration for this branch is -m "blockchain_tests", and for the Phase 1 run, collecting zero tests for pre-allocs is considered an error.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
