### PR TITLE
chore: cache repeated calls to `git rev-parse HEAD` on a test run

### DIFF
--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -6,7 +6,7 @@ import argparse
 import subprocess
 import sys
 from contextlib import ExitStack
-from functools import lru_cache
+from functools import cache
 from typing import Optional, Sequence, Text, TextIO
 
 from ethereum import __version__
@@ -65,7 +65,7 @@ def create_parser() -> argparse.ArgumentParser:
     return new_parser
 
 
-@lru_cache(maxsize=1)
+@cache
 def get_git_commit_hash() -> str:
     """
     Run the 'git rev-parse HEAD' command to get the commit hash.

--- a/src/ethereum_spec_tools/evm_tools/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/__init__.py
@@ -6,6 +6,7 @@ import argparse
 import subprocess
 import sys
 from contextlib import ExitStack
+from functools import lru_cache
 from typing import Optional, Sequence, Text, TextIO
 
 from ethereum import __version__
@@ -64,6 +65,7 @@ def create_parser() -> argparse.ArgumentParser:
     return new_parser
 
 
+@lru_cache(maxsize=1)
 def get_git_commit_hash() -> str:
     """
     Run the 'git rev-parse HEAD' command to get the commit hash.


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

We were launching a process to get the commit hash on every test case. Given that the commit hash won't change for a given run, we can cache the first result.

Extracted from #2368 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
