### PR TITLE
feat(t8n): handle pre-fork typed txs via `supports_tx_type`

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/execution_specs.py
@@ -240,15 +240,20 @@ class ExecutionSpecsExceptionMapper(ExceptionMapper):
             r"InsufficientMaxFeePerGasError|InvalidBlock"
         ),
         TransactionException.TYPE_1_TX_PRE_FORK: (
-            r"module '.*transactions' has no attribute 'AccessListTransaction'"
+            r"module '.*transactions' has no attribute "
+            r"'AccessListTransaction'|"
+            r"transaction type 1 is not supported in .*"
         ),
         TransactionException.TYPE_2_TX_PRE_FORK: (
-            r"'.*transactions' has no attribute 'FeeMarketTransaction'"
+            r"'.*transactions' has no attribute 'FeeMarketTransaction'|"
+            r"transaction type 2 is not supported in .*"
         ),
         TransactionException.TYPE_3_TX_PRE_FORK: (
-            r"module '.*transactions' has no attribute 'BlobTransaction'"
+            r"module '.*transactions' has no attribute 'BlobTransaction'|"
+            r"transaction type 3 is not supported in .*"
         ),
         TransactionException.TYPE_4_TX_PRE_FORK: (
-            r"'.*transactions' has no attribute 'SetCodeTransaction'"
+            r"'.*transactions' has no attribute 'SetCodeTransaction'|"
+            r"transaction type 4 is not supported in .*"
         ),
     }

--- a/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py
@@ -25,6 +25,26 @@ class ForkLoad:
         """Imports a module from the fork."""
         return self.hardfork.module(name)
 
+    def tx_types(self) -> list[int]:
+        """Return the transaction types supported by the given fork."""
+        transactions = self._module("transactions")
+        tx_types = [0]
+
+        for tx_type, attribute in (
+            (1, "AccessListTransaction"),
+            (2, "FeeMarketTransaction"),
+            (3, "BlobTransaction"),
+            (4, "SetCodeTransaction"),
+        ):
+            if hasattr(transactions, attribute):
+                tx_types.append(tx_type)
+
+        return tx_types
+
+    def supports_tx_type(self, tx_type: int) -> bool:
+        """Return whether the given fork supports the provided tx type."""
+        return tx_type in self.tx_types()
+
     @property
     def proof_of_stake(self) -> bool:
         """Whether the fork is proof of stake."""

--- a/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
+++ b/src/ethereum_spec_tools/evm_tools/loaders/transaction_loader.py
@@ -25,7 +25,9 @@ from ethereum_spec_tools.evm_tools.utils import parse_hex_or_int
 class UnsupportedTxError(Exception):
     """Exception for unsupported transactions."""
 
-    def __init__(self, encoded_params: bytes, error_message: str) -> None:
+    def __init__(
+        self, encoded_params: bytes | None, error_message: str
+    ) -> None:
         super().__init__(error_message)
         self.encoded_params = encoded_params
         self.error_message = error_message
@@ -161,20 +163,38 @@ class TransactionLoad:
         else:
             return self.fork.Transaction
 
+    def unsupported_tx_type(self, tx_type: int) -> UnsupportedTxError:
+        """Return an unsupported transaction type error for this fork."""
+        return UnsupportedTxError(
+            None,
+            (
+                f"transaction type {tx_type} is not supported in "
+                f"{self.fork.hardfork.short_name}"
+            ),
+        )
+
     def read(self) -> Any:
         """Convert json transaction data to a transaction object."""
         if "type" in self.raw:
             tx_type = parse_hex_or_int(self.raw.get("type"), Uint)
             if tx_type == Uint(4):
+                if not self.fork.supports_tx_type(4):
+                    raise self.unsupported_tx_type(4)
                 tx_cls = self.fork.SetCodeTransaction
                 tx_byte_prefix = b"\x04"
             elif tx_type == Uint(3):
+                if not self.fork.supports_tx_type(3):
+                    raise self.unsupported_tx_type(3)
                 tx_cls = self.fork.BlobTransaction
                 tx_byte_prefix = b"\x03"
             elif tx_type == Uint(2):
+                if not self.fork.supports_tx_type(2):
+                    raise self.unsupported_tx_type(2)
                 tx_cls = self.fork.FeeMarketTransaction
                 tx_byte_prefix = b"\x02"
             elif tx_type == Uint(1):
+                if not self.fork.supports_tx_type(1):
+                    raise self.unsupported_tx_type(1)
                 tx_cls = self.fork.AccessListTransaction
                 tx_byte_prefix = b"\x01"
             elif tx_type == Uint(0):
@@ -184,15 +204,23 @@ class TransactionLoad:
                 raise ValueError(f"Unknown transaction type: {tx_type}")
         else:
             if "authorizationList" in self.raw:
+                if not self.fork.supports_tx_type(4):
+                    raise self.unsupported_tx_type(4)
                 tx_cls = self.fork.SetCodeTransaction
                 tx_byte_prefix = b"\x04"
             elif "maxFeePerBlobGas" in self.raw:
+                if not self.fork.supports_tx_type(3):
+                    raise self.unsupported_tx_type(3)
                 tx_cls = self.fork.BlobTransaction
                 tx_byte_prefix = b"\x03"
             elif "maxFeePerGas" in self.raw:
+                if not self.fork.supports_tx_type(2):
+                    raise self.unsupported_tx_type(2)
                 tx_cls = self.fork.FeeMarketTransaction
                 tx_byte_prefix = b"\x02"
             elif "accessList" in self.raw:
+                if not self.fork.supports_tx_type(1):
+                    raise self.unsupported_tx_type(1)
                 tx_cls = self.fork.AccessListTransaction
                 tx_byte_prefix = b"\x01"
             else:

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -126,7 +126,8 @@ class Txs:
                 self.rejected_txs[idx] = (
                     f"Unsupported transaction type: {e.error_message}"
                 )
-                self.all_txs.append(e.encoded_params)
+                if e.encoded_params is not None:
+                    self.all_txs.append(e.encoded_params)
             except Exception as e:
                 msg = f"Failed to parse transaction {idx}: {str(e)}"
                 self.t8n.logger.warning(msg, exc_info=e)

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -121,7 +121,8 @@ class Txs:
                     self.successfully_parsed.append(idx)
             except UnsupportedTxError as e:
                 self.t8n.logger.warning(
-                    f"Unsupported transaction type {idx}: {e.error_message}"
+                    f"Unsupported transaction at index {idx}: "
+                    f"{e.error_message}"
                 )
                 self.rejected_txs[idx] = (
                     f"Unsupported transaction type: {e.error_message}"


### PR DESCRIPTION
## 🗒️ Description
Pls read the linked issue below. Before this fix filling certain tests would show critical looking issues in the terminal (even though they were not critical) e.g. 

```
File "/home/user/.cache/ethereum-spec-evm-resolver/Shanghai/src/ethereum_spec_tools/evm_tools/loaders/fork_loader.py", line 229, in BlobTransaction
    return self._module("transactions").BlobTransaction
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'ethereum.shanghai.transactions' has no attribute 'BlobTransaction'. Did you mean: 'Transaction'?
``` 

or 

```
return self._module("transactions").SetCodeTransaction
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'ethereum.cancun.transactions' has no attribute 'SetCodeTransaction'. Did you mean: 'decode_transaction'?
```

with this fix we now get a more helpful `Unsupported transaction at index 0: transaction type 3 is not supported in shanghai` and `Unsupported transaction at index 0: transaction type 4 is not supported in cancun`. this is both more precise and also looks less like an unintended bug. to reproduce run the listed commands in the linked issue below

## 🔗 Related Issues or PRs
Closes #1613 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
