### PR TITLE
refactor(test-benchmark): update account access benchmark

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -1550,12 +1550,16 @@ def test_account_access(
 ) -> None:
     """Benchmark account access with caching strategies."""
     address_retriever: Bytecode
+    # Read start_iteration from calldata so that when transactions are
+    # split across gas limits, each transaction continues from where
+    # the previous one left off instead of re-targeting the same accounts.
+    calldataload_start = Op.CALLDATALOAD(0)
     if account_mode == AccountMode.EXISTING_CONTRACT:
         # Use ENS registry as target
         target_address = Address(0x6090A6E47849629B7245DFA1CA21D94CD15878EF)
         address_retriever = CreatePreimageLayout(
             sender_address=target_address,
-            nonce=1,
+            nonce=Op.ADD(1, calldataload_start),
         )
         increment_op = address_retriever.increment_nonce_op()
     elif account_mode == AccountMode.EXISTING_EOA:
@@ -1563,12 +1567,16 @@ def test_account_access(
         # created these accounts on bloatnet with these values (are also the
         # defaults of SequentialAddressLayout)
         address_retriever = SequentialAddressLayout(
-            starting_address=0x1000, increment=1
+            starting_address=Op.ADD(0x1000, calldataload_start),
+            increment=1,
         )
         increment_op = address_retriever.increment_address_op()
     else:
         address_retriever = SequentialAddressLayout(
-            starting_address=keccak256(b"random"), increment=1
+            starting_address=Op.ADD(
+                keccak256(b"random"), calldataload_start
+            ),
+            increment=1,
         )
         increment_op = address_retriever.increment_address_op()
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -1573,9 +1573,7 @@ def test_account_access(
         increment_op = address_retriever.increment_address_op()
     else:
         address_retriever = SequentialAddressLayout(
-            starting_address=Op.ADD(
-                keccak256(b"random"), calldataload_start
-            ),
+            starting_address=Op.ADD(keccak256(b"random"), calldataload_start),
             increment=1,
         )
         increment_op = address_retriever.increment_address_op()

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -1603,6 +1603,9 @@ def test_account_access(
                 value=value_sent,
                 # Gas accounting
                 address_warm=access_warm,
+                value_transfer=value_sent > 0,
+                account_new=value_sent > 0
+                and account_mode == AccountMode.NON_EXISTING_ACCOUNT,
             )
         )
     elif opcode in (Op.STATICCALL, Op.DELEGATECALL):


### PR DESCRIPTION
## 🗒️ Description
Fixes problems with account benchmark: reads different account each tx / fix gas accounting for CALL/CALLCODE

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
