### PR TITLE
chore(test-fill): fix `PytestUnknownMarkWarning: Unknown pytest.mark.json_loader`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -172,8 +172,7 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "mainnet: Specialty tests crafted for running on mainnet and sanity "
-        "checking.",
+        "mainnet: Tests crafted for running on mainnet and sanity checking.",
     )
     config.addinivalue_line(
         "markers",
@@ -197,6 +196,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "fixture_subfolder(level, prefix): "
         "Signal that fixtures should be placed in a subfolder",
+    )
+    config.addinivalue_line(
+        "markers",
+        "json_loader: tests forming a minimized test set that is used by "
+        "tests/json_loader/",
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
Fix warnings introduced in #2369:
```
tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py:1867
  /home/dtopz/code/github/execution-specs/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py:1867: PytestUnknownMarkWarning: Unknown pytest.mark.json_loader - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.json_loader
```

`json_infra` was registered in #2369, but got lost when it got renamed to `json_loader`!

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:rabbit2: 
