### PR TITLE
chore(specs, tests): restore spilled state gas to reservoir on revert/halt

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/__init__.py
+++ b/src/ethereum/forks/amsterdam/vm/__init__.py
@@ -202,14 +202,14 @@ def incorporate_child_on_success(evm: Evm, child_evm: Evm) -> None:
 def incorporate_child_on_error(
     evm: Evm,
     child_evm: Evm,
-    child_state_gas_reservoir: Uint,
 ) -> None:
     """
     Incorporate the state of an unsuccessful `child_evm` into the parent `evm`.
 
     On failure (revert or exceptional halt) state changes are rolled back,
-    so no state was actually grown.  The full original reservoir is restored
-    to the parent and the child's state_gas_used is not accumulated.
+    so no state was actually grown.  All state gas, both reservoir and any
+    that spilled into `gas_left`, is restored to the parent's reservoir and
+    the child's `state_gas_used` is not accumulated.
 
     Parameters
     ----------
@@ -217,10 +217,8 @@ def incorporate_child_on_error(
         The parent `EVM`.
     child_evm :
         The child evm to incorporate.
-    child_state_gas_reservoir :
-        The original state gas reservoir forwarded to the child frame.
 
     """
     evm.gas_left += child_evm.gas_left
-    evm.state_gas_left += child_state_gas_reservoir
+    evm.state_gas_left += child_evm.state_gas_used + child_evm.state_gas_left
     evm.regular_gas_used += child_evm.regular_gas_used

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -154,9 +154,7 @@ def generic_create(
     child_evm = process_create_message(child_message)
 
     if child_evm.error:
-        incorporate_child_on_error(
-            evm, child_evm, create_message_state_gas_reservoir
-        )
+        incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:
@@ -361,7 +359,7 @@ def generic_call(
     child_evm = process_message(child_message)
 
     if child_evm.error:
-        incorporate_child_on_error(evm, child_evm, state_gas_reservoir)
+        incorporate_child_on_error(evm, child_evm)
         evm.return_data = child_evm.output
         push(evm.stack, U256(0))
     else:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -3,8 +3,9 @@ Test CALL state gas reservoir passing under EIP-8037.
 
 The full state gas reservoir is passed to child call frames with no
 63/64 rule. On child success, remaining state gas returns to the
-parent. On child revert or exceptional halt, the reservoir is also
-returned (only gas_left is consumed for the failed frame).
+parent. On child revert or exceptional halt, all state gas, both
+reservoir and any that spilled into `gas_left`, is restored to the
+parent's reservoir (only CPU gas is consumed for the failed frame).
 
 All CALL-family opcodes (CALL, DELEGATECALL, STATICCALL) pass the
 full reservoir to child frames.
@@ -158,20 +159,21 @@ def test_reservoir_restored_after_child_spill_and_revert(
     pre: Alloc,
 ) -> None:
     """
-    Test full reservoir restored when child spills state gas then reverts.
+    Test all state gas recovered when child spills then reverts.
 
     The child performs two SSTOREs (zero-to-nonzero) but only one
     SSTORE's worth of state gas fits in the reservoir — the second
-    spills into gas_left. The child then REVERTs. Because state
-    changes are rolled back, the full original reservoir is returned
-    to the parent, which can use it for its own SSTORE.
+    spills into `gas_left`. The child then REVERTs. Because state
+    changes are rolled back, all state gas (reservoir + spill) is
+    restored to the parent's reservoir. The parent can then perform
+    two SSTOREs using only the recovered reservoir.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
     sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
 
     # Child does two SSTOREs then reverts — the second SSTORE's
-    # state gas spills from the reservoir into gas_left
+    # state gas spills from the reservoir into `gas_left`
     child = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.REVERT(0, 0)),
     )
@@ -180,7 +182,9 @@ def test_reservoir_restored_after_child_spill_and_revert(
     parent = pre.deploy_contract(
         code=(
             Op.POP(Op.CALL(gas=500_000, address=child))
-            # Reservoir was restored — parent SSTORE succeeds
+            # All state gas recovered (reservoir + spill), parent
+            # can perform two SSTOREs from the recovered reservoir
+            + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.STOP
         ),
@@ -203,12 +207,13 @@ def test_reservoir_restored_after_child_spill_and_halt(
     pre: Alloc,
 ) -> None:
     """
-    Test full reservoir restored when child spills state gas then halts.
+    Test all state gas recovered when child spills then halts.
 
     The child performs two SSTOREs (zero-to-nonzero), exhausting the
-    reservoir and spilling into gas_left, then hits INVALID causing
-    an exceptional halt. On halt gas_left is zeroed but the full
-    original reservoir is returned to the parent.
+    reservoir and spilling into `gas_left`, then hits INVALID causing
+    an exceptional halt. On halt `gas_left` is zeroed but all state gas
+    (reservoir + spill) is restored to the parent's reservoir. The
+    parent can then perform two SSTOREs using the recovered reservoir.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
@@ -223,7 +228,9 @@ def test_reservoir_restored_after_child_spill_and_halt(
     parent = pre.deploy_contract(
         code=(
             Op.POP(Op.CALL(gas=500_000, address=child))
-            # Reservoir was restored — parent SSTORE succeeds
+            # All state gas recovered (reservoir + spill), parent
+            # can perform two SSTOREs from the recovered reservoir
+            + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.STOP
         ),


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

When a child frame's state gas spills from the reservoir into `gas_left` and then reverts or halts, the spilled state gas was lost. Since state changes are rolled back, all state gas (reservoir + spill) should be restored to the parent's reservoir, not just the original reservoir.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.explicit.bing.net%2Fth%2Fid%2FOIP.vq0P_nej_VE1EcBdr7SS5gHaHa%3Fpid%3DApi&f=1&ipt=c4c55f777428125bc541290b97b807ce2fa5c3f456c5d426f89684fac12730c2&ipo=images)
