### PR TITLE
fix(testing): stop inserting empty Account in execute empty_account()

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -741,18 +741,13 @@ class Alloc(SharedAlloc):
 
     def _empty_account(self) -> Address:
         """
-        Execute implementation of empty account creation.
+        Execute implementation of empty_account.
+
+        Return a previously unused address. The account is not
+        created on-chain — it remains nonexistent.
         """
         eoa = next(self._eoa_iterator)
-        logger.debug(f"Creating empty account at {eoa}")
-
-        self.__internal_setitem__(
-            eoa,
-            Account(
-                nonce=0,
-                balance=0,
-            ),
-        )
+        logger.debug(f"Returning unused address {eoa} (nonexistent account)")
         return Address(eoa)
 
     def minimum_balance_for_pending_transactions(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -378,7 +378,7 @@ class Alloc(SharedAlloc):
 
     def _empty_account(self) -> Address:
         """
-        Filler implementation of empty account creation.
+        Filler implementation of empty_account.
         """
         salt = self.get_next_account_salt(EMPTY_ACCOUNT_HASH)
         return Address(eoa_from_hash(EMPTY_ACCOUNT_HASH, salt))

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_pre_alloc.py
@@ -143,13 +143,13 @@ def test_alloc_fund_eoa_basic() -> None:
 
 
 def test_alloc_empty_account() -> None:
-    """Test `Alloc.empty_account` functionality."""
+    """Test `Alloc.empty_account` returns a nonexistent address."""
     pre = create_test_alloc()
     empty_addr = pre.empty_account()
 
-    # Check that we get a valid address (address generation works)
     assert isinstance(empty_addr, Address)
-    # Note: empty_account() only returns address, doesn't add to pre
+    # The address must not be in the pre-state (nonexistent account).
+    assert empty_addr not in pre
 
 
 def test_alloc_deploy_contract_code_types() -> None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -319,10 +319,10 @@ class Alloc(BaseAlloc):
 
     def empty_account(self) -> Address:
         """
-        Return a previously unused account guaranteed to be empty.
+        Return the address of a previously unused nonexistent account.
 
-        This ensures the account has zero balance, zero nonce, no code, and no
-        storage. The account is not a precompile or a system contract.
+        The address is guaranteed to not be a precompile or a system contract.
+        No account is created — it remains nonexistent in the pre-state.
         """
         return self._empty_account()
 

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -483,10 +483,10 @@ class Alloc(BaseAlloc):
 
     def empty_account(self) -> Address:
         """
-        Return a previously unused account guaranteed to be empty.
+        Return the address of a previously unused nonexistent account.
 
-        This ensures the account has zero balance, zero nonce, no code, and no
-        storage. The account is not a precompile or a system contract.
+        The address is guaranteed to not be a precompile or a system contract.
+        No account is created — it remains nonexistent in the pre-state.
         """
         raise NotImplementedError(
             "empty_account is not implemented in the base class"


### PR DESCRIPTION
## 🗒️ Description

The execute backend's `_empty_account()` was inserting `Account(nonce=0, balance=0)` into the pre-state. Since `Account(nonce=0, balance=0)` is falsy (per `Account.__bool__`), the `Alloc.merge()` step during fixture generation silently discarded it — so the insertion had no observable effect, but was conceptually wrong and inconsistent with the filler backend which returns a bare address without touching the pre-state.

This PR removes the unnecessary insertion so both backends behave identically, adds a unit test asserting the address is not in the pre-state after the call, and updates docstrings to clarify that the returned address refers to a nonexistent account.

In a follow-up PR the method will be renamed to `nonexistent_account()` to better reflect its semantics.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

🦔