### PR TITLE
feat(tests): add ecmul large scalar tests for EIP-196

### DIFF
--- a/tests/byzantium/eip196_ec_add_mul/spec.py
+++ b/tests/byzantium/eip196_ec_add_mul/spec.py
@@ -23,6 +23,17 @@ class FP(BytesConcatenation):
 
 
 @dataclass(frozen=True)
+class Scalar(BytesConcatenation):
+    """Dataclass that defines a scalar for EC multiplication."""
+
+    x: int = 0
+
+    def __bytes__(self) -> bytes:
+        """Convert scalar to bytes."""
+        return self.x.to_bytes(32, byteorder="big")
+
+
+@dataclass(frozen=True)
 class PointG1(BytesConcatenation):
     """Dataclass that defines an affine point in the BN254 E(Fp) group (G1)."""
 
@@ -47,6 +58,9 @@ class Spec:
 
     # The prime modulus of the BN254 prime field Fp
     P = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47
+
+    # The order of the BN254 G1 group
+    N = 0x30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001
 
     # G1 generator point
     G1 = PointG1(1, 2)

--- a/tests/byzantium/eip196_ec_add_mul/test_ecmul.py
+++ b/tests/byzantium/eip196_ec_add_mul/test_ecmul.py
@@ -8,7 +8,7 @@ from execution_testing import (
     Transaction,
 )
 
-from .spec import FP, PointG1, Spec, ref_spec_196
+from .spec import PointG1, Scalar, Spec, ref_spec_196
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_196.git_path
 REFERENCE_SPEC_VERSION = ref_spec_196.version
@@ -23,42 +23,42 @@ pytestmark = [
     "input_data, expected_output",
     [
         pytest.param(
-            Spec.G1 + FP(0),
+            Spec.G1 + Scalar(0),
             Spec.INF_G1,
             id="generator_times_zero",
         ),
         pytest.param(
-            Spec.G1 + FP(1),
+            Spec.G1 + Scalar(1),
             Spec.G1,
             id="generator_times_one",
         ),
         pytest.param(
-            Spec.G1 + FP(2),
+            Spec.G1 + Scalar(2),
             Spec.G1x2,
             id="generator_times_two",
         ),
         pytest.param(
-            Spec.P1 + FP(0),
+            Spec.P1 + Scalar(0),
             Spec.INF_G1,
             id="p1_times_zero",
         ),
         pytest.param(
-            Spec.P1 + FP(1),
+            Spec.P1 + Scalar(1),
             Spec.P1,
             id="p1_times_one",
         ),
         pytest.param(
-            Spec.INF_G1 + FP(0),
+            Spec.INF_G1 + Scalar(0),
             Spec.INF_G1,
             id="inf_times_zero",
         ),
         pytest.param(
-            Spec.INF_G1 + FP(1),
+            Spec.INF_G1 + Scalar(1),
             Spec.INF_G1,
             id="inf_times_one",
         ),
         pytest.param(
-            Spec.INF_G1 + FP(2),
+            Spec.INF_G1 + Scalar(2),
             Spec.INF_G1,
             id="inf_times_two",
         ),
@@ -73,9 +73,29 @@ pytestmark = [
             id="no_scalar",
         ),
         pytest.param(
-            Spec.G1 + FP(1) + b"\0" * 32,
+            Spec.G1 + Scalar(1) + b"\0" * 32,
             Spec.G1,
             id="generator_times_one_extra_data",
+        ),
+        pytest.param(
+            Spec.G1 + Scalar(Spec.N),
+            Spec.INF_G1,
+            id="generator_times_group_order",
+        ),
+        pytest.param(
+            Spec.G1 + Scalar(Spec.N + 1),
+            Spec.G1,
+            id="generator_times_group_order_plus_one",
+        ),
+        pytest.param(
+            Spec.G1 + Scalar(2 * Spec.N),
+            Spec.INF_G1,
+            id="generator_times_double_group_order",
+        ),
+        pytest.param(
+            Spec.G1 + Scalar(2 * Spec.N + 1),
+            Spec.G1,
+            id="generator_times_double_group_order_plus_one",
         ),
     ],
 )
@@ -104,52 +124,52 @@ def test_valid(
     "input_data, expected_output",
     [
         pytest.param(
-            PointG1(1, 3) + FP(0),
+            PointG1(1, 3) + Scalar(0),
             b"",
             id="not_on_curve_1_3_times_zero",
         ),
         pytest.param(
-            PointG1(1, 3) + FP(1),
+            PointG1(1, 3) + Scalar(1),
             b"",
             id="not_on_curve_1_3_times_one",
         ),
         pytest.param(
-            PointG1(1, 3) + FP(2),
+            PointG1(1, 3) + Scalar(2),
             b"",
             id="not_on_curve_1_3_times_two",
         ),
         pytest.param(
-            PointG1(7827, 6598) + FP(0),
+            PointG1(7827, 6598) + Scalar(0),
             b"",
             id="not_on_curve_7827_6598_times_zero",
         ),
         pytest.param(
-            PointG1(7827, 6598) + FP(1),
+            PointG1(7827, 6598) + Scalar(1),
             b"",
             id="not_on_curve_7827_6598_times_one",
         ),
         pytest.param(
-            PointG1(0, 3) + FP(1),
+            PointG1(0, 3) + Scalar(1),
             b"",
             id="not_on_curve_0_3",
         ),
         pytest.param(
-            PointG1(Spec.P, 0) + FP(1),
+            PointG1(Spec.P, 0) + Scalar(1),
             b"",
             id="x_eq_P",
         ),
         pytest.param(
-            PointG1(0, Spec.P) + FP(1),
+            PointG1(0, Spec.P) + Scalar(1),
             b"",
             id="y_eq_P",
         ),
         pytest.param(
-            PointG1(Spec.G1.x + Spec.P, Spec.G1.y) + FP(1),
+            PointG1(Spec.G1.x + Spec.P, Spec.G1.y) + Scalar(1),
             b"",
             id="x_plus_P",
         ),
         pytest.param(
-            PointG1(Spec.G1.x, Spec.G1.y + Spec.P) + FP(1),
+            PointG1(Spec.G1.x, Spec.G1.y + Spec.P) + Scalar(1),
             b"",
             id="y_plus_P",
         ),


### PR DESCRIPTION
## 🗒️ Description

Add BN254 group order `N` constant to EIP-196 `Spec` and add ECMUL test cases
for scalars at and above the group order, covering two categories from the
EIP-196 test case list that were missing:
- Scalar between group order and field modulus (`N`, `N+1`)
- Scalar larger than field modulus (`2N`, `2N+1`)

## 🔗 Related Issues or PRs

Closes #2421

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.

#### Cute Animal Picture

🦦🦦