### PR TITLE
chore(tests): Add test for exponent padding in modexp precompile

### DIFF
--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -449,32 +449,6 @@ REFERENCE_SPEC_VERSION = "5c8f066acb210c704ef80c1033a941aa5374aac5"
             ),
             id="truncated_input_4",
         ),
-        # Packed vs padded exponent
-        # The padded form has a higher gas cost due to the larger declared
-        # exponent length in the iteration count formula. Clients should
-        # charges the higher gas for the padded exponent encoding.
-        pytest.param(
-            ModExpInput(
-                base="02",
-                exponent="010001",
-                modulus="ff" * 32,
-            ),
-            ModExpOutput(
-                returned_data="00" * 31 + "02",
-            ),
-            id="exponent-packed-3-bytes",
-        ),
-        pytest.param(
-            ModExpInput(
-                base="02",
-                exponent="00" * 125 + "010001",
-                modulus="ff" * 32,
-            ),
-            ModExpOutput(
-                returned_data="00" * 31 + "02",
-            ),
-            id="exponent-padded-128-bytes",
-        ),
     ],
     ids=lambda param: param.__repr__(),  # only required to remove parameter
     # names (input/output)

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -449,6 +449,32 @@ REFERENCE_SPEC_VERSION = "5c8f066acb210c704ef80c1033a941aa5374aac5"
             ),
             id="truncated_input_4",
         ),
+        # Packed vs padded exponent
+        # The padded form has a higher gas cost due to the larger declared
+        # exponent length in the iteration count formula. Clients should
+        # charges the higher gas for the padded exponent encoding.
+        pytest.param(
+            ModExpInput(
+                base="02",
+                exponent="010001",
+                modulus="ff" * 32,
+            ),
+            ModExpOutput(
+                returned_data="00" * 31 + "02",
+            ),
+            id="exponent-packed-3-bytes",
+        ),
+        pytest.param(
+            ModExpInput(
+                base="02",
+                exponent="00" * 125 + "010001",
+                modulus="ff" * 32,
+            ),
+            ModExpOutput(
+                returned_data="00" * 31 + "02",
+            ),
+            id="exponent-padded-128-bytes",
+        ),
     ],
     ids=lambda param: param.__repr__(),  # only required to remove parameter
     # names (input/output)

--- a/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
@@ -661,6 +661,18 @@ def create_modexp_variable_gas_test_cases() -> Generator:
         ("FF" * 32, "FF" * 32, "", "", None, "IC9"),  # N/A case
         # IC10: Power-of-2 boundary with high bit
         ("01" * 32, "80" + "00" * 31, "02" * 32, "01" * 32, 4080, "IC10"),
+        # Packed vs padded exponent: the padded form has a higher gas cost
+        # due to the larger declared exponent length in the iteration count
+        # formula. Clients must not strip leading zeros before computing gas.
+        ("02", "010001", "ff" * 32, "00" * 31 + "02", 500, "PAD1"),
+        (
+            "02",
+            "00" * 125 + "010001",
+            "ff" * 32,
+            "00" * 31 + "02",
+            24576,
+            "PAD2",
+        ),
     ]
 
     # Gas calculation parameters:
@@ -747,6 +759,8 @@ def create_modexp_variable_gas_test_cases() -> Generator:
     │ IC7 │  L   │  =  │  B   │ True  │   500   │ Vector optimization 128-bit boundary          │
     │ IC9 │  S   │  =  │  B   │  N/A  │   N/A   │ Zero modulus handling                         │
     │ IC10│  S   │  =  │  B   │ False │  4080   │ Power-of-2 boundary with high bit             │
+    │ PAD1│  S   │  <  │  B   │ True  │   500   │ Packed exponent (3 bytes, no padding)         │
+    │ PAD2│  S   │  <  │  C   │ False │ 24576   │ Padded exponent (128 bytes, 125 zero prefix)  │
     └─────┴──────┴─────┴──────┴───────┴─────────┴───────────────────────────────────────────────┘
     """  # noqa: W505, E501
     for (


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Was looking at `0x7b62d5284ea063743e4c5b1817d667ddd601a914dc8b3f547b74127bf453a9e4` on mainnet and was wondering why the modexp operation cost 7M gas for 3072 bits. 

The reason is because the gas cost formula is based on the number of bytes declared and not the number of signifcant bytes. This means that although 2^5 and 2^05 both equal 32, the second is charged more since its two bytes and not 1 byte.

A client that first, strips the padded zeroes would compute the wrong gas formula. I checked that none of the new clients like ethrex do this. If any of the popular clients did this, then the above tx would have caused a chain split.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
