### PR TITLE
feat(zkevm): Add stateless input and output into fixtures

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -291,9 +291,8 @@ class Result(CamelModel):
     block_access_list: BlockAccessList | None = None
     block_access_list_hash: Hash | None = None
     execution_witness: ExecutionWitness | None = None
-    # TODO: Re-enable, compare fixtures will fail
-    # stateless_input_bytes: Bytes | None = None
-    # stateless_output_bytes: Bytes | None = None
+    stateless_input_bytes: Bytes | None = None
+    stateless_output_bytes: Bytes | None = None
     block_exception: Annotated[
         BlockExceptionWithMessage | UndefinedException | None,
         ExceptionMapperValidator,

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -626,9 +626,8 @@ class FixtureBlockBase(CamelModel):
     withdrawals: List[FixtureWithdrawal] | None = None
     receipts: List[FixtureTransactionReceipt] | None = None
     execution_witness: ExecutionWitness | None = None
-    # TODO: Re-enable, compare fixtures will fail
-    # stateless_input_bytes: Bytes | None = None
-    # stateless_output_bytes: Bytes | None = None
+    stateless_input_bytes: Bytes | None = None
+    stateless_output_bytes: Bytes | None = None
     block_access_list: BlockAccessList | None = Field(
         None, description="EIP-7928 Block Access List"
     )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -387,9 +387,8 @@ class BuiltBlock(CamelModel):
     fork: Fork
     block_access_list: BlockAccessList | None
     execution_witness: ExecutionWitness | None = None
-    # TODO: Re-enable, compare fixtures will fail
-    # stateless_input_bytes: Bytes | None = None
-    # stateless_output_bytes: Bytes | None = None
+    stateless_input_bytes: Bytes | None = None
+    stateless_output_bytes: Bytes | None = None
 
     def get_fixture_block(
         self, *, include_receipts: bool = True
@@ -422,13 +421,12 @@ class BuiltBlock(CamelModel):
             execution_witness=self.execution_witness
             if self.execution_witness
             else None,
-            # TODO: Re-enable once SSZ encoding is finalized
-            # stateless_input_bytes=self.stateless_input_bytes
-            # if self.stateless_input_bytes
-            # else None,
-            # stateless_output_bytes=self.stateless_output_bytes
-            # if self.stateless_output_bytes
-            # else None,
+            stateless_input_bytes=self.stateless_input_bytes
+            if self.stateless_input_bytes
+            else None,
+            stateless_output_bytes=self.stateless_output_bytes
+            if self.stateless_output_bytes
+            else None,
             fork=self.fork,
         ).with_rlp(txs=self.txs)
 
@@ -795,13 +793,12 @@ class BlockchainTest(BaseTest):
             execution_witness=(
                 transition_tool_output.result.execution_witness
             ),
-            # TODO: Re-enable, compare fixtures will fail
-            # stateless_input_bytes=(
-            #     transition_tool_output.result.stateless_input_bytes
-            # ),
-            # stateless_output_bytes=(
-            #     transition_tool_output.result.stateless_output_bytes
-            # ),
+            stateless_input_bytes=(
+                transition_tool_output.result.stateless_input_bytes
+            ),
+            stateless_output_bytes=(
+                transition_tool_output.result.stateless_output_bytes
+            ),
         )
 
         try:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -278,9 +278,8 @@ class Result:
     block_access_list: Optional[Any] = None
     block_access_list_hash: Optional[Hash32] = None
     execution_witness: Optional[Any] = None
-    # TODO: Re-enable, compare fixtures will fail
-    # stateless_input_bytes: Optional[bytes] = None
-    # stateless_output_bytes: Optional[bytes] = None
+    stateless_input_bytes: Optional[bytes] = None
+    stateless_output_bytes: Optional[bytes] = None
 
     def get_receipts_from_output(
         self,
@@ -378,8 +377,6 @@ class Result:
                 block_output.block_access_list
             )
 
-        # TODO: Re-enable stateless guest once state test handling is
-        # resolved. Currently fails on state tests.
         if self.execution_witness is not None:
             withdrawals = (
                 tuple(t8n.env.withdrawals) if t8n.env.withdrawals else ()
@@ -450,8 +447,8 @@ class Result:
                 assert result.successful_validation, (
                     "Stateless validation failed"
                 )
-        #     self.stateless_input_bytes = bytes(stateless_input_bytes)
-        #     self.stateless_output_bytes = bytes(stateless_output_bytes)
+            self.stateless_input_bytes = bytes(stateless_input_bytes)
+            self.stateless_output_bytes = bytes(stateless_output_bytes)
 
     @staticmethod
     def _block_access_list_to_json(account_changes: Any) -> Any:
@@ -618,15 +615,14 @@ class Result:
                 "headers": ["0x" + h.hex() for h in ew.headers],
             }
 
-        # TODO: Re-enable but compare fixtures will fail
-        # if self.stateless_input_bytes is not None:
-        #     data["statelessInputBytes"] = (
-        #         "0x" + self.stateless_input_bytes.hex()
-        #     )
-        #
-        # if self.stateless_output_bytes is not None:
-        #     data["statelessOutputBytes"] = (
-        #         "0x" + self.stateless_output_bytes.hex()
-        #     )
+        if self.stateless_input_bytes is not None:
+            data["statelessInputBytes"] = (
+                "0x" + self.stateless_input_bytes.hex()
+            )
+
+        if self.stateless_output_bytes is not None:
+            data["statelessOutputBytes"] = (
+                "0x" + self.stateless_output_bytes.hex()
+            )
 
         return data


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Continuation of https://github.com/ethereum/execution-specs/pull/2362

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
