### PR TITLE
feat(tests): add EIP-2357 BLS infinity flag field validation tests

### DIFF
--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
@@ -232,10 +232,6 @@ def test_valid(
         # infinity) instead of rejecting them.
         # See: https://github.com/lambdaclass/ethrex/pull/6287
         pytest.param(
-            PointG1(0x40 << (47 * 8), 0) + Scalar(0),
-            id="x_bls_infinity_flag",
-        ),
-        pytest.param(
             Spec.G1 + Scalar(1) + PointG1(0x40 << (47 * 8), 0) + Scalar(0),
             id="x_bls_infinity_flag_pos_1",
         ),

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
@@ -225,6 +225,20 @@ def test_valid(
             + Scalar(0),
             id="y_above_p_pos_1",
         ),
+        # BLS serialization flag byte in coordinate: values >= p whose first
+        # coordinate byte has BLS flag bits set. Implementations that parse
+        # BLS serialization flags before validating the field modulus may
+        # misinterpret these as valid special-case points (e.g. point at
+        # infinity) instead of rejecting them.
+        # See: https://github.com/lambdaclass/ethrex/pull/6287
+        pytest.param(
+            PointG1(0x40 << (47 * 8), 0) + Scalar(0),
+            id="x_bls_infinity_flag",
+        ),
+        pytest.param(
+            Spec.G1 + Scalar(1) + PointG1(0x40 << (47 * 8), 0) + Scalar(0),
+            id="x_bls_infinity_flag_pos_1",
+        ),
     ],
     # Input length tests can be found in
     # ./test_bls12_variable_length_input_contracts.py

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
@@ -184,6 +184,13 @@ def test_valid(
             PointG1(Spec.P + 1, 0) + Scalar(0),
             id="x_above_modulus_times_0",
         ),
+        # BLS serialization flag byte in coordinate: values >= p whose first
+        # coordinate byte has BLS flag bits set.
+        # See: https://github.com/lambdaclass/ethrex/pull/6287
+        pytest.param(
+            PointG1(0x40 << (47 * 8), 0) + Scalar(0),
+            id="x_bls_infinity_flag_times_0",
+        ),
         pytest.param(
             PointG1(Spec.P1.y, Spec.P1.x) + Scalar(0),
             id="swapped_coordinates_times_0",

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
@@ -346,6 +346,13 @@ def test_valid_multi_inf(
             + PointG2(Spec.P2.x, (Spec.P2.y[0], Spec.P2.y[1] + Spec.P)),
             id="inf_g1_with_g2_y_c1_above_p",
         ),
+        # BLS serialization flag byte in coordinate: values >= p whose first
+        # coordinate byte has BLS flag bits set.
+        # See: https://github.com/lambdaclass/ethrex/pull/6287
+        pytest.param(
+            PointG1(0x40 << (47 * 8), 0) + Spec.INF_G2,
+            id="g1_x_bls_infinity_flag",
+        ),
         # Non-zero byte 16 boundary violation test cases.
         pytest.param(
             PointG1(Spec.G1.x | Spec.MAX_FP_BIT_SET, Spec.G1.y) + Spec.INF_G2,


### PR DESCRIPTION
## Summary

Adds 4 negative test cases for BLS12-381 G1 precompiles that use coordinates with `0x40` as the first byte of the 48-byte coordinate — the BLS serialization "infinity" flag.

These values are `>= p` (the field modulus) and must be rejected by implementations. However, BLS libraries that parse serialization flags *before* validating the field modulus will misinterpret the coordinate as a valid point-at-infinity encoding, silently returning the identity point instead of an error.

### Tests added

| File | Test ID | Input |
|------|---------|-------|
| `test_bls12_g1msm.py` | `x_bls_infinity_flag` | `PointG1(0x40<<376, 0) + Scalar(0)` |
| `test_bls12_g1msm.py` | `x_bls_infinity_flag_pos_1` | Same invalid point at position 1 in multi-pair |
| `test_bls12_g1mul.py` | `x_bls_infinity_flag_times_0` | `PointG1(0x40<<376, 0) + Scalar(0)` |
| `test_bls12_pairing.py` | `g1_x_bls_infinity_flag` | `PointG1(0x40<<376, 0) + INF_G2` |

### Background

Discovered on [bal-devnet-2](https://dora.bal-devnet-2.ethpandaops.io) where ethrex's BLS12_G2MSM precompile (0x0e) returned the identity point for a coordinate starting with `0x40` (which has bit 6 set — the BLS infinity flag). The precompile consumed only 22,500 gas instead of failing and consuming all 927,742 allocated gas, causing an orphaned block at slot 172,886.

- **Root cause**: lambdaclass's `bls12_381` crate masks the first byte with `& 0x1F` before parsing, interpreting bit 6 as "point at infinity"
- **Fix**: [lambdaclass/ethrex#6287](https://github.com/lambdaclass/ethrex/pull/6287)

### Hive verification

Ran these tests via `hive --dev` + `consume engine` against both buggy and fixed ethrex images:

| Image | Result |
|-------|--------|
| `ethpandaops/ethrex:bal-devnet-2` (buggy) | **4/4 FAILED** |
| `ethpandaops/ethrex:fix-bls-local` (fixed) | **4/4 PASSED** |

### Why only 4 tests?

Initially added 32 tests across all 9 BLS precompile files covering `0x40`, `0x80`, `0xC0`, and `0xE0` flag bytes. Hive testing showed only the `0x40` (infinity flag) on G1 coordinates triggered the bug — the other flag bytes and G2 coordinates passed even on the buggy image. Trimmed to the 4 tests that actually catch the vulnerability.

![cat](https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/1200px-Cat_November_2010-1a.jpg)

*This cat carefully validates every coordinate before accepting it as a point* 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)
