### PR TITLE
fix(zkevm): optimize further bytecode in witness

### DIFF
--- a/src/ethereum/forks/amsterdam/state_tracker.py
+++ b/src/ethereum/forks/amsterdam/state_tracker.py
@@ -164,6 +164,11 @@ def get_code(
 
     Read chain: tx code_writes -> block code_writes -> pre_state.
 
+    Only record a ``code_reads`` entry when the bytecode is actually
+    fetched from ``pre_state``.  Reads satisfied by ``code_writes``
+    (same-tx or earlier-tx CREATEs) are already available to a
+    stateless verifier and do not need to appear in the witness.
+
     Parameters
     ----------
     tx_state :
@@ -181,11 +186,11 @@ def get_code(
     """
     if code_hash == EMPTY_CODE_HASH:
         return b""
-    tx_state.code_reads.add((address, code_hash))
     if code_hash in tx_state.code_writes:
         return tx_state.code_writes[code_hash]
     if code_hash in tx_state.parent.code_writes:
         return tx_state.parent.code_writes[code_hash]
+    tx_state.code_reads.add((address, code_hash))
     return tx_state.parent.pre_state.get_code(code_hash)
 
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_contract_creation.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_contract_creation.py
@@ -293,16 +293,11 @@ def test_witness_codes_create_same_hash_then_read(
     """
     Tx1 deploys a contract, tx2 calls a pre-state contract with same code.
 
-    The pre-state contract's bytecode should appear in
-    executionWitness.codes because get_witness_codes checks per-address
-    pre-state match. The pre-state contract qualifies regardless of the
-    earlier CREATE writing the same hash.
-
-    TODO(zkevm): it might be worth reconsidering how the execution witness
-    generation handles this case, since technically this same bytecode was
-    observed in tx1 thus can in theory be exploited to avoid including it
-    for tx2. Feels inconsistent with the other test
-    test_witness_codes_create_then_call_same_block(...).
+    The pre-state contract's bytecode must not appear in
+    executionWitness.codes because the same code hash was already
+    written by tx1's CREATE.  A stateless verifier observed
+    the bytecode from the CREATE transaction data, so including it
+    in the witness is redundant.
     """
     runtime_code = bytes(Op.STOP)
 
@@ -330,7 +325,7 @@ def test_witness_codes_create_same_hash_then_read(
                 txs=[tx1_create, tx2_read],
                 expected_execution_witness_codes=(
                     ExecutionWitnessCodesExpectation(
-                        codes_present=[Bytes(runtime_code)],
+                        codes_absent=[Bytes(runtime_code)],
                     )
                 ),
             )
@@ -491,5 +486,74 @@ def test_witness_codes_failed_create_after_initcode_read(
         ],
         post={
             creator: Account(nonce=1),
+        },
+    )
+
+
+def test_witness_codes_reverted_create_same_hash_then_read(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Factory CREATEs bytecode A then REVERTs; tx2 calls pre-state contract
+    with also bytecode A.
+
+    Said differently, bytecode A was observed by a contract creation execution
+    but since the creation fails it isn't tracked cross-tx boundary by the
+    state tracker. This means that tx2 access to the pre-state contract's
+    code hash doesn't find it thus falls back to fetching the bytecode
+    from pre-state and including it in the witness.
+    """
+    runtime_code = bytes(Op.STOP)
+
+    existing_contract = pre.deploy_contract(code=runtime_code)
+
+    initcode = bytes(Initcode(deploy_code=runtime_code))
+    factory_code = (
+        Op.MSTORE(0, Op.PUSH32(initcode))
+        + Op.CREATE(
+            offset=32 - len(initcode),
+            size=len(initcode),
+        )
+        # The runtime_code was observed by the CREATE execution,
+        # but since the CREATE fails, it isn't tracked cross-tx
+        # boundary by the state tracker. This means that tx2
+        # access to the pre-state contract's code hash doesn't
+        # find it thus falls back to fetching the bytecode from
+        # pre-state and including it in the witness.
+        + Op.POP
+        + Op.REVERT(offset=0, size=0)
+    )
+    factory = pre.deploy_contract(code=factory_code)
+
+    sender1 = pre.fund_eoa()
+    sender2 = pre.fund_eoa()
+
+    tx1_reverted_create = Transaction(
+        sender=sender1,
+        to=factory,
+        gas_limit=500_000,
+    )
+    tx2_read = Transaction(
+        sender=sender2,
+        to=existing_contract,
+        gas_limit=200_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx1_reverted_create, tx2_read],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[Bytes(runtime_code)],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender1: Account(nonce=1),
+            sender2: Account(nonce=1),
         },
     )


### PR DESCRIPTION
## 🗒️ Description
This PR changes the specs on how created code is observed by the state tracker thus influencing when they appear in the execution witness. For more context, please see this [PR comment](https://github.com/ethereum/execution-specs/pull/2472#discussion_r2914808882).

The spec now only adds bytecode to `code_reads` if it is read from the pre-state, leveraging the fact that the bytecode might have been observed during execution by previous transactions in the block.

More concretely, imagine the case that tx1 CREATE some bytecode with `code_hash_1`, and a later tx2 accesses a separate account with `code_hash_1`:
- Before this PR: the bytecode for `code_hash_1` was part of the witness, since the tx2 code read was unconditionally added.
- After this PR: we leverage `code_writes` which happened earlier in the block, thus in this corner-case we would avoid adding it to the witness since it is already part of the "in memory" guest program bytecode dataset.

This still leaves one even more border case with the "inefficiency" which is that the tx1 contract creation reverts. The way `code_write` works is that it rolls back too, so tx2 can't leverage it. I think this could also be solved, but it will probably make the specs more complex, which I'm not sure is worth it. (An extra test was added to be sure clients behave identically in that case).

I'm opening this PR mainly to tighten up a bit more bytecode optimality in the witness since this change in the spec is quite simple -- I think going the last mile is probably not worth the complexity. 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
