### PR TITLE
refactor(test-forks): replace hardcoded transition timestamps

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/helpers/ruleset.py
@@ -213,7 +213,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_FORK_LONDON": 0,
         "HIVE_FORK_MERGE": 0,
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
-        "HIVE_SHANGHAI_TIMESTAMP": 15000,
+        "HIVE_SHANGHAI_TIMESTAMP": Shanghai.transition_timestamp(),
     },
     Cancun: {
         "HIVE_FORK_HOMESTEAD": 0,
@@ -244,7 +244,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_FORK_MERGE": 0,
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
-        "HIVE_CANCUN_TIMESTAMP": 15000,
+        "HIVE_CANCUN_TIMESTAMP": Cancun.transition_timestamp(),
         **get_blob_schedule_entries(Cancun),
     },
     Prague: {
@@ -278,7 +278,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_TERMINAL_TOTAL_DIFFICULTY": 0,
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
-        "HIVE_PRAGUE_TIMESTAMP": 15000,
+        "HIVE_PRAGUE_TIMESTAMP": Prague.transition_timestamp(),
         **get_blob_schedule_entries(Prague),
     },
     Osaka: {
@@ -314,7 +314,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_SHANGHAI_TIMESTAMP": 0,
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
-        "HIVE_OSAKA_TIMESTAMP": 15000,
+        "HIVE_OSAKA_TIMESTAMP": Osaka.transition_timestamp(),
         **get_blob_schedule_entries(Osaka),
     },
     BPO1: {
@@ -352,7 +352,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_CANCUN_TIMESTAMP": 0,
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_OSAKA_TIMESTAMP": 0,
-        "HIVE_BPO1_TIMESTAMP": 15000,
+        "HIVE_BPO1_TIMESTAMP": BPO1.transition_timestamp(),
         **get_blob_schedule_entries(BPO1),
     },
     BPO2: {
@@ -392,7 +392,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_PRAGUE_TIMESTAMP": 0,
         "HIVE_OSAKA_TIMESTAMP": 0,
         "HIVE_BPO1_TIMESTAMP": 0,
-        "HIVE_BPO2_TIMESTAMP": 15000,
+        "HIVE_BPO2_TIMESTAMP": BPO2.transition_timestamp(),
         **get_blob_schedule_entries(BPO2),
     },
     BPO3: {
@@ -434,7 +434,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_OSAKA_TIMESTAMP": 0,
         "HIVE_BPO1_TIMESTAMP": 0,
         "HIVE_BPO2_TIMESTAMP": 0,
-        "HIVE_BPO3_TIMESTAMP": 15000,
+        "HIVE_BPO3_TIMESTAMP": BPO3.transition_timestamp(),
         **get_blob_schedule_entries(BPO3),
     },
     BPO4: {
@@ -478,7 +478,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_BPO1_TIMESTAMP": 0,
         "HIVE_BPO2_TIMESTAMP": 0,
         "HIVE_BPO3_TIMESTAMP": 0,
-        "HIVE_BPO4_TIMESTAMP": 15000,
+        "HIVE_BPO4_TIMESTAMP": BPO4.transition_timestamp(),
         **get_blob_schedule_entries(BPO4),
     },
     BPO2ToAmsterdamAtTime15k: {
@@ -499,7 +499,7 @@ ruleset: Dict[Fork, Dict[str, int]] = {
         "HIVE_OSAKA_TIMESTAMP": 0,
         "HIVE_BPO1_TIMESTAMP": 0,
         "HIVE_BPO2_TIMESTAMP": 0,
-        "HIVE_AMSTERDAM_TIMESTAMP": 15000,
+        "HIVE_AMSTERDAM_TIMESTAMP": Amsterdam.transition_timestamp(),
         **get_blob_schedule_entries(BPO2),
     },
     Amsterdam: {

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -2187,6 +2187,11 @@ class Paris(
     """Paris (Merge) fork."""
 
     @classmethod
+    def transition_timestamp(cls) -> int:
+        """Return the timestamp used for fork transition tests."""
+        return 15_000
+
+    @classmethod
     def header_prev_randao_required(
         cls, *, block_number: int = 0, timestamp: int = 0
     ) -> bool:

--- a/packages/testing/src/execution_testing/forks/forks/transition.py
+++ b/packages/testing/src/execution_testing/forks/forks/transition.py
@@ -25,67 +25,70 @@ class BerlinToLondonAt5(Berlin):
     pass
 
 
-@transition_fork(to_fork=Shanghai, at_timestamp=15_000)
+@transition_fork(to_fork=Shanghai, at_timestamp=Paris.transition_timestamp())
 class ParisToShanghaiAtTime15k(Paris):
     """Paris to Shanghai transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=Cancun, at_timestamp=15_000)
+@transition_fork(to_fork=Cancun, at_timestamp=Paris.transition_timestamp())
 class ShanghaiToCancunAtTime15k(Shanghai):
     """Shanghai to Cancun transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=Prague, at_timestamp=15_000)
+@transition_fork(to_fork=Prague, at_timestamp=Paris.transition_timestamp())
 class CancunToPragueAtTime15k(Cancun):
     """Cancun to Prague transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=Osaka, at_timestamp=15_000)
+@transition_fork(to_fork=Osaka, at_timestamp=Paris.transition_timestamp())
 class PragueToOsakaAtTime15k(Prague):
     """Prague to Osaka transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=BPO1, at_timestamp=15_000)
+@transition_fork(to_fork=BPO1, at_timestamp=Paris.transition_timestamp())
 class OsakaToBPO1AtTime15k(Osaka):
     """Osaka to BPO1 transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=BPO2, at_timestamp=15_000)
+@transition_fork(to_fork=BPO2, at_timestamp=Paris.transition_timestamp())
 class BPO1ToBPO2AtTime15k(BPO1):
     """BPO1 to BPO2 transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=Amsterdam, at_timestamp=15_000)
+@transition_fork(
+    to_fork=Amsterdam,
+    at_timestamp=Paris.transition_timestamp(),
+)
 class BPO2ToAmsterdamAtTime15k(BPO2):
     """BPO2 to Amsterdam transition at Timestamp 15k."""
 
-    # TODO: We may need to adjust which BPO Amsterdam inherits from as the
-    #  related Amsterdam specs change over time, and before Amsterdam is
-    #  live on mainnet.
+    # TODO: We may need to adjust which BPO Amsterdam inherits
+    #  from as the related Amsterdam specs change over time, and
+    #  before Amsterdam is live on mainnet.
 
     pass
 
 
-@transition_fork(to_fork=BPO3, at_timestamp=15_000)
+@transition_fork(to_fork=BPO3, at_timestamp=Paris.transition_timestamp())
 class BPO2ToBPO3AtTime15k(BPO2):
     """BPO2 to BPO3 transition at Timestamp 15k."""
 
     pass
 
 
-@transition_fork(to_fork=BPO4, at_timestamp=15_000)
+@transition_fork(to_fork=BPO4, at_timestamp=Paris.transition_timestamp())
 class BPO3ToBPO4AtTime15k(BPO3):
     """BPO3 to BPO4 transition at Timestamp 15k."""
 

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -78,13 +78,13 @@ def test_transition_forks() -> None:
 
     assert (
         ParisToShanghaiAtTime15k.transition_tool_name(
-            block_number=0, timestamp=14_999
+            block_number=0, timestamp=Paris.transition_timestamp() - 1
         )
         == "Merge"
     )
     assert (
         ParisToShanghaiAtTime15k.transition_tool_name(
-            block_number=0, timestamp=15_000
+            block_number=0, timestamp=Paris.transition_timestamp()
         )
         == "Shanghai"
     )
@@ -101,26 +101,26 @@ def test_transition_forks() -> None:
 
     assert (
         ParisToShanghaiAtTime15k.header_withdrawals_required(
-            block_number=0, timestamp=14_999
+            block_number=0, timestamp=Paris.transition_timestamp() - 1
         )
         is False
     )
     assert (
         ParisToShanghaiAtTime15k.header_withdrawals_required(
-            block_number=0, timestamp=15_000
+            block_number=0, timestamp=Paris.transition_timestamp()
         )
         is True
     )
 
     assert (
         ParisToShanghaiAtTime15k.engine_new_payload_version(
-            block_number=0, timestamp=14_999
+            block_number=0, timestamp=Paris.transition_timestamp() - 1
         )
         == 1
     )
     assert (
         ParisToShanghaiAtTime15k.engine_new_payload_version(
-            block_number=0, timestamp=15_000
+            block_number=0, timestamp=Paris.transition_timestamp()
         )
         == 2
     )
@@ -128,17 +128,21 @@ def test_transition_forks() -> None:
     assert BerlinToLondonAt5.fork_at(block_number=4, timestamp=0) == Berlin
     assert BerlinToLondonAt5.fork_at(block_number=5, timestamp=0) == London
     assert (
-        ParisToShanghaiAtTime15k.fork_at(block_number=0, timestamp=14_999)
+        ParisToShanghaiAtTime15k.fork_at(
+            block_number=0, timestamp=Paris.transition_timestamp() - 1
+        )
         == Paris
     )
     assert (
-        ParisToShanghaiAtTime15k.fork_at(block_number=0, timestamp=15_000)
+        ParisToShanghaiAtTime15k.fork_at(
+            block_number=0, timestamp=Paris.transition_timestamp()
+        )
         == Shanghai
     )
     assert ParisToShanghaiAtTime15k.fork_at() == Paris
     assert (
         ParisToShanghaiAtTime15k.fork_at(
-            block_number=10_000_000, timestamp=14_999
+            block_number=10_000_000, timestamp=Paris.transition_timestamp() - 1
         )
         == Paris
     )
@@ -202,13 +206,13 @@ def test_forks() -> None:
     )
     assert (
         cast(Fork, ParisToShanghaiAtTime15k).header_withdrawals_required(
-            block_number=0, timestamp=14_999
+            block_number=0, timestamp=Paris.transition_timestamp() - 1
         )
         is False
     )
     assert (
         cast(Fork, ParisToShanghaiAtTime15k).header_withdrawals_required(
-            block_number=0, timestamp=15_000
+            block_number=0, timestamp=Paris.transition_timestamp()
         )
         is True
     )
@@ -367,7 +371,10 @@ class PreAllocFork(PrePreAllocFork):
         return {"test2": "test2"} | super(PreAllocFork, cls).pre_allocation()
 
 
-@transition_fork(to_fork=PreAllocFork, at_timestamp=15_000)
+@transition_fork(
+    to_fork=PreAllocFork,
+    at_timestamp=Paris.transition_timestamp(),
+)
 class PreAllocTransitionFork(PrePreAllocFork):
     """PrePreAllocFork to PreAllocFork transition at Timestamp 15k."""
 

--- a/packages/testing/src/execution_testing/test_types/blob_types.py
+++ b/packages/testing/src/execution_testing/test_types/blob_types.py
@@ -60,7 +60,7 @@ class Blob(CamelModel):
     name: str
     fork: Fork
     seed: int
-    timestamp: int  # fork transitions require timestamp >= 15000 to occur
+    timestamp: int  # transitions require >= transition_timestamp
 
     _trusted_setup: ClassVar[Any | None] = None
 

--- a/packages/testing/src/execution_testing/test_types/tests/test_blob_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_blob_types.py
@@ -10,6 +10,7 @@ from filelock import FileLock
 from execution_testing.forks import (
     Cancun,
     Osaka,
+    Paris,
     Prague,
 )
 from execution_testing.forks.forks.transition import (
@@ -139,7 +140,13 @@ def test_blob_proof_corruption(
     increment_counter()
 
 
-@pytest.mark.parametrize("timestamp", [14999, 15000])
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        Paris.transition_timestamp() - 1,
+        Paris.transition_timestamp(),
+    ],
+)
 @pytest.mark.parametrize(
     "fork",
     [
@@ -153,8 +160,8 @@ def test_transition_fork_blobs(
     timestamp: int,
 ) -> None:
     """
-    Generates blobs for transition forks (time 14999 is old fork, time 15000 is
-    new fork).
+    Generate blobs for transition forks (pre-transition timestamp is old fork,
+    transition timestamp is new fork).
     """
     # line below guarantees that this test runs only after the other blob unit
     # tests are done
@@ -164,10 +171,12 @@ def test_transition_fork_blobs(
 
     print(f"Original fork: {fork}, Timestamp: {timestamp}")
     pre_transition_fork = fork.transitions_from()
-    # only reached if timestamp >= 15000
-    post_transition_fork_at_15k = fork.transitions_to()
+    post_transition_fork = fork.transitions_to()
 
-    if not pre_transition_fork.supports_blobs() and timestamp < 15000:
+    if (
+        not pre_transition_fork.supports_blobs()
+        and timestamp < Paris.transition_timestamp()
+    ):
         print(
             f"Skipping blob creation because pre-transition fork is "
             f"{pre_transition_fork} and timestamp is {timestamp}"
@@ -178,22 +187,26 @@ def test_transition_fork_blobs(
     b = Blob.from_fork(fork=fork, timestamp=timestamp)
     print(f"Fork of created blob: {b.fork.name()}")
 
-    if timestamp == 14999:  # case: no transition yet
+    if timestamp < Paris.transition_timestamp():  # case: no transition yet
         assert b.fork.name() == pre_transition_fork.name(), (
             f"Transition fork failure! Fork {fork.name()} at timestamp: "
             f"{timestamp} should have stayed at fork "
             f"{pre_transition_fork.name()} but has unexpectedly transitioned "
             f"to {b.fork.name()}"
         )
-    elif timestamp == 15000:  # case: transition to next fork has happened
-        assert b.fork.name() == post_transition_fork_at_15k.name(), (
-            f"Transition fork failure! Fork {fork.name()} at timestamp: "
-            f"{timestamp} should have transitioned to "
-            f"{post_transition_fork_at_15k.name()} but is still at "
+    # case: transition has happened
+    elif timestamp == Paris.transition_timestamp():
+        assert b.fork.name() == post_transition_fork.name(), (
+            f"Transition fork failure! Fork {fork.name()} at "
+            f"timestamp: {timestamp} should have transitioned to "
+            f"{post_transition_fork.name()} but is still at "
             f"{b.fork.name()}"
         )
 
     # delete counter at last iteration (otherwise re-running all unit tests
     # will fail)
-    if timestamp == 15_000 and pre_transition_fork == Prague:
+    if (
+        timestamp == Paris.transition_timestamp()
+        and pre_transition_fork == Prague
+    ):
         (CACHED_BLOBS_DIRECTORY / "blob_unit_test_counter.txt").unlink()

--- a/packages/testing/src/execution_testing/tools/utility/generators.py
+++ b/packages/testing/src/execution_testing/tools/utility/generators.py
@@ -10,7 +10,7 @@ import pytest
 
 from execution_testing.base_types import Account, Address, Hash
 from execution_testing.exceptions import BlockException
-from execution_testing.forks import Berlin, Fork
+from execution_testing.forks import Berlin, Fork, Paris
 from execution_testing.specs import BlockchainTestFiller, StateTestFiller
 from execution_testing.specs.blockchain import Block
 from execution_testing.test_types import Alloc, Transaction
@@ -191,34 +191,35 @@ def generate_system_contract_deploy_test(
             assert deployer_address is not None
             assert deploy_tx.created_contract == expected_deploy_address
             blocks: List[Block] = []
+            t = Paris.transition_timestamp()
 
             if test_type == DeploymentTestType.DEPLOY_BEFORE_FORK:
                 blocks = [
                     Block(  # Deployment block
                         txs=[deploy_tx],
-                        timestamp=14_999,
+                        timestamp=t - 1,
                     ),
                     Block(  # Empty block on fork
                         txs=[],
-                        timestamp=15_000,
+                        timestamp=t,
                     ),
                 ]
             elif test_type == DeploymentTestType.DEPLOY_ON_FORK_BLOCK:
                 blocks = [
                     Block(  # Deployment on fork block
                         txs=[deploy_tx],
-                        timestamp=15_000,
+                        timestamp=t,
                     ),
                     Block(  # Empty block after fork
                         txs=[],
-                        timestamp=15_001,
+                        timestamp=t + 1,
                     ),
                 ]
             elif test_type == DeploymentTestType.DEPLOY_AFTER_FORK:
                 blocks = [
                     Block(  # Empty block on fork
                         txs=[],
-                        timestamp=15_000,
+                        timestamp=t,
                         exception=BlockException.SYSTEM_CONTRACT_EMPTY
                         if fail_on_empty_code
                         else None,
@@ -228,13 +229,13 @@ def generate_system_contract_deploy_test(
                     blocks.append(
                         Block(  # Deployment after fork block
                             txs=[deploy_tx],
-                            timestamp=15_001,
+                            timestamp=t + 1,
                         )
                     )
                     blocks.append(
                         Block(  # Empty block after deployment
                             txs=[],
-                            timestamp=15_002,
+                            timestamp=t + 2,
                         ),
                     )
             balance = (

--- a/tests/cancun/eip4788_beacon_root/spec.py
+++ b/tests/cancun/eip4788_beacon_root/spec.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from execution_testing import Storage
+from execution_testing.forks import Cancun
 
 
 @dataclass(frozen=True)
@@ -31,7 +32,7 @@ class Spec:
     BEACON_ROOTS_DEPLOYER_ADDRESS = 0x0B799C86A49DEEB90402691F1041AA3AF2D3C875
     HISTORY_BUFFER_LENGTH = 8_191
     SYSTEM_ADDRESS = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
-    FORK_TIMESTAMP = 15_000  # ShanghaiToCancun timestamp
+    FORK_TIMESTAMP = Cancun.transition_timestamp()
 
 
 @dataclass(frozen=True)

--- a/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
+++ b/tests/cancun/eip4788_beacon_root/test_beacon_root_contract.py
@@ -34,6 +34,7 @@ from execution_testing import (
     Transaction,
     Withdrawal,
 )
+from execution_testing.forks import Cancun
 
 from .spec import Spec, ref_spec_4788
 
@@ -668,7 +669,7 @@ def test_beacon_root_transition(
     )
 
 
-@pytest.mark.parametrize("timestamp", [15_000])
+@pytest.mark.parametrize("timestamp", [Cancun.transition_timestamp()])
 @pytest.mark.valid_at_transition_to("Cancun")
 @pytest.mark.pre_alloc_mutable()
 def test_no_beacon_root_contract_at_transition(
@@ -744,8 +745,8 @@ def test_no_beacon_root_contract_at_transition(
 @pytest.mark.parametrize(
     "timestamp",
     [
-        pytest.param(15_000, id="deploy_on_shanghai"),
-        pytest.param(30_000, id="deploy_on_cancun"),
+        pytest.param(Cancun.transition_timestamp(), id="deploy_on_shanghai"),
+        pytest.param(Cancun.transition_timestamp() * 2, id="deploy_on_cancun"),
     ],
 )
 @pytest.mark.valid_at_transition_to("Cancun")

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -24,14 +24,13 @@ from execution_testing import (
     Transaction,
     add_kzg_version,
 )
+from execution_testing.forks import Cancun
 
 from .spec import Spec, SpecHelpers, ref_spec_4844
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_4844.git_path
 REFERENCE_SPEC_VERSION = ref_spec_4844.version
 
-# Timestamp of the fork
-FORK_TIMESTAMP = 15_000
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
 
 
@@ -73,7 +72,8 @@ def pre_fork_blobs_per_block(fork: Fork) -> int:
 @pytest.fixture
 def post_fork_blobs_per_block(fork: Fork) -> int:
     """Amount of blobs to produce with the post-fork rules."""
-    return fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP) + 1
+    t = Cancun.transition_timestamp()
+    return fork.target_blobs_per_block(timestamp=t) + 1
 
 
 @pytest.fixture
@@ -89,7 +89,7 @@ def pre_fork_blocks(
     """Generate blocks to reach the fork."""
     blocks = []
 
-    for t in range(999, FORK_TIMESTAMP, 1_000):
+    for t in range(999, Cancun.transition_timestamp(), 1_000):
         remaining_gas = block_gas_limit // 2
         if pre_fork_blobs_per_block == 0:
             blocks.append(
@@ -196,8 +196,8 @@ def post_fork_block_count(fork: Fork) -> int:
     return SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
         fork=fork, blob_gas_price=2
     ) // (
-        fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP)
-        - fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP)
+        fork.max_blobs_per_block(timestamp=Cancun.transition_timestamp())
+        - fork.target_blobs_per_block(timestamp=Cancun.transition_timestamp())
     )
 
 
@@ -224,7 +224,7 @@ def fork_block_excess_blob_gas(
     if pre_fork_blobs_per_block == 0:
         return 0
     calc_excess_blob_gas_post_fork = fork.excess_blob_gas_calculator(
-        timestamp=FORK_TIMESTAMP
+        timestamp=Cancun.transition_timestamp()
     )
     return calc_excess_blob_gas_post_fork(
         parent_excess_blob_gas=pre_fork_excess_blob_gas,
@@ -265,7 +265,8 @@ def post_fork_blocks(
         txs = []
         blob_index = 0
         remaining_blobs = post_fork_blobs_per_block
-        max_blobs_per_tx = fork.max_blobs_per_tx(timestamp=FORK_TIMESTAMP)
+        t = Cancun.transition_timestamp()
+        max_blobs_per_tx = fork.max_blobs_per_tx(timestamp=t)
         while remaining_blobs > 0:
             tx_blobs = min(remaining_blobs, max_blobs_per_tx)
             txs.append(
@@ -320,7 +321,8 @@ def post(  # noqa: D103
 
     post_fork_tx_count_per_block = 0
     if post_fork_blobs_per_block > 0:
-        max_blobs_per_tx_post = fork.max_blobs_per_tx(timestamp=FORK_TIMESTAMP)
+        t = Cancun.transition_timestamp()
+        max_blobs_per_tx_post = fork.max_blobs_per_tx(timestamp=t)
         post_fork_tx_count_per_block = (
             post_fork_blobs_per_block + max_blobs_per_tx_post - 1
         ) // max_blobs_per_tx_post
@@ -372,7 +374,7 @@ def test_invalid_pre_fork_block_with_blob_fields(
         blocks=pre_fork_blocks[:-1]
         + [
             Block(
-                timestamp=(FORK_TIMESTAMP - 1),
+                timestamp=(Cancun.transition_timestamp() - 1),
                 rlp_modifier=header_modifier,
                 exception=BlockException.INCORRECT_BLOCK_FORMAT,
                 engine_api_error_code=EngineAPIError.InvalidParams,
@@ -419,7 +421,7 @@ def test_invalid_post_fork_block_without_blob_fields(
         blocks=pre_fork_blocks
         + [
             Block(
-                timestamp=FORK_TIMESTAMP,
+                timestamp=Cancun.transition_timestamp(),
                 rlp_modifier=header_modifier,
                 exception=BlockException.INCORRECT_BLOCK_FORMAT,
                 engine_api_error_code=EngineAPIError.InvalidParams,
@@ -432,26 +434,28 @@ def test_invalid_post_fork_block_without_blob_fields(
 @pytest.mark.valid_at_transition_to("Cancun", subsequent_forks=False)
 @pytest.mark.parametrize_by_fork(
     "post_fork_block_count,post_fork_blobs_per_block",
-    lambda fork: [
-        pytest.param(
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
-                fork=fork, blob_gas_price=2
-            )
-            // (
-                fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP)
-                - fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP)
-            )
-            + 2,
-            fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="max_blobs",
-        ),
-        pytest.param(10, 0, id="no_blobs"),
-        pytest.param(
-            10,
-            fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="target_blobs",
-        ),
-    ],
+    lambda fork: (
+        lambda t: [
+            pytest.param(
+                SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
+                    fork=fork, blob_gas_price=2
+                )
+                // (
+                    fork.max_blobs_per_block(timestamp=t)
+                    - fork.target_blobs_per_block(timestamp=t)
+                )
+                + 2,
+                fork.max_blobs_per_block(timestamp=t),
+                id="max_blobs",
+            ),
+            pytest.param(10, 0, id="no_blobs"),
+            pytest.param(
+                10,
+                fork.target_blobs_per_block(timestamp=t),
+                id="target_blobs",
+            ),
+        ]
+    )(Cancun.transition_timestamp()),
 )
 def test_fork_transition_excess_blob_gas_at_blob_genesis(
     blockchain_test: BlockchainTestFiller,
@@ -479,51 +483,53 @@ def test_fork_transition_excess_blob_gas_at_blob_genesis(
 @pytest.mark.valid_at_transition_to("Prague", subsequent_forks=True)
 @pytest.mark.parametrize_by_fork(
     "post_fork_block_count,pre_fork_blobs_per_block,post_fork_blobs_per_block",
-    lambda fork: [
-        pytest.param(
-            SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
-                fork=fork, blob_gas_price=2
-            )
-            // (
-                fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP)
-                - fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP)
-            )
-            + 2,
-            fork.max_blobs_per_block(timestamp=0),
-            fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="max_blobs_before_and_after",
-        ),
-        pytest.param(
-            10,
-            0,
-            fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="no_blobs_before_and_max_blobs_after",
-        ),
-        pytest.param(
-            10,
-            fork.max_blobs_per_block(timestamp=0),
-            0,
-            id="max_blobs_before_and_no_blobs_after",
-        ),
-        pytest.param(
-            10,
-            fork.target_blobs_per_block(timestamp=0),
-            fork.target_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="target_blobs_before_and_after",
-        ),
-        pytest.param(
-            10,
-            1,
-            fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP),
-            id="single_blob_before_and_max_blobs_after",
-        ),
-        pytest.param(
-            10,
-            fork.max_blobs_per_block(timestamp=0),
-            1,
-            id="max_blobs_before_and_single_blob_after",
-        ),
-    ],
+    lambda fork: (
+        lambda t: [
+            pytest.param(
+                SpecHelpers.get_min_excess_blobs_for_blob_gas_price(
+                    fork=fork, blob_gas_price=2
+                )
+                // (
+                    fork.max_blobs_per_block(timestamp=t)
+                    - fork.target_blobs_per_block(timestamp=t)
+                )
+                + 2,
+                fork.max_blobs_per_block(timestamp=0),
+                fork.max_blobs_per_block(timestamp=t),
+                id="max_blobs_before_and_after",
+            ),
+            pytest.param(
+                10,
+                0,
+                fork.max_blobs_per_block(timestamp=t),
+                id="no_blobs_before_and_max_blobs_after",
+            ),
+            pytest.param(
+                10,
+                fork.max_blobs_per_block(timestamp=0),
+                0,
+                id="max_blobs_before_and_no_blobs_after",
+            ),
+            pytest.param(
+                10,
+                fork.target_blobs_per_block(timestamp=0),
+                fork.target_blobs_per_block(timestamp=t),
+                id="target_blobs_before_and_after",
+            ),
+            pytest.param(
+                10,
+                1,
+                fork.max_blobs_per_block(timestamp=t),
+                id="single_blob_before_and_max_blobs_after",
+            ),
+            pytest.param(
+                10,
+                fork.max_blobs_per_block(timestamp=0),
+                1,
+                id="max_blobs_before_and_single_blob_after",
+            ),
+        ]
+    )(Cancun.transition_timestamp()),
 )
 @pytest.mark.parametrize("block_base_fee_per_gas", [7, 16, 23])
 @pytest.mark.slow

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -53,6 +53,7 @@ from execution_testing import (
     TransactionReceipt,
     call_return_code,
 )
+from execution_testing.forks import Cancun
 
 from .common import INF_POINT, Z_Y_VALID_ENDIANNESS, Z
 from .spec import Spec, ref_spec_4844
@@ -662,14 +663,15 @@ def test_precompile_before_fork(
 
     state_test(
         pre=pre,
-        env=Environment(timestamp=7_500),
+        env=Environment(
+            timestamp=Cancun.transition_timestamp() // 2,
+        ),
         post=post,
         tx=tx,
     )
 
 
-FORK_TIMESTAMP = 15_000
-PRE_FORK_BLOCK_RANGE = range(999, FORK_TIMESTAMP, 1_000)
+PRE_FORK_BLOCK_RANGE = range(999, Cancun.transition_timestamp(), 1_000)
 
 
 @pytest.mark.parametrize(
@@ -727,7 +729,7 @@ def test_precompile_during_fork(
     # Block after fork
     blocks += [
         Block(
-            timestamp=FORK_TIMESTAMP,
+            timestamp=Cancun.transition_timestamp(),
             txs=[
                 Transaction(
                     sender=sender,

--- a/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
+++ b/tests/cancun/eip7516_blobgasfee/test_blobgasfee_opcode.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Storage,
     Transaction,
 )
+from execution_testing.forks import Cancun
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-7516.md"
 REFERENCE_SPEC_VERSION = "dcd2f4ede58a6ed908acd3cc2c198e9f605cbf3b"
@@ -188,8 +189,8 @@ def test_blobbasefee_before_fork(
     Tests that the BLOBBASEFEE opcode results on exception when called before
     the fork.
     """
-    # Fork happens at timestamp 15_000
-    timestamp = 7_500
+    # Fork happens at transition_timestamp
+    timestamp = Cancun.transition_timestamp() // 2
     post = {
         caller_address: Account(
             storage={1: 0},
@@ -208,7 +209,11 @@ def test_blobbasefee_before_fork(
     )
 
 
-timestamps = [7_500, 14_999, 15_000]
+timestamps = [
+    Cancun.transition_timestamp() // 2,
+    Cancun.transition_timestamp() - 1,
+    Cancun.transition_timestamp(),
+]
 
 
 @pytest.mark.parametrize(
@@ -247,7 +252,9 @@ def test_blobbasefee_during_fork(
             ),
         )
         # pre-set storage just to make sure we detect the change
-        code_caller_post_storage[block_number] = 0 if timestamp < 15_000 else 1
+        code_caller_post_storage[block_number] = (
+            0 if timestamp < Cancun.transition_timestamp() else 1
+        )
 
     post = {
         caller_address: Account(

--- a/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
+++ b/tests/osaka/eip7594_peerdas/test_max_blob_per_tx.py
@@ -19,13 +19,12 @@ from execution_testing import (
     TransactionException,
     add_kzg_version,
 )
+from execution_testing.forks import Osaka
 
 from .spec import Spec, ref_spec_7594
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_7594.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7594.version
-
-FORK_TIMESTAMP = 15_000
 
 
 @pytest.fixture
@@ -141,8 +140,14 @@ def test_invalid_max_blobs_per_tx(
 @pytest.mark.parametrize_by_fork(
     "blob_count",
     lambda fork: [
-        fork.max_blobs_per_tx(timestamp=FORK_TIMESTAMP) + 1,
-        fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP) + 1,
+        fork.max_blobs_per_tx(
+            timestamp=Osaka.transition_timestamp(),
+        )
+        + 1,
+        fork.max_blobs_per_block(
+            timestamp=Osaka.transition_timestamp(),
+        )
+        + 1,
     ],
 )
 @pytest.mark.valid_at_transition_to("Osaka")
@@ -156,31 +161,31 @@ def test_max_blobs_per_tx_fork_transition(
     blob_count: int,
 ) -> None:
     """Test `MAX_BLOBS_PER_TX` limit enforcement across fork transition."""
+    t = Osaka.transition_timestamp()
     expected_exception = (
         TransactionException.TYPE_3_TX_MAX_BLOB_GAS_ALLOWANCE_EXCEEDED
-        if blob_count > fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP)
+        if blob_count > fork.max_blobs_per_block(timestamp=t)
         else TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED
     )
     pre_fork_block = Block(
         txs=[
             tx
-            if blob_count
-            < fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP - 1)
+            if blob_count < fork.max_blobs_per_block(timestamp=t - 1)
             else tx.with_error(expected_exception)
         ],
-        timestamp=FORK_TIMESTAMP - 1,
+        timestamp=t - 1,
         exception=None
-        if blob_count < fork.max_blobs_per_block(timestamp=FORK_TIMESTAMP - 1)
+        if blob_count < fork.max_blobs_per_block(timestamp=t - 1)
         else [expected_exception],
     )
     fork_block = Block(
         txs=[tx.with_nonce(1).with_error(expected_exception)],
-        timestamp=FORK_TIMESTAMP,
+        timestamp=t,
         exception=[expected_exception],
     )
     post_fork_block = Block(
         txs=[tx.with_nonce(1).with_error(expected_exception)],
-        timestamp=FORK_TIMESTAMP + 1,
+        timestamp=t + 1,
         exception=[expected_exception],
     )
     blockchain_test(

--- a/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
+++ b/tests/osaka/eip7823_modexp_upper_bounds/test_modexp_upper_bounds.py
@@ -18,6 +18,7 @@ from execution_testing import (
     Transaction,
     keccak256,
 )
+from execution_testing.forks import Osaka
 
 from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
 from ..eip7883_modexp_gas_increase.spec import Spec
@@ -316,7 +317,8 @@ def test_modexp_upper_bounds_fork_transition(
 
     senders = [pre.fund_eoa() for _ in range(3)]
     contracts = [pre.deploy_contract(code) for _ in range(3)]
-    timestamps = [14_999, 15_000, 15_001]  # Before, at, and after transition
+    t = Osaka.transition_timestamp()
+    timestamps = [t - 1, t, t + 1]  # Before, at, and after transition
     expected_results = [True, False, False]
 
     blocks = [

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_transition_fork.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit_transition_fork.py
@@ -17,6 +17,7 @@ from execution_testing import (
     Transaction,
     TransactionException,
 )
+from execution_testing.forks import Osaka
 
 from .spec import ref_spec_7825
 
@@ -45,16 +46,18 @@ def test_transaction_gas_limit_cap_at_transition(
     """
     Test transaction gas limit cap behavior at the Osaka transition.
 
-    Before timestamp 15000: No gas limit cap (transactions with gas > 2^24 are
-    valid) At/after timestamp 15000: Gas limit cap of 2^24 is enforced
+    Before transition_timestamp: No gas limit cap (transactions with
+    gas > 2^24 are valid).
+    At/after transition_timestamp: Gas limit cap of 2^24 is enforced.
     """
+    t = Osaka.transition_timestamp()
     contract_address = pre.deploy_contract(
         code=Op.SSTORE(Op.TIMESTAMP, Op.ADD(Op.SLOAD(Op.TIMESTAMP), 1))
         + Op.STOP,
     )
 
     # Get the gas limit cap at fork activation
-    tx_gas_cap = fork.transaction_gas_limit_cap(timestamp=15_000)
+    tx_gas_cap = fork.transaction_gas_limit_cap(timestamp=t)
     assert tx_gas_cap is not None, (
         "Gas limit cap should not be None after fork activation"
     )
@@ -91,21 +94,21 @@ def test_transaction_gas_limit_cap_at_transition(
 
     blocks = []
 
-    # Before transition (timestamp < 15000): both cap and above_cap
-    # transactions should succeed
+    # Before transition: both cap and above_cap transactions
+    # should succeed
     blocks.append(
         Block(
-            timestamp=14_999,
+            timestamp=t - 1,
             txs=[above_cap_tx_before_fork, at_cap_tx_before_fork],
         )
     )
 
-    # At transition (timestamp = 15000):
+    # At transition:
     # - transaction at cap should succeed
     # - transaction above cap (cap + 1) should fail
     blocks.append(
         Block(
-            timestamp=15_000,
+            timestamp=t,
             txs=[transition_tx],
             exception=post_cap_tx_error if not transaction_at_cap else None,
         )
@@ -115,12 +118,12 @@ def test_transaction_gas_limit_cap_at_transition(
     post = {
         contract_address: Account(
             storage={
-                # Set by both transactions in first block (before transition):
-                14_999: 2,
+                # Set by both txs in first block (before transition):
+                t - 1: 2,
                 # After transition:
                 # - Set by transaction at cap (should succeed)
-                # - Not set by transaction above cap (should fail)
-                15_000: 1 if transaction_at_cap else 0,
+                # - Not set by tx above cap (should fail)
+                t: 1 if transaction_at_cap else 0,
             }
         )
     }

--- a/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds_transition.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds_transition.py
@@ -14,6 +14,7 @@ from execution_testing import (
     Transaction,
     keccak256,
 )
+from execution_testing.forks import Osaka
 
 from ...byzantium.eip198_modexp_precompile.helpers import ModExpInput
 from .spec import Spec, ref_spec_7883
@@ -88,7 +89,8 @@ def test_modexp_fork_transition(
 
     senders = [pre.fund_eoa() for _ in range(3)]
     contracts = [pre.deploy_contract(code) for _ in range(3)]
-    timestamps = [14_999, 15_000, 15_001]
+    t = Osaka.transition_timestamp()
+    timestamps = [t - 1, t, t + 1]
     gas_values = [gas_old, gas_new, gas_new]
 
     blocks = [

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo.py
@@ -10,6 +10,7 @@ from execution_testing import (
     BlockchainTestFiller,
     Environment,
 )
+from execution_testing.forks import BPO1
 
 from .spec import ref_spec_7918
 
@@ -31,6 +32,6 @@ def test_blob_base_fee_with_bpo_transition(
     blockchain_test(
         genesis_environment=env,
         pre=pre,
-        blocks=[Block(timestamp=15_000)],
+        blocks=[Block(timestamp=BPO1.transition_timestamp())],
         post={},
     )

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_reserve_price_with_bpo_transitions.py
@@ -19,7 +19,7 @@ from execution_testing import (
     Transaction,
     add_kzg_version,
 )
-from execution_testing.forks import BPO2ToBPO3AtTime15k
+from execution_testing.forks import BPO2ToBPO3AtTime15k, Osaka
 
 from .spec import Spec, ref_spec_7918
 
@@ -84,13 +84,13 @@ def source_fork_gas_per_blob(fork: Fork) -> int:
 @pytest.fixture
 def transition_fork_target_blobs(fork: Fork) -> int:
     """Transition-to fork target blobs."""
-    return fork.target_blobs_per_block(timestamp=15_000)
+    return fork.target_blobs_per_block(timestamp=Osaka.transition_timestamp())
 
 
 @pytest.fixture
 def transition_fork_gas_per_blob(fork: Fork) -> int:
     """Transition-to fork gas per blob."""
-    return fork.blob_gas_per_blob(timestamp=15_000)
+    return fork.blob_gas_per_blob(timestamp=Osaka.transition_timestamp())
 
 
 @pytest.fixture
@@ -285,7 +285,7 @@ def parent_block(
     """Parent block to satisfy the pre-fork conditions of the test."""
     return Block(
         txs=parent_block_txs,
-        timestamp=14_999,
+        timestamp=Osaka.transition_timestamp() - 1,
         header_verify=Header(
             excess_blob_gas=parent_excess_blob_gas,
             blob_gas_used=parent_blob_count * blob_gas_per_blob,
@@ -333,7 +333,7 @@ def transition_block(
     """Parent block to satisfy the pre-fork conditions of the test."""
     return Block(
         txs=transition_block_txs,
-        timestamp=15_000,
+        timestamp=Osaka.transition_timestamp(),
         header_verify=Header(
             excess_blob_gas=transition_block_expected_excess_blob_gas,
             blob_gas_used=transition_block_blob_count * blob_gas_per_blob,
@@ -432,7 +432,9 @@ def get_fork_scenarios(fork: Fork) -> Iterator[ParameterSet]:
     fork and transition fork properties.
     """
     source_blob_schedule = BlobSchedule(fork=fork, timestamp=0)
-    transition_blob_schedule = BlobSchedule(fork=fork, timestamp=15_000)
+    transition_blob_schedule = BlobSchedule(
+        fork=fork, timestamp=Osaka.transition_timestamp()
+    )
 
     excess_blobs_combinations = [0, 1, 10, 100]
 

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -29,6 +29,7 @@ from execution_testing.fixtures.blockchain import (
     FixtureBlockBase,
     FixtureWithdrawal,
 )
+from execution_testing.forks import Osaka
 
 from .spec import Spec, ref_spec_7934
 
@@ -841,10 +842,11 @@ def test_fork_transition_block_rlp_limit(
     """
     Test block RLP size limit at fork transition boundary.
 
-    - Before fork (timestamp 14999): Block at limit +1 should be accepted
-    - At fork (timestamp 15000): Block at limit should be accepted
-    - At fork (timestamp 15000): Block at limit +1 should be rejected
+    - Before fork: Block at limit +1 should be accepted
+    - At fork (transition_timestamp): Block at limit should be accepted
+    - At fork (transition_timestamp): Block at limit +1 should be rejected
     """
+    t = Osaka.transition_timestamp()
     sender_before_fork = pre.fund_eoa()
     sender_at_fork = pre.fund_eoa()
 
@@ -865,7 +867,7 @@ def test_fork_transition_block_rlp_limit(
     )
 
     # HEADER_TIMESTAMP (123456789) used in calculation takes 4 bytes in RLP
-    # encoding. Transition timestamps (14_999 and 15_000) take 2 bytes.
+    # encoding. Transition timestamps take 2 bytes.
     # Add the difference to extra_data to keep block at the limit.
     timestamp_byte_savings = 2
 
@@ -875,18 +877,18 @@ def test_fork_transition_block_rlp_limit(
     blocks = [
         # before fork, block at limit +1 should be accepted
         Block(
-            timestamp=14_999,
+            timestamp=t - 1,
             txs=transactions_before,
             # +1 to exceed limit
             extra_data=Bytes(b"\x00" * (extra_data_before + 1)),
         )
     ]
 
-    # At fork (timestamp 15000): Test behavior with and without exceeding limit
+    # At fork (transition_timestamp): Test with and without exceeding limit
     if exceeds_limit_at_fork:
         blocks.append(
             Block(
-                timestamp=15_000,
+                timestamp=t,
                 txs=transactions_at_fork,
                 # +1 to exceed limit, should be rejected
                 extra_data=Bytes(b"\x00" * (extra_data_at_fork + 1)),
@@ -896,7 +898,7 @@ def test_fork_transition_block_rlp_limit(
     else:
         blocks.append(
             Block(
-                timestamp=15_000,
+                timestamp=t,
                 txs=transactions_at_fork,
                 # exact limit should be accepted
                 extra_data=Bytes(b"\x00" * extra_data_at_fork),

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -20,6 +20,7 @@ from execution_testing import (
     Transaction,
     compute_create_address,
 )
+from execution_testing.forks import Osaka
 
 from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
 from .spec import Spec, ref_spec_7939
@@ -290,19 +291,20 @@ def test_clz_fork_transition(
 ) -> None:
     """Test CLZ opcode behavior at fork transition."""
     sender = pre.fund_eoa()
+    ts = Osaka.transition_timestamp()
     callee_address = pre.deploy_contract(
         code=Op.SSTORE(Op.TIMESTAMP, Op.CLZ(1 << 100)) + Op.STOP,
-        storage={14_999: "0xdeadbeef"},
+        storage={ts - 1: "0xdeadbeef"},
     )
     caller_address = pre.deploy_contract(
         code=Op.SSTORE(
             Op.TIMESTAMP, Op.CALL(gas=0xFFFF, address=callee_address)
         ),
-        storage={14_999: "0xdeadbeef"},
+        storage={ts - 1: "0xdeadbeef"},
     )
     blocks = [
         Block(
-            timestamp=14_999,
+            timestamp=ts - 1,
             txs=[
                 Transaction(
                     to=caller_address,
@@ -313,7 +315,7 @@ def test_clz_fork_transition(
             ],
         ),
         Block(
-            timestamp=15_000,
+            timestamp=ts,
             txs=[
                 Transaction(
                     to=caller_address,
@@ -324,7 +326,7 @@ def test_clz_fork_transition(
             ],
         ),
         Block(
-            timestamp=15_001,
+            timestamp=ts + 1,
             txs=[
                 Transaction(
                     to=caller_address,
@@ -341,19 +343,22 @@ def test_clz_fork_transition(
         post={
             caller_address: Account(
                 storage={
-                    14_999: 0,  # Call fails as opcode not valid before Osaka
-                    15_000: 1,  # Call succeeds on fork transition block
-                    15_001: 1,  # Call continues to succeed after transition
+                    # Call fails: opcode not valid before Osaka
+                    ts - 1: 0,
+                    # Call succeeds on fork transition block
+                    ts: 1,
+                    # Call continues to succeed after transition
+                    ts + 1: 1,
                 }
             ),
             callee_address: Account(
                 storage={
                     # CLZ not valid before fork, storage unchanged
-                    14_999: "0xdeadbeef",
-                    # CLZ valid on transition block, CLZ(1 << 100) = 155
-                    15_000: 155,
+                    ts - 1: "0xdeadbeef",
+                    # CLZ valid on transition block
+                    ts: 155,
                     # CLZ continues to be valid after transition
-                    15_001: 155,
+                    ts + 1: 155,
                 }
             ),
         },

--- a/tests/prague/eip2935_historical_block_hashes_from_state/spec.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/spec.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from execution_testing.forks import Prague
+
 
 @dataclass(frozen=True)
 class ReferenceSpec:
@@ -23,7 +25,7 @@ class Spec:
     https://eips.ethereum.org/EIPS/eip-2935.
     """
 
-    FORK_TIMESTAMP = 15_000
+    FORK_TIMESTAMP = Prague.transition_timestamp()
     HISTORY_STORAGE_ADDRESS = 0x0000F90827F1C53A10CB7A02335B175320002935
     HISTORY_SERVE_WINDOW = 8191
     BLOCKHASH_OLD_WINDOW = 256

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests_during_fork.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests_during_fork.py
@@ -16,6 +16,7 @@ from execution_testing import (
     Environment,
     Transaction,
 )
+from execution_testing.forks import Prague
 
 from .helpers import WithdrawalRequest, WithdrawalRequestTransaction
 from .spec import Spec, ref_spec_7002
@@ -80,7 +81,11 @@ BLOCKS_BEFORE_FORK = 2
         ),
     ],
 )
-@pytest.mark.parametrize("timestamp", [15_000 - BLOCKS_BEFORE_FORK], ids=[""])
+@pytest.mark.parametrize(
+    "timestamp",
+    [Prague.transition_timestamp() - BLOCKS_BEFORE_FORK],
+    ids=[""],
+)
 @pytest.mark.pre_alloc_mutable
 def test_withdrawal_requests_during_fork(
     blockchain_test: BlockchainTestFiller,

--- a/tests/prague/eip7251_consolidations/test_consolidations_during_fork.py
+++ b/tests/prague/eip7251_consolidations/test_consolidations_during_fork.py
@@ -16,6 +16,7 @@ from execution_testing import (
     Environment,
     Transaction,
 )
+from execution_testing.forks import Prague
 
 from .helpers import ConsolidationRequest, ConsolidationRequestTransaction
 from .spec import Spec, ref_spec_7251
@@ -80,7 +81,11 @@ BLOCKS_BEFORE_FORK = 2
         ),
     ],
 )
-@pytest.mark.parametrize("timestamp", [15_000 - BLOCKS_BEFORE_FORK], ids=[""])
+@pytest.mark.parametrize(
+    "timestamp",
+    [Prague.transition_timestamp() - BLOCKS_BEFORE_FORK],
+    ids=[""],
+)
 @pytest.mark.pre_alloc_mutable
 def test_consolidation_requests_during_fork(
     blockchain_test: BlockchainTestFiller,


### PR DESCRIPTION
## 🗒️ Description

Add `transition_timestamp()` classmethod to `Paris` (inherited by all post-Paris forks) and replace all hardcoded `15_000`/`15000`/`14_999`/`15_001` transition timestamps across tests and packages with `Paris.transition_timestamp()` expressions.

## 🔗 Related Issues or PRs

Closes #1540

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
