### PR TITLE
feat(tests): port goevmlab regression tests for EELS consensus bugs 

### DIFF
--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -11,7 +11,6 @@ from execution_testing import (
     Address,
     Alloc,
     Bytecode,
-    Environment,
     Initcode,
     Op,
     StateTestFiller,
@@ -259,12 +258,7 @@ class TestTransientStorageInContractCreation:
             ),
         }
 
-        state_test(
-            env=Environment(),
-            pre=pre,
-            post=post,
-            tx=tx,
-        )
+        state_test(pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.ported_from(
@@ -346,4 +340,4 @@ def test_tstore_rollback_on_failed_create(
         caller_address: Account(storage={0: 0, 1: 0}),
     }
 
-    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -272,11 +272,11 @@ class TestTransientStorageInContractCreation:
         "https://github.com/holiman/goevmlab/blob/master/examples/tstore_bug-2/main.go",
     ],
 )
-@CreateOpcodeParams.parametrize()
+@pytest.mark.parametrize("create_opcode", [Op.CREATE, Op.CREATE2])
 def test_tstore_rollback_on_failed_create(
     state_test: StateTestFiller,
     pre: Alloc,
-    opcode: Op,
+    create_opcode: Op,
 ) -> None:
     """
     Test TSTORE is rolled back after failed CREATE/CREATE2 initcode.
@@ -317,15 +317,15 @@ def test_tstore_rollback_on_failed_create(
         Om.MSTORE(initcode_bytes, 0)
         + Op.SSTORE(
             0,
-            opcode(0, 0, initcode_len, 0)
-            if opcode == Op.CREATE2
-            else opcode(0, 0, initcode_len),
+            create_opcode(0, 0, initcode_len, 0)
+            if create_opcode == Op.CREATE2
+            else create_opcode(0, 0, initcode_len),
         )
         + Op.SSTORE(
             1,
-            opcode(0, 0, initcode_len, 0)
-            if opcode == Op.CREATE2
-            else opcode(0, 0, initcode_len),
+            create_opcode(0, 0, initcode_len, 0)
+            if create_opcode == Op.CREATE2
+            else create_opcode(0, 0, initcode_len),
         )
     )
     caller_address = pre.deploy_contract(caller_code, storage={0: 1, 1: 1})

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -6,6 +6,7 @@ from enum import unique
 
 import pytest
 from execution_testing import (
+    AccessList,
     Account,
     Address,
     Alloc,
@@ -271,12 +272,14 @@ class TestTransientStorageInContractCreation:
         "https://github.com/holiman/goevmlab/blob/master/examples/tstore_bug-2/main.go",
     ],
 )
-def test_tstore_rollback_on_failed_create2(
+@CreateOpcodeParams.parametrize()
+def test_tstore_rollback_on_failed_create(
     state_test: StateTestFiller,
     pre: Alloc,
+    opcode: Op,
 ) -> None:
     """
-    Test TSTORE is rolled back after failed CREATE2 initcode.
+    Test TSTORE is rolled back after failed CREATE/CREATE2 initcode.
 
     Regression test for
     https://github.com/ethereum/execution-specs/issues/917
@@ -286,9 +289,9 @@ def test_tstore_rollback_on_failed_create2(
     When TLOAD(1) is 0, the return size is 0x600a (exceeds max code
     size 0x6000), so creation fails.
 
-    The caller invokes CREATE2 twice with the same initcode and salt.
+    The caller invokes CREATE/CREATE2 twice with the same initcode.
     If TSTORE from the first (failed) creation is properly rolled
-    back, the second CREATE2 also sees TLOAD(1)==0 and fails the
+    back, the second creation also sees TLOAD(1)==0 and fails the
     same way. If not rolled back, TLOAD(1)==0x6000 and the second
     creation succeeds.
     """
@@ -312,20 +315,34 @@ def test_tstore_rollback_on_failed_create2(
 
     caller_code = (
         Om.MSTORE(initcode_bytes, 0)
-        + Op.SSTORE(0, Op.CREATE2(0, 0, initcode_len, 0))
-        + Op.SSTORE(1, Op.CREATE2(0, 0, initcode_len, 0))
+        + Op.SSTORE(
+            0,
+            opcode(0, 0, initcode_len, 0)
+            if opcode == Op.CREATE2
+            else opcode(0, 0, initcode_len),
+        )
+        + Op.SSTORE(
+            1,
+            opcode(0, 0, initcode_len, 0)
+            if opcode == Op.CREATE2
+            else opcode(0, 0, initcode_len),
+        )
     )
-    caller_address = pre.deploy_contract(caller_code)
+    caller_address = pre.deploy_contract(caller_code, storage={0: 1, 1: 1})
 
     sender = pre.fund_eoa()
     tx = Transaction(
         sender=sender,
         to=caller_address,
-        gas_limit=10_000_000,
+        gas_limit=16_000_000,
+        access_list=[
+            AccessList(address=caller_address, storage_keys=[0, 1]),
+        ],
     )
 
     post = {
-        # Both CREATE2s fail because TSTORE is rolled back
+        # Both creations fail because TSTORE is rolled back;
+        # initial storage {0: 1, 1: 1} is overwritten to zeros
         caller_address: Account(storage={0: 0, 1: 0}),
     }
 

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -17,6 +17,7 @@ from execution_testing import (
     Transaction,
     compute_create_address,
 )
+from execution_testing import Macros as Om
 
 from . import CreateOpcodeParams, PytestParameterEnum
 from .spec import ref_spec_1153
@@ -263,3 +264,69 @@ class TestTransientStorageInContractCreation:
             post=post,
             tx=tx,
         )
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/holiman/goevmlab/blob/master/examples/tstore_bug-2/main.go",
+    ],
+)
+def test_tstore_rollback_on_failed_create2(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test TSTORE is rolled back after failed CREATE2 initcode.
+
+    Regression test for
+    https://github.com/ethereum/execution-specs/issues/917
+
+    Initcode does TLOAD(1) to compute a return size, then does
+    TSTORE(1, 0x6000), then returns data of the computed size.
+    When TLOAD(1) is 0, the return size is 0x600a (exceeds max code
+    size 0x6000), so creation fails.
+
+    The caller invokes CREATE2 twice with the same initcode and salt.
+    If TSTORE from the first (failed) creation is properly rolled
+    back, the second CREATE2 also sees TLOAD(1)==0 and fails the
+    same way. If not rolled back, TLOAD(1)==0x6000 and the second
+    creation succeeds.
+    """
+    # Initcode:
+    #   return_size = 0x600a - TLOAD(1)
+    #   TSTORE(1, 0x6000)
+    #   RETURN(offset=0, size=return_size)
+    #
+    # TLOAD(1)==0:     return_size = 0x600a > max code size -> fail
+    # TLOAD(1)==0x6000: return_size = 0x0a <= max code size -> succeed
+    initcode = (
+        Op.TLOAD(1)
+        + Op.PUSH2(0x600A)
+        + Op.SUB
+        + Op.TSTORE(1, 0x6000)
+        + Op.PUSH1(0)
+        + Op.RETURN
+    )
+    initcode_bytes = bytes(initcode)
+    initcode_len = len(initcode_bytes)
+
+    caller_code = (
+        Om.MSTORE(initcode_bytes, 0)
+        + Op.SSTORE(0, Op.CREATE2(0, 0, initcode_len, 0))
+        + Op.SSTORE(1, Op.CREATE2(0, 0, initcode_len, 0))
+    )
+    caller_address = pre.deploy_contract(caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller_address,
+        gas_limit=10_000_000,
+    )
+
+    post = {
+        # Both CREATE2s fail because TSTORE is rolled back
+        caller_address: Account(storage={0: 0, 1: 0}),
+    }
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -431,4 +431,4 @@ def test_tstore_rollback_on_callcode_revert(
         caller_address: Account(storage={0: 0, 1: 0}),
     }
 
-    state_test(env=Environment(), pre=pre, post=post, tx=tx)
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -384,3 +384,52 @@ def test_subcall(
     - `STATICCALL`
     """
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/holiman/goevmlab/blob/master/examples/tstore_bug/main.go",
+    ],
+)
+def test_tstore_rollback_on_callcode_revert(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test TSTORE is rolled back after CALLCODE sub-call reverts.
+
+    Regression test for
+    https://github.com/ethereum/execution-specs/issues/911
+
+    Contract `callee` does TSTORE(4, 1), calls a precompile, then
+    REVERTs. Contract `caller` uses CALLCODE to invoke `callee`, then
+    checks TLOAD(4). Because CALLCODE executes in the caller's context
+    and the sub-call reverted, TLOAD(4) must return 0.
+    """
+    callee_code = (
+        Op.TSTORE(4, 1)
+        + Op.CALL(address=0x06)  # call identity precompile
+        + Op.POP
+        + Op.REVERT(0, 0)
+    )
+    callee_address = pre.deploy_contract(callee_code)
+
+    caller_code = (
+        Op.SSTORE(0, Op.CALLCODE(address=callee_address))
+        + Op.SSTORE(1, Op.TLOAD(4))
+    )
+    caller_address = pre.deploy_contract(caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller_address,
+        gas_limit=1_000_000,
+    )
+
+    post = {
+        # CALLCODE returns 0 (reverted), TLOAD(4) = 0 (rolled back)
+        caller_address: Account(storage={0: 0, 1: 0}),
+    }
+
+    state_test(env=Environment(), pre=pre, post=post, tx=tx)

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -414,10 +414,9 @@ def test_tstore_rollback_on_callcode_revert(
     )
     callee_address = pre.deploy_contract(callee_code)
 
-    caller_code = (
-        Op.SSTORE(0, Op.CALLCODE(address=callee_address))
-        + Op.SSTORE(1, Op.TLOAD(4))
-    )
+    caller_code = Op.SSTORE(
+        0, Op.CALLCODE(address=callee_address)
+    ) + Op.SSTORE(1, Op.TLOAD(4))
     caller_address = pre.deploy_contract(caller_code)
 
     sender = pre.fund_eoa()

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -637,9 +637,4 @@ def test_create2_oversized_initcode_with_insufficient_balance(
         caller_address: Account(storage={1: expected_storage_1}),
     }
 
-    state_test(
-        env=Environment(),
-        pre=pre,
-        post=post,
-        tx=tx,
-    )
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -592,9 +592,18 @@ class TestCreateInitcode:
         "https://github.com/holiman/goevmlab/blob/master/examples/create2_bug/main.go",
     ],
 )
+@pytest.mark.parametrize(
+    "initcode_oversize,expected_storage_1",
+    [
+        pytest.param(True, 0, id="initcode_oversize"),
+        pytest.param(False, 1, id="initcode_within_limit"),
+    ],
+)
 def test_create2_oversized_initcode_with_insufficient_balance(
     state_test: StateTestFiller,
     pre: Alloc,
+    initcode_oversize: bool,
+    expected_storage_1: int,
 ) -> None:
     """
     Test CREATE2 with oversized initcode and insufficient balance.
@@ -602,21 +611,18 @@ def test_create2_oversized_initcode_with_insufficient_balance(
     Regression test for
     https://github.com/ethereum/execution-specs/issues/914
 
-    CREATE2 is called with initcode size 0x20000 (exceeds
-    MAX_INITCODE_SIZE) and an endowment of 1123123123 (exceeds the
+    CREATE2 is called with an endowment of 1123123123 (exceeds the
     contract's zero balance). The initcode size check must take
     priority over the balance check:
 
-    - Initcode too large: consumes all gas, exits scope (correct).
-    - Insufficient balance: pushes 0, continues execution (wrong).
-
-    If the initcode size check fires correctly, SSTORE(1, 1) is
-    never reached, so storage slot 1 remains 0.
+    - Initcode too large: consumes all gas, exits scope, SSTORE(1, 1)
+      is never reached, so storage slot 1 remains 0.
+    - Initcode within limit: insufficient balance pushes 0, execution
+      continues, SSTORE(1, 1) executes, so storage slot 1 becomes 1.
     """
+    initcode_size = 0x20000 if initcode_oversize else 0x100
     caller_code = (
-        Op.CREATE2(1123123123, 0, 0x20000, 0)
-        + Op.POP
-        + Op.SSTORE(1, 1)
+        Op.CREATE2(1123123123, 0, initcode_size, 0) + Op.POP + Op.SSTORE(1, 1)
     )
     caller_address = pre.deploy_contract(caller_code)
 
@@ -628,8 +634,7 @@ def test_create2_oversized_initcode_with_insufficient_balance(
     )
 
     post = {
-        # SSTORE(1, 1) never executes because CREATE2 exits scope
-        caller_address: Account(storage={1: 0}),
+        caller_address: Account(storage={1: expected_storage_1}),
     }
 
     state_test(

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -585,3 +585,56 @@ class TestCreateInitcode:
             post=post,
             tx=tx,
         )
+
+
+@pytest.mark.ported_from(
+    [
+        "https://github.com/holiman/goevmlab/blob/master/examples/create2_bug/main.go",
+    ],
+)
+def test_create2_oversized_initcode_with_insufficient_balance(
+    state_test: StateTestFiller,
+    pre: Alloc,
+) -> None:
+    """
+    Test CREATE2 with oversized initcode and insufficient balance.
+
+    Regression test for
+    https://github.com/ethereum/execution-specs/issues/914
+
+    CREATE2 is called with initcode size 0x20000 (exceeds
+    MAX_INITCODE_SIZE) and an endowment of 1123123123 (exceeds the
+    contract's zero balance). The initcode size check must take
+    priority over the balance check:
+
+    - Initcode too large: consumes all gas, exits scope (correct).
+    - Insufficient balance: pushes 0, continues execution (wrong).
+
+    If the initcode size check fires correctly, SSTORE(1, 1) is
+    never reached, so storage slot 1 remains 0.
+    """
+    caller_code = (
+        Op.CREATE2(1123123123, 0, 0x20000, 0)
+        + Op.POP
+        + Op.SSTORE(1, 1)
+    )
+    caller_address = pre.deploy_contract(caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller_address,
+        gas_limit=10_000_000,
+    )
+
+    post = {
+        # SSTORE(1, 1) never executes because CREATE2 exits scope
+        caller_address: Account(storage={1: 0}),
+    }
+
+    state_test(
+        env=Environment(),
+        pre=pre,
+        post=post,
+        tx=tx,
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Adds tests for bugs in EELS found by goevmlab a while back. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes https://github.com/ethereum/execution-specs/issues/1482

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
