### PR TITLE
feat(ci): Mark stale issues/PRs workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Manage stale issues and PRs
+on:
+  schedule:
+    - cron: '0 0 * * *'  # runs daily
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
+        with:
+          # --- Stale settings ---
+          days-before-stale: 60
+
+          # --- PR settings ---
+          days-before-pr-close: 0  # PR immediately auto-closes when marked stale
+          stale-pr-label: 'stale'
+          stale-pr-message: 'This PR has had no activity for 60 days and is being closed.'
+          close-pr-message: 'Closing this PR due to 60 days of inactivity.'
+
+          # --- Issue settings ---
+          days-before-issue-close: -1   # Never auto-close issues
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has had no activity for 60 days and has been marked as stale.'


### PR DESCRIPTION
## 🗒️ Description
Adds a scheduled GitHub Actions workflow to automatically manage stale PRs and issues, specifically adds `.github/workflows/stale.yml` which uses [`actions/stale`](https://github.com/actions/stale) to manage them.

### Behaviour

| | PRs | Issues |
|---|---|---|
| Marked stale after | 60 days of inactivity | 60 days of inactivity |
| Action after stale | Closed immediately | Kept open |
| Label applied | `stale` | `stale` |

- The workflow runs on a daily cron schedule
- Any new activity on a stale item will automatically remove the `stale` label
- A comment is posted when a PR or issue is marked stale, and again when a PR is closed





## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### ~~Cute~~ Angry Animal Picture

(He's angry because he sees too many stale PRs)
![Put a link to a cute animal picture inside the parenthesis-->](https://nationalcatgroomers.com/cdn/shop/articles/angrycat_4335da79-c187-4c8f-9d69-2ce95f14f4f5.jpg?v=1750465142&width=1100)
