### PR TITLE
chore(test-consume): delay client stop on test failure to flush logs

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/single_test_client.py
@@ -5,6 +5,7 @@ Common pytest fixtures for simulators with single-test client architecture.
 import io
 import json
 import logging
+import time
 from typing import Generator, Literal, cast
 
 import pytest
@@ -76,6 +77,7 @@ def genesis_header(fixture: BlockchainFixtureCommon) -> FixtureHeader:
 
 @pytest.fixture(scope="function")
 def client(
+    request: pytest.FixtureRequest,
     hive_test: HiveTest,
     # configured within: rlp/conftest.py & engine/conftest.py
     client_files: dict,
@@ -106,6 +108,10 @@ def client(
     assert client is not None, error_message
     logger.info(f"Client ({client_type.name}) ready!")
     yield client
+    # Allow the client to flush logs before stopping on failure.
+    result_call = getattr(request.node, "result_call", None)
+    if result_call is not None and result_call.failed:
+        time.sleep(1)
     logger.info(f"Stopping client ({client_type.name})...")
     with total_timing_data.time("Stop client"):
         client.stop()

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/sync/conftest.py
@@ -6,6 +6,8 @@ Configures the hive back-end & EL clients for each individual test execution.
 
 import io
 import json
+import logging
+import time
 from typing import Dict, Generator, Mapping, cast
 
 import pytest
@@ -188,6 +190,7 @@ def client_enode_url(client: Client) -> str:
 
 @pytest.fixture(scope="function")
 def sync_client(
+    request: pytest.FixtureRequest,
     hive_test: HiveTest,
     sync_client_files: Dict,
     environment: Dict,
@@ -195,8 +198,6 @@ def sync_client(
     client_enode_url: str,  # Get the enode URL from fixture
 ) -> Generator[Client, None, None]:
     """Start a sync client that will sync from the client under test."""
-    import logging
-
     logger = logging.getLogger(__name__)
     logger.info(f"Starting sync client setup for {sync_client_type.name}")
 
@@ -253,6 +254,10 @@ def sync_client(
     yield sync_client
 
     # Cleanup
+    # Allow the client to flush logs before stopping on failure.
+    result_call = getattr(request.node, "result_call", None)
+    if result_call is not None and result_call.failed:
+        time.sleep(1)
     sync_client.stop()
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add a 1-second delay before calling `client.stop()` when a test has failed, giving the client container time to flush its logs. Applied to both the main client fixture and the sync client fixture.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes: https://github.com/ethereum/execution-specs/issues/1556

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

