### PR TITLE
refactor(test-benchmark): ensure no precompile cache issue

### DIFF
--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -637,3 +637,73 @@ def test_ec_pairing(
         skip_gas_used_validation=True,
         blocks=[Block(txs=txs)],
     )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize(
+    "precompile_address,calldata",
+    [
+        pytest.param(
+            0x06,
+            concatenate_parameters(
+                [
+                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
+                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
+                    "07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED",
+                    "06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7",
+                ]
+            ),
+            id="ec_add",
+        ),
+        pytest.param(
+            0x07,
+            concatenate_parameters(
+                [
+                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
+                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
+                    "0000000000000000000000000000000000000000000000000000000000000002",
+                ]
+            ),
+            id="ec_mul_small_scalar",
+        ),
+        pytest.param(
+            0x07,
+            concatenate_parameters(
+                [
+                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
+                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
+                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+                ]
+            ),
+            id="ec_mul_max_scalar",
+        ),
+    ],
+)
+def test_alt_bn128_uncachable(
+    benchmark_test: BenchmarkTestFiller,
+    precompile_address: Address,
+    calldata: bytes,
+) -> None:
+    """
+    Benchmark ecAdd/ecMul with chained output-to-input feedback.
+
+    Result overwrites the input point each iteration, so every call
+    has unique input and cannot benefit from precompile caching.
+    """
+    attack_block = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS,
+            address=precompile_address,
+            args_size=Op.CALLDATASIZE,
+            ret_size=64,  # One G1 point (2 * 32 bytes), overwrites input.
+        ),
+    )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -501,6 +501,9 @@ def test_bn128_pairings_amortized(
     )
 
 
+NUM_INPUT_VARIANTS = 4
+
+
 @pytest.mark.repricing
 @pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
 def test_alt_bn128_benchmark(
@@ -513,6 +516,48 @@ def test_alt_bn128_benchmark(
     attack_block = Op.POP(
         Op.STATICCALL(gas=Op.GAS, address=0x08, args_size=Op.CALLDATASIZE),
     )
+
+    benchmark_test(
+        target_opcode=Op.STATICCALL,
+        code_generator=JumpLoopGenerator(
+            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
+            attack_block=attack_block,
+            tx_kwargs={"data": calldata},
+        ),
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("num_pairs", [1, 12, 24])
+def test_ec_pairing(
+    benchmark_test: BenchmarkTestFiller,
+    num_pairs: int,
+) -> None:
+    """Benchmark ecpairing precompile with rotating inputs to avoid caching."""
+    pair_size = num_pairs * 192
+    counter_offset = NUM_INPUT_VARIANTS * pair_size
+
+    calldata = Bytes(
+        b"".join(
+            _generate_bn128_pairs(num_pairs, seed=42 + i)
+            for i in range(NUM_INPUT_VARIANTS)
+        )
+    )
+
+    attack_block = Op.POP(
+        Op.STATICCALL(
+            gas=Op.GAS,
+            address=0x08,
+            args_offset=Op.MUL(
+                Op.AND(
+                    Op.MLOAD(counter_offset),
+                    NUM_INPUT_VARIANTS - 1,
+                ),
+                pair_size,
+            ),
+            args_size=pair_size,
+        ),
+    ) + Op.MSTORE(counter_offset, Op.ADD(Op.MLOAD(counter_offset), 1))
 
     benchmark_test(
         target_opcode=Op.STATICCALL,

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -549,26 +549,20 @@ def test_ec_pairing(
         + gsc.GAS_PRECOMPILE_ECPAIRING_PER_POINT * num_pairs
     )
 
-    # Each iteration: STATICCALL ecpairing at a rotating calldata offset,
-    # then increment counter at memory[CALLDATASIZE].
+    # Each iteration: STATICCALL ecpairing at advancing calldata offset,
+    # then advance offset by pair_size at memory[CALLDATASIZE].
     # The loop condition checks remaining gas against one body execution.
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
             address=0x08,
-            args_offset=Op.MUL(
-                Op.MOD(
-                    Op.MLOAD(Op.CALLDATASIZE),
-                    Op.DIV(Op.CALLDATASIZE, pair_size),
-                ),
-                pair_size,
-            ),
+            args_offset=Op.MLOAD(Op.CALLDATASIZE),
             args_size=pair_size,
             address_warm=True,
         ),
     ) + Op.MSTORE(
         Op.CALLDATASIZE,
-        Op.ADD(Op.MLOAD(Op.CALLDATASIZE), 1),
+        Op.ADD(Op.MLOAD(Op.CALLDATASIZE), pair_size),
     )
 
     setup = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -568,6 +568,7 @@ def test_ec_pairing(
     setup = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
     loop = While(
         body=attack_block,
+        condition=Op.GT(Op.CALLDATASIZE, Op.MLOAD(Op.CALLDATASIZE)),
     )
     code = setup + loop
     attack_contract_address = pre.deploy_contract(code=code)
@@ -591,7 +592,6 @@ def test_ec_pairing(
 
     seed_offset = 0
     txs: list[Transaction] = []
-    total_gas_used = 0
     remaining_gas = gas_benchmark_value
 
     while remaining_gas > 0:
@@ -621,15 +621,6 @@ def test_ec_pairing(
         if gas_for_loop < iteration_cost:
             break
 
-        num_iterations = gas_for_loop // iteration_cost
-        gas_remaining = gas_for_loop - num_iterations * iteration_cost
-
-        # EIP-7623: gas_used = max(standard_intrinsic + execution, floor).
-        tx_gas_used = max(
-            per_tx_gas - gas_remaining,
-            intrinsic_gas_calculator(calldata=calldata),
-        )
-
         txs.append(
             Transaction(
                 to=attack_contract_address,
@@ -638,11 +629,11 @@ def test_ec_pairing(
                 data=calldata,
             )
         )
-        total_gas_used += tx_gas_used
         remaining_gas -= per_tx_gas
         seed_offset += per_tx_variants
 
     benchmark_test(
         target_opcode=Op.STATICCALL,
+        skip_gas_used_validation=True,
         blocks=[Block(txs=txs)],
     )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -1,15 +1,20 @@
 """Benchmark ALT_BN128 precompile."""
 
+import math
 import random
 
 import pytest
 from execution_testing import (
     Address,
+    Alloc,
     BenchmarkTestFiller,
+    Block,
     Bytes,
     Fork,
     JumpLoopGenerator,
     Op,
+    Transaction,
+    While,
 )
 from py_ecc.bn128 import G1, G2, multiply
 
@@ -501,9 +506,6 @@ def test_bn128_pairings_amortized(
     )
 
 
-NUM_INPUT_VARIANTS = 4
-
-
 @pytest.mark.repricing
 @pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
 def test_alt_bn128_benchmark(
@@ -528,42 +530,127 @@ def test_alt_bn128_benchmark(
 
 
 @pytest.mark.repricing
-@pytest.mark.parametrize("num_pairs", [1, 12, 24])
+@pytest.mark.parametrize("num_pairs", [1, 3, 6, 12, 24])
 def test_ec_pairing(
     benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
     num_pairs: int,
 ) -> None:
-    """Benchmark ecpairing precompile with rotating inputs to avoid caching."""
+    """Benchmark ecpairing precompile with unique inputs per call."""
     pair_size = num_pairs * 192
-    counter_offset = NUM_INPUT_VARIANTS * pair_size
-
-    calldata = Bytes(
-        b"".join(
-            _generate_bn128_pairs(num_pairs, seed=42 + i)
-            for i in range(NUM_INPUT_VARIANTS)
-        )
+    gsc = fork.gas_costs()
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
+    mem_exp = fork.memory_expansion_gas_calculator()
+    precompile_cost = (
+        gsc.GAS_PRECOMPILE_ECPAIRING_BASE
+        + gsc.GAS_PRECOMPILE_ECPAIRING_PER_POINT * num_pairs
     )
 
+    # Each iteration: STATICCALL ecpairing at a rotating calldata offset,
+    # then increment counter at memory[CALLDATASIZE].
+    # The loop condition checks remaining gas against one body execution.
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
             address=0x08,
             args_offset=Op.MUL(
-                Op.AND(
-                    Op.MLOAD(counter_offset),
-                    NUM_INPUT_VARIANTS - 1,
+                Op.MOD(
+                    Op.MLOAD(Op.CALLDATASIZE),
+                    Op.DIV(Op.CALLDATASIZE, pair_size),
                 ),
                 pair_size,
             ),
             args_size=pair_size,
+            address_warm=True,
         ),
-    ) + Op.MSTORE(counter_offset, Op.ADD(Op.MLOAD(counter_offset), 1))
+    ) + Op.MSTORE(
+        Op.CALLDATASIZE,
+        Op.ADD(Op.MLOAD(Op.CALLDATASIZE), 1),
+    )
+
+    setup = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+    loop = While(
+        body=attack_block,
+        condition=Op.GT(Op.GAS, attack_block.gas_cost(fork) + precompile_cost),
+    )
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    iteration_cost = loop.gas_cost(fork) + precompile_cost
+    setup_cost = setup.gas_cost(fork)
+
+    # Conservative per-variant estimate for sizing the calldata:
+    # one loop iteration + worst-case calldata intrinsic (all non-zero)
+    # + CALLDATACOPY copy and linear memory expansion.
+    words_per_variant = math.ceil(pair_size / 32)
+    per_variant_gas = (
+        iteration_cost
+        + pair_size * 16
+        + words_per_variant * (gsc.GAS_COPY + gsc.GAS_MEMORY)
+    )
+    empty_intrinsic = intrinsic_gas_calculator(
+        calldata=[], return_cost_deducted_prior_execution=True
+    )
+    fixed_overhead = empty_intrinsic + setup_cost + mem_exp(new_bytes=32)
+
+    seed_offset = 0
+    txs: list[Transaction] = []
+    total_gas_used = 0
+    remaining_gas = gas_benchmark_value
+
+    while remaining_gas > 0:
+        per_tx_gas = min(tx_gas_limit, remaining_gas)
+        per_tx_variants = max(
+            1, (per_tx_gas - fixed_overhead) // per_variant_gas
+        )
+        calldata = Bytes(
+            b"".join(
+                _generate_bn128_pairs(num_pairs, seed=42 + seed_offset + i)
+                for i in range(per_tx_variants)
+            )
+        )
+
+        execution_intrinsic = intrinsic_gas_calculator(
+            calldata=calldata,
+            return_cost_deducted_prior_execution=True,
+        )
+        gas_for_loop = (
+            per_tx_gas
+            - execution_intrinsic
+            - setup_cost
+            - math.ceil(len(calldata) / 32) * gsc.GAS_COPY
+            - mem_exp(new_bytes=len(calldata) + 32)
+        )
+
+        if gas_for_loop < iteration_cost:
+            break
+
+        num_iterations = gas_for_loop // iteration_cost
+        gas_remaining = gas_for_loop - num_iterations * iteration_cost
+
+        # EIP-7623: gas_used = max(standard_intrinsic + execution, floor).
+        tx_gas_used = max(
+            per_tx_gas - gas_remaining,
+            intrinsic_gas_calculator(calldata=calldata),
+        )
+
+        txs.append(
+            Transaction(
+                to=attack_contract_address,
+                sender=pre.fund_eoa(),
+                gas_limit=per_tx_gas,
+                data=calldata,
+            )
+        )
+        total_gas_used += tx_gas_used
+        remaining_gas -= per_tx_gas
+        seed_offset += per_tx_variants
 
     benchmark_test(
         target_opcode=Op.STATICCALL,
-        code_generator=JumpLoopGenerator(
-            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
-            attack_block=attack_block,
-            tx_kwargs={"data": calldata},
-        ),
+        expected_benchmark_gas_used=total_gas_used,
+        blocks=[Block(txs=txs)],
     )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -639,71 +639,83 @@ def test_ec_pairing(
     )
 
 
+def _generate_g1_point(seed: int) -> Bytes:
+    """Generate a valid random G1 point from a deterministic seed."""
+    rng = random.Random(seed)
+    priv_key = rng.randint(1, 2**32 - 1)
+    point = multiply(G1, priv_key)
+    assert point is not None
+    return Bytes(
+        point[0].n.to_bytes(32, "big") + point[1].n.to_bytes(32, "big")
+    )
+
+
 @pytest.mark.repricing
 @pytest.mark.parametrize(
-    "precompile_address,calldata",
+    "precompile_address,scalar",
     [
-        pytest.param(
-            0x06,
-            concatenate_parameters(
-                [
-                    "18B18ACFB4C2C30276DB5411368E7185B311DD124691610C5D3B74034E093DC9",
-                    "063C909C4720840CB5134CB9F59FA749755796819658D32EFC0D288198F37266",
-                    "07C2B7F58A84BD6145F00C9C2BC0BB1A187F20FF2C92963A88019E7C6A014EED",
-                    "06614E20C147E940F2D70DA3F74C9A17DF361706A4485C742BD6788478FA17D7",
-                ]
-            ),
-            id="ec_add",
-        ),
-        pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
-                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
-                    "0000000000000000000000000000000000000000000000000000000000000002",
-                ]
-            ),
-            id="ec_mul_small_scalar",
-        ),
-        pytest.param(
-            0x07,
-            concatenate_parameters(
-                [
-                    "1A87B0584CE92F4593D161480614F2989035225609F08058CCFA3D0F940FEBE3",
-                    "1A2F3C951F6DADCC7EE9007DFF81504B0FCD6D7CF59996EFDC33D92BF7F9F8F6",
-                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-                ]
-            ),
-            id="ec_mul_max_scalar",
-        ),
+        pytest.param(0x06, None, id="ec_add"),
+        pytest.param(0x07, 2, id="ec_mul_small_scalar"),
+        pytest.param(0x07, 2**256 - 1, id="ec_mul_max_scalar"),
     ],
 )
 def test_alt_bn128_uncachable(
     benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
     precompile_address: Address,
-    calldata: bytes,
+    scalar: int | None,
 ) -> None:
-    """
-    Benchmark ecAdd/ecMul with chained output-to-input feedback.
+    """Benchmark ecAdd/ecMul with unique input per call."""
+    intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
 
-    Result overwrites the input point each iteration, so every call
-    has unique input and cannot benefit from precompile caching.
-    """
     attack_block = Op.POP(
         Op.STATICCALL(
             gas=Op.GAS,
             address=precompile_address,
             args_size=Op.CALLDATASIZE,
-            ret_size=64,  # One G1 point (2 * 32 bytes), overwrites input.
+            # One G1 point (2 * 32 bytes), overwrites the input point
+            # so each iteration has unique precompile input.
+            ret_size=64,
         ),
     )
 
+    setup = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+    loop = While(body=attack_block, condition=Op.GAS)
+    code = setup + loop
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    txs: list[Transaction] = []
+    remaining_gas = gas_benchmark_value
+
+    seed = 0
+    while remaining_gas > 0:
+        gas_available = min(tx_gas_limit, remaining_gas)
+
+        calldata = Bytes(
+            _generate_g1_point(seed) + _generate_g1_point(seed + 1000)
+            if scalar is None
+            else scalar.to_bytes(32, "big")
+        )
+
+        intrinsic = intrinsic_gas_calculator(calldata=calldata)
+        if gas_available <= intrinsic:
+            break
+
+        txs.append(
+            Transaction(
+                to=attack_contract_address,
+                sender=pre.fund_eoa(),
+                gas_limit=gas_available,
+                data=calldata,
+            )
+        )
+        remaining_gas -= gas_available
+        seed += 1
+
     benchmark_test(
         target_opcode=Op.STATICCALL,
-        code_generator=JumpLoopGenerator(
-            setup=Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE),
-            attack_block=attack_block,
-            tx_kwargs={"data": calldata},
-        ),
+        blocks=[Block(txs=txs)],
     )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -668,7 +668,13 @@ def test_alt_bn128_uncachable(
     precompile_address: Address,
     scalar: int | None,
 ) -> None:
-    """Benchmark ecAdd/ecMul with unique input per call."""
+    """
+    Benchmark ecAdd/ecMul with unique input per call.
+
+    Write the precompile's G1 output (64 bytes) back over the
+    input point so each loop iteration receives a distinct
+    input, avoiding precompile result caching in clients.
+    """
     intrinsic_gas_calculator = fork.transaction_intrinsic_cost_calculator()
 
     attack_block = Op.POP(

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -568,7 +568,6 @@ def test_ec_pairing(
     setup = Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
     loop = While(
         body=attack_block,
-        condition=Op.GT(Op.GAS, attack_block.gas_cost(fork) + precompile_cost),
     )
     code = setup + loop
     attack_contract_address = pre.deploy_contract(code=code)
@@ -645,6 +644,5 @@ def test_ec_pairing(
 
     benchmark_test(
         target_opcode=Op.STATICCALL,
-        expected_benchmark_gas_used=total_gas_used,
         blocks=[Block(txs=txs)],
     )

--- a/tests/benchmark/compute/precompile/test_alt_bn128.py
+++ b/tests/benchmark/compute/precompile/test_alt_bn128.py
@@ -697,7 +697,7 @@ def test_alt_bn128_uncachable(
         calldata = Bytes(
             _generate_g1_point(seed) + _generate_g1_point(seed + 1000)
             if scalar is None
-            else scalar.to_bytes(32, "big")
+            else _generate_g1_point(seed) + scalar.to_bytes(32, "big")
         )
 
         intrinsic = intrinsic_gas_calculator(calldata=calldata)

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -42,9 +42,17 @@ def test_ecrecover(
     if precompile_address not in fork.precompiles():
         pytest.skip("Precompile not enabled")
 
-    attack_block = Op.POP(
-        Op.STATICCALL(
-            gas=Op.GAS, address=precompile_address, args_size=Op.CALLDATASIZE
+    attack_block = Op.MSTORE(
+        0,
+        Op.ADD(
+            Op.MLOAD(0),
+            Op.STATICCALL(
+                gas=Op.GAS,
+                address=precompile_address,
+                args_size=Op.CALLDATASIZE,
+                ret_offset=0x80,
+                ret_size=0x20,
+            ),
         ),
     )
 

--- a/tests/benchmark/compute/precompile/test_ecrecover.py
+++ b/tests/benchmark/compute/precompile/test_ecrecover.py
@@ -38,7 +38,14 @@ def test_ecrecover(
     precompile_address: Address,
     calldata: bytes,
 ) -> None:
-    """Benchmark ECRECOVER precompile."""
+    """
+    Benchmark ECRECOVER precompile with unique input per call.
+
+    Each loop iteration increments the hash at memory[0] by
+    the STATICCALL success flag (1) so every call receives a
+    distinct input, avoiding precompile result caching in
+    clients.
+    """
     if precompile_address not in fork.precompiles():
         pytest.skip("Precompile not enabled")
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

For `test_ecrecover` and `test_alt_bn128_benchmark`, they are using the same input for every call. Some clients (e.g., `Nethermind` and `Reth`) might cache the precompile result, thus skewing the result. This PR changes the precompile input for every call.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
close #1603 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
