### PR TITLE
fix(workflow): perform more actions before aborting and prio oldest prs/issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,12 @@ jobs:
           # --- Stale settings ---
           days-before-stale: 60
 
+          # raise this from the default 30
+          operations-per-run: 200
+
+          # process oldest first
+          ascending: true
+
           # --- PR settings ---
           days-before-pr-close: 0  # PR immediately auto-closes when marked stale
           stale-pr-label: 'stale'


### PR DESCRIPTION
## 🗒️ Description
The logs our first run of this workflow revealed:

```
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the  operations-per-run (​[https://github.com/actions/stale#operations-per-run​)](https://github.com/actions/stale#operations-per-run%E2%80%8B))  option which is currently set to  30
Statistics:
Processed items: 129
├── Processed issues: 80
└── Processed PRs   : 49
New stale items: 7
├── New stale issues: 6
└── New stale PRs   : 1
Closed PRs: 1
Added items labels: 7
├── Added issues labels: 6
└── Added PRs labels   : 1
Added items comments: 8
├── Added issues comments: 6
└── Added PRs comments   : 2
Fetched items: 200
Fetched items events: 7
Fetched items comments: 7
Operations performed: 32
Github API rate used: 32
Github API rate remaining: 4959; reset at: Fri Mar 06 2026 00:22:19 GMT+0000 (Coordinated Universal Time)
```

Currently we have a limit of `30` (operations, this does not refer to amount of PRs or whatever) and at the end we can see that increasing the `30` to `200` (what this PR does) is safe because we only consumed `32 out of 4959+32` API calls available to use during that hour. The [stale docs](https://github.com/actions/stale?tab=readme-ov-file#operations-per-run) also show that if your GitHub API limit allows for more you can adjust, the just chose a small safe default for everyone.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
