### PR TITLE
chore(zkevm): Explicitly skip state tests and add witness for invalid blocks

### DIFF
--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -678,7 +678,14 @@ class FixtureBlock(FixtureBlockBase):
     def without_rlp(self) -> FixtureBlockBase:
         """Return FixtureBlockBase without the RLP bytes set."""
         return FixtureBlockBase(
-            **self.model_dump(exclude={"rlp"}),
+            **self.model_dump(
+                exclude={
+                    "rlp",
+                    "execution_witness",
+                    "stateless_input_bytes",
+                    "stateless_output_bytes",
+                },
+            ),
         )
 
 
@@ -698,6 +705,9 @@ class InvalidFixtureBlock(CamelModel):
     rlp: Bytes
     expect_exception: ExceptionInstanceOrList
     rlp_decoded: FixtureBlockBase | None = Field(None, alias="rlp_decoded")
+    execution_witness: ExecutionWitness | None = None
+    stateless_input_bytes: Bytes | None = None
+    stateless_output_bytes: Bytes | None = None
 
 
 @post_state_validator()

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -464,6 +464,9 @@ class BuiltBlock(CamelModel):
                     in self.expected_exception
                     else fixture_block.without_rlp()
                 ),
+                execution_witness=self.execution_witness,
+                stateless_input_bytes=self.stateless_input_bytes,
+                stateless_output_bytes=self.stateless_output_bytes,
             )
 
         return fixture_block

--- a/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/t8n_types.py
@@ -338,11 +338,7 @@ class Result:
             # the witness reads pre-state tries that apply_changes mutates.
             # This is safe because compute_state_root_and_trie_changes
             # does not mutate state (it makes transient copies of MPTs).
-            if (
-                t8n.fork.has_execution_witness
-                and not self.block_exception
-                and t8n.env.block_headers
-            ):
+            if t8n.fork.has_execution_witness:
                 self.execution_witness = t8n.fork.build_execution_witness(
                     block_env.state,
                     expected_post_state_root=state_root_value,
@@ -378,7 +374,7 @@ class Result:
                 block_output.block_access_list
             )
 
-        if self.execution_witness is not None:
+        if self.execution_witness is not None and not t8n.options.state_test:
             withdrawals = (
                 tuple(t8n.env.withdrawals) if t8n.env.withdrawals else ()
             )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
