### PR TITLE
chore(ci): add setup-env to build-fixtures for coincurve build deps

### DIFF
--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -10,6 +10,7 @@ runs:
     - uses: ./.github/actions/setup-uv
       with:
         enable-cache: "false"
+    - uses: ./.github/actions/setup-env
     - name: Install EEST
       shell: bash
       run: uv sync --no-progress


### PR DESCRIPTION
## 🗒️ Description

Add `setup-env` step to `build-fixtures` action so `pkg-config` and `libsecp256k1-dev` are available when `coincurve` needs to build from source (no prebuilt wheels for py3.14/pypy3.11).

## 🔗 Related Issues or PRs

- #2354

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.5fgU2QGOvyiTwuA8ilxJggHaE7%3Fpid%3DApi&f=1&ipt=89a5e055edd1aaa6120b3dc6c18434c9e24a6c8dd07e73f473145f016ec02e77&ipo=images)