### PR TITLE
chore(test-client-clis): map ethrex BAL validation errors to INVALID_DEPOSIT_EVENT_LAYOUT

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -153,6 +153,9 @@ class EthrexExceptionMapper(ExceptionMapper):
             r"Invalid transaction: "
             r"Transaction gas limit exceeds maximum.*"
         ),
+        BlockException.INVALID_DEPOSIT_EVENT_LAYOUT: (
+            r"Invalid deposit request layout|BAL validation failed.*"
+        ),
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (r"System call failed.*"),
         BlockException.SYSTEM_CONTRACT_EMPTY: (
             r"System contract:.* has no code after deployment"


### PR DESCRIPTION
## Summary
- Add `BAL validation failed.*` regex to `INVALID_DEPOSIT_EVENT_LAYOUT` in ethrex exception mapper
- In Amsterdam, blocks with intentionally invalid deposit event layouts may trigger BAL validation errors before deposit validation

## Test plan
- Fixes 3 failing `eip6110_deposits/test_modified_contract` tests in `bal@v5.2.0` consume-engine suite