### PR TITLE
feat(tests): add more EIP-8037 coverage and harden tests

### DIFF
--- a/packages/testing/src/execution_testing/forks/base_fork.py
+++ b/packages/testing/src/execution_testing/forks/base_fork.py
@@ -659,6 +659,38 @@ class BaseFork(ForkOpcodeInterface, metaclass=BaseForkMeta):
 
     @classmethod
     @abstractmethod
+    def sstore_state_gas(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Return state gas for a zero-to-nonzero SSTORE."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def code_deposit_state_gas(
+        cls,
+        *,
+        code_size: int,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """Return state gas for code deposit of the given size."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_state_gas(
+        cls,
+        *,
+        code_size: int = 0,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """Return total state gas for CREATE."""
+        pass
+
+    @classmethod
+    @abstractmethod
     def block_rlp_size_limit(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int | None:

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1167,6 +1167,30 @@ class Frontier(BaseFork, solc_name="homestead"):
         return None
 
     @classmethod
+    def sstore_state_gas(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Return the state gas for a zero-to-nonzero SSTORE."""
+        del block_number, timestamp
+        return 0
+
+    @classmethod
+    def code_deposit_state_gas(
+        cls, *, code_size: int, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Return the state gas for code deposit of the given size."""
+        del code_size, block_number, timestamp
+        return 0
+
+    @classmethod
+    def create_state_gas(
+        cls, *, code_size: int = 0, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Return total state gas for CREATE (new account + code deposit)."""
+        del code_size, block_number, timestamp
+        return 0
+
+    @classmethod
     def block_rlp_size_limit(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> int | None:
@@ -3439,6 +3463,45 @@ class Amsterdam(BPO2):
         """
         del block_number, timestamp
         return True
+
+    @classmethod
+    def sstore_state_gas(
+        cls, *, block_number: int = 0, timestamp: int = 0
+    ) -> int:
+        """Return state gas for a zero-to-nonzero SSTORE (EIP-8037)."""
+        del block_number, timestamp
+        STATE_BYTES_PER_STORAGE_SET = 32  # noqa: N806
+        return STATE_BYTES_PER_STORAGE_SET * cls.cost_per_state_byte()
+
+    @classmethod
+    def code_deposit_state_gas(
+        cls,
+        *,
+        code_size: int,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """Return state gas for code deposit (EIP-8037)."""
+        del block_number, timestamp
+        return code_size * cls.cost_per_state_byte()
+
+    @classmethod
+    def create_state_gas(
+        cls,
+        *,
+        code_size: int = 0,
+        block_number: int = 0,
+        timestamp: int = 0,
+    ) -> int:
+        """Return total state gas for CREATE (EIP-8037)."""
+        gas_costs = cls.gas_costs(
+            block_number=block_number, timestamp=timestamp
+        )
+        return gas_costs.GAS_NEW_ACCOUNT + cls.code_deposit_state_gas(
+            code_size=code_size,
+            block_number=block_number,
+            timestamp=timestamp,
+        )
 
     @classmethod
     def empty_block_bal_item_count(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
@@ -28,7 +28,7 @@ def test_sstore_zero_to_nonzero(
     """Test SSTORE zero-to-nonzero charges state gas and succeeds."""
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -60,7 +60,6 @@ def test_create_charges_state_gas(
                 storage.store_next(True),
                 Op.GT(Op.CREATE(0, 0, len(init_code)), 0),
             )
-            + Op.STOP
         ),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_eip_mainnet.py
@@ -7,13 +7,14 @@ import pytest
 from execution_testing import (
     Account,
     Alloc,
+    Fork,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -24,8 +25,11 @@ pytestmark = [pytest.mark.valid_at("Amsterdam"), pytest.mark.mainnet]
 def test_sstore_zero_to_nonzero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test SSTORE zero-to-nonzero charges state gas and succeeds."""
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -33,7 +37,7 @@ def test_sstore_zero_to_nonzero(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -44,8 +48,11 @@ def test_sstore_zero_to_nonzero(
 def test_create_charges_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test CREATE charges state gas for new account creation."""
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     init_code = Op.STOP
 
     storage = Storage()
@@ -65,7 +72,7 @@ def test_create_charges_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -76,12 +83,15 @@ def test_create_charges_state_gas(
 def test_create_tx_deploys_contract(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """Test contract creation transaction succeeds with state gas."""
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     tx = Transaction(
         to=None,
         data=Op.STOP,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -49,7 +49,7 @@ def test_child_call_uses_reservoir(
 
     child_storage = Storage()
     child = pre.deploy_contract(
-        code=Op.SSTORE(child_storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(child_storage.store_next(1), 1),
     )
 
     parent_storage = Storage()
@@ -59,7 +59,6 @@ def test_child_call_uses_reservoir(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=child),
             )
-            + Op.STOP
         ),
     )
 
@@ -100,7 +99,6 @@ def test_reservoir_returned_on_revert(
             Op.POP(Op.CALL(gas=100_000, address=child))
             # Parent can still use reservoir for its own SSTORE
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -139,7 +137,6 @@ def test_reservoir_returned_on_oog(
             Op.POP(Op.CALL(gas=100, address=child))
             # Parent can still use reservoir for SSTORE
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -186,7 +183,6 @@ def test_reservoir_restored_after_child_spill_and_revert(
             # can perform two SSTOREs from the recovered reservoir
             + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -232,7 +228,6 @@ def test_reservoir_restored_after_child_spill_and_halt(
             # can perform two SSTOREs from the recovered reservoir
             + Op.SSTORE(parent_storage.store_next(1), 1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -272,7 +267,6 @@ def test_reservoir_restored_after_child_full_drain_and_revert(
         code=(
             Op.POP(Op.CALL(gas=500_000, address=child))
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -316,7 +310,6 @@ def test_sequential_calls_reservoir_restored_between_reverts(
             + Op.POP(Op.CALL(gas=500_000, address=child))
             # Parent SSTORE succeeds with restored reservoir
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -348,11 +341,11 @@ def test_nested_calls_reservoir_passing(
 
     c_storage = Storage()
     c = pre.deploy_contract(
-        code=Op.SSTORE(c_storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(c_storage.store_next(1), 1),
     )
 
     b = pre.deploy_contract(
-        code=Op.CALL(gas=200_000, address=c) + Op.STOP,
+        code=Op.CALL(gas=200_000, address=c),
     )
 
     a_storage = Storage()
@@ -362,7 +355,6 @@ def test_nested_calls_reservoir_passing(
                 a_storage.store_next(1),
                 Op.CALL(gas=300_000, address=b),
             )
-            + Op.STOP
         ),
     )
 
@@ -388,7 +380,7 @@ def test_call_value_transfer_new_account(
     Test CALL with value to non-existent account charges state gas.
 
     A CALL that transfers value to a non-existent account creates a
-    new account, charging 112 * cost_per_state_byte of state gas.
+    new account, charging new-account state gas of state gas.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
@@ -404,7 +396,6 @@ def test_call_value_transfer_new_account(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=target, value=1),
             )
-            + Op.STOP
         ),
         balance=1,
     )
@@ -440,7 +431,6 @@ def test_call_value_transfer_existing_account_no_state_gas(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=target, value=1),
             )
-            + Op.STOP
         ),
         balance=1,
     )
@@ -474,7 +464,7 @@ def test_child_state_gas_tracked_in_parent(
 
     child_storage = Storage()
     child = pre.deploy_contract(
-        code=Op.SSTORE(child_storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(child_storage.store_next(1), 1),
     )
 
     parent_storage = Storage()
@@ -487,7 +477,6 @@ def test_child_state_gas_tracked_in_parent(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=child),
             )
-            + Op.STOP
         ),
     )
 
@@ -523,13 +512,13 @@ def test_delegatecall_reservoir_passing(
 
     # Library code that writes to slot 0 — runs in parent's context
     library = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     parent_storage = Storage()
     parent_storage[0] = 1  # Expect slot 0 = 1 after delegatecall
     parent = pre.deploy_contract(
-        code=(Op.DELEGATECALL(gas=100_000, address=library) + Op.STOP),
+        code=(Op.DELEGATECALL(gas=100_000, address=library)),
     )
 
     tx = Transaction(
@@ -560,7 +549,7 @@ def test_staticcall_passes_reservoir(
 
     # Child does a read-only operation
     child = pre.deploy_contract(
-        code=Op.MSTORE(0, Op.ADDRESS) + Op.STOP,
+        code=Op.MSTORE(0, Op.ADDRESS),
     )
 
     parent_storage = Storage()
@@ -569,7 +558,6 @@ def test_staticcall_passes_reservoir(
             Op.POP(Op.STATICCALL(gas=100_000, address=child))
             # Reservoir should still be available for parent's SSTORE
             + Op.SSTORE(parent_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -606,7 +594,6 @@ def test_gas_opcode_excludes_reservoir(
             Op.SSTORE(0, Op.GAS)
             # Store 1 to prove execution reached this point
             + Op.SSTORE(storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -654,7 +641,6 @@ def test_call_insufficient_balance_returns_reservoir(
             )
             # Reservoir should be returned — SSTORE still works
             + Op.SSTORE(storage.store_next(1, "sstore_after"), 1)
-            + Op.STOP
         ),
     )
 
@@ -695,7 +681,6 @@ def test_create_insufficient_balance_returns_reservoir(
             )
             # Reservoir returned — SSTORE still works
             + Op.SSTORE(storage.store_next(1, "sstore_after"), 1)
-            + Op.STOP
         ),
     )
 
@@ -735,7 +720,6 @@ def test_call_stack_depth_returns_reservoir(
             # After recursion unwinds, only the outermost frame
             # reaches this SSTORE
             + Op.SSTORE(storage.store_next(1, "after_recursion"), 1)
-            + Op.STOP
         ),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -17,6 +17,7 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 import pytest
 from execution_testing import (
     Account,
+    Address,
     Alloc,
     Environment,
     Fork,
@@ -644,33 +645,51 @@ def test_gas_opcode_excludes_reservoir(
     state_test(env=env, pre=pre, post=post, tx=tx)
 
 
+@pytest.mark.parametrize(
+    "target_exists",
+    [
+        pytest.param(True, id="existing_account"),
+        pytest.param(False, id="new_account"),
+    ],
+)
 @pytest.mark.valid_from("Amsterdam")
 def test_call_insufficient_balance_returns_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     fork: Fork,
+    target_exists: bool,
 ) -> None:
     """
     Test CALL with insufficient balance returns reservoir to parent.
 
-    When a CALL transfers value but the sender has insufficient balance,
-    the call fails and both gas_left and state_gas_left are returned
-    to the parent frame. The parent can still use the reservoir.
+    When a CALL transfers value but the caller has insufficient balance,
+    the call fails before any state gas is charged for the target
+    account. Both gas_left and state_gas_left are returned to the
+    parent frame. The parent can still use the reservoir for a
+    subsequent SSTORE.
     """
+    gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     env = Environment()
     sstore_state_gas = fork.sstore_state_gas()
 
-    child = pre.deploy_contract(code=Op.STOP)
+    target: int | Address
+    if target_exists:
+        target = pre.deploy_contract(code=Op.STOP)
+        reservoir = sstore_state_gas
+    else:
+        target = 0xDEAD
+        # New account needs new-account state gas too
+        reservoir = sstore_state_gas + gas_costs.GAS_NEW_ACCOUNT
 
     storage = Storage()
     contract = pre.deploy_contract(
         code=(
-            # CALL with 1 wei to child — will fail (contract has 0 balance)
+            # CALL with 1 wei — fails (contract has 0 balance)
             Op.SSTORE(
                 storage.store_next(0, "call_fails"),
-                Op.CALL(100_000, child, 1, 0, 0, 0, 0),
+                Op.CALL(100_000, target, 1, 0, 0, 0, 0),
             )
             # Reservoir should be returned — SSTORE still works
             + Op.SSTORE(storage.store_next(1, "sstore_after"), 1)
@@ -679,7 +698,7 @@ def test_call_insufficient_balance_returns_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=gas_limit_cap + sstore_state_gas,
+        gas_limit=gas_limit_cap + reservoir,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -19,13 +19,14 @@ from execution_testing import (
     Account,
     Alloc,
     Environment,
+    Fork,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -35,6 +36,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_child_call_uses_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test child call can use parent's state gas reservoir.
@@ -43,9 +45,10 @@ def test_child_call_uses_reservoir(
     (zero-to-nonzero). The state gas for the SSTORE is drawn from
     the reservoir passed from the parent.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child_storage = Storage()
     child = pre.deploy_contract(
@@ -64,7 +67,7 @@ def test_child_call_uses_reservoir(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -79,6 +82,7 @@ def test_child_call_uses_reservoir(
 def test_reservoir_returned_on_revert(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas reservoir is returned to parent on child revert.
@@ -86,9 +90,10 @@ def test_reservoir_returned_on_revert(
     The child contract reverts. The parent should recover the
     reservoir and be able to use it for its own SSTORE.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child = pre.deploy_contract(code=Op.REVERT(0, 0))
 
@@ -104,7 +109,7 @@ def test_reservoir_returned_on_revert(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -116,6 +121,7 @@ def test_reservoir_returned_on_revert(
 def test_reservoir_returned_on_oog(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas reservoir is returned to parent on child OOG.
@@ -123,9 +129,10 @@ def test_reservoir_returned_on_oog(
     The child runs out of regular gas. The parent recovers the
     reservoir and can use it for its own state operations.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Child that consumes all gas
     child = pre.deploy_contract(code=Op.INVALID)
@@ -142,7 +149,7 @@ def test_reservoir_returned_on_oog(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -154,6 +161,7 @@ def test_reservoir_returned_on_oog(
 def test_reservoir_restored_after_child_spill_and_revert(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test all state gas recovered when child spills then reverts.
@@ -165,9 +173,10 @@ def test_reservoir_restored_after_child_spill_and_revert(
     restored to the parent's reservoir. The parent can then perform
     two SSTOREs using only the recovered reservoir.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Child does two SSTOREs then reverts — the second SSTORE's
     # state gas spills from the reservoir into `gas_left`
@@ -189,7 +198,7 @@ def test_reservoir_restored_after_child_spill_and_revert(
     # Reservoir = 1 SSTORE's worth of state gas — child will spill
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -201,6 +210,7 @@ def test_reservoir_restored_after_child_spill_and_revert(
 def test_reservoir_restored_after_child_spill_and_halt(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test all state gas recovered when child spills then halts.
@@ -211,9 +221,10 @@ def test_reservoir_restored_after_child_spill_and_halt(
     (reservoir + spill) is restored to the parent's reservoir. The
     parent can then perform two SSTOREs using the recovered reservoir.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Child does two SSTOREs then halts
     child = pre.deploy_contract(
@@ -234,7 +245,7 @@ def test_reservoir_restored_after_child_spill_and_halt(
     # Reservoir = 1 SSTORE's worth of state gas — child will spill
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -246,6 +257,7 @@ def test_reservoir_restored_after_child_spill_and_halt(
 def test_reservoir_restored_after_child_full_drain_and_revert(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test reservoir restored when child exactly exhausts it then reverts.
@@ -254,9 +266,10 @@ def test_reservoir_restored_after_child_full_drain_and_revert(
     (no spill into gas_left), then REVERTs. The full reservoir is
     returned to the parent.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.REVERT(0, 0)),
@@ -272,7 +285,7 @@ def test_reservoir_restored_after_child_full_drain_and_revert(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -284,6 +297,7 @@ def test_reservoir_restored_after_child_full_drain_and_revert(
 def test_sequential_calls_reservoir_restored_between_reverts(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test reservoir restored across sequential child reverts.
@@ -293,9 +307,10 @@ def test_sequential_calls_reservoir_restored_between_reverts(
     child failures restore the reservoir, so the parent can use it
     for its own SSTORE at the end.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.REVERT(0, 0)),
@@ -315,7 +330,7 @@ def test_sequential_calls_reservoir_restored_between_reverts(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -327,6 +342,7 @@ def test_sequential_calls_reservoir_restored_between_reverts(
 def test_nested_calls_reservoir_passing(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test reservoir passes through nested calls.
@@ -335,9 +351,10 @@ def test_nested_calls_reservoir_passing(
     using the reservoir gas. After all calls return, A verifies
     success.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     c_storage = Storage()
     c = pre.deploy_contract(
@@ -360,7 +377,7 @@ def test_nested_calls_reservoir_passing(
 
     tx = Transaction(
         to=a,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -375,6 +392,7 @@ def test_nested_calls_reservoir_passing(
 def test_call_value_transfer_new_account(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CALL with value to non-existent account charges state gas.
@@ -382,9 +400,11 @@ def test_call_value_transfer_new_account(
     A CALL that transfers value to a non-existent account creates a
     new account, charging new-account state gas of state gas.
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    new_account_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     # Target address that doesn't exist in pre-state
     target = 0xDEAD
@@ -402,7 +422,7 @@ def test_call_value_transfer_new_account(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + new_account_state_gas,
+        gas_limit=gas_limit_cap + new_account_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -414,6 +434,7 @@ def test_call_value_transfer_new_account(
 def test_call_value_transfer_existing_account_no_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CALL with value to existing account charges no state gas.
@@ -421,6 +442,8 @@ def test_call_value_transfer_existing_account_no_state_gas(
     A CALL that transfers value to an already-alive account does not
     create new state, so no state gas is charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     # Existing target account
     target = pre.fund_eoa(amount=0)
 
@@ -437,7 +460,7 @@ def test_call_value_transfer_existing_account_no_state_gas(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -449,6 +472,7 @@ def test_call_value_transfer_existing_account_no_state_gas(
 def test_child_state_gas_tracked_in_parent(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas used by child is accumulated in parent.
@@ -458,9 +482,10 @@ def test_child_state_gas_tracked_in_parent(
     succeeding with enough total gas but would OOG if state gas
     wasn't tracked across frames.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child_storage = Storage()
     child = pre.deploy_contract(
@@ -483,7 +508,7 @@ def test_child_state_gas_tracked_in_parent(
     # Provide enough reservoir for both SSTOREs
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas * 2,
+        gas_limit=gas_limit_cap + sstore_state_gas * 2,
         sender=pre.fund_eoa(),
     )
 
@@ -498,6 +523,7 @@ def test_child_state_gas_tracked_in_parent(
 def test_delegatecall_reservoir_passing(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test DELEGATECALL passes full reservoir to child.
@@ -506,9 +532,10 @@ def test_delegatecall_reservoir_passing(
     The child's SSTORE writes to the parent's storage using state
     gas from the reservoir.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Library code that writes to slot 0 — runs in parent's context
     library = pre.deploy_contract(
@@ -523,7 +550,7 @@ def test_delegatecall_reservoir_passing(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -535,6 +562,7 @@ def test_delegatecall_reservoir_passing(
 def test_staticcall_passes_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test STATICCALL passes reservoir but cannot use it for state ops.
@@ -543,9 +571,10 @@ def test_staticcall_passes_reservoir(
     passed to the child but cannot be consumed. After the STATICCALL
     returns, the parent can still use the reservoir for its own SSTORE.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Child does a read-only operation
     child = pre.deploy_contract(
@@ -563,7 +592,7 @@ def test_staticcall_passes_reservoir(
 
     tx = Transaction(
         to=parent,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -575,6 +604,7 @@ def test_staticcall_passes_reservoir(
 def test_gas_opcode_excludes_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test GAS opcode returns gas_left only, excluding the reservoir.
@@ -583,9 +613,10 @@ def test_gas_opcode_excludes_reservoir(
     reservoir is non-empty, the GAS return value should be less than
     the total remaining gas (gas_left + reservoir).
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -601,7 +632,7 @@ def test_gas_opcode_excludes_reservoir(
     reservoir_gas = sstore_state_gas * 100
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + reservoir_gas,
+        gas_limit=gas_limit_cap + reservoir_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -617,6 +648,7 @@ def test_gas_opcode_excludes_reservoir(
 def test_call_insufficient_balance_returns_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CALL with insufficient balance returns reservoir to parent.
@@ -625,9 +657,10 @@ def test_call_insufficient_balance_returns_reservoir(
     the call fails and both gas_left and state_gas_left are returned
     to the parent frame. The parent can still use the reservoir.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     child = pre.deploy_contract(code=Op.STOP)
 
@@ -646,7 +679,7 @@ def test_call_insufficient_balance_returns_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -658,6 +691,7 @@ def test_call_insufficient_balance_returns_reservoir(
 def test_create_insufficient_balance_returns_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CREATE with insufficient balance returns reservoir to parent.
@@ -666,9 +700,10 @@ def test_create_insufficient_balance_returns_reservoir(
     for the endowment, the operation fails and both gas and state gas
     reservoir are returned to the parent frame.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -686,7 +721,7 @@ def test_create_insufficient_balance_returns_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -698,6 +733,7 @@ def test_create_insufficient_balance_returns_reservoir(
 def test_call_stack_depth_returns_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CALL at stack depth limit returns reservoir.
@@ -706,9 +742,10 @@ def test_call_stack_depth_returns_reservoir(
     and gas and state gas reservoir are returned. The parent can still
     use the reservoir for state operations.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Contract that recursively calls itself until depth exhausted,
     # then does an SSTORE using the reservoir
@@ -725,7 +762,7 @@ def test_call_stack_depth_returns_reservoir(
 
     tx = Transaction(
         to=recursive,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -15,6 +15,7 @@ from execution_testing import (
     Account,
     Alloc,
     Environment,
+    Fork,
     Op,
     StateTestFiller,
     Storage,
@@ -22,11 +23,10 @@ from execution_testing import (
 )
 from execution_testing.checklists import EIPChecklist
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
-
 
 
 @EIPChecklist.GasRefundsChanges.Test.CrossFunctional.CalldataCost()
@@ -34,6 +34,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_calldata_floor_with_sstore(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test calldata floor does not affect state gas charging.
@@ -41,6 +42,8 @@ def test_calldata_floor_with_sstore(
     A transaction with large calldata triggers the calldata floor for
     regular gas, but state gas for SSTORE is charged independently.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -52,7 +55,7 @@ def test_calldata_floor_with_sstore(
     tx = Transaction(
         to=contract,
         data=calldata,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -64,6 +67,7 @@ def test_calldata_floor_with_sstore(
 def test_calldata_floor_independent_of_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test calldata floor applies only to regular gas dimension.
@@ -73,6 +77,8 @@ def test_calldata_floor_independent_of_state_gas(
     high calldata and no state operations should succeed even when
     the floor exceeds actual execution gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract = pre.deploy_contract(code=Op.STOP)
 
     # Large calldata so the floor exceeds actual execution gas
@@ -81,7 +87,7 @@ def test_calldata_floor_independent_of_state_gas(
     tx = Transaction(
         to=contract,
         data=calldata,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -92,6 +98,7 @@ def test_calldata_floor_independent_of_state_gas(
 def test_calldata_floor_higher_than_execution_with_state_ops(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas is tracked separately when calldata floor dominates.
@@ -99,9 +106,10 @@ def test_calldata_floor_higher_than_execution_with_state_ops(
     Even when calldata floor > actual regular gas used, state gas for
     SSTORE is charged normally from the reservoir or gas_left.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -114,7 +122,7 @@ def test_calldata_floor_higher_than_execution_with_state_ops(
     tx = Transaction(
         to=contract,
         data=calldata,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -1,10 +1,10 @@
 """
 Test EIP-7623 calldata floor interaction with EIP-8037 state gas.
 
-The calldata floor (tokens_in_calldata * 10 + TX_BASE_COST) applies
-to the regular gas dimension only. It does not affect state gas.
-Block gas accounting uses max(tx_regular_gas, calldata_floor) for
-regular gas and tracks state gas separately.
+The calldata floor applies to the regular gas dimension only. It
+does not affect state gas. Block gas accounting uses
+max(tx_regular_gas, calldata_floor) for regular gas and tracks
+state gas separately.
 
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
@@ -27,11 +27,6 @@ from .spec import Spec, ref_spec_8037
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
-# Calldata floor cost parameters
-COST_PER_TOKEN = 10
-TX_BASE_COST = 21_000
-COST_PER_NONZERO_BYTE = 16
-COST_PER_ZERO_BYTE = 4
 
 
 @EIPChecklist.GasRefundsChanges.Test.CrossFunctional.CalldataCost()
@@ -48,10 +43,10 @@ def test_calldata_floor_with_sstore(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
-    # Large calldata to trigger floor (256 nonzero bytes = 1024 tokens)
+    # Large calldata to trigger the calldata floor
     calldata = b"\x01" * 256
 
     tx = Transaction(
@@ -80,7 +75,7 @@ def test_calldata_floor_independent_of_state_gas(
     """
     contract = pre.deploy_contract(code=Op.STOP)
 
-    # 512 nonzero bytes = 2048 tokens, floor = 2048*10 + 21000 = 41480
+    # Large calldata so the floor exceeds actual execution gas
     calldata = b"\xff" * 512
 
     tx = Transaction(
@@ -110,7 +105,7 @@ def test_calldata_floor_higher_than_execution_with_state_ops(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     # Large calldata so floor dominates regular gas

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -1,10 +1,8 @@
 """
 Test CREATE and CREATE2 state gas charging under EIP-8037.
 
-Contract creation charges state gas for the new account
-(112 * cost_per_state_byte) and for code deposit
-(len(code) * cost_per_state_byte). Regular gas for CREATE is
-REGULAR_GAS_CREATE (9000).
+Contract creation charges state gas for the new account and for
+code deposit. Regular gas for CREATE is charged separately.
 
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
@@ -40,9 +38,8 @@ def test_create_charges_state_gas(
     """
     Test CREATE charges state gas for new account and code deposit.
 
-    A successful CREATE charges 112 * cost_per_state_byte for the new
-    account plus len(runtime_code) * cost_per_state_byte for code
-    deposit.
+    A successful CREATE charges new-account state gas plus code
+    deposit state gas proportional to the deployed code size.
     """
     init_code = Op.STOP
 
@@ -58,7 +55,6 @@ def test_create_charges_state_gas(
                 storage.store_next(True),
                 Op.GT(Op.CREATE(0, 0, len(init_code)), 0),
             )
-            + Op.STOP
         ),
     )
 
@@ -114,7 +110,6 @@ def test_create_with_reservoir(
                 storage.store_next(True),
                 Op.GT(create_call, 0),
             )
-            + Op.STOP
         ),
     )
 
@@ -176,7 +171,7 @@ def test_create_tx_state_gas(
     """
     Test contract creation transaction charges intrinsic state gas.
 
-    A create transaction (to=None) charges 112 * cost_per_state_byte
+    A create transaction (to=None) charges new-account state gas
     as intrinsic state gas for the new account, plus code deposit state
     gas for the deployed bytecode.
     """
@@ -216,7 +211,6 @@ def test_create_revert_no_code_deposit_state_gas(
                 storage.store_next(0),  # CREATE returns 0 on failure
                 Op.CREATE(0, 0, len(init_code)),
             )
-            + Op.STOP
         ),
     )
 
@@ -240,9 +234,9 @@ def test_create_insufficient_state_gas(
     """
     Test CREATE OOGs when state gas is insufficient.
 
-    Provide enough gas for CREATE's regular gas cost (9000) but not
-    enough to cover the 112 * cost_per_state_byte state gas for the
-    new account. The CREATE should fail, returning 0.
+    Provide enough gas for CREATE's regular gas cost but not enough
+    to cover the new-account state gas. The CREATE should fail,
+    returning 0.
     """
     init_code = Op.STOP
 
@@ -258,7 +252,6 @@ def test_create_insufficient_state_gas(
                 storage.store_next(0),  # CREATE returns 0 on OOG
                 Op.CREATE(0, 0, len(init_code)),
             )
-            + Op.STOP
         ),
     )
 
@@ -310,7 +303,6 @@ def test_create2_address_collision(
                 storage.store_next(0, "collision_create2"),
                 Op.CREATE2(0, 0, len(init_code), salt),
             )
-            + Op.STOP
         ),
     )
 
@@ -346,10 +338,8 @@ def test_create_tx_intrinsic_gas_boundary(
     Test CREATE tx intrinsic gas boundary includes state component.
 
     The intrinsic gas for a contract-creating transaction includes
-    both regular gas (GAS_TX_BASE + CREATE_REGULAR + init_code_cost)
-    and state gas (112 * cost_per_state_byte). A transaction with
-    gas_limit exactly at the boundary succeeds; one gas below is
-    rejected.
+    both regular gas and state gas. A transaction with gas_limit
+    exactly at the boundary succeeds; one gas below is rejected.
     """
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
     gas_limit = intrinsic_cost(
@@ -358,7 +348,6 @@ def test_create_tx_intrinsic_gas_boundary(
 
     tx = Transaction(
         to=None,
-        data=Op.STOP,
         gas_limit=gas_limit + gas_delta,
         sender=pre.fund_eoa(),
         error=(
@@ -375,57 +364,70 @@ def test_create_tx_intrinsic_gas_boundary(
 def test_nested_create_code_deposit_cannot_borrow_parent_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test nested CREATE code deposit does not borrow parent gas.
 
-    A parent CALLs a factory that performs CREATE of a 1-byte
-    contract. The parent has no state gas reservoir, so the child
-    also has none. Code deposit requires both regular gas
-    (6 * ceil(1/32) = 6) and state gas (1 * cost_per_state_byte
-    = 1174, spilled from gas_left). The child must have enough
-    gas_left to cover both; it must not succeed by borrowing the
-    parent's retained gas after the child frame merges back.
-
-    Tune gas so the child ends initcode with enough gas for either
-    component alone but not both together.
+    Provide just enough gas for CREATE to start (new account state
+    gas + regular gas) but not enough for the child frame to cover
+    code deposit after init code runs. The CREATE increments the
+    factory nonce but code deposit fails, so no contract is deployed.
     """
-    # Initcode: PUSH1 1, PUSH1 0, RETURN -> deploys 1 byte of 0x00
     init_code = Op.RETURN(0, 1)
+    gas_costs = fork.gas_costs()
+    cpsb = fork.cost_per_state_byte()
+    new_acct_state = gas_costs.GAS_NEW_ACCOUNT
+    code_deposit_state = 1 * cpsb
 
-    storage = Storage()
     factory = pre.deploy_contract(
         code=(
             Op.MSTORE(0, Op.PUSH32(bytes(init_code)))
-            + Op.SSTORE(
-                storage.store_next(0, "create_fails"),
+            + Op.POP(
                 Op.CREATE(
                     value=0,
                     offset=32 - len(init_code),
                     size=len(init_code),
                 ),
             )
-            + Op.STOP
         ),
     )
     created = compute_create_address(
         address=factory, nonce=1
     )
 
-    # Give enough total gas for the parent to execute, but
-    # constrain so the child CREATE frame ends with gas between
-    # code_deposit_state and code_deposit_regular +
-    # code_deposit_state. The child should fail code deposit.
+    # Gas consumed before the child CREATE frame receives gas:
+    # Intrinsic + factory code (PUSH32+PUSH1+MSTORE+mem +
+    # 3xPUSH1) + CREATE regular (+ init_code_cost) + new account
+    # state gas (spilled from gas_left, no reservoir).
+    init_code_word_cost = (
+        gas_costs.GAS_CODE_INIT_PER_WORD
+        * ((len(init_code) + 31) // 32)
+    )
+    pre_child_gas = (
+        gas_costs.GAS_TX_BASE
+        + 7 * gas_costs.GAS_VERY_LOW
+        + gas_costs.GAS_MEMORY
+        + (gas_costs.GAS_CREATE - new_acct_state)
+        + init_code_word_cost
+        + new_acct_state
+    )
+
+    # Init code cost: PUSH1 + PUSH1 + RETURN(+mem expansion)
+    init_cost = 2 * gas_costs.GAS_VERY_LOW + gas_costs.GAS_MEMORY
+    # Target child gas: enough for init, not enough for code deposit
+    target_child = (init_cost + code_deposit_state) // 2
+    factory_remaining = (target_child * 64 + 62) // 63
+    gas_limit = pre_child_gas + factory_remaining
+
     tx = Transaction(
         to=factory,
-        gas_limit=54_225,
+        gas_limit=gas_limit,
         sender=pre.fund_eoa(),
     )
 
     post = {
-        factory: Account(
-            nonce=2, storage=storage
-        ),
+        factory: Account(nonce=2),
         created: Account.NONEXISTENT,
     }
     state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -20,6 +20,8 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionException,
+    compute_create_address,
 )
 from execution_testing.checklists import EIPChecklist
 
@@ -319,4 +321,111 @@ def test_create2_address_collision(
     )
 
     post = {contract: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "gas_delta",
+    [
+        pytest.param(
+            -1,
+            id="below_intrinsic",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(0, id="at_intrinsic"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_create_tx_intrinsic_gas_boundary(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_delta: int,
+) -> None:
+    """
+    Test CREATE tx intrinsic gas boundary includes state component.
+
+    The intrinsic gas for a contract-creating transaction includes
+    both regular gas (GAS_TX_BASE + CREATE_REGULAR + init_code_cost)
+    and state gas (112 * cost_per_state_byte). A transaction with
+    gas_limit exactly at the boundary succeeds; one gas below is
+    rejected.
+    """
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    gas_limit = intrinsic_cost(
+        contract_creation=True,
+    )
+
+    tx = Transaction(
+        to=None,
+        data=Op.STOP,
+        gas_limit=gas_limit + gas_delta,
+        sender=pre.fund_eoa(),
+        error=(
+            TransactionException.INTRINSIC_GAS_TOO_LOW
+            if gas_delta < 0
+            else None
+        ),
+    )
+
+    state_test(pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_nested_create_code_deposit_cannot_borrow_parent_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test nested CREATE code deposit does not borrow parent gas.
+
+    A parent CALLs a factory that performs CREATE of a 1-byte
+    contract. The parent has no state gas reservoir, so the child
+    also has none. Code deposit requires both regular gas
+    (6 * ceil(1/32) = 6) and state gas (1 * cost_per_state_byte
+    = 1174, spilled from gas_left). The child must have enough
+    gas_left to cover both; it must not succeed by borrowing the
+    parent's retained gas after the child frame merges back.
+
+    Tune gas so the child ends initcode with enough gas for either
+    component alone but not both together.
+    """
+    # Initcode: PUSH1 1, PUSH1 0, RETURN -> deploys 1 byte of 0x00
+    init_code = Op.RETURN(0, 1)
+
+    storage = Storage()
+    factory = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, Op.PUSH32(bytes(init_code)))
+            + Op.SSTORE(
+                storage.store_next(0, "create_fails"),
+                Op.CREATE(
+                    value=0,
+                    offset=32 - len(init_code),
+                    size=len(init_code),
+                ),
+            )
+            + Op.STOP
+        ),
+    )
+    created = compute_create_address(
+        address=factory, nonce=1
+    )
+
+    # Give enough total gas for the parent to execute, but
+    # constrain so the child CREATE frame ends with gas between
+    # code_deposit_state and code_deposit_regular +
+    # code_deposit_state. The child should fail code deposit.
+    tx = Transaction(
+        to=factory,
+        gas_limit=54_225,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {
+        factory: Account(
+            nonce=2, storage=storage
+        ),
+        created: Account.NONEXISTENT,
+    }
     state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -23,7 +23,7 @@ from execution_testing import (
 )
 from execution_testing.checklists import EIPChecklist
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -34,6 +34,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_create_charges_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CREATE charges state gas for new account and code deposit.
@@ -41,6 +42,8 @@ def test_create_charges_state_gas(
     A successful CREATE charges new-account state gas plus code
     deposit state gas proportional to the deployed code size.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     init_code = Op.STOP
 
     storage = Storage()
@@ -60,7 +63,7 @@ def test_create_charges_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -80,6 +83,7 @@ def test_create_with_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     opcode: Op,
+    fork: Fork,
 ) -> None:
     """
     Test CREATE/CREATE2 with state gas funded from the reservoir.
@@ -87,9 +91,11 @@ def test_create_with_reservoir(
     Provide gas above TX_MAX_GAS_LIMIT so the new account state gas
     is drawn from the reservoir rather than gas_left.
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    create_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    create_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     storage = Storage()
     init_code = Op.STOP
@@ -115,7 +121,7 @@ def test_create_with_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + create_state_gas,
+        gas_limit=gas_limit_cap + create_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -137,6 +143,7 @@ def test_code_deposit_state_gas_scales_with_size(
     state_test: StateTestFiller,
     pre: Alloc,
     code_size: int,
+    fork: Fork,
 ) -> None:
     """
     Test code deposit state gas scales linearly with code size.
@@ -144,10 +151,11 @@ def test_code_deposit_state_gas_scales_with_size(
     The code deposit charges len(code) * cost_per_state_byte of state
     gas. Larger deployed code requires proportionally more state gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
     # State gas: new account + code deposit
-    total_state_gas = (Spec.STATE_BYTES_PER_NEW_ACCOUNT + code_size) * cpsb
+    total_state_gas = fork.create_state_gas(code_size=code_size)
 
     # Build init code that returns `code_size` bytes of 0x00
     # PUSH2 code_size, PUSH1 0, RETURN
@@ -156,7 +164,7 @@ def test_code_deposit_state_gas_scales_with_size(
     tx = Transaction(
         to=None,
         data=init_code,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + total_state_gas,
+        gas_limit=gas_limit_cap + total_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -167,6 +175,7 @@ def test_code_deposit_state_gas_scales_with_size(
 def test_create_tx_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test contract creation transaction charges intrinsic state gas.
@@ -175,10 +184,12 @@ def test_create_tx_state_gas(
     as intrinsic state gas for the new account, plus code deposit state
     gas for the deployed bytecode.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     tx = Transaction(
         to=None,
         data=Op.STOP,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -189,6 +200,7 @@ def test_create_tx_state_gas(
 def test_create_revert_no_code_deposit_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test reverted CREATE does not charge code deposit state gas.
@@ -197,6 +209,8 @@ def test_create_revert_no_code_deposit_state_gas(
     account state gas is consumed but no code deposit state gas is
     charged because no code was deployed.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     init_code = Op.REVERT(0, 0)
 
     storage = Storage()
@@ -216,7 +230,7 @@ def test_create_revert_no_code_deposit_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -257,8 +271,10 @@ def test_create_insufficient_state_gas(
 
     # Tight gas — enough for intrinsic + CREATE regular gas but not
     # enough for the new account state gas
+    gas_costs = fork.gas_costs()
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    gas_limit = intrinsic_cost() + Spec.REGULAR_GAS_CREATE + 10_000
+    regular_create_gas = gas_costs.GAS_CREATE - gas_costs.GAS_NEW_ACCOUNT
+    gas_limit = intrinsic_cost() + regular_create_gas + 10_000
 
     tx = Transaction(
         to=contract,
@@ -274,6 +290,7 @@ def test_create_insufficient_state_gas(
 def test_create2_address_collision(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test CREATE2 returns zero on address collision.
@@ -282,6 +299,8 @@ def test_create2_address_collision(
     the collision is detected early and returns zero without charging
     state gas. The existing account is left unchanged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     init_code = Op.STOP
     salt = 0
 
@@ -308,7 +327,7 @@ def test_create2_address_collision(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT * 2,
+        gas_limit=gas_limit_cap * 2,
         sender=pre.fund_eoa(),
     )
 
@@ -376,9 +395,8 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
     """
     init_code = Op.RETURN(0, 1)
     gas_costs = fork.gas_costs()
-    cpsb = fork.cost_per_state_byte()
     new_acct_state = gas_costs.GAS_NEW_ACCOUNT
-    code_deposit_state = 1 * cpsb
+    code_deposit_state = fork.code_deposit_state_gas(code_size=1)
 
     factory = pre.deploy_contract(
         code=(
@@ -392,17 +410,14 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
             )
         ),
     )
-    created = compute_create_address(
-        address=factory, nonce=1
-    )
+    created = compute_create_address(address=factory, nonce=1)
 
     # Gas consumed before the child CREATE frame receives gas:
     # Intrinsic + factory code (PUSH32+PUSH1+MSTORE+mem +
     # 3xPUSH1) + CREATE regular (+ init_code_cost) + new account
     # state gas (spilled from gas_left, no reservoir).
-    init_code_word_cost = (
-        gas_costs.GAS_CODE_INIT_PER_WORD
-        * ((len(init_code) + 31) // 32)
+    init_code_word_cost = gas_costs.GAS_CODE_INIT_PER_WORD * (
+        (len(init_code) + 31) // 32
     )
     pre_child_gas = (
         gas_costs.GAS_TX_BASE
@@ -417,6 +432,7 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
     init_cost = 2 * gas_costs.GAS_VERY_LOW + gas_costs.GAS_MEMORY
     # Target child gas: enough for init, not enough for code deposit
     target_child = (init_cost + code_deposit_state) // 2
+    # Invert EIP-150 63/64ths rule: ceil(target_child * 64 / 63)
     factory_remaining = (target_child * 64 + 62) // 63
     gas_limit = pre_child_gas + factory_remaining
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -49,7 +49,7 @@ def test_sstore_via_delegation_pointer(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     # EOA with pre-existing delegation to the contract
@@ -91,7 +91,7 @@ def test_sstore_direct_call_same_contract(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     sender = pre.fund_eoa()
@@ -115,7 +115,7 @@ def test_delegation_pointer_new_account_state_gas(
 
     A contract CALLs with value to a non-existent address. When executed
     via a delegation pointer, the new-account state gas
-    (112 * cost_per_state_byte) is charged identically to a direct call.
+    is charged identically to a direct call.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
@@ -133,7 +133,6 @@ def test_delegation_pointer_new_account_state_gas(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=target, value=1),
             )
-            + Op.STOP
         ),
         balance=1,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_delegation_pointer.py
@@ -15,13 +15,14 @@ from execution_testing import (
     Alloc,
     AuthorizationTuple,
     Environment,
+    Fork,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -31,6 +32,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_sstore_via_delegation_pointer(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas charged when called via delegation pointer.
@@ -40,12 +42,13 @@ def test_sstore_via_delegation_pointer(
     contract code in the EOA's context. The SSTORE state gas should
     be charged from the reservoir just as it would for a direct call.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -58,7 +61,7 @@ def test_sstore_via_delegation_pointer(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=delegator,
-        gas_limit=(Spec.TX_MAX_GAS_LIMIT + auth_state_gas + sstore_state_gas),
+        gas_limit=(gas_limit_cap + auth_state_gas + sstore_state_gas),
         authorization_list=[
             AuthorizationTuple(
                 address=contract,
@@ -78,6 +81,7 @@ def test_sstore_via_delegation_pointer(
 def test_sstore_direct_call_same_contract(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas charged when calling the contract directly.
@@ -85,9 +89,10 @@ def test_sstore_direct_call_same_contract(
     Baseline comparison: calling the contract directly (not via a
     delegation pointer) charges SSTORE state gas identically.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -97,7 +102,7 @@ def test_sstore_direct_call_same_contract(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=sender,
     )
 
@@ -109,6 +114,7 @@ def test_sstore_direct_call_same_contract(
 def test_delegation_pointer_new_account_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test delegation pointer CALL to empty account charges new-account gas.
@@ -117,12 +123,14 @@ def test_delegation_pointer_new_account_state_gas(
     via a delegation pointer, the new-account state gas
     is charged identically to a direct call.
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    new_account_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     target = 0xDEAD
 
@@ -143,9 +151,7 @@ def test_delegation_pointer_new_account_state_gas(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=delegator,
-        gas_limit=(
-            Spec.TX_MAX_GAS_LIMIT + auth_state_gas + new_account_state_gas
-        ),
+        gas_limit=(gas_limit_cap + auth_state_gas + new_account_state_gas),
         authorization_list=[
             AuthorizationTuple(
                 address=contract,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
@@ -22,13 +22,14 @@ from execution_testing import (
     Block,
     BlockchainTestFiller,
     EIPChecklist,
+    Fork,
     Op,
     Storage,
     Transaction,
     TransactionException,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -41,6 +42,7 @@ pytestmark = pytest.mark.valid_at_transition_to("Amsterdam")
 def test_sstore_state_gas_at_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas activates at the Amsterdam fork boundary.
@@ -50,6 +52,8 @@ def test_sstore_state_gas_at_transition(
     operation requires state gas. Both blocks use TX_MAX_GAS_LIMIT
     which provides enough gas in either regime.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract_before = pre.deploy_contract(
         code=Op.SSTORE(0, 1),
     )
@@ -64,7 +68,7 @@ def test_sstore_state_gas_at_transition(
             txs=[
                 Transaction(
                     to=contract_before,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                    gas_limit=gas_limit_cap,
                     sender=pre.fund_eoa(),
                 ),
             ],
@@ -75,7 +79,7 @@ def test_sstore_state_gas_at_transition(
             txs=[
                 Transaction(
                     to=contract_after,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                    gas_limit=gas_limit_cap,
                     sender=pre.fund_eoa(),
                 ),
             ],
@@ -109,6 +113,7 @@ def test_tx_gas_above_cap_at_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     gas_above_cap: bool,
+    fork: Fork,
 ) -> None:
     """
     Test tx.gas > TX_MAX_GAS_LIMIT validity at the Amsterdam transition.
@@ -118,6 +123,8 @@ def test_tx_gas_above_cap_at_transition(
     reservoir. This test sends a tx at the cap (always valid) and one
     above the cap (rejected before, accepted after).
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage_before = Storage()
     contract_before = pre.deploy_contract(
         code=(Op.SSTORE(storage_before.store_next(1), 1)),
@@ -128,9 +135,7 @@ def test_tx_gas_above_cap_at_transition(
         code=(Op.SSTORE(storage_after.store_next(1), 1)),
     )
 
-    gas_limit = (
-        Spec.TX_MAX_GAS_LIMIT + 1 if gas_above_cap else Spec.TX_MAX_GAS_LIMIT
-    )
+    gas_limit = gas_limit_cap + 1 if gas_above_cap else gas_limit_cap
 
     # Before fork: above-cap tx is rejected by EIP-7825
     before_error = (
@@ -179,6 +184,7 @@ def test_tx_gas_above_cap_at_transition(
 def test_reservoir_available_after_transition(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test reservoir is available for state ops after the fork.
@@ -187,8 +193,9 @@ def test_reservoir_available_after_transition(
     no reservoir. After the fork, gas above the cap feeds the reservoir,
     which child calls can draw from for state operations.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
 
     child_storage = Storage()
     child = pre.deploy_contract(
@@ -211,7 +218,7 @@ def test_reservoir_available_after_transition(
             txs=[
                 Transaction(
                     to=parent,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+                    gas_limit=gas_limit_cap + sstore_state_gas,
                     sender=pre.fund_eoa(),
                 ),
             ],

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_fork_transition.py
@@ -51,10 +51,10 @@ def test_sstore_state_gas_at_transition(
     which provides enough gas in either regime.
     """
     contract_before = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
     contract_after = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     blocks = [
@@ -120,12 +120,12 @@ def test_tx_gas_above_cap_at_transition(
     """
     storage_before = Storage()
     contract_before = pre.deploy_contract(
-        code=(Op.SSTORE(storage_before.store_next(1), 1) + Op.STOP),
+        code=(Op.SSTORE(storage_before.store_next(1), 1)),
     )
 
     storage_after = Storage()
     contract_after = pre.deploy_contract(
-        code=(Op.SSTORE(storage_after.store_next(1), 1) + Op.STOP),
+        code=(Op.SSTORE(storage_after.store_next(1), 1)),
     )
 
     gas_limit = (
@@ -192,7 +192,7 @@ def test_reservoir_available_after_transition(
 
     child_storage = Storage()
     child = pre.deploy_contract(
-        code=Op.SSTORE(child_storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(child_storage.store_next(1), 1),
     )
 
     parent_storage = Storage()
@@ -202,7 +202,6 @@ def test_reservoir_available_after_transition(
                 parent_storage.store_next(1),
                 Op.CALL(gas=100_000, address=child),
             )
-            + Op.STOP
         ),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -22,64 +22,59 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Fork,
     Op,
     Storage,
     Transaction,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
-
-# Non-zero priority fee so coinbase balance depends on
-# receipt_gas_used. Default base_fee_per_gas is 7.
-PRIORITY_FEE = 2
-MAX_FEE = 9  # base_fee(7) + PRIORITY_FEE(2)
 
 
 @pytest.mark.valid_from("Amsterdam")
 def test_exact_coinbase_fee_simple_sstore(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Assert exact coinbase balance from a single SSTORE transaction.
 
-    Compute ``tx_gas_used`` from first principles and verify the
-    reporter contract reads exactly ``tx_gas_used * priority_fee``
-    as the coinbase balance. Any error in ``state_gas_left`` or
-    ``refund_counter`` will produce a different coinbase balance,
+    Compute `tx_gas_used` from first principles and verify the
+    reporter contract reads exactly `tx_gas_used` as the coinbase
+    balance (priority fee is 1 wei). Any error in `state_gas_left` or
+    `refund_counter` will produce a different coinbase balance,
     causing the state root to diverge.
 
-    Gas breakdown for tx 1 (SSTORE zero-to-nonzero, no calldata)::
-
-        intrinsic_regular = 21000  (GAS_TX_BASE)
-        evm_regular       =  5006  (PUSH1 + PUSH1 + SSTORE_cold)
-        state_gas         = 32 * cost_per_state_byte  (from reservoir)
-        refund            = 0
-        tx_gas_used       = 21000 + 5006 + state_gas = 26006 + state_gas
-
     Motivated by BAL devnet-3 ethrex/besu coinbase balance mismatch
-    where clients diverged on cumulative ``receipt_gas_used``.
+    where clients diverged on cumulative `receipt_gas_used`.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    sstore_state_gas = (
+        gas_costs.GAS_STORAGE_SET
+        - gas_costs.GAS_STORAGE_UPDATE
+        + gas_costs.GAS_COLD_SLOAD
+    )
 
-    # Exact gas breakdown for tx 1:
+    # Gas breakdown for tx 1 (SSTORE zero-to-nonzero, no calldata):
     # PUSH1(1) + PUSH1(0) + SSTORE(cold, zero-to-nonzero) + STOP
-    # Regular: 3 + 3 + (2100 cold + 2900 update) + 0 = 5006
-    intrinsic_regular = 21000
-    evm_regular = 5006
+    intrinsic_regular = gas_costs.GAS_TX_BASE
+    evm_regular = (
+        2 * gas_costs.GAS_VERY_LOW  # PUSH1 + PUSH1
+        + gas_costs.GAS_STORAGE_UPDATE  # SSTORE cold zero-to-nonzero
+    )
     tx1_gas_used = intrinsic_regular + evm_regular + sstore_state_gas
-    expected_coinbase = tx1_gas_used * PRIORITY_FEE
+    expected_coinbase = tx1_gas_used
 
     # Tx 1: single SSTORE zero-to-nonzero
     sstore_storage = Storage()
     sstore_contract = pre.deploy_contract(
         code=(
             Op.SSTORE(sstore_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -88,7 +83,6 @@ def test_exact_coinbase_fee_simple_sstore(
         code=(
             Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
             + Op.SSTORE(1, 1)
-            + Op.STOP
         ),
     )
 
@@ -98,18 +92,18 @@ def test_exact_coinbase_fee_simple_sstore(
                 Transaction(
                     to=sstore_contract,
                     gas_limit=(
-                        Spec.TX_MAX_GAS_LIMIT
+                        gas_limit_cap
                         + sstore_state_gas
                     ),
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
                 Transaction(
                     to=reporter,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    gas_limit=gas_limit_cap,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
             ]
@@ -129,6 +123,7 @@ def test_exact_coinbase_fee_simple_sstore(
 def test_multi_block_mixed_state_operations(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Verify coinbase fee across blocks with diverse state operations.
@@ -137,11 +132,16 @@ def test_multi_block_mixed_state_operations(
     Block 2: Child spill + revert transactions (reservoir recovery).
     Block 3: Child spill + halt transactions (halt recovery).
 
-    This mixed scenario tests that ``receipt_gas_used`` is consistent
+    This mixed scenario tests that `receipt_gas_used` is consistent
     across different state gas paths within a multi-block chain.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    sstore_state_gas = (
+        gas_costs.GAS_STORAGE_SET
+        - gas_costs.GAS_STORAGE_UPDATE
+        + gas_costs.GAS_COLD_SLOAD
+    )
 
     reverting_child = pre.deploy_contract(
         code=(
@@ -161,14 +161,13 @@ def test_multi_block_mixed_state_operations(
     all_contracts = []
     all_storages = []
 
-    # --- Block 1: simple SSTOREs from reservoir ---
+    # Simple SSTOREs from reservoir
     block1_txs = []
     for _ in range(2):
         storage = Storage()
         contract = pre.deploy_contract(
             code=(
                 Op.SSTORE(storage.store_next(1), 1)
-                + Op.STOP
             ),
         )
         all_contracts.append(contract)
@@ -177,16 +176,16 @@ def test_multi_block_mixed_state_operations(
             Transaction(
                 to=contract,
                 gas_limit=(
-                    Spec.TX_MAX_GAS_LIMIT
+                    gas_limit_cap
                     + sstore_state_gas
                 ),
-                max_priority_fee_per_gas=PRIORITY_FEE,
-                max_fee_per_gas=MAX_FEE,
+                max_priority_fee_per_gas=1,
+                max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
             )
         )
 
-    # --- Block 2: child spill + revert ---
+    # Child spill + revert
     block2_txs = []
     for _ in range(2):
         storage = Storage()
@@ -199,7 +198,6 @@ def test_multi_block_mixed_state_operations(
                     )
                 )
                 + Op.SSTORE(storage.store_next(1), 1)
-                + Op.STOP
             ),
         )
         all_contracts.append(parent)
@@ -208,16 +206,16 @@ def test_multi_block_mixed_state_operations(
             Transaction(
                 to=parent,
                 gas_limit=(
-                    Spec.TX_MAX_GAS_LIMIT
+                    gas_limit_cap
                     + sstore_state_gas
                 ),
-                max_priority_fee_per_gas=PRIORITY_FEE,
-                max_fee_per_gas=MAX_FEE,
+                max_priority_fee_per_gas=1,
+                max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
             )
         )
 
-    # --- Block 3: child spill + exceptional halt ---
+    # Child spill + exceptional halt
     block3_txs = []
     for _ in range(2):
         storage = Storage()
@@ -230,7 +228,6 @@ def test_multi_block_mixed_state_operations(
                     )
                 )
                 + Op.SSTORE(storage.store_next(1), 1)
-                + Op.STOP
             ),
         )
         all_contracts.append(parent)
@@ -239,11 +236,11 @@ def test_multi_block_mixed_state_operations(
             Transaction(
                 to=parent,
                 gas_limit=(
-                    Spec.TX_MAX_GAS_LIMIT
+                    gas_limit_cap
                     + sstore_state_gas
                 ),
-                max_priority_fee_per_gas=PRIORITY_FEE,
-                max_fee_per_gas=MAX_FEE,
+                max_priority_fee_per_gas=1,
+                max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
             )
         )
@@ -264,45 +261,41 @@ def test_multi_block_mixed_state_operations(
 def test_multi_block_observed_coinbase_balance(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Observe coinbase balance between state-creating transactions.
 
-    A reporter contract reads ``BALANCE(COINBASE)`` and stores a flag
-    indicating whether the coinbase has received fees. This makes
-    ``receipt_gas_used`` directly observable: if a client computes a
-    different ``receipt_gas_used`` for prior transactions, the stored
-    balance observation will differ and the state root will not match.
+    A reporter contract reads `BALANCE(COINBASE)` and stores it.
+    This makes `receipt_gas_used` directly observable: if a client
+    computes a different `receipt_gas_used` for prior transactions,
+    the stored balance will differ and the state root will not match.
 
     Block 1:
-      Tx 1 -- SSTORE zero-to-nonzero (coinbase earns fee).
-      Tx 2 -- Store ``BALANCE(COINBASE)`` in slot 0; store 1 in
-      slot 1 as success marker.
+      Tx 1: SSTORE zero-to-nonzero (coinbase earns fee).
+      Tx 2: Store `BALANCE(COINBASE)` in slot 0.
 
     Block 2:
-      Tx 3 -- Child spills state gas then reverts; parent SSTOREs
+      Tx 3: Child spills state gas then reverts; parent SSTOREs
       (coinbase earns fee through different code path).
-      Tx 4 -- Store ``BALANCE(COINBASE)`` in slot 0; store 1 in
-      slot 1 as success marker.
+      Tx 4: Store `BALANCE(COINBASE)` in slot 0.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    sstore_state_gas = (
+        gas_costs.GAS_STORAGE_SET
+        - gas_costs.GAS_STORAGE_UPDATE
+        + gas_costs.GAS_COLD_SLOAD
+    )
 
-    # Reporters store BALANCE(COINBASE) in slot 0 and a marker
-    # in slot 1. The exact slot 0 value is validated by the state
-    # root; the marker confirms execution completed.
     reporter1 = pre.deploy_contract(
         code=(
             Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
-            + Op.SSTORE(1, 1)
-            + Op.STOP
         ),
     )
     reporter2 = pre.deploy_contract(
         code=(
             Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
-            + Op.SSTORE(1, 1)
-            + Op.STOP
         ),
     )
 
@@ -311,7 +304,6 @@ def test_multi_block_observed_coinbase_balance(
     sstore_contract = pre.deploy_contract(
         code=(
             Op.SSTORE(sstore_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -332,7 +324,6 @@ def test_multi_block_observed_coinbase_balance(
                 )
             )
             + Op.SSTORE(spill_storage.store_next(1), 1)
-            + Op.STOP
         ),
     )
 
@@ -342,18 +333,18 @@ def test_multi_block_observed_coinbase_balance(
                 Transaction(
                     to=sstore_contract,
                     gas_limit=(
-                        Spec.TX_MAX_GAS_LIMIT
+                        gas_limit_cap
                         + sstore_state_gas
                     ),
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
                 Transaction(
                     to=reporter1,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    gas_limit=gas_limit_cap,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
             ]
@@ -363,18 +354,18 @@ def test_multi_block_observed_coinbase_balance(
                 Transaction(
                     to=spill_parent,
                     gas_limit=(
-                        Spec.TX_MAX_GAS_LIMIT
+                        gas_limit_cap
                         + sstore_state_gas
                     ),
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
                 Transaction(
                     to=reporter2,
-                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
-                    max_priority_fee_per_gas=PRIORITY_FEE,
-                    max_fee_per_gas=MAX_FEE,
+                    gas_limit=gas_limit_cap,
+                    max_priority_fee_per_gas=1,
+                    max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
                 ),
             ]
@@ -384,9 +375,5 @@ def test_multi_block_observed_coinbase_balance(
     post = {
         sstore_contract: Account(storage=sstore_storage),
         spill_parent: Account(storage=spill_storage),
-        # Only check the success marker. Slot 0 (coinbase
-        # balance) is validated by the state root.
-        reporter1: Account(storage={1: 1}),
-        reporter2: Account(storage={1: 1}),
     }
     blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -1,0 +1,392 @@
+"""
+Multi-block tests for EIP-8037 state gas receipt accounting and
+coinbase fee accumulation.
+
+Verify that `receipt_gas_used` is computed correctly across multiple
+blocks under two-dimensional gas accounting. These tests exercise:
+
+- Receipt gas accounting over multi-block sequences with diverse
+  state gas paths (reservoir, spill+revert, spill+halt)
+- Observable coinbase balance between state-creating transactions
+
+Any disagreement in `receipt_gas_used` between clients causes the
+coinbase balance to diverge, producing a different state root.
+
+Tests for [EIP-8037: State Creation Gas Cost Increase]
+(https://eips.ethereum.org/EIPS/eip-8037).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Op,
+    Storage,
+    Transaction,
+)
+
+from .spec import Spec, ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+# Non-zero priority fee so coinbase balance depends on
+# receipt_gas_used. Default base_fee_per_gas is 7.
+PRIORITY_FEE = 2
+MAX_FEE = 9  # base_fee(7) + PRIORITY_FEE(2)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_exact_coinbase_fee_simple_sstore(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Assert exact coinbase balance from a single SSTORE transaction.
+
+    Compute ``tx_gas_used`` from first principles and verify the
+    reporter contract reads exactly ``tx_gas_used * priority_fee``
+    as the coinbase balance. Any error in ``state_gas_left`` or
+    ``refund_counter`` will produce a different coinbase balance,
+    causing the state root to diverge.
+
+    Gas breakdown for tx 1 (SSTORE zero-to-nonzero, no calldata)::
+
+        intrinsic_regular = 21000  (GAS_TX_BASE)
+        evm_regular       =  5006  (PUSH1 + PUSH1 + SSTORE_cold)
+        state_gas         = 32 * cost_per_state_byte  (from reservoir)
+        refund            = 0
+        tx_gas_used       = 21000 + 5006 + state_gas = 26006 + state_gas
+
+    Motivated by BAL devnet-3 ethrex/besu coinbase balance mismatch
+    where clients diverged on cumulative ``receipt_gas_used``.
+    """
+    cpsb = Spec.COST_PER_STATE_BYTE
+    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+
+    # Exact gas breakdown for tx 1:
+    # PUSH1(1) + PUSH1(0) + SSTORE(cold, zero-to-nonzero) + STOP
+    # Regular: 3 + 3 + (2100 cold + 2900 update) + 0 = 5006
+    intrinsic_regular = 21000
+    evm_regular = 5006
+    tx1_gas_used = intrinsic_regular + evm_regular + sstore_state_gas
+    expected_coinbase = tx1_gas_used * PRIORITY_FEE
+
+    # Tx 1: single SSTORE zero-to-nonzero
+    sstore_storage = Storage()
+    sstore_contract = pre.deploy_contract(
+        code=(
+            Op.SSTORE(sstore_storage.store_next(1), 1)
+            + Op.STOP
+        ),
+    )
+
+    # Tx 2: reporter reads BALANCE(COINBASE) into slot 0
+    reporter = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
+            + Op.SSTORE(1, 1)
+            + Op.STOP
+        ),
+    )
+
+    blocks = [
+        Block(
+            txs=[
+                Transaction(
+                    to=sstore_contract,
+                    gas_limit=(
+                        Spec.TX_MAX_GAS_LIMIT
+                        + sstore_state_gas
+                    ),
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+                Transaction(
+                    to=reporter,
+                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+            ]
+        ),
+    ]
+
+    post = {
+        sstore_contract: Account(storage=sstore_storage),
+        reporter: Account(
+            storage={0: expected_coinbase, 1: 1}
+        ),
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_multi_block_mixed_state_operations(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Verify coinbase fee across blocks with diverse state operations.
+
+    Block 1: Simple SSTORE transactions (state gas from reservoir).
+    Block 2: Child spill + revert transactions (reservoir recovery).
+    Block 3: Child spill + halt transactions (halt recovery).
+
+    This mixed scenario tests that ``receipt_gas_used`` is consistent
+    across different state gas paths within a multi-block chain.
+    """
+    cpsb = Spec.COST_PER_STATE_BYTE
+    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+
+    reverting_child = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, 1)
+            + Op.SSTORE(1, 1)
+            + Op.REVERT(0, 0)
+        ),
+    )
+    halting_child = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, 1)
+            + Op.SSTORE(1, 1)
+            + Op.INVALID
+        ),
+    )
+
+    all_contracts = []
+    all_storages = []
+
+    # --- Block 1: simple SSTOREs from reservoir ---
+    block1_txs = []
+    for _ in range(2):
+        storage = Storage()
+        contract = pre.deploy_contract(
+            code=(
+                Op.SSTORE(storage.store_next(1), 1)
+                + Op.STOP
+            ),
+        )
+        all_contracts.append(contract)
+        all_storages.append(storage)
+        block1_txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=(
+                    Spec.TX_MAX_GAS_LIMIT
+                    + sstore_state_gas
+                ),
+                max_priority_fee_per_gas=PRIORITY_FEE,
+                max_fee_per_gas=MAX_FEE,
+                sender=pre.fund_eoa(),
+            )
+        )
+
+    # --- Block 2: child spill + revert ---
+    block2_txs = []
+    for _ in range(2):
+        storage = Storage()
+        parent = pre.deploy_contract(
+            code=(
+                Op.POP(
+                    Op.CALL(
+                        gas=500_000,
+                        address=reverting_child,
+                    )
+                )
+                + Op.SSTORE(storage.store_next(1), 1)
+                + Op.STOP
+            ),
+        )
+        all_contracts.append(parent)
+        all_storages.append(storage)
+        block2_txs.append(
+            Transaction(
+                to=parent,
+                gas_limit=(
+                    Spec.TX_MAX_GAS_LIMIT
+                    + sstore_state_gas
+                ),
+                max_priority_fee_per_gas=PRIORITY_FEE,
+                max_fee_per_gas=MAX_FEE,
+                sender=pre.fund_eoa(),
+            )
+        )
+
+    # --- Block 3: child spill + exceptional halt ---
+    block3_txs = []
+    for _ in range(2):
+        storage = Storage()
+        parent = pre.deploy_contract(
+            code=(
+                Op.POP(
+                    Op.CALL(
+                        gas=500_000,
+                        address=halting_child,
+                    )
+                )
+                + Op.SSTORE(storage.store_next(1), 1)
+                + Op.STOP
+            ),
+        )
+        all_contracts.append(parent)
+        all_storages.append(storage)
+        block3_txs.append(
+            Transaction(
+                to=parent,
+                gas_limit=(
+                    Spec.TX_MAX_GAS_LIMIT
+                    + sstore_state_gas
+                ),
+                max_priority_fee_per_gas=PRIORITY_FEE,
+                max_fee_per_gas=MAX_FEE,
+                sender=pre.fund_eoa(),
+            )
+        )
+
+    blocks = [
+        Block(txs=block1_txs),
+        Block(txs=block2_txs),
+        Block(txs=block3_txs),
+    ]
+    post = {
+        c: Account(storage=s)
+        for c, s in zip(all_contracts, all_storages)
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_multi_block_observed_coinbase_balance(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Observe coinbase balance between state-creating transactions.
+
+    A reporter contract reads ``BALANCE(COINBASE)`` and stores a flag
+    indicating whether the coinbase has received fees. This makes
+    ``receipt_gas_used`` directly observable: if a client computes a
+    different ``receipt_gas_used`` for prior transactions, the stored
+    balance observation will differ and the state root will not match.
+
+    Block 1:
+      Tx 1 -- SSTORE zero-to-nonzero (coinbase earns fee).
+      Tx 2 -- Store ``BALANCE(COINBASE)`` in slot 0; store 1 in
+      slot 1 as success marker.
+
+    Block 2:
+      Tx 3 -- Child spills state gas then reverts; parent SSTOREs
+      (coinbase earns fee through different code path).
+      Tx 4 -- Store ``BALANCE(COINBASE)`` in slot 0; store 1 in
+      slot 1 as success marker.
+    """
+    cpsb = Spec.COST_PER_STATE_BYTE
+    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+
+    # Reporters store BALANCE(COINBASE) in slot 0 and a marker
+    # in slot 1. The exact slot 0 value is validated by the state
+    # root; the marker confirms execution completed.
+    reporter1 = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
+            + Op.SSTORE(1, 1)
+            + Op.STOP
+        ),
+    )
+    reporter2 = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
+            + Op.SSTORE(1, 1)
+            + Op.STOP
+        ),
+    )
+
+    # Block 1 tx 1: simple SSTORE
+    sstore_storage = Storage()
+    sstore_contract = pre.deploy_contract(
+        code=(
+            Op.SSTORE(sstore_storage.store_next(1), 1)
+            + Op.STOP
+        ),
+    )
+
+    # Block 2 tx 3: child spill + revert, parent SSTORE
+    reverting_child = pre.deploy_contract(
+        code=(
+            Op.SSTORE(0, 1)
+            + Op.SSTORE(1, 1)
+            + Op.REVERT(0, 0)
+        ),
+    )
+    spill_storage = Storage()
+    spill_parent = pre.deploy_contract(
+        code=(
+            Op.POP(
+                Op.CALL(
+                    gas=500_000, address=reverting_child
+                )
+            )
+            + Op.SSTORE(spill_storage.store_next(1), 1)
+            + Op.STOP
+        ),
+    )
+
+    blocks = [
+        Block(
+            txs=[
+                Transaction(
+                    to=sstore_contract,
+                    gas_limit=(
+                        Spec.TX_MAX_GAS_LIMIT
+                        + sstore_state_gas
+                    ),
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+                Transaction(
+                    to=reporter1,
+                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+            ]
+        ),
+        Block(
+            txs=[
+                Transaction(
+                    to=spill_parent,
+                    gas_limit=(
+                        Spec.TX_MAX_GAS_LIMIT
+                        + sstore_state_gas
+                    ),
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+                Transaction(
+                    to=reporter2,
+                    gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                    max_priority_fee_per_gas=PRIORITY_FEE,
+                    max_fee_per_gas=MAX_FEE,
+                    sender=pre.fund_eoa(),
+                ),
+            ]
+        ),
+    ]
+
+    post = {
+        sstore_contract: Account(storage=sstore_storage),
+        spill_parent: Account(storage=spill_storage),
+        # Only check the success marker. Slot 0 (coinbase
+        # balance) is validated by the state root.
+        reporter1: Account(storage={1: 1}),
+        reporter2: Account(storage={1: 1}),
+    }
+    blockchain_test(pre=pre, blocks=blocks, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_multi_block.py
@@ -54,11 +54,8 @@ def test_exact_coinbase_fee_simple_sstore(
     """
     gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
-    sstore_state_gas = (
-        gas_costs.GAS_STORAGE_SET
-        - gas_costs.GAS_STORAGE_UPDATE
-        + gas_costs.GAS_COLD_SLOAD
-    )
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
 
     # Gas breakdown for tx 1 (SSTORE zero-to-nonzero, no calldata):
     # PUSH1(1) + PUSH1(0) + SSTORE(cold, zero-to-nonzero) + STOP
@@ -73,17 +70,12 @@ def test_exact_coinbase_fee_simple_sstore(
     # Tx 1: single SSTORE zero-to-nonzero
     sstore_storage = Storage()
     sstore_contract = pre.deploy_contract(
-        code=(
-            Op.SSTORE(sstore_storage.store_next(1), 1)
-        ),
+        code=(Op.SSTORE(sstore_storage.store_next(1), 1)),
     )
 
     # Tx 2: reporter reads BALANCE(COINBASE) into slot 0
     reporter = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
-            + Op.SSTORE(1, 1)
-        ),
+        code=(Op.SSTORE(0, Op.BALANCE(Op.COINBASE)) + Op.SSTORE(1, 1)),
     )
 
     blocks = [
@@ -91,10 +83,7 @@ def test_exact_coinbase_fee_simple_sstore(
             txs=[
                 Transaction(
                     to=sstore_contract,
-                    gas_limit=(
-                        gas_limit_cap
-                        + sstore_state_gas
-                    ),
+                    gas_limit=(gas_limit_cap + sstore_state_gas),
                     max_priority_fee_per_gas=1,
                     max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
@@ -112,9 +101,7 @@ def test_exact_coinbase_fee_simple_sstore(
 
     post = {
         sstore_contract: Account(storage=sstore_storage),
-        reporter: Account(
-            storage={0: expected_coinbase, 1: 1}
-        ),
+        reporter: Account(storage={0: expected_coinbase, 1: 1}),
     }
     blockchain_test(pre=pre, blocks=blocks, post=post)
 
@@ -135,27 +122,15 @@ def test_multi_block_mixed_state_operations(
     This mixed scenario tests that `receipt_gas_used` is consistent
     across different state gas paths within a multi-block chain.
     """
-    gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
-    sstore_state_gas = (
-        gas_costs.GAS_STORAGE_SET
-        - gas_costs.GAS_STORAGE_UPDATE
-        + gas_costs.GAS_COLD_SLOAD
-    )
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
 
     reverting_child = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, 1)
-            + Op.SSTORE(1, 1)
-            + Op.REVERT(0, 0)
-        ),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.REVERT(0, 0)),
     )
     halting_child = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, 1)
-            + Op.SSTORE(1, 1)
-            + Op.INVALID
-        ),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.INVALID),
     )
 
     all_contracts = []
@@ -166,19 +141,14 @@ def test_multi_block_mixed_state_operations(
     for _ in range(2):
         storage = Storage()
         contract = pre.deploy_contract(
-            code=(
-                Op.SSTORE(storage.store_next(1), 1)
-            ),
+            code=(Op.SSTORE(storage.store_next(1), 1)),
         )
         all_contracts.append(contract)
         all_storages.append(storage)
         block1_txs.append(
             Transaction(
                 to=contract,
-                gas_limit=(
-                    gas_limit_cap
-                    + sstore_state_gas
-                ),
+                gas_limit=(gas_limit_cap + sstore_state_gas),
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
@@ -205,10 +175,7 @@ def test_multi_block_mixed_state_operations(
         block2_txs.append(
             Transaction(
                 to=parent,
-                gas_limit=(
-                    gas_limit_cap
-                    + sstore_state_gas
-                ),
+                gas_limit=(gas_limit_cap + sstore_state_gas),
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
@@ -235,10 +202,7 @@ def test_multi_block_mixed_state_operations(
         block3_txs.append(
             Transaction(
                 to=parent,
-                gas_limit=(
-                    gas_limit_cap
-                    + sstore_state_gas
-                ),
+                gas_limit=(gas_limit_cap + sstore_state_gas),
                 max_priority_fee_per_gas=1,
                 max_fee_per_gas=8,
                 sender=pre.fund_eoa(),
@@ -252,7 +216,7 @@ def test_multi_block_mixed_state_operations(
     ]
     post = {
         c: Account(storage=s)
-        for c, s in zip(all_contracts, all_storages)
+        for c, s in zip(all_contracts, all_storages, strict=False)
     }
     blockchain_test(pre=pre, blocks=blocks, post=post)
 
@@ -280,49 +244,31 @@ def test_multi_block_observed_coinbase_balance(
       (coinbase earns fee through different code path).
       Tx 4: Store `BALANCE(COINBASE)` in slot 0.
     """
-    gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
-    sstore_state_gas = (
-        gas_costs.GAS_STORAGE_SET
-        - gas_costs.GAS_STORAGE_UPDATE
-        + gas_costs.GAS_COLD_SLOAD
-    )
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
 
     reporter1 = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
-        ),
+        code=(Op.SSTORE(0, Op.BALANCE(Op.COINBASE))),
     )
     reporter2 = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, Op.BALANCE(Op.COINBASE))
-        ),
+        code=(Op.SSTORE(0, Op.BALANCE(Op.COINBASE))),
     )
 
     # Block 1 tx 1: simple SSTORE
     sstore_storage = Storage()
     sstore_contract = pre.deploy_contract(
-        code=(
-            Op.SSTORE(sstore_storage.store_next(1), 1)
-        ),
+        code=(Op.SSTORE(sstore_storage.store_next(1), 1)),
     )
 
     # Block 2 tx 3: child spill + revert, parent SSTORE
     reverting_child = pre.deploy_contract(
-        code=(
-            Op.SSTORE(0, 1)
-            + Op.SSTORE(1, 1)
-            + Op.REVERT(0, 0)
-        ),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.REVERT(0, 0)),
     )
     spill_storage = Storage()
     spill_parent = pre.deploy_contract(
         code=(
-            Op.POP(
-                Op.CALL(
-                    gas=500_000, address=reverting_child
-                )
-            )
+            Op.POP(Op.CALL(gas=500_000, address=reverting_child))
             + Op.SSTORE(spill_storage.store_next(1), 1)
         ),
     )
@@ -332,10 +278,7 @@ def test_multi_block_observed_coinbase_balance(
             txs=[
                 Transaction(
                     to=sstore_contract,
-                    gas_limit=(
-                        gas_limit_cap
-                        + sstore_state_gas
-                    ),
+                    gas_limit=(gas_limit_cap + sstore_state_gas),
                     max_priority_fee_per_gas=1,
                     max_fee_per_gas=8,
                     sender=pre.fund_eoa(),
@@ -353,10 +296,7 @@ def test_multi_block_observed_coinbase_balance(
             txs=[
                 Transaction(
                     to=spill_parent,
-                    gas_limit=(
-                        gas_limit_cap
-                        + sstore_state_gas
-                    ),
+                    gas_limit=(gas_limit_cap + sstore_state_gas),
                     max_priority_fee_per_gas=1,
                     max_fee_per_gas=8,
                     sender=pre.fund_eoa(),

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -50,6 +50,7 @@ def test_pricing_at_various_gas_limits(
     state_test: StateTestFiller,
     pre: Alloc,
     block_gas_limit: int,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE succeeds at various block gas limits.
@@ -59,9 +60,10 @@ def test_pricing_at_various_gas_limits(
     when given sufficient total gas, confirming the pricing function
     produces a valid (nonzero) cost.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment(gas_limit=block_gas_limit)
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -70,7 +72,7 @@ def test_pricing_at_various_gas_limits(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -82,6 +84,7 @@ def test_pricing_at_various_gas_limits(
 def test_charge_draws_entirely_from_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas is drawn entirely from the reservoir.
@@ -90,9 +93,10 @@ def test_charge_draws_entirely_from_reservoir(
     gas_left should not be reduced by the state charge. Verify by
     performing a regular-gas-heavy computation after the SSTORE.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -110,7 +114,7 @@ def test_charge_draws_entirely_from_reservoir(
     # Provide exact state gas in the reservoir
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas * 2,
+        gas_limit=gas_limit_cap + sstore_state_gas * 2,
         sender=pre.fund_eoa(),
     )
 
@@ -122,6 +126,7 @@ def test_charge_draws_entirely_from_reservoir(
 def test_charge_spills_to_gas_left(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test state gas spills from reservoir to gas_left.
@@ -130,9 +135,10 @@ def test_charge_spills_to_gas_left(
     state charge, the remainder is taken from gas_left. The SSTORE
     should still succeed.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -143,7 +149,7 @@ def test_charge_spills_to_gas_left(
     half_state_gas = sstore_state_gas // 2
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + half_state_gas,
+        gas_limit=gas_limit_cap + half_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -165,13 +171,14 @@ def test_charge_oog_both_pools_insufficient(
     not enough for the state gas charge. Neither the reservoir (empty
     at TX_MAX_GAS_LIMIT) nor gas_left can cover the cost.
     """
+    gas_costs = fork.gas_costs()
     contract = pre.deploy_contract(
         code=Op.SSTORE(0, 1),
     )
 
     # Tight gas: intrinsic + SSTORE regular gas only
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    gas_limit = intrinsic_cost() + Spec.GAS_STORAGE_UPDATE
+    gas_limit = intrinsic_cost() + gas_costs.GAS_STORAGE_UPDATE
 
     tx = Transaction(
         to=contract,
@@ -189,6 +196,7 @@ def test_charge_oog_both_pools_insufficient(
 def test_refund_cap_includes_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test the 1/5 refund cap includes state gas used from gas_left.
@@ -199,6 +207,8 @@ def test_refund_cap_includes_state_gas(
     performs an SSTORE zero-to-nonzero-to-zero sequence to generate
     a refund and verifies the transaction succeeds.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
     )
@@ -206,7 +216,7 @@ def test_refund_cap_includes_state_gas(
     # No reservoir — all gas from gas_left, refund cap applies
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -220,6 +230,7 @@ def test_refund_cap_includes_state_gas(
 def test_refund_with_reservoir_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test refund when state gas is drawn from reservoir.
@@ -230,9 +241,10 @@ def test_refund_with_reservoir_state_gas(
     both dimensions. An SSTORE zero-to-nonzero-to-zero sequence
     should refund correctly.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     contract = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
@@ -240,7 +252,7 @@ def test_refund_with_reservoir_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -262,6 +274,7 @@ def test_pricing_changes_with_block_gas_limit(
     pre: Alloc,
     gas_limit_block_1: int,
     gas_limit_block_2: int,
+    fork: Fork,
 ) -> None:
     """
     Test state gas cost changes when block gas limit changes.
@@ -271,10 +284,9 @@ def test_pricing_changes_with_block_gas_limit(
     (targeting constant state growth). Each block's SSTORE should
     succeed with the appropriate state gas for that block's gas limit.
     """
-    cpsb_1 = Spec.COST_PER_STATE_BYTE
-    cpsb_2 = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas_1 = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb_1
-    sstore_state_gas_2 = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb_2
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage_1 = Storage()
     contract_1 = pre.deploy_contract(
@@ -293,7 +305,7 @@ def test_pricing_changes_with_block_gas_limit(
         txs=[
             Transaction(
                 to=contract_1,
-                gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas_1,
+                gas_limit=gas_limit_cap + sstore_state_gas,
                 sender=pre.fund_eoa(),
             ),
         ],
@@ -304,7 +316,7 @@ def test_pricing_changes_with_block_gas_limit(
         txs=[
             Transaction(
                 to=contract_2,
-                gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas_2,
+                gas_limit=gas_limit_cap + sstore_state_gas,
                 sender=pre.fund_eoa(),
             ),
         ],
@@ -371,6 +383,7 @@ def test_intrinsic_regular_gas_exceeds_cap(
     """
     gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     # One more non-zero byte than needed to exceed the cap
     calldata_len = gas_limit_cap // gas_costs.GAS_TX_DATA_PER_NON_ZERO + 1
     calldata = b"\x01" * calldata_len

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -385,3 +385,45 @@ def test_intrinsic_regular_gas_exceeds_cap(
     )
 
     state_test(pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "gas_limit,error",
+    [
+        pytest.param(
+            23_000,
+            TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+            id="below_floor",
+            marks=pytest.mark.exception_test,
+        ),
+        pytest.param(25_000, None, id="at_floor"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_calldata_floor_enforced_with_state_gas(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    gas_limit: int,
+    error: TransactionException | None,
+) -> None:
+    """
+    Test EIP-7623 calldata floor is enforced when EIP-8037 is active.
+
+    With 100 non-zero calldata bytes (tokens = 400):
+    - regular_intrinsic = 21000 + 400*4 = 22600
+    - state_intrinsic = 0 (call tx, no creation)
+    - floor = 21000 + 400*10 = 25000
+
+    A gas_limit of 23000 satisfies regular + state (22600) but not
+    the floor (25000), so it must be rejected. A gas_limit of 25000
+    meets the floor and is accepted.
+    """
+    tx = Transaction(
+        to=pre.fund_eoa(0),
+        data=b"\x01" * 100,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+        error=error,
+    )
+
+    state_test(pre=pre, post={}, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_pricing.py
@@ -65,7 +65,7 @@ def test_pricing_at_various_gas_limits(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -104,7 +104,6 @@ def test_charge_draws_entirely_from_reservoir(
                 storage.store_next(1),
                 Op.ADD(1, 0),  # Cheap regular-gas op
             )
-            + Op.STOP
         ),
     )
 
@@ -137,7 +136,7 @@ def test_charge_spills_to_gas_left(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     # Provide half the state gas in the reservoir, rest from gas_left
@@ -167,7 +166,7 @@ def test_charge_oog_both_pools_insufficient(
     at TX_MAX_GAS_LIMIT) nor gas_left can cover the cost.
     """
     contract = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     # Tight gas: intrinsic + SSTORE regular gas only
@@ -201,7 +200,7 @@ def test_refund_cap_includes_state_gas(
     a refund and verifies the transaction succeeds.
     """
     contract = pre.deploy_contract(
-        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0) + Op.STOP),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
     )
 
     # No reservoir — all gas from gas_left, refund cap applies
@@ -236,7 +235,7 @@ def test_refund_with_reservoir_state_gas(
     sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
 
     contract = pre.deploy_contract(
-        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0) + Op.STOP),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
     )
 
     tx = Transaction(
@@ -279,12 +278,12 @@ def test_pricing_changes_with_block_gas_limit(
 
     storage_1 = Storage()
     contract_1 = pre.deploy_contract(
-        code=Op.SSTORE(storage_1.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage_1.store_next(1), 1),
     )
 
     storage_2 = Storage()
     contract_2 = pre.deploy_contract(
-        code=Op.SSTORE(storage_2.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage_2.store_next(1), 1),
     )
 
     env = Environment(gas_limit=gas_limit_block_1)
@@ -341,7 +340,7 @@ def test_pricing_minimum_cpsb_floor(
     env = Environment(gas_limit=block_gas_limit)
 
     contract = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     # State gas = 32 * 1 = 32, very cheap
@@ -360,25 +359,27 @@ def test_pricing_minimum_cpsb_floor(
 def test_intrinsic_regular_gas_exceeds_cap(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test that tx is rejected when intrinsic regular gas exceeds cap.
 
     validate_transaction checks that the intrinsic regular gas (or
-    calldata floor) does not exceed TX_MAX_GAS_LIMIT. A transaction
-    with enough calldata to push intrinsic cost above the cap is
-    invalid even with a high gas_limit.
+    calldata floor) does not exceed the transaction gas limit cap.
+    A transaction with enough calldata to push intrinsic cost above
+    the cap is invalid even with a high gas_limit.
     """
-    # TX_MAX_GAS_LIMIT = 2^24 = 16_777_216
-    # TX_DATA_NON_ZERO_GAS = 16 per byte
-    # We need 16_777_216 / 16 + 1 = 1_048_577 non-zero bytes
-    calldata = b"\x01" * 1_048_577
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    # One more non-zero byte than needed to exceed the cap
+    calldata_len = gas_limit_cap // gas_costs.GAS_TX_DATA_PER_NON_ZERO + 1
+    calldata = b"\x01" * calldata_len
 
     contract = pre.deploy_contract(code=Op.STOP)
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT * 2,
+        gas_limit=gas_limit_cap * 2,
         data=calldata,
         sender=pre.fund_eoa(),
         error=TransactionException.INTRINSIC_GAS_TOO_LOW,
@@ -388,39 +389,52 @@ def test_intrinsic_regular_gas_exceeds_cap(
 
 
 @pytest.mark.parametrize(
-    "gas_limit,error",
+    "above_floor",
     [
         pytest.param(
-            23_000,
-            TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST,
+            False,
             id="below_floor",
             marks=pytest.mark.exception_test,
         ),
-        pytest.param(25_000, None, id="at_floor"),
+        pytest.param(True, id="at_floor"),
     ],
 )
 @pytest.mark.valid_from("Amsterdam")
 def test_calldata_floor_enforced_with_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
-    gas_limit: int,
-    error: TransactionException | None,
+    fork: Fork,
+    above_floor: bool,
 ) -> None:
     """
     Test EIP-7623 calldata floor is enforced when EIP-8037 is active.
 
-    With 100 non-zero calldata bytes (tokens = 400):
-    - regular_intrinsic = 21000 + 400*4 = 22600
-    - state_intrinsic = 0 (call tx, no creation)
-    - floor = 21000 + 400*10 = 25000
-
-    A gas_limit of 23000 satisfies regular + state (22600) but not
-    the floor (25000), so it must be rejected. A gas_limit of 25000
-    meets the floor and is accepted.
+    Send 100 non-zero calldata bytes to a call transaction so the
+    regular intrinsic cost is below the calldata floor. A gas_limit
+    at the floor succeeds; one below the floor is rejected.
     """
+    calldata = b"\x01" * 100
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    floor_cost = fork.transaction_data_floor_cost_calculator()
+
+    regular_gas = intrinsic_cost(
+        calldata=calldata,
+        return_cost_deducted_prior_execution=True,
+    )
+    floor_gas = floor_cost(data=calldata)
+    assert floor_gas > regular_gas, "floor must exceed regular for test"
+
+    if above_floor:
+        gas_limit = floor_gas
+        error = None
+    else:
+        # Between regular and floor: satisfies regular but not floor
+        gas_limit = (regular_gas + floor_gas) // 2
+        error = TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST
+
     tx = Transaction(
         to=pre.fund_eoa(0),
-        data=b"\x01" * 100,
+        data=calldata,
         gas_limit=gas_limit,
         sender=pre.fund_eoa(),
         error=error,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -62,7 +62,7 @@ def test_reservoir_allocation_boundary(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -107,7 +107,6 @@ def test_sstore_state_gas_source(
     code = Bytecode()
     for _ in range(num_sstores):
         code += Op.SSTORE(storage.store_next(1), 1)
-    code += Op.STOP
     contract = pre.deploy_contract(code=code)
 
     if reservoir_covers_state_gas:
@@ -138,7 +137,7 @@ def test_sstore_state_gas_entirely_from_gas_left(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -166,7 +165,7 @@ def test_insufficient_gas_for_sstore_state_cost(
     should OOG, leaving storage slot 0 unchanged at zero.
     """
     contract = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     # Enough for intrinsic + warm SSTORE regular gas, but not the
@@ -258,7 +257,7 @@ def test_block_state_gas_limit(
 
     # Contract that performs a single SSTORE (consumes state gas)
     state_gas_spender = pre.deploy_contract(
-        code=Op.SSTORE(0, 1) + Op.STOP,
+        code=Op.SSTORE(0, 1),
     )
 
     txs = [
@@ -333,7 +332,7 @@ def test_block_gas_used_with_state_ops(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -366,7 +365,7 @@ def test_create_tx_reservoir(
     Test contract creation with state gas from reservoir or gas_left.
 
     Contract creation charges intrinsic state gas for the new account
-    (112 * cost_per_state_byte). When gas_above_cap is True, extra gas
+    (new-account state gas). When gas_above_cap is True, extra gas
     beyond TX_MAX_GAS_LIMIT feeds the reservoir. When False, all state
     gas comes from gas_left (reservoir is zero).
     """

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -31,7 +31,7 @@ from execution_testing import (
 )
 from execution_testing.checklists import EIPChecklist
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -51,6 +51,7 @@ def test_reservoir_allocation_boundary(
     state_test: StateTestFiller,
     pre: Alloc,
     gas_limit_delta: int,
+    fork: Fork,
 ) -> None:
     """
     Test state gas reservoir allocation at TX_MAX_GAS_LIMIT boundary.
@@ -60,6 +61,8 @@ def test_reservoir_allocation_boundary(
     excess goes to the reservoir. In all cases, an SSTORE should
     succeed because state gas can spill from gas_left.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -67,7 +70,7 @@ def test_reservoir_allocation_boundary(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + gas_limit_delta,
+        gas_limit=gas_limit_cap + gas_limit_delta,
         sender=pre.fund_eoa(),
     )
 
@@ -90,6 +93,7 @@ def test_sstore_state_gas_source(
     pre: Alloc,
     num_sstores: int,
     reservoir_covers_state_gas: bool,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE zero-to-nonzero drawing state gas from different sources.
@@ -99,9 +103,10 @@ def test_sstore_state_gas_source(
     When False, the reservoir is minimal (1 gas unit) and state gas must
     spill into gas_left.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     code = Bytecode()
@@ -116,7 +121,7 @@ def test_sstore_state_gas_source(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + extra_gas,
+        gas_limit=gas_limit_cap + extra_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -128,6 +133,7 @@ def test_sstore_state_gas_source(
 def test_sstore_state_gas_entirely_from_gas_left(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas charged entirely from gas_left (no reservoir).
@@ -135,6 +141,8 @@ def test_sstore_state_gas_entirely_from_gas_left(
     When tx.gas <= TX_MAX_GAS_LIMIT, the reservoir is zero. All state
     gas must come from gas_left.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -142,7 +150,7 @@ def test_sstore_state_gas_entirely_from_gas_left(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -164,6 +172,7 @@ def test_insufficient_gas_for_sstore_state_cost(
     gas, but not enough to also cover the SSTORE state gas. The SSTORE
     should OOG, leaving storage slot 0 unchanged at zero.
     """
+    gas_costs = fork.gas_costs()
     contract = pre.deploy_contract(
         code=Op.SSTORE(0, 1),
     )
@@ -171,7 +180,7 @@ def test_insufficient_gas_for_sstore_state_cost(
     # Enough for intrinsic + warm SSTORE regular gas, but not the
     # state gas cost for zero-to-nonzero transition
     intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
-    gas_limit = intrinsic_cost() + Spec.GAS_STORAGE_UPDATE
+    gas_limit = intrinsic_cost() + gas_costs.GAS_STORAGE_UPDATE
 
     tx = Transaction(
         to=contract,
@@ -196,6 +205,7 @@ def test_block_regular_gas_limit(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     exceed_block_gas_limit: bool,
+    fork: Fork,
 ) -> None:
     """
     Test check_transaction enforcement of regular gas against block limit.
@@ -204,8 +214,10 @@ def test_block_regular_gas_limit(
     Fill the block with transactions at TX_MAX_GAS_LIMIT and verify
     the last one is accepted or rejected based on remaining capacity.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    tx_count = env.gas_limit // Spec.TX_MAX_GAS_LIMIT
+    tx_count = env.gas_limit // gas_limit_cap
 
     gas_spender = pre.deploy_contract(code=Op.INVALID)
 
@@ -215,7 +227,7 @@ def test_block_regular_gas_limit(
             Transaction(
                 to=gas_spender,
                 sender=pre.fund_eoa(),
-                gas_limit=Spec.TX_MAX_GAS_LIMIT,
+                gas_limit=gas_limit_cap,
                 error=TransactionException.GAS_ALLOWANCE_EXCEEDED
                 if i >= tx_count
                 else None,
@@ -322,6 +334,7 @@ def test_block_gas_used_no_state_ops(
 def test_block_gas_used_with_state_ops(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test block gas_used includes state gas contribution.
@@ -330,6 +343,8 @@ def test_block_gas_used_with_state_ops(
     block_gas_used and block_state_gas_used. The block header gas_used
     is max(block_gas_used, block_state_gas_used).
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -337,7 +352,7 @@ def test_block_gas_used_with_state_ops(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -360,6 +375,7 @@ def test_create_tx_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
     gas_above_cap: bool,
+    fork: Fork,
 ) -> None:
     """
     Test contract creation with state gas from reservoir or gas_left.
@@ -369,16 +385,18 @@ def test_create_tx_reservoir(
     beyond TX_MAX_GAS_LIMIT feeds the reservoir. When False, all state
     gas comes from gas_left (reservoir is zero).
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     init_code = Op.STOP
 
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    create_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    create_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     if gas_above_cap:
-        gas_limit = Spec.TX_MAX_GAS_LIMIT + create_state_gas
+        gas_limit = gas_limit_cap + create_state_gas
     else:
-        gas_limit = Spec.TX_MAX_GAS_LIMIT
+        gas_limit = gas_limit_cap
 
     tx = Transaction(
         to=None,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -1,7 +1,7 @@
 """
 Test SELFDESTRUCT state gas charging under EIP-8037.
 
-SELFDESTRUCT charges 112 * cost_per_state_byte of state gas when the
+SELFDESTRUCT charges new-account state gas of state gas when the
 beneficiary account does not exist AND the originating contract has
 a nonzero balance. No state gas is charged when the beneficiary
 already exists or the originator has zero balance.
@@ -34,7 +34,7 @@ def test_selfdestruct_new_beneficiary_charges_state_gas(
     Test SELFDESTRUCT to non-existent beneficiary charges state gas.
 
     When the beneficiary does not exist and the originator has nonzero
-    balance, SELFDESTRUCT charges 112 * cost_per_state_byte for
+    balance, SELFDESTRUCT charges new-account state gas for
     creating the new beneficiary account.
     """
     env = Environment()
@@ -170,7 +170,6 @@ def test_selfdestruct_to_self_in_create_tx(
                 << (256 - 8 * len(inner_code)),
             )
             + Op.POP(Op.CREATE(1, 0, len(inner_code)))
-            + Op.STOP
         ),
         balance=1,
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -14,12 +14,13 @@ import pytest
 from execution_testing import (
     Alloc,
     Environment,
+    Fork,
     Op,
     StateTestFiller,
     Transaction,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -29,6 +30,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_selfdestruct_new_beneficiary_charges_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SELFDESTRUCT to non-existent beneficiary charges state gas.
@@ -37,9 +39,11 @@ def test_selfdestruct_new_beneficiary_charges_state_gas(
     balance, SELFDESTRUCT charges new-account state gas for
     creating the new beneficiary account.
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    new_account_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     # Non-existent beneficiary
     beneficiary = 0xDEAD
@@ -51,7 +55,7 @@ def test_selfdestruct_new_beneficiary_charges_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + new_account_state_gas,
+        gas_limit=gas_limit_cap + new_account_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -62,6 +66,7 @@ def test_selfdestruct_new_beneficiary_charges_state_gas(
 def test_selfdestruct_existing_beneficiary_no_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SELFDESTRUCT to existing beneficiary charges no state gas.
@@ -69,6 +74,8 @@ def test_selfdestruct_existing_beneficiary_no_state_gas(
     When the beneficiary already exists, no new account is created
     and no state gas is charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     beneficiary = pre.fund_eoa(amount=0)
 
     contract = pre.deploy_contract(
@@ -78,7 +85,7 @@ def test_selfdestruct_existing_beneficiary_no_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -89,6 +96,7 @@ def test_selfdestruct_existing_beneficiary_no_state_gas(
 def test_selfdestruct_zero_balance_no_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SELFDESTRUCT with zero balance charges no state gas.
@@ -97,6 +105,8 @@ def test_selfdestruct_zero_balance_no_state_gas(
     transferred, so no new account is created even if the beneficiary
     does not exist.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     # Non-existent beneficiary but contract has zero balance
     beneficiary = 0xDEAD
 
@@ -107,7 +117,7 @@ def test_selfdestruct_zero_balance_no_state_gas(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -118,6 +128,7 @@ def test_selfdestruct_zero_balance_no_state_gas(
 def test_selfdestruct_state_gas_from_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SELFDESTRUCT state gas drawn from reservoir.
@@ -125,9 +136,11 @@ def test_selfdestruct_state_gas_from_reservoir(
     Provide gas above TX_MAX_GAS_LIMIT so the new account state gas
     for the non-existent beneficiary is drawn from the reservoir.
     """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    new_account_state_gas = Spec.STATE_BYTES_PER_NEW_ACCOUNT * cpsb
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
 
     beneficiary = 0xDEAD
 
@@ -138,7 +151,7 @@ def test_selfdestruct_state_gas_from_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + new_account_state_gas,
+        gas_limit=gas_limit_cap + new_account_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -149,6 +162,7 @@ def test_selfdestruct_state_gas_from_reservoir(
 def test_selfdestruct_to_self_in_create_tx(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SELFDESTRUCT to self in the transaction the contract was created.
@@ -158,6 +172,8 @@ def test_selfdestruct_to_self_in_create_tx(
     new account state gas is charged since the beneficiary already
     exists.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
 
     inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
@@ -176,7 +192,7 @@ def test_selfdestruct_to_self_in_create_tx(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT * 2,
+        gas_limit=gas_limit_cap * 2,
         sender=pre.fund_eoa(),
     )
 

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -1,10 +1,10 @@
 """
 Test EIP-7702 SetCode authorization state gas under EIP-8037.
 
-Each authorization charges (112 + 23) * cost_per_state_byte intrinsic
-state gas and 7500 intrinsic regular gas. When the authority account
-already exists, 112 * cost_per_state_byte is refunded to the state
-gas reservoir.
+Each authorization charges intrinsic state gas for the new account
+plus auth base bytes, and intrinsic regular gas. When the authority
+account already exists, the new-account state gas is refunded to the
+state gas reservoir.
 
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
@@ -91,7 +91,7 @@ def test_existing_account_refund(
     """
     Test authorization targeting existing account refunds state gas.
 
-    When the authority account already exists, 112 * cost_per_state_byte
+    When the authority account already exists, new-account state gas
     is refunded to the state gas reservoir and subtracted from
     intrinsic_state_gas. Only 23 * cost_per_state_byte is effectively
     charged.
@@ -144,7 +144,7 @@ def test_mixed_new_and_existing_auths(
 
     contract = pre.deploy_contract(code=Op.STOP)
 
-    # Existing account (gets 112*cpsb refund)
+    # Existing account (gets new-account state gas refund)
     existing_signer = pre.fund_eoa()
 
     # New account — fund_eoa creates it in pre-state, so we need
@@ -171,7 +171,7 @@ def test_mixed_new_and_existing_auths(
         ),
     ]
 
-    # Both are existing accounts, so both get the 112*cpsb refund
+    # Both are existing accounts, so both get the new-account state gas refund
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
@@ -204,7 +204,7 @@ def test_authorization_with_sstore(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     signer = pre.fund_eoa()
@@ -237,7 +237,7 @@ def test_existing_account_refund_enables_sstore(
     Test auth refund to reservoir enables subsequent state ops.
 
     When an authorization targets an existing account, the
-    112 * cost_per_state_byte refund goes to state_gas_reservoir.
+    new-account state gas refund goes to state_gas_reservoir.
     This refunded gas should then be available for SSTORE state
     gas in the execution phase.
     """
@@ -250,10 +250,10 @@ def test_existing_account_refund_enables_sstore(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
-    # Existing signer — gets 112*cpsb refunded to reservoir
+    # Existing signer — gets new-account state gas refunded to reservoir
     signer = pre.fund_eoa()
     authorization_list = [
         AuthorizationTuple(
@@ -411,7 +411,7 @@ def test_self_sponsored_authorization(
     The sender authorizes delegation to a contract and is also the
     authority. The intrinsic state gas for the authorization is still
     charged. Since the sender account already exists, the
-    112 * cpsb refund applies.
+    new-account state gas refund applies.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
@@ -421,7 +421,7 @@ def test_self_sponsored_authorization(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     # Sender is also the signer (self-sponsored)
@@ -517,7 +517,7 @@ def test_auth_with_calldata_and_access_list(
     # Contract that reads calldata and stores it
     contract = pre.deploy_contract(
         code=(
-            Op.SSTORE(storage.store_next(0x42), Op.CALLDATALOAD(0)) + Op.STOP
+            Op.SSTORE(storage.store_next(0x42), Op.CALLDATALOAD(0))
         ),
     )
 
@@ -553,7 +553,7 @@ def test_re_authorization_existing_delegation(
 
     When an authority already has a delegation (set-code) and is
     re-authorized in a new transaction, the account exists so the
-    112 * cpsb refund applies. The new delegation replaces the old one.
+    new-account state gas refund applies. The new delegation replaces the old one.
     """
     env = Environment()
     cpsb = Spec.COST_PER_STATE_BYTE
@@ -564,7 +564,7 @@ def test_re_authorization_existing_delegation(
     contract_old = pre.deploy_contract(code=Op.STOP)
     storage = Storage()
     contract_new = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     # Signer already has a delegation from a previous tx
@@ -578,7 +578,7 @@ def test_re_authorization_existing_delegation(
         ),
     ]
 
-    # Existing account — gets 112*cpsb refund
+    # Existing account — gets new-account state gas refund
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract_new,
@@ -725,7 +725,6 @@ def test_auth_with_multiple_sstores(
     code = Bytecode()
     for _ in range(num_sstores):
         code += Op.SSTORE(storage.store_next(1), 1)
-    code += Op.STOP
 
     contract = pre.deploy_contract(code=code)
 
@@ -870,7 +869,7 @@ def test_multi_tx_block_auth_refund_and_sstore(
     Test multi-transaction block with auth refund and SSTORE state gas.
 
     Two transactions in one block:
-    1. A SetCode tx authorizing an existing account (gets 112*cpsb
+    1. A SetCode tx authorizing an existing account (gets new-account state gas
        refund to reservoir). The refund reduces intrinsic_state_gas.
     2. A regular tx performing an SSTORE (charges 32*cpsb state gas).
 
@@ -905,7 +904,7 @@ def test_multi_tx_block_auth_refund_and_sstore(
     # TX 2: SSTORE zero-to-nonzero (charges state gas)
     storage = Storage()
     sstore_contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
     sender_2 = pre.fund_eoa()
     tx_2 = Transaction(
@@ -929,7 +928,7 @@ def test_auth_refund_bypasses_one_fifth_cap(
     """
     Test auth refund to reservoir bypasses the 1/5 refund cap.
 
-    The existing-account auth refund (112 * cpsb) goes directly to
+    The existing-account auth refund (new-account state gas) goes directly to
     state_gas_reservoir, NOT to refund_counter. This means it is not
     subject to the 1/5 refund cap. The test provides just enough gas
     for the auth intrinsic state gas and multiple SSTOREs whose state
@@ -946,11 +945,11 @@ def test_auth_refund_bypasses_one_fifth_cap(
         Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
     ) * cpsb
     sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
-    # Auth refund for existing account = 112 * cpsb (unused in assertion,
+    # Auth refund for existing account = new-account state gas (unused in assertion,
     # but documents the expected value for reasoning about gas budgets).
 
     # Use 3 SSTOREs: 3 * 32 * cpsb = 96 * cpsb of state gas needed.
-    # Auth refund gives 112 * cpsb to the reservoir — enough for all 3.
+    # Auth refund gives new-account state gas to the reservoir — enough for all 3.
     # If it were 1/5 capped: refund would be at most
     # (135 * cpsb) / 5 = 27 * cpsb, which can only fund 0 SSTOREs.
     num_sstores = 3
@@ -959,7 +958,6 @@ def test_auth_refund_bypasses_one_fifth_cap(
     code = Bytecode()
     for _ in range(num_sstores):
         code += Op.SSTORE(storage.store_next(1), 1)
-    code += Op.STOP
 
     contract = pre.deploy_contract(code=code)
 
@@ -974,7 +972,7 @@ def test_auth_refund_bypasses_one_fifth_cap(
     ]
 
     # Provide auth intrinsic state gas + SSTORE state gas.
-    # After the auth refund (112*cpsb) returns to the reservoir,
+    # After the auth refund (new-account state gas) returns to the reservoir,
     # the reservoir holds auth_refund which covers 3 SSTOREs (96*cpsb).
     sender = pre.fund_eoa()
     tx = Transaction(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_set_code.py
@@ -27,7 +27,7 @@ from execution_testing import (
     TransactionException,
 )
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -45,6 +45,7 @@ def test_authorization_state_gas_scaling(
     state_test: StateTestFiller,
     pre: Alloc,
     num_auths: int,
+    fork: Fork,
 ) -> None:
     """
     Test authorization intrinsic state gas scales with count.
@@ -53,11 +54,12 @@ def test_authorization_state_gas_scaling(
     intrinsic state gas. The transaction should succeed with enough
     total gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -75,7 +77,7 @@ def test_authorization_state_gas_scaling(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas * num_auths,
+        gas_limit=gas_limit_cap + auth_state_gas * num_auths,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -87,6 +89,7 @@ def test_authorization_state_gas_scaling(
 def test_existing_account_refund(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test authorization targeting existing account refunds state gas.
@@ -96,6 +99,8 @@ def test_existing_account_refund(
     intrinsic_state_gas. Only 23 * cost_per_state_byte is effectively
     charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
 
     contract = pre.deploy_contract(code=Op.STOP)
@@ -116,7 +121,7 @@ def test_existing_account_refund(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -128,6 +133,7 @@ def test_existing_account_refund(
 def test_mixed_new_and_existing_auths(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test mixed new and existing account authorizations.
@@ -136,11 +142,12 @@ def test_mixed_new_and_existing_auths(
     another targets a new account (no refund). The total state gas
     should reflect the mixed charges.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    full_auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    full_auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -175,7 +182,7 @@ def test_mixed_new_and_existing_auths(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + full_auth_state_gas * 2,
+        gas_limit=gas_limit_cap + full_auth_state_gas * 2,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -187,6 +194,7 @@ def test_mixed_new_and_existing_auths(
 def test_authorization_with_sstore(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SetCode authorization combined with SSTORE.
@@ -195,12 +203,13 @@ def test_authorization_with_sstore(
     contract performs an SSTORE. Both the authorization state gas and
     the SSTORE state gas are charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -219,7 +228,7 @@ def test_authorization_with_sstore(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=(Spec.TX_MAX_GAS_LIMIT + auth_state_gas + sstore_state_gas),
+        gas_limit=(gas_limit_cap + auth_state_gas + sstore_state_gas),
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -232,6 +241,7 @@ def test_authorization_with_sstore(
 def test_existing_account_refund_enables_sstore(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test auth refund to reservoir enables subsequent state ops.
@@ -241,12 +251,13 @@ def test_existing_account_refund_enables_sstore(
     This refunded gas should then be available for SSTORE state
     gas in the execution phase.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -268,7 +279,7 @@ def test_existing_account_refund_enables_sstore(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=(Spec.TX_MAX_GAS_LIMIT + auth_state_gas + sstore_state_gas),
+        gas_limit=(gas_limit_cap + auth_state_gas + sstore_state_gas),
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -281,6 +292,7 @@ def test_existing_account_refund_enables_sstore(
 def test_auth_refund_block_gas_accounting(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test block gas accounting with authorization existing-account refund.
@@ -289,10 +301,11 @@ def test_auth_refund_block_gas_accounting(
     Block regular gas is unaffected by the auth refund — it reduces
     intrinsic_state_gas, which only affects block_state_gas_used.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -308,7 +321,7 @@ def test_auth_refund_block_gas_accounting(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -324,6 +337,7 @@ def test_auth_refund_block_gas_accounting(
 def test_invalid_nonce_auth_still_charges_intrinsic_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test invalid-nonce authorization still charges intrinsic state gas.
@@ -332,11 +346,12 @@ def test_invalid_nonce_auth_still_charges_intrinsic_state_gas(
     but its intrinsic state gas (135 * cpsb) is still charged upfront
     as part of the transaction's intrinsic gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -352,7 +367,7 @@ def test_invalid_nonce_auth_still_charges_intrinsic_state_gas(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -364,6 +379,7 @@ def test_invalid_nonce_auth_still_charges_intrinsic_state_gas(
 def test_invalid_chain_id_auth_still_charges_intrinsic_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test invalid-chain-id authorization still charges intrinsic state gas.
@@ -371,11 +387,12 @@ def test_invalid_chain_id_auth_still_charges_intrinsic_state_gas(
     An authorization with a mismatched chain ID is skipped during
     processing, but intrinsic state gas is still charged upfront.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -392,7 +409,7 @@ def test_invalid_chain_id_auth_still_charges_intrinsic_state_gas(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -404,6 +421,7 @@ def test_invalid_chain_id_auth_still_charges_intrinsic_state_gas(
 def test_self_sponsored_authorization(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test self-sponsored authorization where sender is also the signer.
@@ -413,11 +431,12 @@ def test_self_sponsored_authorization(
     charged. Since the sender account already exists, the
     new-account state gas refund applies.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -436,7 +455,7 @@ def test_self_sponsored_authorization(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -449,6 +468,7 @@ def test_self_sponsored_authorization(
 def test_duplicate_signer_authorizations(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test multiple authorizations from the same signer.
@@ -458,11 +478,12 @@ def test_duplicate_signer_authorizations(
     Only the last valid authorization takes effect, but all contribute
     to intrinsic state gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract_a = pre.deploy_contract(code=Op.STOP)
     contract_b = pre.deploy_contract(code=Op.STOP)
@@ -486,7 +507,7 @@ def test_duplicate_signer_authorizations(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract_a,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas * 2,
+        gas_limit=gas_limit_cap + auth_state_gas * 2,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -498,6 +519,7 @@ def test_duplicate_signer_authorizations(
 def test_auth_with_calldata_and_access_list(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test authorization combined with calldata and access list.
@@ -506,19 +528,18 @@ def test_auth_with_calldata_and_access_list(
     authorization state gas. All components contribute to the total
     intrinsic gas requirement.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     # Contract that reads calldata and stores it
     contract = pre.deploy_contract(
-        code=(
-            Op.SSTORE(storage.store_next(0x42), Op.CALLDATALOAD(0))
-        ),
+        code=(Op.SSTORE(storage.store_next(0x42), Op.CALLDATALOAD(0))),
     )
 
     signer = pre.fund_eoa()
@@ -533,7 +554,7 @@ def test_auth_with_calldata_and_access_list(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=(Spec.TX_MAX_GAS_LIMIT + auth_state_gas + sstore_state_gas),
+        gas_limit=(gas_limit_cap + auth_state_gas + sstore_state_gas),
         data=b"\x00" * 31 + b"\x42",  # Calldata adds to intrinsic gas
         authorization_list=authorization_list,
         sender=sender,
@@ -547,19 +568,22 @@ def test_auth_with_calldata_and_access_list(
 def test_re_authorization_existing_delegation(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test re-authorization of an account that already has a delegation.
 
     When an authority already has a delegation (set-code) and is
     re-authorized in a new transaction, the account exists so the
-    new-account state gas refund applies. The new delegation replaces the old one.
+    new-account state gas refund applies. The new delegation replaces
+    the old one.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract_old = pre.deploy_contract(code=Op.STOP)
     storage = Storage()
@@ -582,7 +606,7 @@ def test_re_authorization_existing_delegation(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract_new,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -605,6 +629,7 @@ def test_mixed_valid_and_invalid_auths(
     pre: Alloc,
     num_valid: int,
     num_invalid: int,
+    fork: Fork,
 ) -> None:
     """
     Test mixed valid and invalid authorizations state gas charging.
@@ -614,11 +639,12 @@ def test_mixed_valid_and_invalid_auths(
     state gas is still consumed. The total intrinsic state gas equals
     (num_valid + num_invalid) * 135 * cpsb.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -650,7 +676,7 @@ def test_mixed_valid_and_invalid_auths(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas * total_auths,
+        gas_limit=gas_limit_cap + auth_state_gas * total_auths,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -662,6 +688,7 @@ def test_mixed_valid_and_invalid_auths(
 def test_many_authorizations_state_gas(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test many authorizations with state gas from reservoir.
@@ -670,11 +697,12 @@ def test_many_authorizations_state_gas(
     The total state gas is drawn from the reservoir. Verifies that
     large authorization lists scale correctly.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
     num_auths = 10
 
     contract = pre.deploy_contract(code=Op.STOP)
@@ -693,7 +721,7 @@ def test_many_authorizations_state_gas(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas * num_auths,
+        gas_limit=gas_limit_cap + auth_state_gas * num_auths,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -705,6 +733,7 @@ def test_many_authorizations_state_gas(
 def test_auth_with_multiple_sstores(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test authorization combined with multiple SSTOREs.
@@ -713,12 +742,13 @@ def test_auth_with_multiple_sstores(
     charges all draw from the same reservoir. Verifies combined state
     gas accounting across intrinsic and execution phases.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
     num_sstores = 5
 
     storage = Storage()
@@ -741,7 +771,7 @@ def test_auth_with_multiple_sstores(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + total_state_gas,
+        gas_limit=gas_limit_cap + total_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -822,6 +852,7 @@ def test_authorization_exact_state_gas_boundary(
 def test_authorization_to_precompile_address(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test authorization targeting a precompile address charges state gas.
@@ -831,11 +862,12 @@ def test_authorization_to_precompile_address(
     The authorization is processed and the signer's code is set to
     the precompile address delegation designator.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
 
     # ecrecover precompile at 0x01
     precompile_addr = 0x01
@@ -852,7 +884,7 @@ def test_authorization_to_precompile_address(
     sender = pre.fund_eoa()
     tx = Transaction(
         to=signer,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender,
     )
@@ -864,6 +896,7 @@ def test_authorization_to_precompile_address(
 def test_multi_tx_block_auth_refund_and_sstore(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test multi-transaction block with auth refund and SSTORE state gas.
@@ -876,11 +909,12 @@ def test_multi_tx_block_auth_refund_and_sstore(
     Verifies block-level state gas accounting correctly handles both
     the auth refund from tx1 and the SSTORE charge from tx2.
     """
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
 
     contract = pre.deploy_contract(code=Op.STOP)
 
@@ -896,7 +930,7 @@ def test_multi_tx_block_auth_refund_and_sstore(
     sender_1 = pre.fund_eoa()
     tx_1 = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + auth_state_gas,
+        gas_limit=gas_limit_cap + auth_state_gas,
         authorization_list=authorization_list,
         sender=sender_1,
     )
@@ -909,7 +943,7 @@ def test_multi_tx_block_auth_refund_and_sstore(
     sender_2 = pre.fund_eoa()
     tx_2 = Transaction(
         to=sstore_contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=sender_2,
     )
 
@@ -924,6 +958,7 @@ def test_multi_tx_block_auth_refund_and_sstore(
 def test_auth_refund_bypasses_one_fifth_cap(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test auth refund to reservoir bypasses the 1/5 refund cap.
@@ -939,17 +974,18 @@ def test_auth_refund_bypasses_one_fifth_cap(
     the SSTOREs would OOG. By succeeding, this test proves the refund
     bypasses the cap.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    auth_state_gas = (
-        Spec.STATE_BYTES_PER_NEW_ACCOUNT + Spec.STATE_BYTES_PER_AUTH_BASE
-    ) * cpsb
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
-    # Auth refund for existing account = new-account state gas (unused in assertion,
-    # but documents the expected value for reasoning about gas budgets).
+    auth_state_gas = fork.transaction_intrinsic_state_gas(
+        authorization_count=1,
+    )
+    sstore_state_gas = fork.sstore_state_gas()
+    # Auth refund for existing account = new-account state gas
+    # (documents the expected value for reasoning about gas budgets).
 
-    # Use 3 SSTOREs: 3 * 32 * cpsb = 96 * cpsb of state gas needed.
-    # Auth refund gives new-account state gas to the reservoir — enough for all 3.
+    # Use 3 SSTOREs: 3 * 32 * cpsb = 96 * cpsb state gas needed.
+    # Auth refund gives new-account state gas to reservoir for all 3.
     # If it were 1/5 capped: refund would be at most
     # (135 * cpsb) / 5 = 27 * cpsb, which can only fund 0 SSTOREs.
     num_sstores = 3
@@ -978,9 +1014,7 @@ def test_auth_refund_bypasses_one_fifth_cap(
     tx = Transaction(
         to=contract,
         gas_limit=(
-            Spec.TX_MAX_GAS_LIMIT
-            + auth_state_gas
-            + sstore_state_gas * num_sstores
+            gas_limit_cap + auth_state_gas + sstore_state_gas * num_sstores
         ),
         authorization_list=authorization_list,
         sender=sender,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -43,7 +43,7 @@ def test_sstore_zero_to_nonzero(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -69,7 +69,7 @@ def test_sstore_nonzero_to_nonzero(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(2), 2) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(2), 2),
         storage={0: 1},
     )
 
@@ -96,7 +96,7 @@ def test_sstore_nonzero_to_zero(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(0), 0) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(0), 0),
         storage={0: 1},
     )
 
@@ -123,7 +123,7 @@ def test_sstore_zero_to_zero(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(0), 0) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(0), 0),
     )
 
     tx = Transaction(
@@ -151,7 +151,7 @@ def test_sstore_restoration_refund(
     with the regular gas write cost.
     """
     contract = pre.deploy_contract(
-        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0) + Op.STOP),
+        code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
     )
 
     tx = Transaction(
@@ -178,7 +178,7 @@ def test_sstore_restoration_nonzero_no_state_refund(
     so only regular gas refunds apply.
     """
     contract = pre.deploy_contract(
-        code=(Op.SSTORE(0, 2) + Op.SSTORE(0, 1) + Op.STOP),
+        code=(Op.SSTORE(0, 2) + Op.SSTORE(0, 1)),
         storage={0: 1},
     )
 
@@ -205,7 +205,7 @@ def test_sstore_clear_refund_reversal(
     nonzero value, the clear refund is reversed via refund_counter.
     """
     contract = pre.deploy_contract(
-        code=(Op.SSTORE(0, 0) + Op.SSTORE(0, 2) + Op.STOP),
+        code=(Op.SSTORE(0, 0) + Op.SSTORE(0, 2)),
         storage={0: 1},
     )
 
@@ -243,7 +243,6 @@ def test_sstore_multiple_slots(
     code = Bytecode()
     for _ in range(num_slots):
         code += Op.SSTORE(storage.store_next(1), 1)
-    code += Op.STOP
     contract = pre.deploy_contract(code=code)
 
     tx = Transaction(
@@ -274,7 +273,7 @@ def test_sstore_state_gas_drawn_from_reservoir(
 
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = Transaction(
@@ -304,7 +303,7 @@ def test_sstore_state_gas_all_tx_types(
     """
     storage = Storage()
     contract = pre.deploy_contract(
-        code=Op.SSTORE(storage.store_next(1), 1) + Op.STOP,
+        code=Op.SSTORE(storage.store_next(1), 1),
     )
 
     tx = typed_transaction.copy(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -16,6 +16,7 @@ from execution_testing import (
     Alloc,
     Bytecode,
     Environment,
+    Fork,
     Op,
     StateTestFiller,
     Storage,
@@ -23,7 +24,7 @@ from execution_testing import (
 )
 from execution_testing.checklists import EIPChecklist
 
-from .spec import Spec, ref_spec_8037
+from .spec import ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -34,6 +35,7 @@ REFERENCE_SPEC_VERSION = ref_spec_8037.version
 def test_sstore_zero_to_nonzero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE zero-to-nonzero charges state gas.
@@ -41,6 +43,8 @@ def test_sstore_zero_to_nonzero(
     Writing a nonzero value to a previously-zero slot charges
     32 * cost_per_state_byte of state gas in addition to regular gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -48,7 +52,7 @@ def test_sstore_zero_to_nonzero(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -60,6 +64,7 @@ def test_sstore_zero_to_nonzero(
 def test_sstore_nonzero_to_nonzero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE nonzero-to-nonzero charges no state gas.
@@ -67,6 +72,8 @@ def test_sstore_nonzero_to_nonzero(
     Updating a slot that already holds a nonzero value to a different
     nonzero value does not create new state, so no state gas is charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(2), 2),
@@ -75,7 +82,7 @@ def test_sstore_nonzero_to_nonzero(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -87,6 +94,7 @@ def test_sstore_nonzero_to_nonzero(
 def test_sstore_nonzero_to_zero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE nonzero-to-zero charges no state gas.
@@ -94,6 +102,8 @@ def test_sstore_nonzero_to_zero(
     Clearing a storage slot (setting to zero) does not grow state and
     earns a regular gas refund (GAS_STORAGE_CLEAR_REFUND).
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(0), 0),
@@ -102,7 +112,7 @@ def test_sstore_nonzero_to_zero(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -114,6 +124,7 @@ def test_sstore_nonzero_to_zero(
 def test_sstore_zero_to_zero(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE zero-to-zero charges no state gas.
@@ -121,6 +132,8 @@ def test_sstore_zero_to_zero(
     Writing zero to an already-zero slot creates no new state. Only
     the warm access regular gas cost is charged.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(0), 0),
@@ -128,7 +141,7 @@ def test_sstore_zero_to_zero(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -141,6 +154,7 @@ def test_sstore_zero_to_zero(
 def test_sstore_restoration_refund(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE zero-to-nonzero-to-zero restoration refunds state gas.
@@ -150,13 +164,15 @@ def test_sstore_restoration_refund(
     (32 * cost_per_state_byte) is refunded via refund_counter along
     with the regular gas write cost.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract = pre.deploy_contract(
         code=(Op.SSTORE(0, 1) + Op.SSTORE(0, 0)),
     )
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -169,6 +185,7 @@ def test_sstore_restoration_refund(
 def test_sstore_restoration_nonzero_no_state_refund(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test nonzero-to-nonzero-to-original restoration has no state gas refund.
@@ -177,6 +194,8 @@ def test_sstore_restoration_nonzero_no_state_refund(
     restoring it never involves state gas (no state growth occurred),
     so only regular gas refunds apply.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract = pre.deploy_contract(
         code=(Op.SSTORE(0, 2) + Op.SSTORE(0, 1)),
         storage={0: 1},
@@ -184,7 +203,7 @@ def test_sstore_restoration_nonzero_no_state_refund(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -196,6 +215,7 @@ def test_sstore_restoration_nonzero_no_state_refund(
 def test_sstore_clear_refund_reversal(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test clearing a nonzero slot then un-clearing reverses the refund.
@@ -204,6 +224,8 @@ def test_sstore_clear_refund_reversal(
     the clear refund is granted. If the slot is then set back to a
     nonzero value, the clear refund is reversed via refund_counter.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     contract = pre.deploy_contract(
         code=(Op.SSTORE(0, 0) + Op.SSTORE(0, 2)),
         storage={0: 1},
@@ -211,7 +233,7 @@ def test_sstore_clear_refund_reversal(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -232,6 +254,7 @@ def test_sstore_multiple_slots(
     state_test: StateTestFiller,
     pre: Alloc,
     num_slots: int,
+    fork: Fork,
 ) -> None:
     """
     Test multiple zero-to-nonzero SSTOREs each charge state gas.
@@ -239,6 +262,8 @@ def test_sstore_multiple_slots(
     Each slot written from zero to nonzero independently charges
     32 * cost_per_state_byte of state gas.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     code = Bytecode()
     for _ in range(num_slots):
@@ -247,7 +272,7 @@ def test_sstore_multiple_slots(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
         sender=pre.fund_eoa(),
     )
 
@@ -259,6 +284,7 @@ def test_sstore_multiple_slots(
 def test_sstore_state_gas_drawn_from_reservoir(
     state_test: StateTestFiller,
     pre: Alloc,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas drawn from reservoir before gas_left.
@@ -267,9 +293,10 @@ def test_sstore_state_gas_drawn_from_reservoir(
     SSTORE state gas from the reservoir, leaving gas_left untouched
     by the state gas charge.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     env = Environment()
-    cpsb = Spec.COST_PER_STATE_BYTE
-    sstore_state_gas = Spec.STATE_BYTES_PER_STORAGE_SET * cpsb
+    sstore_state_gas = fork.sstore_state_gas()
 
     storage = Storage()
     contract = pre.deploy_contract(
@@ -278,7 +305,7 @@ def test_sstore_state_gas_drawn_from_reservoir(
 
     tx = Transaction(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT + sstore_state_gas,
+        gas_limit=gas_limit_cap + sstore_state_gas,
         sender=pre.fund_eoa(),
     )
 
@@ -292,6 +319,7 @@ def test_sstore_state_gas_all_tx_types(
     state_test: StateTestFiller,
     pre: Alloc,
     typed_transaction: Transaction,
+    fork: Fork,
 ) -> None:
     """
     Test SSTORE state gas works across all transaction types.
@@ -301,6 +329,8 @@ def test_sstore_state_gas_all_tx_types(
     gas_left and state_gas_reservoir. Verify SSTORE succeeds with
     each type.
     """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     storage = Storage()
     contract = pre.deploy_contract(
         code=Op.SSTORE(storage.store_next(1), 1),
@@ -308,7 +338,7 @@ def test_sstore_state_gas_all_tx_types(
 
     tx = typed_transaction.copy(
         to=contract,
-        gas_limit=Spec.TX_MAX_GAS_LIMIT,
+        gas_limit=gas_limit_cap,
     )
 
     post = {contract: Account(storage=storage)}

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -118,10 +118,18 @@ SINGLE_BYTE_INITCODE.opcode_list = _single_bytecode.opcode_list
         INITCODE_ZEROS_MAX_LIMIT,
         INITCODE_ONES_MAX_LIMIT,
         pytest.param(
-            INITCODE_ZEROS_OVER_LIMIT, marks=pytest.mark.exception_test
+            INITCODE_ZEROS_OVER_LIMIT,
+            marks=[
+                pytest.mark.exception_test,
+                pytest.mark.valid_until("Osaka"),
+            ],
         ),
         pytest.param(
-            INITCODE_ONES_OVER_LIMIT, marks=pytest.mark.exception_test
+            INITCODE_ONES_OVER_LIMIT,
+            marks=[
+                pytest.mark.exception_test,
+                pytest.mark.valid_until("Osaka"),
+            ],
         ),
     ],
     ids=get_initcode_name,
@@ -136,6 +144,9 @@ def test_contract_creating_tx(
 ) -> None:
     """
     Test creating a contract with initcode that is on/over the allowed limit.
+
+    Over-limit cases are valid until Osaka because EIP-7954 increases
+    the max initcode size in Amsterdam.
     """
     create_contract_address = compute_create_address(
         address=sender,


### PR DESCRIPTION
## 🗒️ Description

Harden EIP-8037 tests with new coverage and dynamic fork calculators.

- Multi-block receipt accounting and exact coinbase fee tests prompted by the BAL kurtosis devnet-3 coinbase balance mismatch between ethrex and besu ([discord](https://discord.com/channels/1359927674746835211/1479288628386725920/1479320527075147776)), where clients diverged on `receiptGasUsed` computation due to differing `state_gas_reservoir`/`state_gas_refund` handling. Discovered from @qu0b
- Gas validation edge cases (CREATE intrinsic boundary, nested CREATE code deposit, calldata floor interaction) from @benaadams ([#2426](https://github.com/ethereum/execution-specs/issues/2426), [#2427](https://github.com/ethereum/execution-specs/pull/2427)).
- Add `new_account` variant to insufficient balance CALL test, from @qu0b
- Add `sstore_state_gas()`, `code_deposit_state_gas()`, `create_state_gas()` calculator methods to `BaseFork`/`Frontier`/`Amsterdam`.
- Replace all `Spec` class constant usages with dynamic `fork` method equivalents across all test files.

## 🔗 Related Issues or PRs

Closes https://github.com/ethereum/execution-specs/issues/2426
Closes https://github.com/ethereum/execution-specs/pull/2427

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://camo.githubusercontent.com/7684cd70afde7af3940a26f13295a0c0ef5d4cd7036946c8624e3e4049c2a1a3/68747470733a2f2f696d616765732e756e73706c6173682e636f6d2f70686f746f2d313531373834393834353533372d346432353739303234353461)