### PR TITLE
chore(zkevm): Document HashedNode collapse behaviour with test

### DIFF
--- a/tests/json_infra/test_incremental_mpt.py
+++ b/tests/json_infra/test_incremental_mpt.py
@@ -444,6 +444,47 @@ class TestPartialWitness:
         with pytest.raises(AssertionError, match="cannot be invalidated"):
             mpt_set(decoded_mpt, b"ba", b"new_c")
 
+    def test_partial_witness_delete_collapses_to_hashed_node(self) -> None:
+        """
+        Delete a key whose sibling is a HashedNode.
+
+        When a branch has two children and one is deleted, the branch
+        must collapse. If the remaining child is a HashedNode (from a
+        partial witness), _collapse_branch cannot merge the nibble into
+        it because its structure is unknown. This currently raises
+        AssertionError.
+        """
+        fake_hash = keccak256(b"some large subtree")
+        hashed_child = HashedNode(_hash=fake_hash)
+
+        # Branch with a leaf at nibble 0 and a HashedNode at nibble 1.
+        # Key b"\x01" -> nibbles [0, 1]: child index 0, rest_of_key [1].
+        branch = MutableBranchNode(
+            children=[None] * 16,
+            value=b"",
+        )
+        branch.children[0] = MutableLeafNode(
+            rest_of_key=Bytes(b"\x01"),
+            value=b"hello",
+        )
+        branch.children[1] = hashed_child
+
+        mpt: IncrementalMPT[Bytes, Bytes] = IncrementalMPT(
+            secured=False,
+            default=b"",
+            root_node=branch,
+            _data={Bytes(b"\x01"): b"hello"},
+        )
+
+        # Deleting the leaf at nibble 0 leaves only the HashedNode,
+        # triggering a branch collapse. _collapse_branch calls
+        # _record_witness on the remaining child, which fails
+        # because HashedNode cannot be witnessed.
+        with pytest.raises(
+            AssertionError, match="HashedNode cannot be witnessed"
+        ):
+            mpt_set(mpt, Bytes(b"\x01"), b"")
+
 
 def _encode_root_for_db(
     node: object,


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Adds a test to document what happens when a branch has two children and we delete one of them (meaning the branch collapses to its remaining child). If the remaining child is a HashedNode, we raise an error because HashedNodes cannot be witnessed (with the current `_record_witness` code)

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
