### PR TITLE
fix(benchmarks): fix mint test

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -51,6 +51,13 @@ from tests.benchmark.stateful.helpers import (
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
 REFERENCE_SPEC_VERSION = "1.0"
 
+# keccak256("random") for non-existing slots, masked as address,
+# Solidity does input checks on the size and throws if we input
+# something different than an address
+START_SLOT = (
+    0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
+    % (2**160)
+)
 
 # SLOAD BENCHMARK ARCHITECTURE:
 #
@@ -212,16 +219,8 @@ def test_sload_erc20_balanceof(
     txs = []
     cache_txs = []
     gas_remaining = gas_benchmark_value
-    # Start at 1 (ERC20 bloater writes the balance of address to the slot)
-    # or start at keccak256("random") for non-existing slots
-    slot_offset = (
-        1
-        if existing_slots
-        else (
-            0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
-        )
-        % (2**160)  # Mask it as address otherwise Solidity rejects the input
-    )
+    # Start offset
+    slot_offset = 1 if existing_slots else START_SLOT
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
@@ -613,13 +612,8 @@ def test_sstore_erc20_mint(
     # Storage key to read and write address pointer to
     slot_offset = 0
 
-    # Start at 1 for existing balance slots,
-    # or at keccak256("random") for non-existing slots
-    start_slot = (
-        1
-        if existing_slots
-        else 0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
-    )
+    # Start slot
+    start_slot = 1 if existing_slots else START_SLOT
 
     # Stub Account
     erc20_address = pre.deploy_contract(


### PR DESCRIPTION
## 🗒️ Description
Same problem in this test where Solidity throws if we input to an `address` where the original start offset was higher than uint160, the max address size. Put this constant at the top as mini refactor.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
