### PR TITLE
feat(test-execute): Defer pre-alloc methods remote checks to batch them

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -706,6 +706,8 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     fork=fork,
                 )
 
+                pre.resolve_deferred_checks()
+
                 minimum_balance, gas_consumption = (
                     pre.minimum_balance_for_pending_transactions(
                         required_balances,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -1,5 +1,6 @@
 """Pre-allocation fixtures used for test filling."""
 
+from dataclasses import dataclass
 from itertools import count
 from pathlib import Path
 from random import randint
@@ -20,6 +21,9 @@ from execution_testing.base_types import (
     Number,
     Storage,
     StorageRootType,
+)
+from execution_testing.base_types import (
+    Alloc as BaseAlloc,
 )
 from execution_testing.base_types.conversions import (
     BytesConvertible,
@@ -225,6 +229,36 @@ class PendingTransaction(Transaction):
     value: HexNumber | None = None  # type: ignore
 
 
+@dataclass
+class _DeferredDeterministicDeploy:
+    """Descriptor for a deferred deterministic contract deployment."""
+
+    contract_address: Address
+    deploy_code: Bytes
+    salt: Hash
+    initcode: Bytes | Initcode
+    label: str | None
+    deploy_gas_limit: int
+
+
+@dataclass
+class _DeferredStubCheck:
+    """Descriptor for a deferred stub contract account fetch."""
+
+    contract_address: Address
+    stub: str
+    label: str | None
+
+
+@dataclass
+class _DeferredFundAddress:
+    """Descriptor for a deferred address funding balance check."""
+
+    address: Address
+    amount: int
+    minimum_balance: bool
+
+
 class Alloc(SharedAlloc):
     """A custom class that inherits from the original Alloc class."""
 
@@ -238,6 +272,15 @@ class Alloc(SharedAlloc):
     _chain_id: int = PrivateAttr()
     _node_id: str = PrivateAttr("")
     _address_stubs: AddressStubs = PrivateAttr()
+    _deferred_deterministic_deploys: List[_DeferredDeterministicDeploy] = (
+        PrivateAttr(default_factory=list)
+    )
+    _deferred_stub_checks: List[_DeferredStubCheck] = PrivateAttr(
+        default_factory=list
+    )
+    _deferred_fund_addresses: List[_DeferredFundAddress] = PrivateAttr(
+        default_factory=list
+    )
 
     def __init__(
         self,
@@ -301,6 +344,10 @@ class Alloc(SharedAlloc):
         """
         Execute implementation of contract deployment to a deterministic
         location.
+
+        Chain verification is deferred to ``resolve_deferred_checks`` so
+        that multiple deployments can be batched into a single RPC round
+        trip.
         """
         del storage
         gas_costs = self._fork.gas_costs()
@@ -320,80 +367,53 @@ class Alloc(SharedAlloc):
         contract_address = compute_deterministic_create2_address(
             salt=salt, initcode=initcode, fork=self._fork
         )
-        # 1) Determine if this contract already exists
-        chain_code = self._eth_rpc.get_code(contract_address)
-        if chain_code != b"":
-            assert chain_code == deploy_code, (
-                "Deterministic deployed contract's code on chain does not "
-                "match the expected code: "
-                f"Expected: {deploy_code}, "
-                f"Current: {chain_code}"
-            )
-            logger.info(
-                f"Contract already deployed at {contract_address} "
-                f"(label={label})"
-            )
-        else:
-            # Assert the deployment contract is already on chain
-            assert (
-                check_deterministic_factory_deployment(
-                    eth_rpc=self._eth_rpc, fork=self._fork
-                )
-                is not None
-            ), "Deployment contract code is not found"
 
-            # Deploy the actual contract.
-            max_code_size = self._fork.max_code_size()
-            if len(deploy_code) > max_code_size:
-                raise ValueError(
-                    f"code too large: {len(deploy_code)} > {max_code_size}"
-                )
-            max_initcode_size = self._fork.max_initcode_size()
-            if len(initcode) > max_initcode_size:
-                raise ValueError(
-                    f"initcode too large {len(initcode)} > {max_initcode_size}"
-                )
-            deploy_gas_limit = gas_costs.GAS_TX_BASE + gas_costs.GAS_TX_CREATE
-            deploy_gas_limit += (
-                len(deploy_code) * gas_costs.GAS_CODE_DEPOSIT_PER_BYTE
+        # Pre-compute the gas limit for the deploy transaction.
+        max_code_size = self._fork.max_code_size()
+        if len(deploy_code) > max_code_size:
+            raise ValueError(
+                f"code too large: {len(deploy_code)} > {max_code_size}"
             )
-            deploy_gas_limit += memory_expansion_gas_calculator(
-                new_bytes=len(initcode)
+        max_initcode_size = self._fork.max_initcode_size()
+        if len(initcode) > max_initcode_size:
+            raise ValueError(
+                f"initcode too large {len(initcode)} > {max_initcode_size}"
             )
-            deploy_gas_limit += calldata_gas_calculator(data=initcode)
-            deploy_gas_limit = deploy_gas_limit * 2
-            tx_gas_limit_cap = self._fork.transaction_gas_limit_cap()
-            if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
-                raise ValueError(
-                    f"deterministic deploy gas limit exceeds the transaction "
-                    f"gas limit cap: {deploy_gas_limit} > {tx_gas_limit_cap}"
-                )
-            deploy_tx = self._add_pending_tx(
-                action="deterministic_deploy_contract",
-                target=label,
-                to=DETERMINISTIC_FACTORY_ADDRESS,
-                data=Bytes(salt) + Bytes(initcode),
-                gas_limit=deploy_gas_limit,
-                value=0,
-            )
-            code_size = len(deploy_code)
-            initcode_size = len(initcode)
-            logger.info(
-                f"Contract deployment tx created (label={label}): "
-                f"tx_nonce={deploy_tx.nonce}, gas_limit={deploy_gas_limit}, "
-                f"code_size={code_size} bytes, initcode_size={initcode_size} "
-                "bytes"
+        deploy_gas_limit = gas_costs.GAS_TX_BASE + gas_costs.GAS_TX_CREATE
+        deploy_gas_limit += (
+            len(deploy_code) * gas_costs.GAS_CODE_DEPOSIT_PER_BYTE
+        )
+        deploy_gas_limit += memory_expansion_gas_calculator(
+            new_bytes=len(initcode)
+        )
+        deploy_gas_limit += calldata_gas_calculator(data=initcode)
+        deploy_gas_limit = deploy_gas_limit * 2
+        tx_gas_limit_cap = self._fork.transaction_gas_limit_cap()
+        if tx_gas_limit_cap and deploy_gas_limit > tx_gas_limit_cap:
+            raise ValueError(
+                f"deterministic deploy gas limit exceeds the transaction "
+                f"gas limit cap: {deploy_gas_limit} > {tx_gas_limit_cap}"
             )
 
-            logger.debug(
-                f"Contract will be deployed at {contract_address} "
-                f"(label={label}, tx_index={len(self._pending_txs) - 1})"
+        # Defer the on-chain check; the deploy tx (if needed) and the
+        # alloc update will happen in resolve_deferred_checks.
+        self._deferred_deterministic_deploys.append(
+            _DeferredDeterministicDeploy(
+                contract_address=contract_address,
+                deploy_code=deploy_code,
+                salt=salt,
+                initcode=initcode,
+                label=label,
+                deploy_gas_limit=deploy_gas_limit,
             )
+        )
 
-            self._deployed_contracts.append((contract_address, deploy_code))
-
-        account = self._eth_rpc.get_account(contract_address)
-        self.__internal_setitem__(contract_address, account)
+        # Set a placeholder so the address is visible in the alloc
+        # immediately.
+        self.__internal_setitem__(
+            contract_address,
+            Account(code=deploy_code),
+        )
 
         contract_address.label = label
         return contract_address
@@ -435,20 +455,16 @@ class Alloc(SharedAlloc):
                 f"Using address stub '{stub}' at {contract_address} "
                 f"(label={label})"
             )
-            account = self._eth_rpc.get_account(contract_address)
-            code = account.code
-            if code == b"":
-                raise ValueError(
-                    f"Stub {stub} at {contract_address} has no code"
+            # Defer the account fetch; the alloc will be updated in
+            # resolve_deferred_checks.
+            self._deferred_stub_checks.append(
+                _DeferredStubCheck(
+                    contract_address=contract_address,
+                    stub=stub,
+                    label=label,
                 )
-            balance = account.balance
-            nonce = account.nonce
-            bal_eth = balance / 10**18
-            logger.debug(
-                f"Stub contract {contract_address}: balance={bal_eth:.18f} "
-                f"ETH, nonce={nonce}, code_size={len(code)} bytes"
             )
-            self.__internal_setitem__(contract_address, account)
+            contract_address.label = label
             return contract_address
 
         initcode_prefix = Bytecode()
@@ -691,52 +707,17 @@ class Alloc(SharedAlloc):
     ) -> None:
         """
         Execute implementation of address funding.
+
+        The balance check is deferred to ``resolve_deferred_checks`` so
+        that multiple fund_address calls can be batched into a single
+        RPC round trip.
         """
-        current_balance = self._eth_rpc.get_balance(address)
-        if minimum_balance:
-            if current_balance >= amount:
-                cur_eth = current_balance / 10**18
-                min_eth = amount / 10**18
-                logger.info(
-                    f"Skipping funding for address {address} "
-                    f"(label={address.label}): current balance "
-                    f"{cur_eth:.18f} ETH >= minimum {min_eth:.18f} ETH"
-                )
-                self.__internal_setitem__(
-                    address, Account(balance=current_balance)
-                )
-                return
-            fund_eth = amount / 10**18
-            logger.debug(
-                f"Funding address to minimum balance {address} "
-                f"(label={address.label}): {fund_eth:.18f} ETH"
+        self._deferred_fund_addresses.append(
+            _DeferredFundAddress(
+                address=address,
+                amount=amount,
+                minimum_balance=minimum_balance,
             )
-            self._add_pending_tx(
-                action="fund_address",
-                target=address.label,
-                to=address,
-                value=amount - current_balance,
-            )
-            new_balance = amount
-        else:
-            fund_eth = amount / 10**18
-            logger.debug(
-                f"Funding address {address} (label={address.label}): "
-                f"{fund_eth:.18f} ETH"
-            )
-            self._add_pending_tx(
-                action="fund_address",
-                target=address.label,
-                to=address,
-                value=amount,
-            )
-            new_balance = current_balance + amount
-
-        self.__internal_setitem__(address, Account(balance=new_balance))
-
-        logger.info(
-            f"Address {address} funding tx created (label={address.label}): "
-            f"{Number(amount) / 10**18:.18f} ETH"
         )
 
     def _nonexistent_account(self) -> Address:
@@ -749,6 +730,183 @@ class Alloc(SharedAlloc):
         eoa = next(self._eoa_iterator)
         logger.debug(f"Returning unused address {eoa} (nonexistent account)")
         return Address(eoa)
+
+    def resolve_deferred_checks(self) -> None:
+        """
+        Resolve all deferred on-chain checks using batched RPC calls.
+
+        Must be called after the test function finishes and before
+        ``minimum_balance_for_pending_transactions``.  This turns the
+        deferred descriptors into concrete pending transactions and
+        updates the alloc with real on-chain data.
+        """
+        self._resolve_deterministic_deploys()
+        self._resolve_stub_checks()
+        self._resolve_fund_addresses()
+
+    def _resolve_deterministic_deploys(self) -> None:
+        """Batch-resolve deferred deterministic contract deployments."""
+        deferred = self._deferred_deterministic_deploys
+        if not deferred:
+            return
+        self._deferred_deterministic_deploys = []
+
+        addresses = [d.contract_address for d in deferred]
+        chain_codes = self._eth_rpc.get_codes(addresses)
+
+        factory_checked = False
+
+        for d, chain_code in zip(deferred, chain_codes, strict=True):
+            if chain_code != b"":
+                assert chain_code == d.deploy_code, (
+                    "Deterministic deployed contract's code on chain "
+                    "does not match the expected code: "
+                    f"Expected: {d.deploy_code}, "
+                    f"Current: {chain_code}"
+                )
+                logger.info(
+                    f"Contract already deployed at {d.contract_address} "
+                    f"(label={d.label})"
+                )
+            else:
+                if not factory_checked:
+                    assert (
+                        check_deterministic_factory_deployment(
+                            eth_rpc=self._eth_rpc, fork=self._fork
+                        )
+                        is not None
+                    ), "Deployment contract code is not found"
+                    factory_checked = True
+
+                logger.info(
+                    f"Contract {d.contract_address} not found, "
+                    f"deploying (label={d.label})"
+                )
+                deploy_tx = self._add_pending_tx(
+                    action="deterministic_deploy_contract",
+                    target=d.label,
+                    to=DETERMINISTIC_FACTORY_ADDRESS,
+                    data=Bytes(d.salt) + Bytes(d.initcode),
+                    gas_limit=d.deploy_gas_limit,
+                    value=0,
+                )
+                code_size = len(d.deploy_code)
+                initcode_size = len(d.initcode)
+                logger.info(
+                    f"Contract deployment tx created (label={d.label}): "
+                    f"tx_nonce={deploy_tx.nonce}, "
+                    f"gas_limit={d.deploy_gas_limit}, "
+                    f"code_size={code_size} bytes, "
+                    f"initcode_size={initcode_size} bytes"
+                )
+                logger.debug(
+                    f"Contract will be deployed at "
+                    f"{d.contract_address} "
+                    f"(label={d.label}, "
+                    f"tx_index={len(self._pending_txs) - 1})"
+                )
+                self._deployed_contracts.append(
+                    (d.contract_address, d.deploy_code)
+                )
+
+        # Batch-fetch the current account state for all addresses and
+        # update the alloc.
+        alloc_query = BaseAlloc(root={addr: Account() for addr in addresses})
+        actual_alloc = self._eth_rpc.get_alloc(alloc_query)
+        for addr in addresses:
+            account = actual_alloc.root.get(addr)
+            if account is not None:
+                self.__internal_setitem__(addr, account)
+
+    def _resolve_stub_checks(self) -> None:
+        """Batch-resolve deferred stub contract account fetches."""
+        deferred = self._deferred_stub_checks
+        if not deferred:
+            return
+        self._deferred_stub_checks = []
+
+        alloc_query = BaseAlloc(
+            root={d.contract_address: Account() for d in deferred}
+        )
+        actual_alloc = self._eth_rpc.get_alloc(alloc_query)
+
+        for d in deferred:
+            account = actual_alloc.root.get(d.contract_address)
+            assert account is not None, (
+                f"Failed to fetch account for stub '{d.stub}' "
+                f"at {d.contract_address}"
+            )
+            if account.code == b"":
+                raise ValueError(
+                    f"Stub {d.stub} at {d.contract_address} has no code"
+                )
+            bal_eth = account.balance / 10**18
+            logger.debug(
+                f"Stub contract {d.contract_address}: "
+                f"balance={bal_eth:.18f} ETH, "
+                f"nonce={account.nonce}, "
+                f"code_size={len(account.code)} bytes"
+            )
+            self.__internal_setitem__(d.contract_address, account)
+
+    def _resolve_fund_addresses(self) -> None:
+        """Batch-resolve deferred address funding balance checks."""
+        deferred = self._deferred_fund_addresses
+        if not deferred:
+            return
+        self._deferred_fund_addresses = []
+
+        addresses = [d.address for d in deferred]
+        current_balances = self._eth_rpc.get_balances(addresses)
+
+        for d, current_balance in zip(deferred, current_balances, strict=True):
+            if d.minimum_balance:
+                if current_balance >= d.amount:
+                    cur_eth = current_balance / 10**18
+                    min_eth = d.amount / 10**18
+                    logger.info(
+                        f"Skipping funding for address {d.address} "
+                        f"(label={d.address.label}): current balance "
+                        f"{cur_eth:.18f} ETH >= minimum "
+                        f"{min_eth:.18f} ETH"
+                    )
+                    self.__internal_setitem__(
+                        d.address, Account(balance=current_balance)
+                    )
+                    continue
+                fund_eth = d.amount / 10**18
+                logger.debug(
+                    f"Funding address to minimum balance {d.address} "
+                    f"(label={d.address.label}): {fund_eth:.18f} ETH"
+                )
+                self._add_pending_tx(
+                    action="fund_address",
+                    target=d.address.label,
+                    to=d.address,
+                    value=d.amount - current_balance,
+                )
+                new_balance = d.amount
+            else:
+                fund_eth = d.amount / 10**18
+                logger.debug(
+                    f"Funding address {d.address} "
+                    f"(label={d.address.label}): "
+                    f"{fund_eth:.18f} ETH"
+                )
+                self._add_pending_tx(
+                    action="fund_address",
+                    target=d.address.label,
+                    to=d.address,
+                    value=d.amount,
+                )
+                new_balance = current_balance + d.amount
+
+            self.__internal_setitem__(d.address, Account(balance=new_balance))
+            logger.info(
+                f"Address {d.address} funding tx created "
+                f"(label={d.address.label}): "
+                f"{Number(d.amount) / 10**18:.18f} ETH"
+            )
 
     def minimum_balance_for_pending_transactions(
         self,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -464,6 +464,12 @@ class Alloc(SharedAlloc):
                     label=label,
                 )
             )
+            # Set a placeholder so the address is visible in the alloc
+            # immediately.
+            self.__internal_setitem__(
+                contract_address,
+                Account(code=code),
+            )
             contract_address.label = label
             return contract_address
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -725,6 +725,7 @@ class Alloc(SharedAlloc):
                 minimum_balance=minimum_balance,
             )
         )
+        self.__internal_setitem__(address, Account(balance=amount))
 
     def _nonexistent_account(self) -> Address:
         """

--- a/packages/testing/src/execution_testing/rpc/rpc.py
+++ b/packages/testing/src/execution_testing/rpc/rpc.py
@@ -587,6 +587,30 @@ class EthRPC(BaseRPC):
         ).result_or_raise()
         return int(response, 16)
 
+    def get_balances(
+        self,
+        addresses: List[Address],
+        block_number: BlockNumberType = "latest",
+    ) -> List[int]:
+        """`eth_getBalance` batch: Return balance for multiple addresses."""
+        if not addresses:
+            return []
+        block = (
+            hex(block_number)
+            if isinstance(block_number, int)
+            else block_number
+        )
+        logger.info(
+            f"Batch requesting balance of {len(addresses)} addresses "
+            f"at block {block}"
+        )
+        calls = [
+            RPCCall(method="getBalance", params=[f"{addr}", block])
+            for addr in addresses
+        ]
+        responses = self.post_batch_request(calls=calls)
+        return [int(r.result_or_raise(), 16) for r in responses]
+
     def get_code(
         self, address: Address, block_number: BlockNumberType = "latest"
     ) -> Bytes:
@@ -602,6 +626,30 @@ class EthRPC(BaseRPC):
             request=RPCCall(method="getCode", params=params)
         ).result_or_raise()
         return Bytes(response)
+
+    def get_codes(
+        self,
+        addresses: List[Address],
+        block_number: BlockNumberType = "latest",
+    ) -> List[Bytes]:
+        """`eth_getCode` batch: Return code for multiple addresses."""
+        if not addresses:
+            return []
+        block = (
+            hex(block_number)
+            if isinstance(block_number, int)
+            else block_number
+        )
+        logger.info(
+            f"Batch requesting code of {len(addresses)} addresses "
+            f"at block {block}"
+        )
+        calls = [
+            RPCCall(method="getCode", params=[f"{addr}", block])
+            for addr in addresses
+        ]
+        responses = self.post_batch_request(calls=calls)
+        return [Bytes(r.result_or_raise()) for r in responses]
 
     def get_transaction_count(
         self, address: Address, block_number: BlockNumberType = "latest"


### PR DESCRIPTION
## 🗒️ Description

Adds on-chain checks to lists to defer them in order to be able to batch them instead of trying to immediately resolve.

Affected methods:
- Deterministic contract code checks and deployment in `_deterministic_deploy_contract`
- Balance checks in `_fund_address`
- Stub code checks in `_deploy_contract`

Reduces execution time significantly in tests that do heavy use of these functions.

## 🔗 Related Issues or PRs
PR #2436 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
