### PR TITLE
feat(zkevm): add execution witness bytecode tests for SELFDESTRUCT and extra CALL-like opcode scenarios

### DIFF
--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
@@ -111,3 +111,125 @@ def test_witness_codes_nested_calls(
             sender: Account(nonce=1),
         },
     )
+
+
+def test_witness_codes_dedup_identical_bytecode(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Two pre-state contracts with identical bytecode, both CALLed.
+
+    Only one copy of the bytecode should appear in executionWitness.codes
+    because get_witness_codes() deduplicates by code hash.
+    """
+    shared_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
+    contract_a = pre.deploy_contract(code=shared_code)
+    contract_b = pre.deploy_contract(code=shared_code)
+
+    caller_code = (
+        Op.CALL(Op.GAS, contract_a, 0, 0, 0, 0, 0)
+        + Op.POP
+        + Op.CALL(Op.GAS, contract_b, 0, 0, 0, 0, 0)
+        + Op.POP
+        + Op.STOP
+    )
+    caller = pre.deploy_contract(code=caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[Bytes(bytes(shared_code))],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )
+
+
+def test_witness_codes_reverted_transaction(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Transaction that fully reverts still records accessed code.
+    """
+    target_code = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
+    target = pre.deploy_contract(code=target_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=target, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[Bytes(bytes(target_code))],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            target: Account(storage={0: 0}),
+        },
+    )
+
+
+def test_witness_codes_reverted_inner_call(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Inner CALL that reverts while outer transaction succeeds.
+
+    The reverted callee's code must still be in executionWitness.codes.
+    """
+    callee_code = Op.SSTORE(0, 1) + Op.REVERT(0, 0)
+    callee = pre.deploy_contract(code=callee_code)
+
+    caller_code = (
+        Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 0)
+        + Op.POP
+        + Op.SSTORE(0, 1)
+        + Op.STOP
+    )
+    caller = pre.deploy_contract(code=caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[
+                            Bytes(bytes(caller_code)),
+                            Bytes(bytes(callee_code)),
+                        ],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            callee: Account(storage={0: 0}), # Check reverted storage change
+            caller: Account(storage={0: 1}),
+        },
+    )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
@@ -115,6 +115,7 @@ def test_witness_codes_nested_calls(
 
 def test_witness_codes_dedup_identical_bytecode(
     pre: Alloc,
+    system_codes: list[Bytes],
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """
@@ -123,7 +124,7 @@ def test_witness_codes_dedup_identical_bytecode(
     Only one copy of the bytecode should appear in executionWitness.codes
     because get_witness_codes() deduplicates by code hash.
     """
-    shared_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
+    shared_code = Op.SSTORE(0, 1) + Op.STOP
     contract_a = pre.deploy_contract(code=shared_code)
     contract_b = pre.deploy_contract(code=shared_code)
 
@@ -146,13 +147,20 @@ def test_witness_codes_dedup_identical_bytecode(
                 txs=[tx],
                 expected_execution_witness_codes=(
                     ExecutionWitnessCodesExpectation(
-                        codes_present=[Bytes(bytes(shared_code))],
+                        codes_present=system_codes
+                        + [
+                            Bytes(bytes(caller_code)),
+                            Bytes(bytes(shared_code)),
+                        ],
+                        allow_unexpected=False,
                     )
                 ),
             )
         ],
         post={
             sender: Account(nonce=1),
+            contract_a: Account(storage={0: 1}),
+            contract_b: Account(storage={0: 1}),
         },
     )
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py
@@ -237,7 +237,7 @@ def test_witness_codes_reverted_inner_call(
         ],
         post={
             sender: Account(nonce=1),
-            callee: Account(storage={0: 0}), # Check reverted storage change
+            callee: Account(storage={0: 0}),  # Check reverted storage change
             caller: Account(storage={0: 1}),
         },
     )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
@@ -328,6 +328,7 @@ def test_witness_codes_selfdestruct_beneficiary_no_code(
     sender = pre.fund_eoa()
 
     target_balance = 1
+    beneficiary: Address
     if beneficiary_type == "eoa":
         beneficiary_initial_balance = 1
         beneficiary = pre.fund_eoa(amount=beneficiary_initial_balance)

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
@@ -1,0 +1,236 @@
+"""Witness bytecode collection for SELFDESTRUCT."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Address,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytes,
+    ExecutionWitnessCodesExpectation,
+    Initcode,
+    Op,
+    Transaction,
+    compute_create_address,
+)
+
+from ...prague.eip7702_set_code_tx.spec import Spec as Spec7702
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def test_witness_codes_selfdestruct(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Contract executing SELFDESTRUCT has its code in witness.
+
+    The beneficiary is a contract whose code must NOT appear in the
+    witness because SELFDESTRUCT does not call get_code on the
+    beneficiary.
+    """
+    sender = pre.fund_eoa()
+
+    beneficiary_code = Op.STOP
+    beneficiary = pre.deploy_contract(code=beneficiary_code)
+
+    target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
+    target = pre.deploy_contract(code=target_code)
+
+    caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
+    caller = pre.deploy_contract(code=caller_code)
+
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[Bytes(bytes(target_code))],
+                        codes_absent=[Bytes(bytes(beneficiary_code))],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )
+
+
+def test_witness_codes_create_then_selfdestruct_same_tx(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Factory CREATEs a contract then CALLs it; created contract SELFDESTRUCTs.
+
+    The created contract was added to created_accounts by CREATE, so
+    SELFDESTRUCT actually deletes the account (EIP-6780).  Its runtime
+    code should NOT appear in executionWitness.codes because get_code()
+    returned it from tx-local code_writes, never from pre-state.
+    The factory's code IS in the witness.
+    """
+    # PUSH0 pushes address(0) as the beneficiary for SELFDESTRUCT.
+    runtime_code = bytes(Op.PUSH0 + Op.SELFDESTRUCT)
+    initcode = Initcode(deploy_code=runtime_code)
+    initcode_bytes = bytes(initcode)
+
+    factory_code = (
+        Op.MSTORE(0, Op.PUSH32(initcode_bytes))
+        + Op.SSTORE(
+            0,
+            Op.CREATE(
+                offset=32 - len(initcode_bytes),
+                size=len(initcode_bytes),
+            ),
+        )
+        + Op.CALL(address=Op.SLOAD(0))
+        + Op.STOP
+    )
+    factory = pre.deploy_contract(code=factory_code, balance=10**18)
+    sender = pre.fund_eoa()
+
+    created = compute_create_address(address=factory, nonce=1)
+
+    tx = Transaction(sender=sender, to=factory, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[
+                            Bytes(bytes(factory_code)),
+                        ],
+                        codes_absent=[
+                            Bytes(runtime_code),
+                        ],
+                    )
+                ),
+            )
+        ],
+        post={
+            created: Account.NONEXISTENT,
+            factory: Account(storage={0: created}),
+        },
+    )
+
+
+def test_witness_codes_selfdestruct_beneficiary_delegated_eoa(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    SELFDESTRUCT with a 7702 delegated EOA as beneficiary.
+
+    SELFDESTRUCT does not call get_code() on the beneficiary, so the
+    delegation marker and the delegate's bytecode must NOT appear in
+    executionWitness.codes.
+    """
+    sender = pre.fund_eoa()
+
+    delegate_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
+    delegate = pre.deploy_contract(code=delegate_code)
+
+    beneficiary = pre.fund_eoa(delegation=delegate)
+    marker = Spec7702.delegation_designation(delegate)
+
+    target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
+    target = pre.deploy_contract(code=target_code)
+
+    caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
+    caller = pre.deploy_contract(code=caller_code)
+
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[
+                            Bytes(bytes(target_code)),
+                        ],
+                        codes_absent=[
+                            Bytes(marker),
+                            Bytes(bytes(delegate_code)),
+                        ],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "beneficiary_type",
+    [
+        pytest.param("eoa", id="eoa"),
+        pytest.param("nonexistent", id="nonexistent"),
+    ],
+)
+def test_witness_codes_selfdestruct_beneficiary_no_code(
+    pre: Alloc,
+    system_codes: list[Bytes],
+    blockchain_test: BlockchainTestFiller,
+    beneficiary_type: str,
+) -> None:
+    """
+    SELFDESTRUCT where beneficiary has no code (EOA or nonexistent).
+
+    Only system contract bytecodes, the caller's code, and the
+    target's code should appear in executionWitness.codes.  Nothing
+    else should leak into the witness.
+    """
+    sender = pre.fund_eoa()
+
+    if beneficiary_type == "eoa":
+        beneficiary = pre.fund_eoa()
+    else:
+        beneficiary = Address(0xDEAD)
+
+    target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
+    target = pre.deploy_contract(code=target_code)
+
+    caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
+    caller = pre.deploy_contract(code=caller_code)
+
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=system_codes
+                        + [
+                            Bytes(bytes(caller_code)),
+                            Bytes(bytes(target_code)),
+                        ],
+                        allow_unexpected=False,
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
@@ -25,6 +25,7 @@ REFERENCE_SPEC_VERSION = "N/A"
 
 def test_witness_codes_selfdestruct(
     pre: Alloc,
+    system_codes: list[Bytes],
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """
@@ -36,11 +37,12 @@ def test_witness_codes_selfdestruct(
     """
     sender = pre.fund_eoa()
 
-    beneficiary_code = Op.STOP
+    beneficiary_code = Op.PUSH1(0xAA) + Op.POP + Op.STOP
     beneficiary = pre.deploy_contract(code=beneficiary_code)
 
+    target_balance = 1
     target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
-    target = pre.deploy_contract(code=target_code)
+    target = pre.deploy_contract(code=target_code, balance=target_balance)
 
     caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
     caller = pre.deploy_contract(code=caller_code)
@@ -54,33 +56,87 @@ def test_witness_codes_selfdestruct(
                 txs=[tx],
                 expected_execution_witness_codes=(
                     ExecutionWitnessCodesExpectation(
-                        codes_present=[Bytes(bytes(target_code))],
+                        codes_present=system_codes
+                        + [
+                            Bytes(bytes(caller_code)),
+                            Bytes(bytes(target_code)),
+                        ],
                         codes_absent=[Bytes(bytes(beneficiary_code))],
+                        allow_unexpected=False,
                     )
                 ),
             )
         ],
         post={
             sender: Account(nonce=1),
-            target: Account(code=target_code),
+            beneficiary: Account(balance=target_balance),
+            target: Account(balance=0, code=target_code),
+        },
+    )
+
+
+def test_witness_codes_selfdestruct_top_level_tx(
+    pre: Alloc,
+    system_codes: list[Bytes],
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Top-level transaction to a selfdestructing contract.
+
+    The target bytecode should appear in the witness, the beneficiary's
+    bytecode should not, and the beneficiary must receive the target's
+    balance to prove SELFDESTRUCT actually executed.
+    """
+    sender = pre.fund_eoa()
+
+    beneficiary_code = Op.PUSH1(0xBB) + Op.POP + Op.STOP
+    beneficiary = pre.deploy_contract(code=beneficiary_code)
+
+    target_balance = 1
+    target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
+    target = pre.deploy_contract(code=target_code, balance=target_balance)
+
+    tx = Transaction(sender=sender, to=target, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=system_codes
+                        + [
+                            Bytes(bytes(target_code)),
+                        ],
+                        codes_absent=[Bytes(bytes(beneficiary_code))],
+                        allow_unexpected=False,
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            beneficiary: Account(balance=target_balance),
+            target: Account(balance=0, code=target_code),
         },
     )
 
 
 def test_witness_codes_create_then_selfdestruct_same_tx(
     pre: Alloc,
+    system_codes: list[Bytes],
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """
     Factory CREATEs a contract then CALLs it; created contract SELFDESTRUCTs.
 
     The created contract was added to created_accounts by CREATE, so
-    SELFDESTRUCT actually deletes the account (EIP-6780).  Its runtime
+    SELFDESTRUCT actually deletes the account (EIP-6780). Its runtime
     code should NOT appear in executionWitness.codes because get_code()
     returned it from tx-local code_writes, never from pre-state.
     The factory's code IS in the witness.
     """
-    # PUSH0 pushes address(0) as the beneficiary for SELFDESTRUCT.
     runtime_code = bytes(Op.PUSH0 + Op.SELFDESTRUCT)
     initcode = Initcode(deploy_code=runtime_code)
     initcode_bytes = bytes(initcode)
@@ -111,25 +167,83 @@ def test_witness_codes_create_then_selfdestruct_same_tx(
                 txs=[tx],
                 expected_execution_witness_codes=(
                     ExecutionWitnessCodesExpectation(
-                        codes_present=[
+                        codes_present=system_codes
+                        + [
                             Bytes(bytes(factory_code)),
                         ],
                         codes_absent=[
                             Bytes(runtime_code),
                         ],
+                        allow_unexpected=False,
                     )
                 ),
             )
         ],
         post={
+            sender: Account(nonce=1),
             created: Account.NONEXISTENT,
             factory: Account(storage={0: created}),
         },
     )
 
 
+def test_witness_codes_selfdestruct_in_initcode(
+    pre: Alloc,
+    system_codes: list[Bytes],
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    Initcode that executes SELFDESTRUCT during contract creation.
+
+    The initcode comes from tx data and must not appear in the witness.
+    The beneficiary's code must also stay out of the witness, while the
+    beneficiary balance change proves SELFDESTRUCT executed.
+    """
+    creator = pre.fund_eoa()
+
+    beneficiary_code = Op.PUSH1(0xCC) + Op.POP + Op.STOP
+    beneficiary = pre.deploy_contract(code=beneficiary_code)
+
+    tx_value = 7
+    initcode = bytes(Op.PUSH20(beneficiary) + Op.SELFDESTRUCT)
+    created = compute_create_address(address=creator, nonce=0)
+
+    tx = Transaction(
+        sender=creator,
+        to=None,
+        data=initcode,
+        value=tx_value,
+        gas_limit=500_000,
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=system_codes,
+                        codes_absent=[
+                            Bytes(initcode),
+                            Bytes(bytes(beneficiary_code)),
+                        ],
+                        allow_unexpected=False,
+                    )
+                ),
+            )
+        ],
+        post={
+            creator: Account(nonce=1),
+            beneficiary: Account(balance=tx_value),
+            created: Account.NONEXISTENT,
+        },
+    )
+
+
 def test_witness_codes_selfdestruct_beneficiary_delegated_eoa(
     pre: Alloc,
+    system_codes: list[Bytes],
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """
@@ -144,11 +258,16 @@ def test_witness_codes_selfdestruct_beneficiary_delegated_eoa(
     delegate_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
     delegate = pre.deploy_contract(code=delegate_code)
 
-    beneficiary = pre.fund_eoa(delegation=delegate)
+    beneficiary_initial_balance = 1
+    beneficiary = pre.fund_eoa(
+        amount=beneficiary_initial_balance,
+        delegation=delegate,
+    )
     marker = Spec7702.delegation_designation(delegate)
 
+    target_balance = 1
     target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
-    target = pre.deploy_contract(code=target_code)
+    target = pre.deploy_contract(code=target_code, balance=target_balance)
 
     caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
     caller = pre.deploy_contract(code=caller_code)
@@ -162,19 +281,26 @@ def test_witness_codes_selfdestruct_beneficiary_delegated_eoa(
                 txs=[tx],
                 expected_execution_witness_codes=(
                     ExecutionWitnessCodesExpectation(
-                        codes_present=[
+                        codes_present=system_codes
+                        + [
+                            Bytes(bytes(caller_code)),
                             Bytes(bytes(target_code)),
                         ],
                         codes_absent=[
                             Bytes(marker),
                             Bytes(bytes(delegate_code)),
                         ],
+                        allow_unexpected=False,
                     )
                 ),
             )
         ],
         post={
             sender: Account(nonce=1),
+            beneficiary: Account(
+                balance=beneficiary_initial_balance + target_balance
+            ),
+            target: Account(balance=0, code=target_code),
         },
     )
 
@@ -196,18 +322,21 @@ def test_witness_codes_selfdestruct_beneficiary_no_code(
     SELFDESTRUCT where beneficiary has no code (EOA or nonexistent).
 
     Only system contract bytecodes, the caller's code, and the
-    target's code should appear in executionWitness.codes.  Nothing
+    target's code should appear in executionWitness.codes. Nothing
     else should leak into the witness.
     """
     sender = pre.fund_eoa()
 
+    target_balance = 1
     if beneficiary_type == "eoa":
-        beneficiary = pre.fund_eoa()
+        beneficiary_initial_balance = 1
+        beneficiary = pre.fund_eoa(amount=beneficiary_initial_balance)
     else:
+        beneficiary_initial_balance = 0
         beneficiary = Address(0xDEAD)
 
     target_code = Op.PUSH20(beneficiary) + Op.SELFDESTRUCT
-    target = pre.deploy_contract(code=target_code)
+    target = pre.deploy_contract(code=target_code, balance=target_balance)
 
     caller_code = Op.CALL(Op.GAS, target, 0, 0, 0, 0, 0) + Op.STOP
     caller = pre.deploy_contract(code=caller_code)
@@ -233,5 +362,9 @@ def test_witness_codes_selfdestruct_beneficiary_no_code(
         ],
         post={
             sender: Account(nonce=1),
+            beneficiary: Account(
+                balance=beneficiary_initial_balance + target_balance
+            ),
+            target: Account(balance=0, code=target_code),
         },
     )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py
@@ -62,6 +62,7 @@ def test_witness_codes_selfdestruct(
         ],
         post={
             sender: Account(nonce=1),
+            target: Account(code=target_code),
         },
     )
 


### PR DESCRIPTION
## 🗒️ Description
This PR adds tests for SELFDESTRUCT opcodes relevant cases, plus some extra situations in CALL-like opcodes.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
