### PR TITLE
feat(tests): add ecpairing test for fq2 multiplicative inverse bug

### DIFF
--- a/tests/byzantium/eip197_ec_pairing/test_ecpairing.py
+++ b/tests/byzantium/eip197_ec_pairing/test_ecpairing.py
@@ -143,6 +143,29 @@ pytestmark = [
             Spec.PAIRING_TRUE,
             id="three_point_match_1",
         ),
+        pytest.param(
+            # e(16*G1, G2) * e(G1, -16*G2) == 1
+            # Exercises the FQ2 multiplicative inverse for scalar 16,
+            # which previously triggered a bug in the specification.
+            PointG1(
+                0x17F485337F6E10FCA0E385F7A93D1AC0A977E43995C3E4D9B8F89DAA6A183F44,
+                0x05CCDC1561DB963516DA62C66EDD39D1BB9C6C4674990C4440403C88025C95AD,
+            )
+            + Spec.G2
+            + Spec.G1
+            + PointG2(
+                (
+                    0x27A819BCF5C2C30229550CC0D34EE9C923EE6C3033A89F0BE27204893B112207,
+                    0x29E39258393EE0C24EB66B69973E9FEB8B02E9D94A9897492C98EFE5B0EB459A,
+                ),
+                (
+                    0x12C79F74D498D73F3F1C4F2489FF4C5EF88C6A2C932560FEC4B5D2A1AE20D274,
+                    0x1FBD1A0CA265F11112AF813152C1AD30B95AA1CBF94F7571552CA27658A6940C,
+                ),
+            ),
+            Spec.PAIRING_TRUE,
+            id="fq2_inverse_scalar_16",
+        ),
     ],
 )
 @pytest.mark.ported_from(


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

- Add ecpairing test case exercising the FQ2 multiplicative inverse for scalar 16
- This value previously triggered a bug in the specification where `BNF2.from_int(16).multiplicative_inverse()` incorrectly returned zero
- Test verifies `e(16*G1, G2) * e(G1, -16*G2) == 1` using bilinearity

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes #1539

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).