### PR TITLE
chore(spec): use `bytes.count` instead of for loop for counting zeroes

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -756,13 +756,13 @@ class Frontier(BaseFork, solc_name="homestead"):
         def fn(*, data: BytesConvertible, floor: bool = False) -> int:
             del floor
 
-            cost = 0
-            for b in Bytes(data):
-                if b == 0:
-                    cost += gas_costs.GAS_TX_DATA_PER_ZERO
-                else:
-                    cost += gas_costs.GAS_TX_DATA_PER_NON_ZERO
-            return cost
+            raw = bytes(Bytes(data))
+            num_zeros = raw.count(0)
+            num_non_zeros = len(raw) - num_zeros
+            return (
+                num_zeros * gas_costs.GAS_TX_DATA_PER_ZERO
+                + num_non_zeros * gas_costs.GAS_TX_DATA_PER_NON_ZERO
+            )
 
         return fn
 
@@ -2836,12 +2836,10 @@ class Prague(Cancun):
         )
 
         def fn(*, data: BytesConvertible, floor: bool = False) -> int:
-            tokens = 0
-            for b in Bytes(data):
-                if b == 0:
-                    tokens += 1
-                else:
-                    tokens += 4
+            raw = bytes(Bytes(data))
+            num_zeros = raw.count(0)
+            num_non_zeros = len(raw) - num_zeros
+            tokens = num_zeros + num_non_zeros * 4
             if floor:
                 return tokens * gas_costs.GAS_TX_DATA_TOKEN_FLOOR
             return tokens * gas_costs.GAS_TX_DATA_TOKEN_STANDARD

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -2836,7 +2836,7 @@ class Prague(Cancun):
         )
 
         def fn(*, data: BytesConvertible, floor: bool = False) -> int:
-            raw = bytes(Bytes(data))
+            raw = Bytes(data)
             num_zeros = raw.count(0)
             num_non_zeros = len(raw) - num_zeros
             tokens = num_zeros + num_non_zeros * 4

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -756,7 +756,7 @@ class Frontier(BaseFork, solc_name="homestead"):
         def fn(*, data: BytesConvertible, floor: bool = False) -> int:
             del floor
 
-            raw = bytes(Bytes(data))
+            raw = Bytes(data)
             num_zeros = raw.count(0)
             num_non_zeros = len(raw) - num_zeros
             return (

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -598,9 +598,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -598,12 +598,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -598,10 +598,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -598,10 +598,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/arrow_glacier/transactions.py
+++ b/src/ethereum/forks/arrow_glacier/transactions.py
@@ -378,11 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/arrow_glacier/transactions.py
+++ b/src/ethereum/forks/arrow_glacier/transactions.py
@@ -378,12 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/arrow_glacier/transactions.py
+++ b/src/ethereum/forks/arrow_glacier/transactions.py
@@ -378,13 +378,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/berlin/transactions.py
+++ b/src/ethereum/forks/berlin/transactions.py
@@ -295,13 +295,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/berlin/transactions.py
+++ b/src/ethereum/forks/berlin/transactions.py
@@ -295,12 +295,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/berlin/transactions.py
+++ b/src/ethereum/forks/berlin/transactions.py
@@ -295,11 +295,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/byzantium/transactions.py
+++ b/src/ethereum/forks/byzantium/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/byzantium/transactions.py
+++ b/src/ethereum/forks/byzantium/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/byzantium/transactions.py
+++ b/src/ethereum/forks/byzantium/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -489,12 +489,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -489,11 +489,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/cancun/transactions.py
+++ b/src/ethereum/forks/cancun/transactions.py
@@ -489,13 +489,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE + init_code_cost(ulen(tx.data))

--- a/src/ethereum/forks/constantinople/transactions.py
+++ b/src/ethereum/forks/constantinople/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/constantinople/transactions.py
+++ b/src/ethereum/forks/constantinople/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/constantinople/transactions.py
+++ b/src/ethereum/forks/constantinople/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/dao_fork/transactions.py
+++ b/src/ethereum/forks/dao_fork/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/dao_fork/transactions.py
+++ b/src/ethereum/forks/dao_fork/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/dao_fork/transactions.py
+++ b/src/ethereum/forks/dao_fork/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/frontier/transactions.py
+++ b/src/ethereum/forks/frontier/transactions.py
@@ -144,12 +144,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     return GAS_TX_BASE + data_cost

--- a/src/ethereum/forks/frontier/transactions.py
+++ b/src/ethereum/forks/frontier/transactions.py
@@ -144,13 +144,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     return GAS_TX_BASE + data_cost
 

--- a/src/ethereum/forks/frontier/transactions.py
+++ b/src/ethereum/forks/frontier/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -144,11 +144,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     return GAS_TX_BASE + data_cost

--- a/src/ethereum/forks/gray_glacier/transactions.py
+++ b/src/ethereum/forks/gray_glacier/transactions.py
@@ -378,11 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/gray_glacier/transactions.py
+++ b/src/ethereum/forks/gray_glacier/transactions.py
@@ -378,12 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/gray_glacier/transactions.py
+++ b/src/ethereum/forks/gray_glacier/transactions.py
@@ -378,13 +378,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/homestead/transactions.py
+++ b/src/ethereum/forks/homestead/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/homestead/transactions.py
+++ b/src/ethereum/forks/homestead/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/homestead/transactions.py
+++ b/src/ethereum/forks/homestead/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/istanbul/transactions.py
+++ b/src/ethereum/forks/istanbul/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/istanbul/transactions.py
+++ b/src/ethereum/forks/istanbul/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/istanbul/transactions.py
+++ b/src/ethereum/forks/istanbul/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/london/transactions.py
+++ b/src/ethereum/forks/london/transactions.py
@@ -378,11 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/london/transactions.py
+++ b/src/ethereum/forks/london/transactions.py
@@ -378,12 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/london/transactions.py
+++ b/src/ethereum/forks/london/transactions.py
@@ -378,13 +378,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/muir_glacier/transactions.py
+++ b/src/ethereum/forks/muir_glacier/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/muir_glacier/transactions.py
+++ b/src/ethereum/forks/muir_glacier/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/muir_glacier/transactions.py
+++ b/src/ethereum/forks/muir_glacier/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -597,10 +597,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -597,9 +597,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -597,12 +597,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -378,11 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -378,12 +378,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/paris/transactions.py
+++ b/src/ethereum/forks/paris/transactions.py
@@ -378,13 +378,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -589,10 +589,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
+    tokens_in_calldata = num_zeros + num_non_zeros * Uint(4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -589,12 +589,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = 0
-    for byte in tx.data:
-        if byte == 0:
-            zero_bytes += 1
+    raw = bytes(tx.data)
+    zero_bytes = raw.count(0)
+    num_non_zeros = len(raw) - zero_bytes
 
-    tokens_in_calldata = Uint(zero_bytes + (len(tx.data) - zero_bytes) * 4)
+    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -589,10 +589,10 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    zero_bytes = tx.data.count(0)
-    num_non_zeros = len(tx.data) - zero_bytes
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
 
-    tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
+    tokens_in_calldata = Uint(num_zeros + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)
     calldata_floor_gas_cost = (
         tokens_in_calldata * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -589,9 +589,8 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    zero_bytes = raw.count(0)
-    num_non_zeros = len(raw) - zero_bytes
+    zero_bytes = tx.data.count(0)
+    num_non_zeros = len(tx.data) - zero_bytes
 
     tokens_in_calldata = Uint(zero_bytes + num_non_zeros * 4)
     # EIP-7623 floor price (note: no EVM costs)

--- a/src/ethereum/forks/shanghai/transactions.py
+++ b/src/ethereum/forks/shanghai/transactions.py
@@ -390,13 +390,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE + init_code_cost(ulen(tx.data))

--- a/src/ethereum/forks/shanghai/transactions.py
+++ b/src/ethereum/forks/shanghai/transactions.py
@@ -390,11 +390,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/shanghai/transactions.py
+++ b/src/ethereum/forks/shanghai/transactions.py
@@ -390,12 +390,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     """
     from .vm.gas import init_code_cost
 
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/spurious_dragon/transactions.py
+++ b/src/ethereum/forks/spurious_dragon/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/spurious_dragon/transactions.py
+++ b/src/ethereum/forks/spurious_dragon/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/spurious_dragon/transactions.py
+++ b/src/ethereum/forks/spurious_dragon/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/tangerine_whistle/transactions.py
+++ b/src/ethereum/forks/tangerine_whistle/transactions.py
@@ -150,13 +150,13 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    data_cost = Uint(0)
-
-    for byte in tx.data:
-        if byte == 0:
-            data_cost += GAS_TX_DATA_PER_ZERO
-        else:
-            data_cost += GAS_TX_DATA_PER_NON_ZERO
+    raw = bytes(tx.data)
+    num_zeros = Uint(raw.count(0))
+    num_non_zeros = Uint(len(raw)) - num_zeros
+    data_cost = (
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+    )
 
     if tx.to == Bytes0(b""):
         create_cost = GAS_TX_CREATE

--- a/src/ethereum/forks/tangerine_whistle/transactions.py
+++ b/src/ethereum/forks/tangerine_whistle/transactions.py
@@ -150,12 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    raw = bytes(tx.data)
-    num_zeros = Uint(raw.count(0))
-    num_non_zeros = Uint(len(raw)) - num_zeros
+    num_zeros = tx.data.count(0)
+    num_non_zeros = len(tx.data) - num_zeros
     data_cost = (
-        num_zeros * GAS_TX_DATA_PER_ZERO
-        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
+        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
+        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):

--- a/src/ethereum/forks/tangerine_whistle/transactions.py
+++ b/src/ethereum/forks/tangerine_whistle/transactions.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.elliptic_curve import SECP256K1N, secp256k1_recover
 from ethereum.crypto.hash import Hash32, keccak256
@@ -150,11 +150,11 @@ def calculate_intrinsic_cost(tx: Transaction) -> Uint:
     This function takes a transaction as a parameter and returns the intrinsic
     gas cost of the transaction.
     """
-    num_zeros = tx.data.count(0)
-    num_non_zeros = len(tx.data) - num_zeros
+    num_zeros = Uint(tx.data.count(0))
+    num_non_zeros = ulen(tx.data) - num_zeros
     data_cost = (
-        Uint(num_zeros) * GAS_TX_DATA_PER_ZERO
-        + Uint(num_non_zeros) * GAS_TX_DATA_PER_NON_ZERO
+        num_zeros * GAS_TX_DATA_PER_ZERO
+        + num_non_zeros * GAS_TX_DATA_PER_NON_ZERO
     )
 
     if tx.to == Bytes0(b""):


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Was profiling the calldata related EIPs and came across this for loop. 

The equivalent and faster way to do this was with `bytes.count` - For 1MB of calldata, its about 80x faster since it just calls into a C function and avoids the interpreter overhead that is paid on each iteration. It doesn't take a long time to do the for loop, though this gets called quite a lot.

Happy to close if folks think `bytes.count` is less readable. 

Extracted from #2368 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
