### PR TITLE
chore(ci): warn when local markdownlint-cli2 version diverges from CI

### DIFF
--- a/packages/testing/src/execution_testing/cli/tox_helpers.py
+++ b/packages/testing/src/execution_testing/cli/tox_helpers.py
@@ -250,7 +250,6 @@ def codespell() -> None:
         sys.exit(1)
 
     sys.exit(0)
-    sys.exit(pyspelling_main.main())
 
 
 @click.command()

--- a/packages/testing/src/execution_testing/cli/tox_helpers.py
+++ b/packages/testing/src/execution_testing/cli/tox_helpers.py
@@ -106,7 +106,7 @@ def markdownlint(args: tuple[str, ...]) -> None:
         text=True,
     )
     if result.returncode == 0:
-        version_match = re.search(r"v(\d+\.\d+\.\d+)", result.stdout)
+        version_match = re.search(r"v?(\d+\.\d+\.\d+)", result.stdout)
         installed_version = version_match.group(1) if version_match else None
         if installed_version:
             installed = semver.Version.parse(installed_version)

--- a/packages/testing/src/execution_testing/cli/tox_helpers.py
+++ b/packages/testing/src/execution_testing/cli/tox_helpers.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 import click
+import semver
 from pyspelling import __main__ as pyspelling_main  # type: ignore
 from rich.console import Console
 
@@ -85,19 +86,49 @@ def markdownlint(args: tuple[str, ...]) -> None:
 
     Allows argument forwarding to markdownlint-cli2.
     """
+    expected_version = "0.20.0"
     markdownlint = shutil.which("markdownlint-cli2")
     if not markdownlint:
         # Note: There's an additional step in test.yaml to run markdownlint-
         # cli2 in GitHub Actions
         click.echo(
-            "********* Install 'markdownlint-cli2' to enable markdown linting\
-            *********\
-            ```\
-            sudo npm install -g markdownlint-cli2@0.20.0\
-            ```\
-            "
+            "********* Install 'markdownlint-cli2' to enable markdown linting"
+            " *********\n"
+            "```\n"
+            f"sudo npm install -g markdownlint-cli2@{expected_version}\n"
+            "```"
         )
         sys.exit(0)
+
+    result = subprocess.run(
+        [markdownlint, "--version"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        version_match = re.search(r"v(\d+\.\d+\.\d+)", result.stdout)
+        installed_version = version_match.group(1) if version_match else None
+        if installed_version:
+            installed = semver.Version.parse(installed_version)
+            expected = semver.Version.parse(expected_version)
+            minor_mismatch = (installed.major, installed.minor) != (
+                expected.major,
+                expected.minor,
+            )
+        else:
+            minor_mismatch = False
+        if minor_mismatch:
+            lines = [
+                f"WARNING: markdownlint-cli2 {installed_version} "
+                f"installed, CI uses {expected_version}",
+                "",
+                "Lint results may differ from CI.",
+                f"  npm install -g markdownlint-cli2@{expected_version}",
+            ]
+            width = max(len(line) for line in lines) + 4
+            border = "*" * width
+            box = "\n".join(f"* {line:<{width - 4}} *" for line in lines)
+            click.echo(f"\n{border}\n{box}\n{border}\n")
 
     args_list: list[str] = (
         list(args) if len(args) > 0 else ["./docs/**/*.md", "./*.md"]


### PR DESCRIPTION
## 🗒️ Description

- Add version check for the markdownlint-cli2 binary.
- Warn with a visible banner when the installed `major.minor` differs from the CI target version.

```
tox -e markdownlint
ROOT: will run in automatically provisioned tox, host /home/dtopz/.local/share/uv/tools/tox/bin/python is missing [requires (has)]: tox-uv<2,>=1.29
ROOT: install_deps> python -I -m pip install tox 'tox-uv<2,>=1.29' 'tox<5,>=4'
ROOT: provision> .tox/.tox/bin/python -m tox --colored yes -e markdownlint
markdownlint: venv> .tox/.tox/bin/uv venv -p /home/dtopz/code/github/execution-specs.markdownlint-version-mismatch/.tox/.tox/bin/python --allow-existing '--prompt=execution-specs.markdownlint-version-mismatch[markdownlint]' --python-preference system /home/dtopz/code/github/execution-specs.markdownlint-version-mismatch/.tox/markdownlint
markdownlint: uv-sync> .tox/.tox/bin/uv sync --locked --python-preference system -p /home/dtopz/code/github/execution-specs.markdownlint-version-mismatch/.tox/.tox/bin/python
markdownlint: commands[0]> markdownlintcli2_soft_fail

***************************************************************
* WARNING: markdownlint-cli2 0.17.2 installed, CI uses 0.20.0 *
*                                                             *
* Lint results may differ from CI.                            *
*   npm install -g markdownlint-cli2@0.20.0                   *
***************************************************************

markdownlint-cli2 v0.17.2 (markdownlint v0.37.4)
Finding: ./docs/**/*.md ./*.md
Linting: 104 file(s)
Summary: 0 error(s)
  markdownlint: OK (3.18=setup[0.84]+cmd[2.34] seconds)
  congratulations :) (3.20 seconds)
```

## 🔗 Related Issues or PRs
Small follow-up triggered by/for:
- #2503

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:worm: 