### PR TITLE
feat(hasher compare): add --ignore-missing flag

### DIFF
--- a/docs/getting_started/code_standards_details.md
+++ b/docs/getting_started/code_standards_details.md
@@ -163,3 +163,21 @@ For a granular comparison:
 ```console
 diff <(hasher --tests fixtures/) <(hasher --tests fixtures_new/)
 ```
+
+#### The `compare` Subcommand
+
+The `hasher compare` subcommand directly compares two fixture directories
+and shows only the differences:
+
+```console
+hasher compare fixtures/ fixtures_new/
+```
+
+| Flag                | Description                                               |
+| ------------------- | --------------------------------------------------------- |
+| `--depth N` / `-d`  | Limit to N levels (0=root, 1=folders, 2=files, 3=tests).  |
+| `--files` / `-f`    | Show differences at file level.                           |
+| `--tests` / `-t`    | Show differences at individual test level.                |
+| `--root` / `-r`     | Show only the root-level hash difference.                 |
+| `--ignore-missing`  | Hide entries that exist in only one directory.            |
+```

--- a/docs/getting_started/code_standards_details.md
+++ b/docs/getting_started/code_standards_details.md
@@ -179,5 +179,4 @@ hasher compare fixtures/ fixtures_new/
 | `--files` / `-f`    | Show differences at file level.                           |
 | `--tests` / `-t`    | Show differences at individual test level.                |
 | `--root` / `-r`     | Show only the root-level hash difference.                 |
-| `--ignore-missing`  | Hide entries that exist in only one directory.            |
-```
+| `--ignore-missing`  | Hide entries that exist in only one directory.             |

--- a/packages/testing/src/execution_testing/cli/hasher.py
+++ b/packages/testing/src/execution_testing/cli/hasher.py
@@ -311,6 +311,7 @@ def display_diff(
     *,
     left_label: str,
     right_label: str,
+    ignore_missing: bool = False,
 ) -> None:
     """Render diff showing only changed hashes."""
     differences: List[tuple[str, str, str]] = []
@@ -318,10 +319,14 @@ def display_diff(
     for path in left:
         right_hash = right.get(path, "<missing>")
         if left[path] != right_hash:
+            if ignore_missing and right_hash == "<missing>":
+                continue
             differences.append((path, left[path], right_hash))
 
     for path in right:
         if path not in left:
+            if ignore_missing:
+                continue
             differences.append((path, "<missing>", right[path]))
 
     if not differences:
@@ -433,6 +438,12 @@ def hash_cmd(
     default=None,
     help="Limit to N levels (0=root, 1=folders, 2=files, 3=tests).",
 )
+@click.option(
+    "--ignore-missing",
+    is_flag=True,
+    default=False,
+    help="Hide entries that exist in only one directory.",
+)
 @hash_options
 def compare_cmd(
     left_folder: str,
@@ -441,6 +452,7 @@ def compare_cmd(
     tests: bool,
     root: bool,
     depth: Optional[int],
+    ignore_missing: bool,
 ) -> None:
     """Compare two fixture directories and show differences."""
     try:
@@ -474,6 +486,7 @@ def compare_cmd(
             right_hashes,
             left_label=left_folder,
             right_label=right_folder,
+            ignore_missing=ignore_missing,
         )
         sys.exit(1)
     except PermissionError as e:


### PR DESCRIPTION
## 🗒️ Description
This PR adds a new flag `--ignore-missing` to `uv run hasher compare`. By default is `false`, so any current use of `uv run hasher compare` is unaffected.

The main goal of this new flag is to help validate feature branches rebasing. The reason is that, usually, the pre-rebase feature branch is missing newer tests than the default branch. This makes `uv run hasher compare` show a lot of `+missing` difference which are expected.

By using `--ignore-missing`, the comparison shows only differences between tests that existed in both the to-be-rebased feature branch and the default branch — if there are differences, it might be worth inspecting. For missing tests, there isn't much to do.

This flag was used to test the correctness of rebasing the `project/zkevm` feature branch.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
