### PR TITLE
refactor(testing): rename empty_account() to nonexistent_account()

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -739,9 +739,9 @@ class Alloc(SharedAlloc):
             f"{Number(amount) / 10**18:.18f} ETH"
         )
 
-    def _empty_account(self) -> Address:
+    def _nonexistent_account(self) -> Address:
         """
-        Execute implementation of empty_account.
+        Execute implementation of nonexistent_account.
 
         Return a previously unused address. The account is not
         created on-chain — it remains nonexistent.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -376,9 +376,9 @@ class Alloc(SharedAlloc):
         del minimum_balance
         self.__internal_setitem__(address, Account(balance=amount))
 
-    def _empty_account(self) -> Address:
+    def _nonexistent_account(self) -> Address:
         """
-        Filler implementation of empty_account.
+        Filler implementation of nonexistent_account.
         """
         salt = self.get_next_account_salt(EMPTY_ACCOUNT_HASH)
         return Address(eoa_from_hash(EMPTY_ACCOUNT_HASH, salt))

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_pre_alloc.py
@@ -142,14 +142,18 @@ def test_alloc_fund_eoa_basic() -> None:
     assert account_2.balance == 2 * 10**18
 
 
-def test_alloc_empty_account() -> None:
-    """Test `Alloc.empty_account` returns a nonexistent address."""
+def test_alloc_nonexistent_account() -> None:
+    """Test `Alloc.nonexistent_account` returns a nonexistent address."""
     pre = create_test_alloc()
-    empty_addr = pre.empty_account()
+    addr_1 = pre.nonexistent_account()
+    addr_2 = pre.nonexistent_account()
 
-    assert isinstance(empty_addr, Address)
+    assert isinstance(addr_1, Address)
     # The address must not be in the pre-state (nonexistent account).
-    assert empty_addr not in pre
+    assert addr_1 not in pre
+    assert addr_2 not in pre
+    # Each call returns a unique address.
+    assert addr_1 != addr_2
 
 
 def test_alloc_deploy_contract_code_types() -> None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -317,19 +317,19 @@ class Alloc(BaseAlloc):
             "_fund_address is not implemented in the base class"
         )
 
-    def empty_account(self) -> Address:
+    def nonexistent_account(self) -> Address:
         """
         Return the address of a previously unused nonexistent account.
 
         The address is guaranteed to not be a precompile or a system contract.
         No account is created — it remains nonexistent in the pre-state.
         """
-        return self._empty_account()
+        return self._nonexistent_account()
 
-    def _empty_account(self) -> Address:
+    def _nonexistent_account(self) -> Address:
         """
-        Sub-class implementation of empty_account.
+        Sub-class implementation of nonexistent_account.
         """
         raise NotImplementedError(
-            "_empty_account is not implemented in the base class"
+            "_nonexistent_account is not implemented in the base class"
         )

--- a/packages/testing/src/execution_testing/test_types/account_types.py
+++ b/packages/testing/src/execution_testing/test_types/account_types.py
@@ -481,7 +481,7 @@ class Alloc(BaseAlloc):
             "fund_address is not implemented in the base class"
         )
 
-    def empty_account(self) -> Address:
+    def nonexistent_account(self) -> Address:
         """
         Return the address of a previously unused nonexistent account.
 
@@ -489,5 +489,5 @@ class Alloc(BaseAlloc):
         No account is created — it remains nonexistent in the pre-state.
         """
         raise NotImplementedError(
-            "empty_account is not implemented in the base class"
+            "nonexistent_account is not implemented in the base class"
         )

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -421,7 +421,7 @@ def test_bal_call_no_delegation_and_oog_before_target_access(
     alice = pre.fund_eoa()
 
     target = (
-        pre.empty_account()
+        pre.nonexistent_account()
         if target_is_empty
         else pre.deploy_contract(code=Op.STOP)
     )
@@ -567,7 +567,7 @@ def test_bal_call_no_delegation_oog_after_target_access(
     alice = pre.fund_eoa()
 
     # empty target required for create_cost gap
-    target = pre.empty_account()
+    target = pre.nonexistent_account()
     # value > 0 required for create_cost
     value = 1
 

--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -208,7 +208,7 @@ def test_ext_account_query_warm(
 
     # Case 1: Completely empty account (no balance, no storage, no code)
     if not initial_balance and not initial_storage and empty_code:
-        target_addr = pre.empty_account()
+        target_addr = pre.nonexistent_account()
     # Case 2: EOA with optional balance and storage
     elif empty_code:
         eoa_kwargs: dict[str, Any] = {}

--- a/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
+++ b/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
@@ -90,7 +90,7 @@ def test_extcodehash_of_empty(
     Test EXTCODEHASH/EXTCODESIZE for non-existent and empty accounts.
     """
     storage = Storage()
-    target_address = pre.empty_account()
+    target_address = pre.nonexistent_account()
 
     if target_exists:
         pre.fund_address(target_address, 1)
@@ -139,7 +139,7 @@ def test_extcodehash_empty_send_value(
     the account receives value within the same transaction.
     """
     storage = Storage()
-    target_address = pre.empty_account()
+    target_address = pre.nonexistent_account()
 
     code = (
         # EXTCODEHASH before sending value: expect 0 (non-existent).
@@ -243,7 +243,7 @@ def test_extcodehash_empty_account_variants(
     Test EXTCODEHASH/EXTCODESIZE/EXTCODECOPY for empty-account variants.
     """
     storage = Storage()
-    target_address = pre.empty_account()
+    target_address = pre.nonexistent_account()
     pre[target_address] = account
 
     code = Op.JUMPDEST + (
@@ -391,7 +391,7 @@ def test_extcodehash_codeless_with_storage(
     so EXTCODEHASH returns keccak256("") and EXTCODESIZE returns 0.
     Storage is not part of the EIP-161 emptiness check.
     """
-    target_address = pre.empty_account()
+    target_address = pre.nonexistent_account()
     pre[target_address] = Account(balance=balance, nonce=nonce, storage={1: 1})
 
     storage = Storage()
@@ -1226,7 +1226,7 @@ def test_extcodehash_call_to_nonexistent(
     EXTCODEHASH — it returns 0 because the account does not exist.
     """
     storage = Storage()
-    nonexistent = pre.empty_account()
+    nonexistent = pre.nonexistent_account()
 
     code = Op.SSTORE(
         storage.store_next(1),
@@ -1275,7 +1275,7 @@ def test_extcodehash_call_to_selfdestruct(
     contract at end of transaction.
     """
     storage = Storage()
-    beneficiary = pre.empty_account()
+    beneficiary = pre.nonexistent_account()
     target_code = Op.SELFDESTRUCT(beneficiary)
     target = pre.deploy_contract(target_code, balance=5_555_555_555)
 
@@ -1553,7 +1553,7 @@ def test_extcodehash_subcall_selfdestruct(
     pre-existing; a dynamically created A is still deleted (EIP-6780).
     """
     storage = Storage()
-    beneficiary = pre.empty_account()
+    beneficiary = pre.nonexistent_account()
     selfdestruct_code = Op.SELFDESTRUCT(beneficiary)
     target_c = pre.deploy_contract(selfdestruct_code)
 

--- a/tests/frontier/create/test_create_suicide_store.py
+++ b/tests/frontier/create/test_create_suicide_store.py
@@ -59,7 +59,7 @@ def test_create_suicide_store(
             cases=[
                 CalldataCase(
                     value=Operation.SUICIDE,
-                    action=Op.SELFDESTRUCT(pre.empty_account()),
+                    action=Op.SELFDESTRUCT(pre.nonexistent_account()),
                 ),
                 CalldataCase(
                     value=Operation.ADD_STORAGE,

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -112,14 +112,14 @@ def sufficient_gas(
 
 
 @pytest.fixture
-def empty_account(pre: Alloc) -> Address:
-    """A guaranteed-to-be-empty account."""
-    return pre.empty_account()
+def nonexistent_account(pre: Alloc) -> Address:
+    """A guaranteed-to-be nonexistent account."""
+    return pre.nonexistent_account()
 
 
 @pytest.fixture
 def callee_code(
-    callee_opcode: Op, fork: Fork, empty_account: Address
+    callee_opcode: Op, fork: Fork, nonexistent_account: Address
 ) -> Bytecode:
     """
     Code called by the caller contract:
@@ -142,7 +142,7 @@ def callee_code(
     return callee_opcode(
         unchecked=False,
         gas=1 if fork < Byzantium else Op.GAS,
-        address=empty_account,
+        address=nonexistent_account,
         args_offset=0,
         args_size=0,
         ret_offset=0,
@@ -226,7 +226,7 @@ def expected_block_access_list(
     caller_address: Address,
     callee_address: Address,
     callee_opcode: Bytecode,
-    empty_account: Account,
+    nonexistent_account: Account,
     gas_shortage: int,
 ) -> None | BlockAccessListExpectation:
     """The expected block access list for >=Amsterdam cases."""
@@ -252,7 +252,7 @@ def expected_block_access_list(
 
         return BlockAccessListExpectation(
             account_expectations={
-                empty_account: empty_account_expectation,
+                nonexistent_account: empty_account_expectation,
                 caller_address: BalAccountExpectation(
                     balance_changes=[
                         BalBalanceChange(block_access_index=1, post_balance=4)


### PR DESCRIPTION
## 🗒️ Description

Rename `Alloc.empty_account()` to `Alloc.nonexistent_account()`.

The method returns an address where no account exists in the pre-state — a truly nonexistent account. In Ethereum terminology (EIP-161), "empty" means an account that *exists* but has zero nonce, zero balance, and no code. The returned address has no state at all, so "nonexistent" is the correct term.

Also strengthens the unit test to verify that consecutive calls return unique addresses.

## 🔗 Related Issues or PRs
Follow-up to #2461.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

🦔