### PR TITLE
feat(test): SELFDESTRUCT: add test case requested by nethermind

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -30,6 +30,7 @@ from ethereum.exceptions import (
 )
 from ethereum.forks.bpo5.blocks import Header as PreviousHeader
 from ethereum.state import EMPTY_CODE_HASH, Address, BlockDiff, PreState
+from ethereum.utils.byte import left_pad_zero_bytes
 
 from . import vm
 from .block_access_lists import (

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_eip_mainnet.py
@@ -27,7 +27,7 @@ def test_simple_transfer_mainnet(
 ) -> None:
     """Test that a simple ETH transfer emits a transfer log on mainnet."""
     sender = pre.fund_eoa()
-    recipient = pre.empty_account()
+    recipient = pre.nonexistent_account()
 
     tx = Transaction(
         ty=0x02,
@@ -76,7 +76,7 @@ def test_selfdestruct_mainnet(
 ) -> None:
     """Test that SELFDESTRUCT emits a transfer log on mainnet."""
     sender = pre.fund_eoa()
-    beneficiary = pre.empty_account()
+    beneficiary = pre.nonexistent_account()
 
     contract_code = Op.SELFDESTRUCT(beneficiary)
     contract = pre.deploy_contract(contract_code, balance=500)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_fork_transition.py
@@ -100,7 +100,7 @@ def test_burn_log_at_fork_transition(
         expected_logs = [[], [], []]
         post = {sender: Account(nonce=3)}
     else:
-        beneficiary = pre.empty_account()
+        beneficiary = pre.nonexistent_account()
         targets = [
             pre.deploy_contract(
                 Op.SELFDESTRUCT(beneficiary), balance=contract_balance
@@ -146,7 +146,7 @@ def test_transfer_log_fork_transition(
     At/after Amsterdam: ETH transfers emit Transfer logs.
     """
     sender = pre.fund_eoa()
-    recipient = pre.empty_account()
+    recipient = pre.nonexistent_account()
 
     blocks = [
         Block(

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -43,7 +43,7 @@ def test_simple_transfer_emits_log(
     sender: EOA,
 ) -> None:
     """Test that a simple ETH transfer emits a transfer log."""
-    recipient = pre.empty_account()
+    recipient = pre.nonexistent_account()
 
     tx = Transaction(
         sender=sender,
@@ -113,7 +113,7 @@ def test_zero_value_transfer_no_log(
     sender: EOA,
 ) -> None:
     """Test that a zero-value transfer does NOT emit a transfer log."""
-    recipient = pre.empty_account()
+    recipient = pre.nonexistent_account()
 
     tx = Transaction(
         sender=sender,
@@ -647,7 +647,7 @@ def test_selfdestruct_with_value_emits_log(
     sender: EOA,
 ) -> None:
     """Test that SELFDESTRUCT with value emits a transfer log."""
-    beneficiary = pre.empty_account()
+    beneficiary = pre.nonexistent_account()
     contract_balance = 2000
 
     contract_code = Op.SELFDESTRUCT(beneficiary)
@@ -710,7 +710,7 @@ def test_zero_value_operations_no_log(
     op_type: str,
 ) -> None:
     """Test that zero-value operations do NOT emit transfer logs."""
-    target = pre.empty_account()
+    target = pre.nonexistent_account()
 
     if op_type == "call":
         contract_code = Op.CALL(gas=100_000, address=target, value=0)
@@ -902,7 +902,7 @@ def test_nested_calls_log_order(
     tx_value = 1000
 
     # Build chain: contracts[0] -> contracts[1] -> ... -> final_recipient
-    final_recipient = pre.empty_account()
+    final_recipient = pre.nonexistent_account()
     contracts: list[Address] = []
     expected_logs: list[TransactionLog] = []
 
@@ -1076,7 +1076,7 @@ def test_transfer_with_all_tx_types(
     typed_transaction: Transaction,
 ) -> None:
     """Test that ETH transfers emit logs for all transaction types."""
-    recipient = pre.empty_account()
+    recipient = pre.nonexistent_account()
     transfer_amount = 1000
 
     tx = typed_transaction.copy(
@@ -1101,8 +1101,8 @@ def test_multiple_transfers_same_block(
     verifying logs don't bleed across transactions.
     """
     sender = pre.fund_eoa()
-    recipient1 = pre.empty_account()
-    recipient2 = pre.empty_account()
+    recipient1 = pre.nonexistent_account()
+    recipient2 = pre.nonexistent_account()
 
     blocks = [
         Block(
@@ -1156,7 +1156,7 @@ def test_selfdestruct_then_transfer_same_block(
     - Tx2: sender -> contract (100) + contract -> beneficiary (100)
     """
     sender = pre.fund_eoa()
-    beneficiary = pre.empty_account()
+    beneficiary = pre.nonexistent_account()
 
     contract_code = Op.SELFDESTRUCT(beneficiary)
     contract = pre.deploy_contract(contract_code, balance=500)

--- a/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
+++ b/tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py
@@ -1201,8 +1201,15 @@ def test_selfdestruct_then_transfer_same_block(
     )
 
 
+@pytest.mark.parametrize(
+    "cross_block",
+    [
+        pytest.param(False, id="same_block"),
+        pytest.param(True, id="cross_block"),
+    ],
+)
 def test_selfdestruct_to_self_cross_tx_no_log(
-    blockchain_test: BlockchainTestFiller, pre: Alloc
+    blockchain_test: BlockchainTestFiller, pre: Alloc, cross_block: bool
 ) -> None:
     """
     Test that selfdestruct-to-self in a cross-tx context emits no log.
@@ -1215,6 +1222,10 @@ def test_selfdestruct_to_self_cross_tx_no_log(
          value=2000. Logs: [transfer_log(sender, created, 2000)]
     Tx2: Call created contract directly, value=0. Logs: []
     Post: contract keeps balance (not deleted, not in created_accounts in Tx2)
+
+    When cross_block=True, Tx1 and Tx2 are in separate blocks, verifying
+    that created_accounts is properly scoped per-transaction across block
+    boundaries.
     """
     contract_balance = 2000
     sender = pre.fund_eoa()
@@ -1225,37 +1236,38 @@ def test_selfdestruct_to_self_cross_tx_no_log(
     # Calculate the address that will be created by the first tx
     created_address = compute_create_address(address=sender, nonce=0)
 
-    blocks = [
-        Block(
-            txs=[
-                # Tx1: Create the contract directly via contract creation tx
-                Transaction(
-                    to=None,
-                    sender=sender,
-                    nonce=0,
-                    value=contract_balance,
-                    data=bytes(initcode),
-                    gas_limit=300_000,
-                    expected_receipt=TransactionReceipt(
-                        logs=[
-                            transfer_log(
-                                sender, created_address, contract_balance
-                            ),
-                        ]
-                    ),
-                ),
-                # Tx2: Call the created contract directly (cross-tx)
-                Transaction(
-                    to=created_address,
-                    sender=sender,
-                    nonce=1,
-                    value=0,
-                    gas_limit=100_000,
-                    expected_receipt=TransactionReceipt(logs=[]),
-                ),
-            ],
+    tx_create = Transaction(
+        to=None,
+        sender=sender,
+        nonce=0,
+        value=contract_balance,
+        data=bytes(initcode),
+        gas_limit=300_000,
+        expected_receipt=TransactionReceipt(
+            logs=[
+                transfer_log(sender, created_address, contract_balance),
+            ]
         ),
-    ]
+    )
+
+    tx_selfdestruct = Transaction(
+        to=created_address,
+        sender=sender,
+        nonce=1,
+        value=0,
+        gas_limit=100_000,
+        expected_receipt=TransactionReceipt(logs=[]),
+    )
+
+    if cross_block:
+        blocks = [
+            Block(txs=[tx_create]),
+            Block(txs=[tx_selfdestruct]),
+        ]
+    else:
+        blocks = [
+            Block(txs=[tx_create, tx_selfdestruct]),
+        ]
 
     blockchain_test(
         pre=pre,


### PR DESCRIPTION
## 🗒️ Description
Improves test coverage

## How to reproduce

Cherry-pick every commit of 7843 (slotnum) branch, 

then fill with 
`uv run fill --clean -v -s -k "test_selfdestruct_to_self_cross_tx_no_log and cross_block" tests/amsterdam/eip7708_eth_transfer_logs/test_transfer_logs.py --fork=amsterdam`

then start `bal-devnet-3` nethermind in hive and run:
`uv run consume engine ./fixtures/blockchain_tests_engine/ -v -s`

and they pass


## 🔗 Related Issues or PRs
Solves [#2409](https://github.com/ethereum/execution-specs/issues/2497)

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.discordapp.com/attachments/1349696533922320478/1482020934020759705/IMG_0186.png?ex=69b56f0d&is=69b41d8d&hm=1e747a9080b7d7998366818508a4e2d8d90cb92d64031f6fa3ae7e821b1f0d35&)
