### PR TITLE
chore(ci,deps): bump pinned action SHAs & golang, markdownlint-cli2 versions

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -19,7 +19,7 @@ runs:
         path: hive
 
     - name: Setup Go for Hive
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ">=1.24"
         cache-dependency-path: hive/go.sum

--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Hive
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ethereum/hive
         ref: master

--- a/.github/actions/build-evm-client/besu/action.yaml
+++ b/.github/actions/build-evm-client/besu/action.yaml
@@ -21,13 +21,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Besu
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: besu
     - name: Setup Java
-      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ inputs.java }}
         distribution: ${{ inputs.java-distro }}

--- a/.github/actions/build-evm-client/ethjs/action.yaml
+++ b/.github/actions/build-evm-client/ethjs/action.yaml
@@ -13,14 +13,14 @@ runs:
   using: "composite"
   steps:
     - name: Checkout EthereumJS monorepo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
         path: ethereumjs
 
     - name: Setup node
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: 18
 

--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -45,7 +45,8 @@ runs:
         submodules: true
     - name: Setup cmake
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+      # TODO: Still on node20 — update when upstream releases a node22+ version
+      uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
       with:
         cmake-version: '3.x'
     - name: "Install GMP Linux"

--- a/.github/actions/build-evm-client/evmone/action.yaml
+++ b/.github/actions/build-evm-client/evmone/action.yaml
@@ -28,7 +28,7 @@ runs:
       run: mkdir -p "$GITHUB_WORKSPACE/evmone/build"
     - name: Restore build cache
       id: cache-restore
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/evmone/build
@@ -37,7 +37,7 @@ runs:
           evmone-build-targets=${{ inputs.targets }}-
     - name: Checkout evmone
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ steps.evmone-sha.outputs.sha }}
@@ -70,7 +70,7 @@ runs:
       run: echo $GITHUB_WORKSPACE/evmone/build/bin/ >> $GITHUB_PATH
     - name: Save build cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/evmone/build

--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -12,7 +12,7 @@ inputs:
   golang:
     description: 'Golang version to use to build Geth'
     required: false
-    default: '1.21.x'
+    default: '1.24.x'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/build-evm-client/geth/action.yaml
+++ b/.github/actions/build-evm-client/geth/action.yaml
@@ -28,7 +28,7 @@ runs:
       run: mkdir -p "$GITHUB_WORKSPACE/go-ethereum/cmd/evm"
     - name: Restore build cache
       id: cache-restore
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/go-ethereum/cmd/evm/evm
@@ -37,14 +37,14 @@ runs:
           geth-evm-build-
     - name: Checkout go-ethereum
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ steps.geth-sha.outputs.sha }}
         path: go-ethereum
     - name: Setup golang
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: ${{ inputs.golang }}
         cache-dependency-path: go-ethereum/go.sum
@@ -59,7 +59,7 @@ runs:
       run: echo $GITHUB_WORKSPACE/go-ethereum/cmd/evm >> $GITHUB_PATH
     - name: Save build cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/go-ethereum/cmd/evm/evm

--- a/.github/actions/build-evmone/action.yaml
+++ b/.github/actions/build-evmone/action.yaml
@@ -39,7 +39,7 @@ runs:
     # Restore previously built binaries if cache hit
     - name: Restore build cache
       id: cache-restore
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/evmone/build
@@ -52,7 +52,7 @@ runs:
     # Checkout and build evmone if cache miss
     - name: Checkout evmone
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.ref }}
@@ -92,7 +92,7 @@ runs:
     # Save cache only when we actually built
     - name: Save build cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ${{ github.workspace }}/evmone/build

--- a/.github/actions/build-evmone/action.yaml
+++ b/.github/actions/build-evmone/action.yaml
@@ -61,7 +61,8 @@ runs:
 
     - name: Setup cmake
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+      # TODO: Still on node20 — update when upstream releases a node22+ version
+      uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
       with:
         cmake-version: '3.x'
 

--- a/.github/actions/build-fixtures/action.yaml
+++ b/.github/actions/build-fixtures/action.yaml
@@ -42,11 +42,11 @@ runs:
         fixtures_path: fixtures_${{ inputs.release_name }}.tar.gz
     - name: Upload Benchmark Genesis Artifact
       if: contains(inputs.release_name, 'benchmark')
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: benchmark_genesis_${{ inputs.release_name }}
         path: benchmark_genesis.tar.gz
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: fixtures_${{ inputs.release_name }}
         path: fixtures_${{ inputs.release_name }}.tar.gz

--- a/.github/actions/cache-docker-images/action.yaml
+++ b/.github/actions/cache-docker-images/action.yaml
@@ -21,7 +21,7 @@ runs:
 
     - name: Restore Docker image cache
       id: cache-restore
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: /tmp/docker-images
         key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}
@@ -45,7 +45,7 @@ runs:
 
     - name: Save Docker image cache 
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: /tmp/docker-images
         key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}

--- a/.github/actions/load-docker-images/action.yaml
+++ b/.github/actions/load-docker-images/action.yaml
@@ -16,7 +16,7 @@ runs:
       run: echo "num=$(date +%U)" >> $GITHUB_OUTPUT
 
     - name: Restore Docker image cache
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: /tmp/docker-images
         key: ${{ inputs.cache-key-prefix }}-week${{ steps.week.outputs.num }}-${{ hashFiles('.github/actions/cache-docker-images/action.yaml', 'execution-specs/.github/actions/cache-docker-images/action.yaml') }}

--- a/.github/actions/setup-uv/action.yaml
+++ b/.github/actions/setup-uv/action.yaml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Install uv and python ${{ inputs.python-version }}
-      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b  # v7.3.0
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82  # v7.5.0
       with:
         enable-cache: ${{ inputs.enable-cache }}
         cache-dependency-glob: ${{ inputs.cache-dependency-glob }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Benchmark Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
@@ -63,7 +63,7 @@ jobs:
           - name: Fixed Opcode Count Config
             tox-env: benchmark-fixed-opcode-config
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-gigachungus-x64]
     timeout-minutes: 720
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
 
       - name: Rebase EIP branches onto fork
         uses: ./.github/actions/rebase-eip-branch

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload Pages Artifact
         id: artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: .tox/docs
 
@@ -64,4 +64,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        # TODO: Still on node20 — update when upstream releases a node22+ version
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -108,7 +108,7 @@ jobs:
           path: hive
 
       - name: Setup go env and cache
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ">=1.24"
           cache-dependency-path: hive/go.sum

--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-l-x64]
     steps:
       - name: Checkout execution-specs
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache Docker images
         uses: ./.github/actions/cache-docker-images
@@ -96,12 +96,12 @@ jobs:
           #   test_filter: "(fork_shanghai or fork_cancun) and push0"
     steps:
       - name: Checkout execution-specs
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: execution-specs
 
       - name: Checkout Hive
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ethereum/hive
           ref: master

--- a/.github/workflows/release_fixture_feature.yaml
+++ b/.github/workflows/release_fixture_feature.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       names: ${{ steps.feature-name.outputs.names }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
 
@@ -34,7 +34,7 @@ jobs:
       matrix:
         feature: ${{ fromJSON(needs.feature-names.outputs.names) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 
@@ -67,7 +67,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/tests-')
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
 

--- a/.github/workflows/release_fixture_full.yaml
+++ b/.github/workflows/release_fixture_full.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       features: ${{ steps.parse.outputs.features }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get names from .github/configs/feature.yaml
         id: parse
         shell: bash
@@ -36,7 +36,7 @@ jobs:
       matrix:
         name: ${{ fromJson(needs.features.outputs.features) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Fetch lllc
@@ -66,7 +66,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/tests-')
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
 

--- a/.github/workflows/test-checklist.yaml
+++ b/.github/workflows/test-checklist.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-specs
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-uv
       - name: Run checklist consistency test
         run: tox -e tests_pytest_py3 -- -k test_checklist_template_consistency

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-specs
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-uv
       - name: Build html documentation with mkdocs via tox
         run: tox -e mkdocs
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-specs
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-uv
       - name: Run changelog validation via tox
         run: tox -e changelog
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ethereum/execution-specs
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265
         with:
           globs: |

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -49,7 +49,8 @@ jobs:
     steps:
       - name: Checkout ethereum/execution-specs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265
+      # TODO: Still on node20 — update when upstream releases a node22+ version
+      - uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
         with:
           globs: |
             docs/**/*.md

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Ensure SHA pinned actions
@@ -59,7 +59,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
@@ -81,7 +81,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
@@ -98,7 +98,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
@@ -112,7 +112,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv
@@ -127,7 +127,7 @@ jobs:
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-uv

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,7 @@ jobs:
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           files: .tox/coverage.xml
           flags: unittests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           submodules: recursive
       - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@6124774845927d14c601359ab8138699fa5b70c3 # v4.0.1
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # v5.0.1
       - uses: ./.github/actions/setup-uv
       - name: Install build dependencies
         shell: bash
@@ -71,7 +71,7 @@ jobs:
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
         with:
           files: .tox/coverage.xml
           flags: unittests

--- a/.github/workflows/update-devnet-branch.yaml
+++ b/.github/workflows/update-devnet-branch.yaml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
 
       - name: Merge EIP branches into devnet
         uses: ./.github/actions/merge-eip-branches

--- a/.github/workflows/update-devnet-branch.yaml
+++ b/.github/workflows/update-devnet-branch.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,6 +5,7 @@ MD034: false # no-bare-urls - We use pymdownx.magiclink which allows bare urls
 MD046: false # code-block-style - This doesn't play well with material's admonitions)
 MD024: false # no-duplicate-heading - We use duplicate headings in the changelog.
 MD033: false # no-inline-html - Too strict.
+MD060: false # table-column-style - New in markdownlint v0.40.0; too strict for existing tables.
 ul-indent:
   indent: 4
   start_indent: 4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -179,7 +179,7 @@ git push origin v1.15.0 # Replace the tag name here too.
 
 ### Creating the GitHub Release
 
-Go [here][release], choose the newly created tag, and generate some release
+Go to the [release page][release], choose the newly created tag, and generate some release
 notes.
 
 [release]: https://github.com/ethereum/execution-specs/releases/new

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ The generated test fixtures can be used:
 1. Directly by client teams' test frameworks, and,
 2. In the integration tests executed in the @ethereum/hive framework.
 
-More information on how to use and download the [released test fixtures](https://github.com/ethereum/execution-spec-tests/releases) can be found [here](running_tests/index.md).
+More information on how to use and download the [released test fixtures](https://github.com/ethereum/execution-spec-tests/releases) can be found in the [running tests guide](running_tests/index.md).
 
 ## Relationship to ethereum/tests
 

--- a/packages/testing/src/execution_testing/cli/tox_helpers.py
+++ b/packages/testing/src/execution_testing/cli/tox_helpers.py
@@ -93,7 +93,7 @@ def markdownlint(args: tuple[str, ...]) -> None:
             "********* Install 'markdownlint-cli2' to enable markdown linting\
             *********\
             ```\
-            sudo npm install -g markdownlint-cli2@0.17.2\
+            sudo npm install -g markdownlint-cli2@0.20.0\
             ```\
             "
         )


### PR DESCRIPTION
## 🗒️ Description

While testing releases, [here](https://github.com/ethereum/execution-specs/actions/runs/23060342081/job/66984928785#step:7:4), I ran into a warning about using Node20 for a github action and how we will be forced to update by June, 2026.

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I asked Claude to fetch me direct links for all the shas so we can manually check. I think it's important at least for the 3rd party dependency updates here, e.g. `DavidAnson/madkdownlint`.

---

First commit, for updating all Node20 deps to latest versions:

  - actions/checkout v6.0.2: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd
  - actions/cache v5.0.3: https://github.com/actions/cache/commit/cdf6c1fa76f9f475f3d7449005a359c84ca0f306
  - actions/upload-artifact v7.0.0: https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
  - actions/setup-go v6.3.0: https://github.com/actions/setup-go/commit/4b73464bb391d4059bd26b0524d20df3927bd417
  - actions/setup-node v6.3.0: https://github.com/actions/setup-node/commit/53b83947a5a98c8d113130e565377fae1a50d02f
  - actions/setup-java v5.2.0: https://github.com/actions/setup-java/commit/be666c2fcd27ec809703dec50e508c2fdc7f6654

Second commit that updates a few more, unrelated to Node20 versions:

  - codecov/codecov-action v5.5.2: https://github.com/codecov/codecov-action/commit/671740ac38dd9b0130fbe1cec585b89eea48d3de
  - zgosalvez/github-actions-ensure-sha-pinned-actions v5.0.1: https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/commit/70c4af2ed5282c51ba40566d026d6647852ffa3e
  - astral-sh/setup-uv v7.5.0: https://github.com/astral-sh/setup-uv/commit/e06108dd0aef18192324c70427afc47652e63a82
  - DavidAnson/markdownlint-cli2-action v22.0.0: https://github.com/DavidAnson/markdownlint-cli2-action/commit/07035fd053f7be764496c0f8d8f9f41f98305101
  - jwlawson/actions-setup-cmake v2.1.1: https://github.com/jwlawson/actions-setup-cmake/commit/3a6cbe35ba64df7ca70c51365c4aff65db9a9037

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [c] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [c] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="731" height="536" alt="Screenshot 2026-03-13 at 12 04 41" src="https://github.com/user-attachments/assets/72ebc5f9-f32b-4fab-8e11-ffd2fcacba6a" />
