### PR TITLE
feat(test-benchmark): support repricing marker for stateful benchmark

### DIFF
--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -13,7 +13,6 @@ Supported Opcodes:
 """
 
 import math
-from typing import Any
 
 import pytest
 from execution_testing import (
@@ -149,90 +148,6 @@ def test_extcodecopy_warm(
         code_generator=JumpLoopGenerator(
             setup=Op.PUSH10(copy_size) + Op.PUSH20(copied_contract_address),
             attack_block=Op.EXTCODECOPY(Op.DUP4, 0, 0, Op.DUP2),
-        ),
-    )
-
-
-@pytest.mark.repricing(
-    empty_code=True,
-    initial_balance=True,
-    initial_storage=True,
-)
-@pytest.mark.parametrize(
-    "opcode",
-    [
-        Op.BALANCE,
-        Op.EXTCODESIZE,
-        Op.EXTCODEHASH,
-        Op.CALL,
-        Op.CALLCODE,
-        Op.DELEGATECALL,
-        Op.STATICCALL,
-    ],
-)
-@pytest.mark.parametrize(
-    "empty_code",
-    [
-        True,
-        False,
-    ],
-)
-@pytest.mark.parametrize(
-    "initial_balance",
-    [
-        True,
-        False,
-    ],
-)
-@pytest.mark.parametrize(
-    "initial_storage",
-    [
-        True,
-        False,
-    ],
-)
-def test_ext_account_query_warm(
-    benchmark_test: BenchmarkTestFiller,
-    pre: Alloc,
-    opcode: Op,
-    empty_code: bool,
-    initial_balance: bool,
-    initial_storage: bool,
-) -> None:
-    """
-    Test running a block with as many stateful opcodes doing warm access
-    for an account.
-    """
-    # Setup
-    post = {}
-
-    # Case 1: Completely empty account (no balance, no storage, no code)
-    if not initial_balance and not initial_storage and empty_code:
-        target_addr = pre.nonexistent_account()
-    # Case 2: EOA with optional balance and storage
-    elif empty_code:
-        eoa_kwargs: dict[str, Any] = {}
-        if initial_balance:
-            eoa_kwargs["amount"] = 100
-        if initial_storage:
-            eoa_kwargs["storage"] = {0: 0x1337}
-        target_addr = pre.fund_eoa(**eoa_kwargs)
-    # Case 3: Contract with optional balance and storage
-    else:
-        contract_kwargs: dict[str, Any] = {"code": Op.STOP + Op.JUMPDEST * 100}
-        if initial_balance:
-            contract_kwargs["balance"] = 100
-        if initial_storage:
-            contract_kwargs["storage"] = {0: 0x1337}
-        target_addr = pre.deploy_contract(**contract_kwargs)
-        post[target_addr] = Account(**contract_kwargs)
-
-    benchmark_test(
-        target_opcode=opcode,
-        post=post,
-        code_generator=JumpLoopGenerator(
-            setup=Op.MSTORE(0, target_addr),
-            attack_block=Op.POP(opcode(address=Op.MLOAD(0))),
         ),
     )
 

--- a/tests/benchmark/stateful/bloatnet/test_account_query.py
+++ b/tests/benchmark/stateful/bloatnet/test_account_query.py
@@ -12,7 +12,7 @@ Supported Opcodes:
 - BALANCE
 """
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import pytest
 from execution_testing import (
@@ -26,6 +26,7 @@ from execution_testing import (
     Fork,
     Hash,
     IteratingBytecode,
+    JumpLoopGenerator,
     Op,
     ParameterSet,
     TestPhaseManager,
@@ -100,7 +101,6 @@ def generate_account_query_params() -> List[ParameterSet]:
     return params
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize(
     "opcode,access_warm,mem_size,code_size,value_sent",
     generate_account_query_params(),
@@ -302,4 +302,88 @@ def test_account_query(
         ],
         target_opcode=opcode,
         expected_benchmark_gas_used=total_gas_cost,
+    )
+
+
+@pytest.mark.repricing(
+    empty_code=True,
+    initial_balance=True,
+    initial_storage=True,
+)
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.BALANCE,
+        Op.EXTCODESIZE,
+        Op.EXTCODEHASH,
+        Op.CALL,
+        Op.CALLCODE,
+        Op.DELEGATECALL,
+        Op.STATICCALL,
+    ],
+)
+@pytest.mark.parametrize(
+    "empty_code",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "initial_balance",
+    [
+        True,
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "initial_storage",
+    [
+        True,
+        False,
+    ],
+)
+def test_ext_account_query_warm(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    opcode: Op,
+    empty_code: bool,
+    initial_balance: bool,
+    initial_storage: bool,
+) -> None:
+    """
+    Test running a block with as many stateful opcodes doing warm access
+    for an account.
+    """
+    # Setup
+    post = {}
+
+    # Case 1: Completely empty account (no balance, no storage, no code)
+    if not initial_balance and not initial_storage and empty_code:
+        target_addr = pre.nonexistent_account()
+    # Case 2: EOA with optional balance and storage
+    elif empty_code:
+        eoa_kwargs: dict[str, Any] = {}
+        if initial_balance:
+            eoa_kwargs["amount"] = 100
+        if initial_storage:
+            eoa_kwargs["storage"] = {0: 0x1337}
+        target_addr = pre.fund_eoa(**eoa_kwargs)
+    # Case 3: Contract with optional balance and storage
+    else:
+        contract_kwargs: dict[str, Any] = {"code": Op.STOP + Op.JUMPDEST * 100}
+        if initial_balance:
+            contract_kwargs["balance"] = 100
+        if initial_storage:
+            contract_kwargs["storage"] = {0: 0x1337}
+        target_addr = pre.deploy_contract(**contract_kwargs)
+        post[target_addr] = Account(**contract_kwargs)
+
+    benchmark_test(
+        target_opcode=opcode,
+        post=post,
+        code_generator=JumpLoopGenerator(
+            setup=Op.MSTORE(0, target_addr),
+            attack_block=Op.POP(opcode(address=Op.MLOAD(0))),
+        ),
     )

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -105,6 +105,7 @@ START_SLOT = (
 #   - Simulates real-world contract state accumulation over time
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("token_name", SLOAD_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
@@ -625,6 +626,7 @@ def build_external_call(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("token_name", SSTORE_MINT_TOKENS)
 @pytest.mark.parametrize("existing_slots", [False, True])
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
@@ -1529,6 +1531,7 @@ def test_storage_sload_benchmark(
     )
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("storage_keys_pre_set", [False, True])
 def test_storage_sload_same_key_benchmark(
     benchmark_test: BenchmarkTestFiller,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

In the past, we could not provide `-m repricing` flag to limit the test run. This PR adds repricing marker support to `stateful` benchmark.

And add repricing marker label for:

- test_account_access
- test_sstore_erc20_mint
- test_sload_erc20_balanceof
- test_storage_sload_same_key_benchmark
- test_ext_account_query_warm

Also, move `test_ext_account_query_warm` under stateful folder. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
