### PR TITLE
fix(test-execute): restore `!= nonce` comparison to handle chain reverts

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -422,7 +422,7 @@ def worker_key(
             session_worker_key, block_number="pending", skip_code=True
         )
     rpc_nonce = Number(session_worker_account.nonce)
-    if rpc_nonce > session_worker_key.nonce:
+    if rpc_nonce != session_worker_key.nonce:
         wk_nonce = session_worker_key.nonce
         logger.info(f"Worker key nonce mismatch: {wk_nonce} != {rpc_nonce}")
         logger.info(f"Updating worker key nonce to {rpc_nonce}")


### PR DESCRIPTION
## 🗒️ Description
PR #2085 changed the worker_key nonce comparison from != to > to prevent false resets when using block_number="latest" (which doesn't reflect in-flight transactions). However, this breaks scenarios where the chain legitimately reverts to a lower nonce (e.g. overlay restore for gas benchmarking), as the worker key keeps the stale higher nonce and subsequent transactions fail.

Restoring != ensures the nonce is always synced with the chain state.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
