### PR TITLE
fix(test-benchmark): update `approve` function for `SSTORE` benchmark

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -34,6 +34,7 @@ from execution_testing import (
     While,
     keccak256,
 )
+from execution_testing.base_types.base_types import Number
 
 from tests.benchmark.stateful.helpers import (
     ALLOWANCE_SELECTOR,
@@ -273,6 +274,8 @@ def test_sload_erc20_balanceof(
 
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
+@pytest.mark.parametrize("write_new_value", [False, True])
+@pytest.mark.parametrize("existing_slot", [True, False])
 def test_sstore_erc20_approve(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -280,9 +283,21 @@ def test_sstore_erc20_approve(
     gas_benchmark_value: int,
     tx_gas_limit: int,
     token_name: str,
+    write_new_value: bool,
+    existing_slot: bool,
     cache_strategy: CacheStrategy,
 ) -> None:
     """Benchmark SSTORE using ERC20 approve on bloatnet."""
+    sender = EOA(
+        key=0x90655B60A56E01389173510C3DDF1B969803A9F41844BF344CBF3D1AC3A80845,
+        # nonce fetched from the pre-deployed state on the network
+        nonce=45344,
+    )
+    pre.fund_address(address=sender, amount=10**9)
+    assert Address(sender) == Address(
+        0x6C2624662DC514A69955E9A6A195ECE23ACED5A0
+    ), "EOA address mismatch"
+
     # Stub Account
     erc20_address = pre.deploy_contract(
         code=Bytecode(),
@@ -309,7 +324,14 @@ def test_sstore_erc20_approve(
         + Op.CALLDATALOAD(0)  # [num_calls]
     )
 
-    call_approve = Op.MSTORE(64, Op.MLOAD(32)) + Op.POP(
+    value_to_write: Bytecode | int
+    if write_new_value:
+        # non-zero, avoids refund and always differs from existing values
+        value_to_write = 1
+    else:
+        value_to_write = Op.MLOAD(32) if existing_slot else 0
+
+    call_approve = Op.MSTORE(64, value_to_write) + Op.POP(
         Op.CALL(
             address=erc20_address,
             value=0,
@@ -322,6 +344,7 @@ def test_sstore_erc20_approve(
         )
     )
 
+    cache_warmup = Bytecode()
     if cache_strategy == CacheStrategy.CACHE_TX:
         # Call allowance(ADDRESS, spender) to warm the allowance
         # storage slot that approve will later write to.
@@ -346,8 +369,6 @@ def test_sstore_erc20_approve(
             + Op.MSTORE(0, APPROVE_SELECTOR)
             + Op.MSTORE(32, Op.MLOAD(64))
         )
-    else:
-        cache_warmup = Bytecode()
 
     loop = While(
         body=cache_warmup
@@ -364,6 +385,22 @@ def test_sstore_erc20_approve(
     setup_cost = setup.gas_cost(fork)
     loop_cost = loop.gas_cost(fork)
     access_list = [AccessList(address=erc20_address, storage_keys=[])]
+    # Delegate sender to attack_contract_address once in setup
+    delegation_tx = Transaction(
+        gas_limit=100_000,
+        to=sender,
+        value=0,
+        sender=pre.fund_eoa(),
+        authorization_list=[
+            AuthorizationTuple(
+                chain_id=0,
+                address=attack_contract_address,
+                nonce=sender.nonce,
+                signer=sender,
+            ),
+        ],
+    )
+    sender.nonce = Number(sender.nonce + 1)
     intrinsic_gas_with_access_list = (
         fork.transaction_intrinsic_cost_calculator()(
             access_list=access_list,
@@ -420,6 +457,9 @@ def test_sstore_erc20_approve(
 
     function_dispatch_cost = function_dispatch.gas_cost(fork)
 
+    with TestPhaseManager.setup():
+        delegation_block = Block(txs=[delegation_tx])
+
     if cache_strategy == CacheStrategy.CACHE_TX:
         # Add allowance dispatch cost for the warmup call.
         # allowance(owner, spender) computes the same double-
@@ -462,7 +502,10 @@ def test_sstore_erc20_approve(
     txs = []
     cache_txs = []
     gas_remaining = gas_benchmark_value
-    slot_offset = 0
+    # This sender is a stub account, the first initialized
+    # slot is 371 on perfnet. The initialized slots range
+    # is 371-45139; existing slots fall within that range.
+    slot_offset = 371 if existing_slot else START_SLOT
 
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
@@ -485,8 +528,8 @@ def test_sstore_erc20_approve(
                     Transaction(
                         gas_limit=gas_available,
                         data=calldata,
-                        to=attack_contract_address,
-                        sender=pre.fund_eoa(),
+                        to=sender,
+                        sender=sender,
                         access_list=access_list,
                     )
                 )
@@ -496,8 +539,8 @@ def test_sstore_erc20_approve(
                 Transaction(
                     gas_limit=gas_available,
                     data=calldata,
-                    to=attack_contract_address,
-                    sender=pre.fund_eoa(),
+                    to=sender,
+                    sender=sender,
                     access_list=access_list,
                 )
             )
@@ -505,7 +548,9 @@ def test_sstore_erc20_approve(
         gas_remaining -= gas_available
         slot_offset += num_calls
 
-    blocks = build_cache_strategy_blocks(cache_strategy, txs, cache_txs)
+    blocks = [delegation_block] + build_cache_strategy_blocks(
+        cache_strategy, txs, cache_txs
+    )
     # TODO: this test can currently not estimate the gas used
     # It will also overestimate the num_calls it can make to an unknown
     # ERC20 contract and will therefore OOG

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -272,6 +272,7 @@ def test_sload_erc20_balanceof(
     benchmark_test(pre=pre, blocks=blocks, skip_gas_used_validation=True)
 
 
+@pytest.mark.repricing
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)
 @pytest.mark.parametrize("write_new_value", [False, True])

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -499,14 +499,15 @@ def test_sstore_erc20_approve(
         function_dispatch_cost += function_dispatch_allowance.gas_cost(fork)
 
     # Transaction Loops
-    txs = []
-    cache_txs = []
     gas_remaining = gas_benchmark_value
     # This sender is a stub account, the first initialized
     # slot is 371 on perfnet. The initialized slots range
     # is 371-45139; existing slots fall within that range.
     slot_offset = 371 if existing_slot else START_SLOT
 
+    # Collect tx params first, then build Transaction objects
+    # so that nonces are allocated contiguously per block.
+    tx_params: list[tuple[int, bytes]] = []
     while gas_remaining > intrinsic_gas_with_access_list:
         gas_available = min(gas_remaining, tx_gas_limit)
 
@@ -521,9 +522,15 @@ def test_sstore_erc20_approve(
             break
 
         calldata = Hash(num_calls) + Hash(slot_offset)
+        tx_params.append((gas_available, calldata))
 
-        if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
-            with TestPhaseManager.setup():
+        gas_remaining -= gas_available
+        slot_offset += num_calls
+
+    cache_txs = []
+    if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
+        with TestPhaseManager.setup():
+            for gas_available, calldata in tx_params:
                 cache_txs.append(
                     Transaction(
                         gas_limit=gas_available,
@@ -534,7 +541,9 @@ def test_sstore_erc20_approve(
                     )
                 )
 
-        with TestPhaseManager.execution():
+    txs = []
+    with TestPhaseManager.execution():
+        for gas_available, calldata in tx_params:
             txs.append(
                 Transaction(
                     gas_limit=gas_available,
@@ -544,9 +553,6 @@ def test_sstore_erc20_approve(
                     access_list=access_list,
                 )
             )
-
-        gas_remaining -= gas_available
-        slot_offset += num_calls
 
     blocks = [delegation_block] + build_cache_strategy_blocks(
         cache_strategy, txs, cache_txs


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## Background

After the first round of `SSTORE` benchmark data collection, we found that `test_sstore_erc20_mint` is unreliable — it cannot produce the non-cached `SSTORE` scenario because there is always one `SLOAD` before `SSTORE` is executed. We switched to `test_sstore_erc20_approve`, which we verified has no `SLOAD` along the execution path by inspecting the [[execution trace](https://evmole.xyz/#0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/eth/control_flow)](https://evmole.xyz/#0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/eth/control_flow) (see function selector `0x095ea7b3`).

## Changes

This PR ensures the benchmark meets the requirements by addressing two issues:

1. Correct slot interaction via account delegation

In the bloated ERC20 contract, the bloating logic updates allowances as `allowance[msg.sender][i] = i`:

```python
function bloatStorage(uint256 startSlot, uint256 numAddresses) external {
    uint256 endSlot = startSlot + numAddresses;
    unchecked {
        for (uint256 i = startSlot; i < endSlot; i++) {
            address targetAddr = address(uint160(i));
            balanceOf[msg.sender] -= i;
            balanceOf[targetAddr] += i;

            // This is equivalent to allowance[sender][i] = i
            allowance[msg.sender][targetAddr] = i;
        }
    }
    nextStorageSlot = endSlot;
    emit StorageBloated(startSlot, endSlot, numAddresses * 2); // 2 slots per address
}
```

Here, `msg.sender` is the account that initiated the bloating transaction (denoted as `sender`), so the bloated slots are of the form `allowance[sender][i]`.

To touch these same slots via `approve`, in the `test_sstore_erc20_approve` benchmark, we must use the private key of this `sender` and delegate the account to the contract that batch-calls the `approve` function.

2. Missing `SSTORE` benchmark configurations

Two new configurations are added:

- **`write_new_value`**: Controls whether the slot value is overwritten with a new value.
- **`existing_slot`**: Controls whether the slot is initialized before the benchmark runs.

By inspecting the bloatnet account that initiated the bloating process, we found that account `0x6c2624662dC514A69955E9A6a195ECe23AcED5a0` bloats slots from 371 to 45,139 (~44,770 slots). Therefore, we set the starting slot to 371 when touching existing slots.

For the "write same value" scenario: since the bloating pattern is `allowance[sender][i] = i`, the current value stored in each slot equals its slot offset. In the benchmark, we fetch the value via `MLOAD(32)`, where `MEM[32]` originates from `CALLDATA[32]` (the slot offset), which increments with each iteration — thus writing the same value back.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
