### PR TITLE
refactor(test-execute): split function + add unit test for nonce comparison

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/sender.py
@@ -9,7 +9,7 @@ import pytest
 from filelock import FileLock
 from pytest_metadata.plugin import metadata_key
 
-from execution_testing.base_types import Address, Number, Wei
+from execution_testing.base_types import Account, Address, Number, Wei
 from execution_testing.logging import get_logger
 from execution_testing.rpc import EthRPC
 from execution_testing.rpc.rpc_types import JSONRPCError
@@ -406,12 +406,16 @@ def session_worker_key(
     logger.info(f"Refund transaction confirmed: {refund_tx.hash}")
 
 
-@pytest.fixture(scope="function")
-def worker_key(
-    eth_rpc: EthRPC, session_worker_key: EOA
-) -> Generator[EOA, None, None]:
-    """Prepare the worker key for the current test."""
-    logger.debug(f"Preparing worker key {session_worker_key} for test")
+def sync_worker_key_nonce(eth_rpc: EthRPC, session_worker_key: EOA) -> Account:
+    """
+    Synchronize the worker key nonce with the on-chain nonce.
+
+    Fetch the account state and update the local nonce if it differs
+    from the RPC nonce. This handles both nonce increases (normal
+    progression) and decreases (chain reverts).
+
+    Return the fetched account for further use.
+    """
     try:
         session_worker_account = eth_rpc.get_account(
             session_worker_key, block_number="latest", skip_code=True
@@ -427,6 +431,16 @@ def worker_key(
         logger.info(f"Worker key nonce mismatch: {wk_nonce} != {rpc_nonce}")
         logger.info(f"Updating worker key nonce to {rpc_nonce}")
         session_worker_key.nonce = rpc_nonce
+    return session_worker_account
+
+
+@pytest.fixture(scope="function")
+def worker_key(
+    eth_rpc: EthRPC, session_worker_key: EOA
+) -> Generator[EOA, None, None]:
+    """Prepare the worker key for the current test."""
+    logger.debug(f"Preparing worker key {session_worker_key} for test")
+    session_worker_account = sync_worker_key_nonce(eth_rpc, session_worker_key)
 
     # Record the start balance of the worker key
     worker_key_start_balance = session_worker_account.balance

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_sender.py
@@ -1,0 +1,77 @@
+"""Test the sender plugin's worker key nonce synchronization."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from execution_testing.base_types import Account, Number
+from execution_testing.test_types import EOA
+
+from ..sender import sync_worker_key_nonce
+
+
+@pytest.fixture
+def mock_eth_rpc() -> MagicMock:
+    """Create a mock EthRPC instance."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_eoa() -> EOA:
+    """Create a mock EOA with a known nonce."""
+    return EOA(
+        key=b"\x01" * 32,
+        nonce=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "initial_nonce,rpc_nonce",
+    [
+        pytest.param(
+            5,
+            10,
+            id="rpc_nonce_higher_than_local",
+        ),
+        pytest.param(
+            10,
+            5,
+            id="rpc_nonce_lower_than_local_chain_revert",
+        ),
+        pytest.param(
+            7,
+            0,
+            id="rpc_nonce_reset_to_zero_full_revert",
+        ),
+    ],
+)
+def test_worker_key_nonce_sync(
+    mock_eth_rpc: MagicMock,
+    mock_eoa: EOA,
+    initial_nonce: int,
+    rpc_nonce: int,
+) -> None:
+    """Test worker key nonce is updated whenever it differs from RPC."""
+    mock_eoa.nonce = Number(initial_nonce)
+    mock_eth_rpc.get_account.return_value = Account(
+        nonce=rpc_nonce, balance=10**18
+    )
+
+    sync_worker_key_nonce(mock_eth_rpc, mock_eoa)
+
+    assert mock_eoa.nonce == Number(rpc_nonce), (
+        f"Expected nonce to be synced to {rpc_nonce}, got {mock_eoa.nonce}"
+    )
+
+
+def test_worker_key_nonce_unchanged_when_matching(
+    mock_eth_rpc: MagicMock,
+    mock_eoa: EOA,
+) -> None:
+    """Test worker key nonce is not modified when it matches RPC."""
+    mock_eoa.nonce = Number(5)
+    mock_eth_rpc.get_account.return_value = Account(nonce=5, balance=10**18)
+
+    sync_worker_key_nonce(mock_eth_rpc, mock_eoa)
+
+    assert mock_eoa.nonce == Number(5)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_sender.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_sender.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from execution_testing.base_types import Account, Number
+from execution_testing.rpc.rpc_types import JSONRPCError
 from execution_testing.test_types import EOA
 
 from ..sender import sync_worker_key_nonce
@@ -75,3 +76,22 @@ def test_worker_key_nonce_unchanged_when_matching(
     sync_worker_key_nonce(mock_eth_rpc, mock_eoa)
 
     assert mock_eoa.nonce == Number(5)
+
+
+def test_sync_falls_back_to_pending_on_jsonrpc_error(
+    mock_eth_rpc: MagicMock,
+    mock_eoa: EOA,
+) -> None:
+    """Test fallback to pending block when latest is unavailable."""
+    mock_eoa.nonce = Number(3)
+    pending_account = Account(nonce=5, balance=10**18)
+    mock_eth_rpc.get_account.side_effect = [
+        JSONRPCError(code=-32000, message="not available"),
+        pending_account,
+    ]
+
+    result = sync_worker_key_nonce(mock_eth_rpc, mock_eoa)
+
+    assert mock_eoa.nonce == Number(5)
+    assert result is pending_account
+    assert mock_eth_rpc.get_account.call_count == 2


### PR DESCRIPTION
## 🗒️ Description
To prevent accidentally breaking this part again a unit test is added. Before Kamil's fix this unit test would have failed with `AssertionError: Expected nonce to be synced to x, got y`, with the fix all 3+1 cases pass. Please confirm that the function split is not problematic.

## 🔗 Related Issues or PRs
#2406 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
