### PR TITLE
feat(tests,spec-specs): code deposit ordering and regression tests

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -124,6 +124,7 @@ def generic_create(
         tx_state, contract_address
     ) or account_has_storage(tx_state, contract_address):
         increment_nonce(tx_state, evm.message.current_target)
+        evm.regular_gas_used += create_message_gas
         evm.state_gas_left += create_message_state_gas_reservoir
         push(evm.stack, U256(0))
         return

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -221,13 +221,8 @@ def process_create_message(message: Message) -> Evm:
             if len(contract_code) > 0:
                 if contract_code[0] == 0xEF:
                     raise InvalidContractPrefix
-            cost_per_state_byte = state_gas_per_byte(
-                message.block_env.block_gas_limit
-            )
-            code_deposit_state_gas = (
-                Uint(len(contract_code)) * cost_per_state_byte
-            )
-            charge_state_gas(evm, code_deposit_state_gas)
+            if len(contract_code) > MAX_CODE_SIZE:
+                raise OutOfGasError
             # Hash cost for computing keccak256 of deployed bytecode
             code_hash_gas = (
                 GAS_KECCAK256_PER_WORD
@@ -235,8 +230,13 @@ def process_create_message(message: Message) -> Evm:
                 // Uint(32)
             )
             charge_gas(evm, code_hash_gas)
-            if len(contract_code) > MAX_CODE_SIZE:
-                raise OutOfGasError
+            cost_per_state_byte = state_gas_per_byte(
+                message.block_env.block_gas_limit
+            )
+            code_deposit_state_gas = (
+                Uint(len(contract_code)) * cost_per_state_byte
+            )
+            charge_state_gas(evm, code_deposit_state_gas)
         except ExceptionalHalt as error:
             restore_tx_state(tx_state, snapshot)
             evm.regular_gas_used += evm.gas_left

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -8,6 +8,8 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
 """
 
+from typing import Optional
+
 import pytest
 from execution_testing import (
     Account,
@@ -136,13 +138,14 @@ def test_create_with_reservoir(
         pytest.param(32, id="one_word"),
         pytest.param(256, id="small_contract"),
         pytest.param(1024, id="medium_contract"),
+        pytest.param(None, id="over_max_code_size"),
     ],
 )
 @pytest.mark.valid_from("Amsterdam")
 def test_code_deposit_state_gas_scales_with_size(
     state_test: StateTestFiller,
     pre: Alloc,
-    code_size: int,
+    code_size: Optional[int],
     fork: Fork,
 ) -> None:
     """
@@ -150,7 +153,12 @@ def test_code_deposit_state_gas_scales_with_size(
 
     The code deposit charges len(code) * cost_per_state_byte of state
     gas. Larger deployed code requires proportionally more state gas.
+    When code exceeds MAX_CODE_SIZE, the size check rejects before
+    any gas is charged and the contract is not deployed.
     """
+    if code_size is None:
+        code_size = fork.max_code_size() + 1
+
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
     env = Environment()
@@ -161,14 +169,21 @@ def test_code_deposit_state_gas_scales_with_size(
     # PUSH2 code_size, PUSH1 0, RETURN
     init_code = Op.RETURN(0, code_size)
 
+    sender = pre.fund_eoa()
     tx = Transaction(
         to=None,
         data=init_code,
         gas_limit=gas_limit_cap + total_state_gas,
-        sender=pre.fund_eoa(),
+        sender=sender,
     )
 
-    state_test(env=env, pre=pre, post={}, tx=tx)
+    if code_size > fork.max_code_size():
+        create_address = compute_create_address(address=sender, nonce=0)
+        post = {create_address: Account.NONEXISTENT}
+    else:
+        post = {}
+
+    state_test(env=env, pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.valid_from("Amsterdam")
@@ -377,6 +392,61 @@ def test_create_tx_intrinsic_gas_boundary(
     )
 
     state_test(pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_code_deposit_oog_preserves_parent_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Test parent reservoir preserved after child code deposit OOG.
+
+    Child returns enough bytes that code deposit state gas exceeds
+    available gas. Parent's SSTORE after the failed CREATE proves
+    the reservoir was not inflated by a spill-then-halt refund.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # Choose deploy_size so code deposit state gas exceeds the child
+    # frame's available gas, guaranteeing OOG.
+    cost_per_byte = fork.code_deposit_state_gas(code_size=1)
+    deploy_size = gas_limit_cap // cost_per_byte + 1
+    init_code = Op.RETURN(0, deploy_size)
+
+    factory_storage = Storage()
+    factory = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, Op.PUSH32(bytes(init_code)))
+            + Op.SSTORE(
+                factory_storage.store_next(0, "create_fails"),
+                Op.CREATE(
+                    value=0,
+                    offset=32 - len(init_code),
+                    size=len(init_code),
+                ),
+            )
+            # Reservoir must be fully preserved after failed CREATE;
+            # parent can still perform its own SSTORE.
+            + Op.SSTORE(
+                factory_storage.store_next(1, "parent_sstore"),
+                1,
+            )
+        ),
+    )
+
+    # Reservoir = 1 SSTORE's worth of state gas
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {factory: Account(storage=factory_storage)}
+    state_test(pre=pre, post=post, tx=tx)
 
 
 @pytest.mark.valid_from("Amsterdam")

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -8,7 +8,7 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
 """
 
-from typing import Optional
+from typing import Union
 
 import pytest
 from execution_testing import (
@@ -138,14 +138,15 @@ def test_create_with_reservoir(
         pytest.param(32, id="one_word"),
         pytest.param(256, id="small_contract"),
         pytest.param(1024, id="medium_contract"),
-        pytest.param(None, id="over_max_code_size"),
+        pytest.param("max", id="max_code_size"),
+        pytest.param("max+1", id="over_max_code_size"),
     ],
 )
 @pytest.mark.valid_from("Amsterdam")
 def test_code_deposit_state_gas_scales_with_size(
     state_test: StateTestFiller,
     pre: Alloc,
-    code_size: Optional[int],
+    code_size: Union[int, str],
     fork: Fork,
 ) -> None:
     """
@@ -156,8 +157,11 @@ def test_code_deposit_state_gas_scales_with_size(
     When code exceeds MAX_CODE_SIZE, the size check rejects before
     any gas is charged and the contract is not deployed.
     """
-    if code_size is None:
+    if code_size == "max":
+        code_size = fork.max_code_size()
+    elif code_size == "max+1":
         code_size = fork.max_code_size() + 1
+    assert isinstance(code_size, int)
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -403,19 +407,27 @@ def test_code_deposit_oog_preserves_parent_reservoir(
     """
     Test parent reservoir preserved after child code deposit OOG.
 
-    Child returns enough bytes that code deposit state gas exceeds
-    available gas. Parent's SSTORE after the failed CREATE proves
-    the reservoir was not inflated by a spill-then-halt refund.
+    A caller contract invokes the factory via CALL with limited gas.
+    The child CREATE returns enough bytes that code deposit state gas
+    exceeds the child frame's available gas (reservoir spillover plus
+    the limited gas_left). The factory's SSTORE after the failed
+    CREATE proves the reservoir was not inflated by a spill-then-halt
+    refund.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
     sstore_state_gas = fork.sstore_state_gas()
 
-    # Choose deploy_size so code deposit state gas exceeds the child
-    # frame's available gas, guaranteeing OOG.
-    cost_per_byte = fork.code_deposit_state_gas(code_size=1)
-    deploy_size = gas_limit_cap // cost_per_byte + 1
+    # Small deploy size; code deposit state gas will exceed the
+    # limited gas available in the CREATE child frame.
+    deploy_size = 4096
     init_code = Op.RETURN(0, deploy_size)
+
+    # Limited regular gas forwarded to the factory.  After CREATE
+    # takes 63/64, the factory retains ~15 K for its SSTOREs.
+    child_gas = 1_000_000
 
     factory_storage = Storage()
     factory = pre.deploy_contract(
@@ -438,10 +450,17 @@ def test_code_deposit_oog_preserves_parent_reservoir(
         ),
     )
 
-    # Reservoir = 1 SSTORE's worth of state gas
+    # Caller invokes factory with limited gas via CALL.
+    caller = pre.deploy_contract(
+        code=Op.CALL(gas=child_gas, address=factory),
+    )
+
+    # Reservoir = new-account state gas + one SSTORE's state gas.
+    # Code deposit draws from the reservoir first then spills into
+    # gas_left, which the limited CALL gas cannot cover.
     tx = Transaction(
-        to=factory,
-        gas_limit=gas_limit_cap + sstore_state_gas,
+        to=caller,
+        gas_limit=(gas_limit_cap + new_account_state_gas + sstore_state_gas),
         sender=pre.fund_eoa(),
     )
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Following a bug found by @rakita in our recent bal v5.3.0 test release: https://discord.com/channels/1359927674746835211/1428002540661899274/1480763553718730874

- Move `MAX_CODE_SIZE` check before state gas and hash cost charges in `process_create_message`, matching EIP-8037 spec ordering.
- Add `over_max_code_size` param to `test_code_deposit_state_gas_scales_with_size` to catch regressions.
- Charge keccak hash cost (regular gas) before code deposit state gas, preventing spill-then-halt reservoir inflation.



## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
