### PR TITLE
feat(zkevm): add test to assert 7702 delegation code loading in failed CALL/CALLCODE because of insufficient balance

### DIFF
--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_7702.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_7702.py
@@ -76,6 +76,80 @@ def test_witness_codes_delegated_eoa(
     )
 
 
+@pytest.mark.parametrize(
+    "call_opcode",
+    [
+        pytest.param(Op.CALL, id="call"),
+        pytest.param(Op.CALLCODE, id="callcode"),
+    ],
+)
+def test_witness_codes_delegated_eoa_insufficient_balance(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+    call_opcode: Op,
+) -> None:
+    """
+    CALL/CALLCODE to a delegated EOA with value greater than caller balance.
+
+    The call must fail and return 0, but delegation resolution still reads
+    both the marker code and the delegated bytecode into the witness before
+    the insufficient-balance early return.
+    """
+    delegate_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
+    delegate = pre.deploy_contract(code=delegate_code)
+
+    delegated_eoa = pre.fund_eoa(amount=0, delegation=delegate)
+
+    caller_balance = 100
+    transfer_value = 1_000
+    caller_code = (
+        Op.SSTORE(
+            0,
+            call_opcode(
+                Op.GAS,
+                delegated_eoa,
+                transfer_value,
+                0,
+                0,
+                0,
+                0,
+            ),
+        )
+        + Op.STOP
+    )
+    caller = pre.deploy_contract(
+        code=caller_code,
+        balance=caller_balance,
+        storage={0: 1},
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    marker = Spec7702.delegation_designation(delegate)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[
+                            Bytes(marker),
+                            Bytes(bytes(delegate_code)),
+                        ],
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            caller: Account(balance=caller_balance, storage={0: 0}),
+        },
+    )
+
+
 def test_witness_codes_sender_delegation_marker_included(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,


### PR DESCRIPTION
## 🗒️ Description
This PR adds a test to surface the situation described in https://github.com/ethereum/execution-specs/issues/2501

I think now that we have good overall coverage, we need to do another pass to cover:
- OOGs
- Stack overflows
- any other border-case situation of partial execution of opcodes

(some of them already exists, but this was already expected/planned as a second phase of test coverage)

This particular test/scenario is one of these cases.

## 🔗 Related Issues or PRs
Fixes https://github.com/ethereum/execution-specs/issues/2501

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
