### PR TITLE
feat(tests): add missing legacy modexp cases with oversized lengths

### DIFF
--- a/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
@@ -118,6 +118,94 @@ def test_modexp_invalid_inputs(
 
 
 @pytest.mark.parametrize(
+    "modexp_input,",
+    [
+        pytest.param(
+            # base_len=0, exp_len=32, mod_len=2^256-1
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd"
+            ),
+            id="legacy-case-2",
+        ),
+        pytest.param(
+            # base_len=4TiB, exp_len=0, mod_len=0
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000040000000000"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            id="legacy-case-28",
+        ),
+        pytest.param(
+            # base_len=0, exp_len=4TiB, mod_len=0
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                "0000000000000000000000000000000000000000000000000000040000000000"
+            ),
+            id="legacy-case-29",
+        ),
+        pytest.param(
+            # base_len=0, exp_len=2^255, mod_len=0
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                "8000000000000000000000000000000000000000000000000000000000000000"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            id="legacy-case-30",
+        ),
+        pytest.param(
+            # base_len=255, exp_len overflows gas calculation (Oct 2017)
+            bytes.fromhex(
+                "00000000000000000000000000000000000000000000000000000000000000ff"
+                "2a1e530000000000000000000000000000000000000000000000000000000000"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+            id="legacy-case-36",
+        ),
+        pytest.param(
+            # base_len=1, exp_len overflows gas calculation (July 2022)
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+                "2000000000000000000000000000000000000000000000000000000000000020"
+                "0000000000000000000000000000000000000000000000000000000000000001"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                "010001"
+            ),
+            id="legacy-case-37",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "modexp_expected,call_succeeds",
+    [
+        pytest.param(bytes(), False),
+    ],
+    ids=[""],
+)
+@EIPChecklist.Precompile.Test.Inputs.Invalid()
+@pytest.mark.valid_from("Osaka")
+def test_modexp_legacy_oversized_inputs(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    tx: Transaction,
+    post: Dict,
+) -> None:
+    """
+    Test ModExp with legacy modexpFiller cases that have oversized declared
+    lengths. EIP-7823 rejects inputs with any declared length exceeding
+    1024 bytes.
+    """
+    state_test(
+        pre=pre,
+        tx=tx,
+        post=post,
+    )
+
+
+@pytest.mark.parametrize(
     "modexp_input,modexp_expected,call_succeeds",
     [
         pytest.param(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Add 6 legacy modexpFiller.json test cases (2, 28, 29, 30, 36, 37) that were excluded due to oversized declared lengths. These cases fail under EIP-7823 upper bounds (Osaka+). A future port can handle older forks.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes https://github.com/ethereum/execution-specs/issues/1564

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

