### PR TITLE
fix(test-benchmark): refactor failing benchmark on Amsterdam

### DIFF
--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -13,5 +13,5 @@ static:
   targets: ["evmone-t8n"]
 benchmark:
   impl: geth
-  repo: ethereum/go-ethereum
-  ref: master
+  repo: fselmo/go-ethereum
+  ref: feat/opcode-count-t8n-bals

--- a/tests/benchmark/compute/scenario/test_transaction_types.py
+++ b/tests/benchmark/compute/scenario/test_transaction_types.py
@@ -20,6 +20,7 @@ from execution_testing import (
     Transaction,
     compute_create_address,
 )
+from execution_testing.forks import Amsterdam
 
 
 def test_empty_block(
@@ -590,7 +591,9 @@ def test_auth_transaction(
         )
         total_gas_used += tx_gas_used
 
-        if not empty_authority:
+        # From Amsterdam onwards (EIP-7778), GasUsed in receipts reflects
+        # pre-refund gas (MaxUsedGas), so refunds are not subtracted.
+        if not empty_authority and fork < Amsterdam:
             total_refund += min(
                 tx_gas_used // 5,
                 (

--- a/tox.ini
+++ b/tox.ini
@@ -148,9 +148,9 @@ passenv =
 commands =
     fill \
         --evm-bin={env:EVM_BIN:evm} \
-        --gas-benchmark-values 1 \
+        --gas-benchmark-values 60 \
         --generate-pre-alloc-groups \
-        --fork Osaka \
+        --fork Amsterdam \
         -m "benchmark and not slow" \
         -n auto --maxprocesses 10 --dist=loadgroup \
         --basetemp="{temp_dir}/pytest" \
@@ -169,7 +169,7 @@ commands =
     fill \
         --evm-bin={env:EVM_BIN:evm} \
         --fixed-opcode-count 1 \
-        --fork Osaka \
+        --fork Amsterdam \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         # TODO: remove skip once working for all precompiles PR#1955
@@ -191,7 +191,7 @@ commands =
     fill \
         --evm-bin={env:EVM_BIN:evm} \
         --fixed-opcode-count \
-        --fork Osaka \
+        --fork Amsterdam \
         -m repricing \
         -n auto --maxprocesses 10 --dist=loadgroup \
         # TODO: remove skip once working for all precompiles PR#1955


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

WIP

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
