### PR TITLE
refactor(spec-specs,test-types): replace `pycryptodome` with `hashlib` for keccak

### DIFF
--- a/packages/testing/src/execution_testing/base_types/base_types.py
+++ b/packages/testing/src/execution_testing/base_types/base_types.py
@@ -1,5 +1,6 @@
 """Basic type primitives used to define other types."""
 
+import hashlib
 from abc import ABCMeta
 from hashlib import sha256
 from re import sub
@@ -13,7 +14,6 @@ from typing import (
     TypeVar,
 )
 
-from Crypto.Hash import keccak
 from pydantic import GetCoreSchemaHandler, StringConstraints
 from pydantic_core.core_schema import (
     PlainValidatorFunctionSchema,
@@ -201,8 +201,7 @@ class Bytes(bytes, ToStringSchema):
 
     def keccak256(self) -> "Hash":
         """Return the keccak256 hash of the opcode byte representation."""
-        k = keccak.new(digest_bits=256)
-        return Hash(k.update(bytes(self)).digest())
+        return Hash(hashlib.new("keccak-256", bytes(self)).digest())
 
     def sha256(self) -> "Hash":
         """Return the sha256 hash of the opcode byte representation."""

--- a/packages/testing/src/execution_testing/base_types/base_types.py
+++ b/packages/testing/src/execution_testing/base_types/base_types.py
@@ -1,6 +1,5 @@
 """Basic type primitives used to define other types."""
 
-import hashlib
 from abc import ABCMeta
 from hashlib import sha256
 from re import sub
@@ -14,6 +13,7 @@ from typing import (
     TypeVar,
 )
 
+from ethereum.crypto.hash import keccak256 as _keccak256
 from pydantic import GetCoreSchemaHandler, StringConstraints
 from pydantic_core.core_schema import (
     PlainValidatorFunctionSchema,
@@ -201,7 +201,7 @@ class Bytes(bytes, ToStringSchema):
 
     def keccak256(self) -> "Hash":
         """Return the keccak256 hash of the opcode byte representation."""
-        return Hash(hashlib.new("keccak-256", bytes(self)).digest())
+        return Hash(_keccak256(self))
 
     def sha256(self) -> "Hash":
         """Return the sha256 hash of the opcode byte representation."""

--- a/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
+++ b/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
@@ -124,7 +124,7 @@ def test_fallback_engages_when_hashlib_lacks_keccak(
     with patch.object(hashlib, "new", side_effect=mocked_new):
         h = _clean_reimport_hash()
 
-        assert hasattr(h, "_pycryptodome_keccak"), (
+        assert h._USE_HASHLIB is False, (
             "module did not engage pycryptodome fallback"
         )
         for buffer, expected_hex in KECCAK256_VECTORS:
@@ -148,7 +148,7 @@ def test_native_path_used_when_hashlib_has_keccak(
         pytest.skip("hashlib lacks keccak-256 on this OpenSSL build")
 
     h = _clean_reimport_hash()
-    assert not hasattr(h, "_pycryptodome_keccak"), (
+    assert h._USE_HASHLIB is True, (
         "module engaged pycryptodome fallback despite hashlib having keccak"
     )
 

--- a/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
+++ b/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
@@ -16,7 +16,6 @@ succeeds. These tests verify:
 
 import hashlib
 import importlib
-import sys
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
@@ -61,8 +60,8 @@ def _hashlib_has_keccak() -> bool:
 
 def _clean_reimport_hash() -> Any:
     """Drop and reimport `ethereum.crypto.hash` for a fresh dispatch run."""
-    sys.modules.pop("ethereum.crypto.hash", None)
-    return importlib.import_module("ethereum.crypto.hash")
+    mod = importlib.import_module("ethereum.crypto.hash")
+    return importlib.reload(mod)
 
 
 @pytest.fixture

--- a/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
+++ b/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
@@ -1,0 +1,175 @@
+"""
+Tests for the Keccak backend dispatch in `ethereum.crypto.hash`.
+
+The module decides at import time whether to use hashlib (linked OpenSSL)
+or pycryptodome, depending on whether `hashlib.new("keccak-256", ...)`
+succeeds. These tests verify:
+
+* both backends produce byte-identical output (cross-backend equivalence);
+* the fallback engages cleanly when hashlib raises, simulated via
+  monkeypatch so we can exercise the path on a Python whose OpenSSL does
+  expose Keccak;
+* on a Python where hashlib supports Keccak, the fast path is selected
+  (guards against a regression where `algorithms_available` lies and the
+  module silently forces every user onto pycryptodome).
+"""
+
+import hashlib
+import importlib
+import sys
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Pre-NIST Keccak vectors. Empty-input digests are widely published; the
+# `hashme` vector was confirmed against a working hashlib build during
+# PR #2370 review.
+KECCAK256_VECTORS: list[tuple[bytes, str]] = [
+    (
+        b"",
+        "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+    ),
+    (
+        b"abc",
+        "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+    ),
+    (
+        b"hashme",
+        "7f98885dc9cf152c0bb08eaf056668f99c47cabd8fe01b1276f9a305b1389646",
+    ),
+]
+
+KECCAK512_VECTORS: list[tuple[bytes, str]] = [
+    (
+        b"",
+        "0eab42de4c3ceb9235fc91acffe746b29c29a8c366b7c60e4e67c466f36a4304"
+        "c00fa9caf9d87976ba469bcbe06713b435f091ef2769fb160cdab33d3670680e",
+    ),
+]
+
+
+def _hashlib_has_keccak() -> bool:
+    """Return True if `hashlib.new("keccak-256", ...)` succeeds here."""
+    try:
+        hashlib.new("keccak-256", b"")
+    except ValueError:
+        return False
+    return True
+
+
+def _clean_reimport_hash() -> Any:
+    """Drop and reimport `ethereum.crypto.hash` for a fresh dispatch run."""
+    sys.modules.pop("ethereum.crypto.hash", None)
+    return importlib.import_module("ethereum.crypto.hash")
+
+
+@pytest.fixture
+def restore_hash_module() -> Iterator[None]:
+    """Restore the natural-state `ethereum.crypto.hash` after each test."""
+    yield
+    _clean_reimport_hash()
+
+
+@pytest.mark.parametrize("buffer, expected_hex", KECCAK256_VECTORS)
+def test_keccak256_known_vectors(buffer: bytes, expected_hex: str) -> None:
+    """Active backend produces published Keccak-256 digests."""
+    from ethereum.crypto.hash import keccak256
+
+    assert keccak256(buffer).hex() == expected_hex
+
+
+@pytest.mark.parametrize("buffer, expected_hex", KECCAK512_VECTORS)
+def test_keccak512_known_vectors(buffer: bytes, expected_hex: str) -> None:
+    """Active backend produces published Keccak-512 digests."""
+    from ethereum.crypto.hash import keccak512
+
+    assert keccak512(buffer).hex() == expected_hex
+
+
+def test_both_backends_agree() -> None:
+    """Hashlib and pycryptodome produce byte-identical Keccak-256 output."""
+    if not _hashlib_has_keccak():
+        pytest.skip("hashlib lacks keccak-256 on this OpenSSL build")
+
+    from Crypto.Hash import keccak as pyc_keccak
+
+    inputs = [
+        b"",
+        b"x",
+        b"\x00" * 64,
+        bytes(range(256)),
+        b"a" * 4096,
+        b"\xff" * 65536,
+    ]
+    for buf in inputs:
+        hl = hashlib.new("keccak-256", buf).digest()
+        pc = pyc_keccak.new(digest_bits=256).update(buf).digest()
+        assert hl == pc, f"backends disagree on input of length {len(buf)}"
+
+
+def test_fallback_engages_when_hashlib_lacks_keccak(
+    restore_hash_module: None,
+) -> None:
+    """If hashlib raises for Keccak, the module uses pycryptodome instead."""
+    del restore_hash_module
+    real_new = hashlib.new
+
+    def mocked_new(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name in ("keccak-256", "keccak-512"):
+            raise ValueError(f"unsupported hash type {name}")
+        return real_new(name, *args, **kwargs)
+
+    with patch.object(hashlib, "new", side_effect=mocked_new):
+        h = _clean_reimport_hash()
+
+        assert hasattr(h, "_pycryptodome_keccak"), (
+            "module did not engage pycryptodome fallback"
+        )
+        for buffer, expected_hex in KECCAK256_VECTORS:
+            assert h.keccak256(buffer).hex() == expected_hex
+        for buffer, expected_hex in KECCAK512_VECTORS:
+            assert h.keccak512(buffer).hex() == expected_hex
+
+
+def test_native_path_used_when_hashlib_has_keccak(
+    restore_hash_module: None,
+) -> None:
+    """
+    Verify hashlib path is selected when keccak-256 is supported.
+
+    Guards against a regression where a bogus availability check (e.g.
+    one that relied on `hashlib.algorithms_available`) would silently
+    force every user onto the slower pycryptodome path.
+    """
+    del restore_hash_module
+    if not _hashlib_has_keccak():
+        pytest.skip("hashlib lacks keccak-256 on this OpenSSL build")
+
+    h = _clean_reimport_hash()
+    assert not hasattr(h, "_pycryptodome_keccak"), (
+        "module engaged pycryptodome fallback despite hashlib having keccak"
+    )
+
+
+def test_eest_bytes_keccak256_matches_eels() -> None:
+    """`Bytes.keccak256()` returns the same digest as EELS `keccak256`."""
+    from ethereum.crypto.hash import keccak256
+
+    from ..base_types import Bytes
+
+    for buffer in (b"", b"hashme", bytes(range(256))):
+        from_eest = bytes(Bytes(buffer).keccak256())
+        from_eels = bytes(keccak256(buffer))
+        assert from_eest == from_eels
+
+
+def test_eest_trie_keccak256_matches_eels() -> None:
+    """`trie.keccak256` and EELS `keccak256` return identical digests."""
+    from ethereum.crypto.hash import keccak256 as eels
+
+    from ...test_types.trie import keccak256 as trie
+
+    for buffer in (b"", b"hashme", bytes(range(256))):
+        assert bytes(trie(buffer)) == bytes(eels(buffer))

--- a/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
+++ b/packages/testing/src/execution_testing/base_types/tests/test_keccak_dispatch.py
@@ -53,7 +53,7 @@ KECCAK512_VECTORS: list[tuple[bytes, str]] = [
 def _hashlib_has_keccak() -> bool:
     """Return True if `hashlib.new("keccak-256", ...)` succeeds here."""
     try:
-        hashlib.new("keccak-256", b"")
+        hashlib.new("keccak-256")
     except ValueError:
         return False
     return True

--- a/packages/testing/src/execution_testing/test_types/trie.py
+++ b/packages/testing/src/execution_testing/test_types/trie.py
@@ -3,6 +3,7 @@ The state trie is the structure responsible for storing Ethereum state.
 """
 
 import copy
+import hashlib
 from dataclasses import dataclass, field
 from typing import (
     Callable,
@@ -18,7 +19,6 @@ from typing import (
     cast,
 )
 
-from Crypto.Hash import keccak
 from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.frozen import slotted_freezable
@@ -38,8 +38,7 @@ class FrontierAccount:
 
 def keccak256(buffer: Bytes) -> Bytes32:
     """Compute the keccak256 hash of the input `buffer`."""
-    k = keccak.new(digest_bits=256)
-    return Bytes32(k.update(buffer).digest())
+    return Bytes32(hashlib.new("keccak-256", buffer).digest())
 
 
 def encode_account(

--- a/packages/testing/src/execution_testing/test_types/trie.py
+++ b/packages/testing/src/execution_testing/test_types/trie.py
@@ -3,7 +3,6 @@ The state trie is the structure responsible for storing Ethereum state.
 """
 
 import copy
-import hashlib
 from dataclasses import dataclass, field
 from typing import (
     Callable,
@@ -19,6 +18,7 @@ from typing import (
     cast,
 )
 
+from ethereum.crypto.hash import keccak256
 from ethereum_rlp import Extended, rlp
 from ethereum_types.bytes import Bytes, Bytes20, Bytes32
 from ethereum_types.frozen import slotted_freezable
@@ -34,11 +34,6 @@ class FrontierAccount:
     nonce: Uint
     balance: U256
     code: Bytes
-
-
-def keccak256(buffer: Bytes) -> Bytes32:
-    """Compute the keccak256 hash of the input `buffer`."""
-    return Bytes32(hashlib.new("keccak-256", buffer).digest())
 
 
 def encode_account(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ actionlint = [
     "shellcheck-py>=0.10",
 ]
 doc = [
-    "docc>=0.6.0,<0.7.0",
+    "docc>=0.6.1,<0.7.0",
     "fladrif>=0.2.0,<0.3.0",
     "mistletoe>=1.5.0,<2",
 ]

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -11,7 +11,8 @@ Introduction
 Cryptographic hashing functions.
 """
 
-from Crypto.Hash import keccak
+import hashlib
+
 from ethereum_types.bytes import Bytes, Bytes32, Bytes64
 
 Hash32 = Bytes32
@@ -33,8 +34,7 @@ def keccak256(buffer: Bytes | bytearray) -> Hash32:
         Output of the hash function.
 
     """
-    k = keccak.new(digest_bits=256)
-    return Hash32(k.update(buffer).digest())
+    return Hash32(hashlib.new("keccak-256", buffer).digest())
 
 
 def keccak512(buffer: Bytes | bytearray) -> Hash64:
@@ -52,5 +52,4 @@ def keccak512(buffer: Bytes | bytearray) -> Hash64:
         Output of the hash function.
 
     """
-    k = keccak.new(digest_bits=512)
-    return Hash64(k.update(buffer).digest())
+    return Hash64(hashlib.new("keccak-512", buffer).digest())

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -13,13 +13,42 @@ Cryptographic hashing functions.
 
 import hashlib
 
-from ethereum_types.bytes import Bytes, Bytes32, Bytes64
+from ethereum_types.bytes import Bytes32, Bytes64
 
 Hash32 = Bytes32
 Hash64 = Bytes64
 
+# Prefer hashlib (linked OpenSSL) when it exposes the pre-NIST Keccak digests;
+# fall back to pycryptodome's self-contained implementation otherwise.
+# OpenSSL only gained default-provider Keccak in 3.2.0 (Nov 2023); LTS 3.0.x
+# and 3.1.x (still shipped by Debian 12, RHEL 9, etc.) do not provide it.
+# We probe with `hashlib.new()` because `hashlib.algorithms_available` omits
+# some OpenSSL-provider digests on common builds (e.g. python-build-standalone
+# / uv-managed CPython on OpenSSL 3.5.x), yielding false negatives.
+try:
+    hashlib.new("keccak-256", b"")
 
-def keccak256(buffer: Bytes | bytearray) -> Hash32:
+    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
+        return hashlib.new("keccak-256", buffer).digest()
+
+    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
+        return hashlib.new("keccak-512", buffer).digest()
+
+except ValueError:
+    from Crypto.Hash import keccak as _pycryptodome_keccak
+
+    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
+        return (
+            _pycryptodome_keccak.new(digest_bits=256).update(buffer).digest()
+        )
+
+    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
+        return (
+            _pycryptodome_keccak.new(digest_bits=512).update(buffer).digest()
+        )
+
+
+def keccak256(buffer: bytes | bytearray) -> Hash32:
     """
     Computes the keccak256 hash of the input `buffer`.
 
@@ -34,10 +63,10 @@ def keccak256(buffer: Bytes | bytearray) -> Hash32:
         Output of the hash function.
 
     """
-    return Hash32(hashlib.new("keccak-256", buffer).digest())
+    return Hash32(_keccak256_digest(buffer))
 
 
-def keccak512(buffer: Bytes | bytearray) -> Hash64:
+def keccak512(buffer: bytes | bytearray) -> Hash64:
     """
     Computes the keccak512 hash of the input `buffer`.
 
@@ -52,4 +81,4 @@ def keccak512(buffer: Bytes | bytearray) -> Hash64:
         Output of the hash function.
 
     """
-    return Hash64(hashlib.new("keccak-512", buffer).digest())
+    return Hash64(_keccak512_digest(buffer))

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -13,39 +13,42 @@ Cryptographic hashing functions.
 
 import hashlib
 
+from Crypto.Hash import keccak as _pycryptodome_keccak
 from ethereum_types.bytes import Bytes32, Bytes64
 
 Hash32 = Bytes32
 Hash64 = Bytes64
 
-# Prefer hashlib (linked OpenSSL) when it exposes the pre-NIST Keccak digests;
-# fall back to pycryptodome's self-contained implementation otherwise.
-# OpenSSL only gained default-provider Keccak in 3.2.0 (Nov 2023); LTS 3.0.x
-# and 3.1.x (still shipped by Debian 12, RHEL 9, etc.) do not provide it.
-# We probe with `hashlib.new()` because `hashlib.algorithms_available` omits
-# some OpenSSL-provider digests on common builds (e.g. python-build-standalone
-# / uv-managed CPython on OpenSSL 3.5.x), yielding false negatives.
-try:
-    hashlib.new("keccak-256", b"")
 
-    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
+def _hashlib_has_keccak() -> bool:
+    """Return `True` if `hashlib` can compute pre-NIST Keccak digests."""
+    try:
+        hashlib.new("keccak-256", b"")
+    except ValueError:
+        return False
+    return True
+
+
+# Decide once at import time whether to dispatch to hashlib (linked OpenSSL)
+# or to pycryptodome's bundled implementation. OpenSSL only gained
+# default-provider Keccak in 3.2.0 (Nov 2023); LTS 3.0.x and 3.1.x (still
+# shipped by Debian 12, RHEL 9, etc.) do not provide it. We probe with
+# `hashlib.new()` because `hashlib.algorithms_available` omits some
+# OpenSSL-provider digests on common builds (e.g. python-build-standalone /
+# uv-managed CPython on OpenSSL 3.5.x), yielding false negatives.
+_USE_HASHLIB = _hashlib_has_keccak()
+
+
+def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
+    if _USE_HASHLIB:
         return hashlib.new("keccak-256", buffer).digest()
+    return _pycryptodome_keccak.new(digest_bits=256).update(buffer).digest()
 
-    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
+
+def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
+    if _USE_HASHLIB:
         return hashlib.new("keccak-512", buffer).digest()
-
-except ValueError:
-    from Crypto.Hash import keccak as _pycryptodome_keccak
-
-    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
-        return (
-            _pycryptodome_keccak.new(digest_bits=256).update(buffer).digest()
-        )
-
-    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
-        return (
-            _pycryptodome_keccak.new(digest_bits=512).update(buffer).digest()
-        )
+    return _pycryptodome_keccak.new(digest_bits=512).update(buffer).digest()
 
 
 def keccak256(buffer: bytes | bytearray) -> Hash32:

--- a/src/ethereum/crypto/hash.py
+++ b/src/ethereum/crypto/hash.py
@@ -39,16 +39,24 @@ def _hashlib_has_keccak() -> bool:
 _USE_HASHLIB = _hashlib_has_keccak()
 
 
-def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
-    if _USE_HASHLIB:
+if _USE_HASHLIB:
+
+    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
         return hashlib.new("keccak-256", buffer).digest()
-    return _pycryptodome_keccak.new(digest_bits=256).update(buffer).digest()
 
-
-def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
-    if _USE_HASHLIB:
+    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
         return hashlib.new("keccak-512", buffer).digest()
-    return _pycryptodome_keccak.new(digest_bits=512).update(buffer).digest()
+else:
+
+    def _keccak256_digest(buffer: bytes | bytearray) -> bytes:
+        return (
+            _pycryptodome_keccak.new(digest_bits=256).update(buffer).digest()
+        )
+
+    def _keccak512_digest(buffer: bytes | bytearray) -> bytes:
+        return (
+            _pycryptodome_keccak.new(digest_bits=512).update(buffer).digest()
+        )
 
 
 def keccak256(buffer: bytes | bytearray) -> Hash32:

--- a/uv.lock
+++ b/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 
 [[package]]
 name = "docc"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
@@ -749,9 +749,9 @@ dependencies = [
     { name = "tomli" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/37/cd2e718c92e26da0e1129700467f62efd8bd1f53dc1dae59b3e0e0402574/docc-0.6.0.tar.gz", hash = "sha256:d335be8f509884fefb507e75a184a3c9824e50e511dd5464be9089d1ad744912", size = 72398, upload-time = "2026-04-29T02:02:30.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/e2/47252138c9978ca2ab7a3637bba1464f8da2d1f34e1886babaef0459c1b6/docc-0.6.1.tar.gz", hash = "sha256:c4cc94f542afa76e2d9b10ce5e43ec4cdddc87897dde52a2a0f07a1db0af9499", size = 74268, upload-time = "2026-05-14T23:51:53.862Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/66/b81c58e0514531a26201f3d6b437b24375b996db5a8105d3e21420ccfc08/docc-0.6.0-py3-none-any.whl", hash = "sha256:bb4ed18f23926f1cea649a407c67d6794a92361826593e6ba374e80892fe98d1", size = 99176, upload-time = "2026-04-29T02:02:28.829Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0b/56f73ba7767f53796d43e86e2a3e77d04211b214f09b8fc96cbb5fb110c5/docc-0.6.1-py3-none-any.whl", hash = "sha256:c058a8207603270d437d4f1887eb850ddfc2519f336627d4f373d87d296a0198", size = 100269, upload-time = "2026-05-14T23:51:52.256Z" },
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ dev = [
     { name = "cairosvg", specifier = ">=2.7.0,<3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "codespell", specifier = ">=2.4.1,<3" },
-    { name = "docc", specifier = ">=0.6.0,<0.7.0" },
+    { name = "docc", specifier = ">=0.6.1,<0.7.0" },
     { name = "ethereum-execution", extras = ["optimized"] },
     { name = "ethereum-execution-testing", editable = "packages/testing" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
@@ -1003,7 +1003,7 @@ dev = [
     { name = "vulture", specifier = "==2.14.0" },
 ]
 doc = [
-    { name = "docc", specifier = ">=0.6.0,<0.7.0" },
+    { name = "docc", specifier = ">=0.6.1,<0.7.0" },
     { name = "fladrif", specifier = ">=0.2.0,<0.3.0" },
     { name = "mistletoe", specifier = ">=1.5.0,<2" },
 ]


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Both expose keccak, however I found hashlib to be around 60% faster on my laptop 

Extracted from #2368 

### Update (2026-05-11)

#### Benchmark of `fill tests/osaka`, hashlib vs pycryptodome 

Using ad1440bb89e.

Command (per row, only `--python` differs):

```
taskset -c 0,2,4,5,6,7 uv run --python <interp> \
    fill tests/osaka --output=<dir> --clean -x --no-html --skip-index -n=6
```

Host: Ubuntu (kernel `6.11.0-1017-oem`), x86_64. `n=10` runs per configuration.

| Python                  | Source         | OpenSSL (linked)     | Keccak backend          | Mean ± σ (s)     | Range (s)        |
| ----------------------- | -------------- | -------------------- | ----------------------- | ---------------- | ---------------- |
| CPython 3.12.12         | uv-managed     | 3.5.5 (27 Jan 2026)  | `hashlib`               | 69.27 ± 6.74     | 58.04 – 76.62    |
| CPython 3.12.3          | Ubuntu system  | 3.0.13 (30 Jan 2024) | `pycryptodome` fallback | 74.08 ± 6.47     | 65.95 – 81.54    |

**Delta:** 4.81 s (≈ 6.5 %) faster on the hashlib path. Welch t ≈ 1.63 (df ≈ 18), one-tailed p ≈ 0.06 — directionally consistent with prior runs, just shy of p < 0.05 two-tailed at this sample size.

The Ubuntu-system interpreter is linked against OpenSSL 3.0.13, which predates the OpenSSL 3.2.0 default-provider Keccak addition (Nov 2023), so `hashlib.new("keccak-256", ...)` raises `ValueError` and the module dispatches to `pycryptodome` instead. The uv-managed `cpython-3.12.12` from `python-build-standalone` bundles OpenSSL 3.5.5, which exposes Keccak via the default provider, so the fast `hashlib` path is taken.

<img width="720" height="124" alt="image" src="https://github.com/user-attachments/assets/d9ca5069-0fef-4854-8a4e-f59870072a0f" />

### Targeted Benchmarking 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:rabbit: 
