### PR TITLE
test(amsterdam): add EIP-8037 gas accounting coverage

### DIFF
--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -50,9 +50,9 @@ gas cost for transactions that include calldata.
 [EIP-7623]: https://eips.ethereum.org/EIPS/eip-7623
 """
 
-GAS_TX_CREATE = Uint(32000)
+GAS_TX_CREATE = Uint(9000 + 112 * 1174)
 """
-Additional gas cost for creating a new contract.
+Additional intrinsic gas cost for creating a new contract under [EIP-8037].
 """
 
 GAS_TX_ACCESS_LIST_ADDRESS = Uint(2400)
@@ -63,6 +63,12 @@ Gas cost for including an address in the access list of a transaction.
 GAS_TX_ACCESS_LIST_STORAGE_KEY = Uint(1900)
 """
 Gas cost for including a storage key in the access list of a transaction.
+"""
+
+GAS_TX_SET_CODE_AUTHORIZATION = Uint(7500 + (23 + 112) * 1174)
+"""
+Additional intrinsic gas cost per authorization in a set-code transaction
+under [EIP-8037]. This is separate from the runtime authorization charge.
 """
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
@@ -602,7 +608,6 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     gas cost of the transaction and the minimum gas cost used by the
     transaction based on the calldata size.
     """
-    from .vm.eoa_delegation import GAS_AUTH_PER_EMPTY_ACCOUNT
     from .vm.gas import init_code_cost
 
     num_zeros = Uint(tx.data.count(0))
@@ -639,7 +644,9 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
 
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
-        auth_cost += Uint(GAS_AUTH_PER_EMPTY_ACCOUNT * len(tx.authorizations))
+        auth_cost += Uint(
+            GAS_TX_SET_CODE_AUTHORIZATION * len(tx.authorizations)
+        )
 
     return (
         Uint(

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -53,6 +53,8 @@ gas cost for transactions that include calldata.
 GAS_TX_CREATE = Uint(9000 + 112 * 1174)
 """
 Additional intrinsic gas cost for creating a new contract under [EIP-8037].
+
+[EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 """
 
 GAS_TX_ACCESS_LIST_ADDRESS = Uint(2400)
@@ -69,6 +71,8 @@ GAS_TX_SET_CODE_AUTHORIZATION = Uint(7500 + (23 + 112) * 1174)
 """
 Additional intrinsic gas cost per authorization in a set-code transaction
 under [EIP-8037]. This is separate from the runtime authorization charge.
+
+[EIP-8037]: https://eips.ethereum.org/EIPS/eip-8037
 """
 
 TX_MAX_GAS_LIMIT = Uint(16_777_216)
@@ -645,7 +649,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     auth_cost = Uint(0)
     if isinstance(tx, SetCodeTransaction):
         auth_cost += Uint(
-            GAS_TX_SET_CODE_AUTHORIZATION * len(tx.authorizations)
+            GAS_TX_SET_CODE_AUTHORIZATION * ulen(tx.authorizations)
         )
 
     return (

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -45,7 +45,8 @@ GAS_LOG = Uint(375)
 GAS_LOG_DATA_PER_BYTE = Uint(8)
 GAS_LOG_TOPIC = Uint(375)
 GAS_CREATE = Uint(32000)
-GAS_CODE_DEPOSIT_PER_BYTE = Uint(200)
+GAS_CODE_DEPOSIT_PER_WORD = Uint(6)
+GAS_CODE_DEPOSIT_STATE_PER_BYTE = Uint(1174)
 GAS_ZERO = Uint(0)
 GAS_NEW_ACCOUNT = Uint(25000)
 GAS_CALL_VALUE = Uint(9000)
@@ -304,6 +305,28 @@ def init_code_cost(init_code_length: Uint) -> Uint:
 
     """
     return GAS_CODE_INIT_PER_WORD * ceil32(init_code_length) // Uint(32)
+
+
+def calculate_code_deposit_cost(code_length: Uint) -> Uint:
+    """
+    Calculates the total EIP-8037 code-deposit cost.
+
+    Parameters
+    ----------
+    code_length :
+        The length of the code returned by initcode.
+
+    Returns
+    -------
+    code_deposit_gas: `ethereum.base_types.Uint`
+        The total gas charged for depositing the returned code.
+
+    """
+    code_words = ceil32(code_length) // Uint(32)
+    return (
+        code_words * GAS_CODE_DEPOSIT_PER_WORD
+        + code_length * GAS_CODE_DEPOSIT_STATE_PER_BYTE
+    )
 
 
 def calculate_excess_blob_gas(

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -46,7 +46,7 @@ from ..state_tracker import (
 )
 from ..vm import Message
 from ..vm.eoa_delegation import get_delegated_code_address, set_delegation
-from ..vm.gas import GAS_CODE_DEPOSIT_PER_BYTE, charge_gas
+from ..vm.gas import calculate_code_deposit_cost, charge_gas
 from ..vm.precompiled_contracts.mapping import PRE_COMPILED_CONTRACTS
 from . import Evm
 from .exceptions import (
@@ -200,8 +200,8 @@ def process_create_message(message: Message) -> Evm:
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output
-        contract_code_gas = (
-            Uint(len(contract_code)) * GAS_CODE_DEPOSIT_PER_BYTE
+        contract_code_gas = calculate_code_deposit_cost(
+            Uint(len(contract_code))
         )
         try:
             if len(contract_code) > 0:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/__init__.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EIP-8037 state creation gas cost increase."""

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/spec.py
@@ -1,0 +1,34 @@
+"""Defines EIP-8037 specification constants and functions."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Defines the reference spec version and git path."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_8037 = ReferenceSpec(
+    "EIPS/eip-8037.md", "e8ad70217a9853a16e1d78aeb37dd738e6ef3694"
+)
+
+
+@dataclass(frozen=True)
+class Spec:
+    """
+    Parameters from the EIP-8037 specification as defined at
+    https://eips.ethereum.org/EIPS/eip-8037.
+    """
+
+    COST_PER_STATE_BYTE = 1_174
+    CREATE_REGULAR = 9_000
+    CREATE_STATE = 112 * COST_PER_STATE_BYTE
+    PER_AUTH_BASE_REGULAR = 7_500
+    PER_AUTH_BASE_STATE = 23 * COST_PER_STATE_BYTE
+    PER_EMPTY_ACCOUNT_STATE = 112 * COST_PER_STATE_BYTE
+    TOTAL_AUTH_STATE = PER_AUTH_BASE_STATE + PER_EMPTY_ACCOUNT_STATE
+    CODE_DEPOSIT_REGULAR_PER_WORD = 6
+    CODE_DEPOSIT_STATE_PER_BYTE = COST_PER_STATE_BYTE

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
@@ -1,0 +1,141 @@
+"""Tests for EIP-8037 gas validation and code-deposit edge cases."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    AuthorizationTuple,
+    Op,
+    StateTestFiller,
+    Transaction,
+    TransactionException,
+    compute_create_address,
+)
+
+from .spec import Spec, ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+
+@pytest.mark.exception_test
+@pytest.mark.with_all_contract_creating_tx_types()
+def test_create_tx_intrinsic_gas_includes_state_component(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx_type: int,
+) -> None:
+    """
+    Contract-creating transactions must include the EIP-8037 intrinsic state
+    gas for account creation.
+    """
+    tx = Transaction(
+        ty=tx_type,
+        sender=pre.fund_eoa(),
+        to=None,
+        data=b"",
+        gas_limit=21_000 + Spec.CREATE_REGULAR,
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.exception_test
+def test_set_code_tx_intrinsic_gas_includes_state_component(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Set-code transactions must include the EIP-8037 intrinsic state gas for
+    each authorization.
+    """
+    auth_signer = pre.fund_eoa()
+    delegated_to = pre.fund_eoa(0)
+    destination = pre.deploy_contract(code=Op.STOP)
+
+    tx = Transaction(
+        ty=4,
+        sender=pre.fund_eoa(),
+        to=destination,
+        gas_limit=21_000 + Spec.PER_AUTH_BASE_REGULAR,
+        authorization_list=[
+            AuthorizationTuple(
+                address=delegated_to,
+                nonce=0,
+                signer=auth_signer,
+            )
+        ],
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "gas_limit,error",
+    [
+        pytest.param(
+            23_000,
+            TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+            id="below_floor",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(25_000, None, id="at_floor"),
+    ],
+)
+def test_floor_gas_is_still_enforced_when_state_gas_is_enabled(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    gas_limit: int,
+    error: TransactionException | None,
+) -> None:
+    """
+    Amsterdam inherits EIP-7623 floor gas, so below-floor calldata-heavy
+    transactions must still be rejected when EIP-8037 is active.
+    """
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=pre.fund_eoa(0),
+        data=b"\x01" * 100,
+        gas_limit=gas_limit,
+        error=error,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
+def test_nested_create_code_deposit_does_not_borrow_parent_regular_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    A CREATE child that ends initcode execution with 1,175 regular gas must
+    fail a 1-byte code deposit, which needs 6 regular gas plus a 1,174 gas
+    state spill.
+    """
+    initcode = Op.PUSH1(1) + Op.PUSH1(0) + Op.RETURN
+    factory_code = (
+        Op.MSTORE(0, Op.PUSH32(bytes(initcode)))
+        + Op.POP(Op.CREATE(offset=32 - len(initcode), size=len(initcode)))
+        + Op.STOP
+    )
+    factory = pre.deploy_contract(code=factory_code)
+    created_contract = compute_create_address(address=factory, nonce=1)
+
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=factory,
+        gas_limit=54_225,
+    )
+
+    state_test(
+        pre=pre,
+        tx=tx,
+        post={
+            factory: Account(nonce=2),
+            created_contract: Account.NONEXISTENT,
+        },
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
@@ -31,12 +31,14 @@ def test_create_tx_intrinsic_gas_includes_state_component(
     Contract-creating transactions must include the EIP-8037 intrinsic state
     gas for account creation.
     """
+    intrinsic_gas = 21_000 + Spec.CREATE_REGULAR + Spec.CREATE_STATE
+
     tx = Transaction(
         ty=tx_type,
         sender=pre.fund_eoa(),
         to=None,
         data=b"",
-        gas_limit=21_000 + Spec.CREATE_REGULAR,
+        gas_limit=intrinsic_gas - 1,
         error=TransactionException.INTRINSIC_GAS_TOO_LOW,
     )
 
@@ -52,6 +54,9 @@ def test_set_code_tx_intrinsic_gas_includes_state_component(
     Set-code transactions must include the EIP-8037 intrinsic state gas for
     each authorization.
     """
+    intrinsic_gas = (
+        21_000 + Spec.PER_AUTH_BASE_REGULAR + Spec.TOTAL_AUTH_STATE
+    )
     auth_signer = pre.fund_eoa()
     delegated_to = pre.fund_eoa(0)
     destination = pre.deploy_contract(code=Op.STOP)
@@ -60,7 +65,7 @@ def test_set_code_tx_intrinsic_gas_includes_state_component(
         ty=4,
         sender=pre.fund_eoa(),
         to=destination,
-        gas_limit=21_000 + Spec.PER_AUTH_BASE_REGULAR,
+        gas_limit=intrinsic_gas - 1,
         authorization_list=[
             AuthorizationTuple(
                 address=delegated_to,
@@ -128,6 +133,9 @@ def test_nested_create_code_deposit_does_not_borrow_parent_regular_gas(
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=factory,
+        # 54,225 is the smallest tx gas limit that makes the inner CREATE
+        # finish initcode with 1,175 gas: enough for the 6-gas regular
+        # pre-check, but not enough for the 6 + 1,174 state-spill deposit.
         gas_limit=54_225,
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_gas_accounting.py
@@ -54,9 +54,7 @@ def test_set_code_tx_intrinsic_gas_includes_state_component(
     Set-code transactions must include the EIP-8037 intrinsic state gas for
     each authorization.
     """
-    intrinsic_gas = (
-        21_000 + Spec.PER_AUTH_BASE_REGULAR + Spec.TOTAL_AUTH_STATE
-    )
+    intrinsic_gas = 21_000 + Spec.PER_AUTH_BASE_REGULAR + Spec.TOTAL_AUTH_STATE
     auth_signer = pre.fund_eoa()
     delegated_to = pre.fund_eoa(0)
     destination = pre.deploy_contract(code=Op.STOP)


### PR DESCRIPTION
## 🗒️ Description

Add Amsterdam EIP-8037 coverage for the three missing gas-accounting cases from #2426:

- intrinsic gas must include the EIP-8037 state component for contract-creating transactions
- intrinsic gas must include the EIP-8037 state component for set-code transactions
- EIP-7623 floor gas must still be enforced when EIP-8037 is active
- nested CREATE code deposit must not succeed by effectively borrowing parent gas

This PR adds a new Amsterdam test module for those scenarios and updates the Amsterdam EELS code-deposit charging path to use the EIP-8037 total code-deposit cost, which was required for the nested CREATE regression to fill correctly.

## 🔗 Related Issues or PRs

Closes #2426.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/)
and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
  ```console
  uvx tox -e static
  ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-
titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/
tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/
post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/
static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Cute animal picture](https://images.unsplash.com/photo-1517849845537-4d257902454a)