### PR TITLE
feat(tests): add v=29 to EIP-7702 invalid auth signature test

### DIFF
--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -2376,6 +2376,8 @@ def test_set_code_using_valid_synthetic_signatures(
         pytest.param(2, 1, 1, id="v=2"),
         pytest.param(27, 1, 1, id="v=27"),  # Type-0 transaction valid value
         pytest.param(28, 1, 1, id="v=28"),  # Type-0 transaction valid value
+        pytest.param(29, 1, 1, id="v=29"),  # Type-0 replay-protected
+        # transaction valid value (chain_id=2)
         pytest.param(35, 1, 1, id="v=35"),  # Type-0 replay-protected
         # transaction valid value
         pytest.param(36, 1, 1, id="v=36"),  # Type-0 replay-protected


### PR DESCRIPTION
## 🗒️ Description

Add missing test case for `y_parity=29` in the EIP-7702 authorization
signature validation. This value is valid for legacy type-0 replay-protected
transactions (chain_id=2) but must be rejected for EIP-7702 authorizations
where `y_parity` must be strictly 0 or 1.

This triggered a bug in evmone's testing infrastructure (see ipsilon/evmone#1444).

## 🔗 Related Issues or PRs

Closes #2177.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [x] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

🦊