### PR TITLE
feat(test-fixture): add `metadata` subfield to `_info` with `target_opcode` 

### DIFF
--- a/packages/testing/src/execution_testing/cli/diff_opcode_counts.py
+++ b/packages/testing/src/execution_testing/cli/diff_opcode_counts.py
@@ -55,17 +55,16 @@ def load_fixtures_from_file(
 def extract_opcode_counts_from_fixtures(
     fixtures: Fixtures,
 ) -> Dict[str, OpcodeCount]:
-    """Extract opcode_count from info field for each fixture."""
+    """Extract opcode_count from the metadata field for each fixture."""
     opcode_counts = {}
     for fixture_name, fixture in fixtures.items():
-        if (
-            hasattr(fixture, "info")
-            and fixture.info
-            and "opcode_count" in fixture.info
-        ):
+        if not (hasattr(fixture, "info") and fixture.info):
+            continue
+        metadata = fixture.info.get("metadata")
+        if isinstance(metadata, dict) and "opcode_count" in metadata:
             try:
                 opcode_count = OpcodeCount.model_validate(
-                    fixture.info["opcode_count"]
+                    metadata["opcode_count"]
                 )
                 opcode_counts[fixture_name] = opcode_count
             except Exception as e:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1811,14 +1811,21 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                             fixture.post_state, group.pre
                         )
 
+                fill_metadata: Dict[str, Any] = {}
+                if t8n.opcode_count is not None:
+                    fill_metadata["opcode_count"] = (
+                        t8n.opcode_count.model_dump()
+                    )
+                if fill_result.metadata:
+                    fill_metadata.update(fill_result.metadata)
+
                 fixture.fill_info(
                     t8n.version(),
                     test_case_description,
                     fixture_source_url=fixture_source_url,
-                    opcode_count=t8n.opcode_count,
                     ref_spec=reference_spec,
                     _info_metadata=t8n._info_metadata,
-                    fill_metadata=fill_result.metadata or None,
+                    metadata=fill_metadata,
                 )
 
                 output_subdir = resolve_fixture_subfolder(

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1818,6 +1818,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     opcode_count=t8n.opcode_count,
                     ref_spec=reference_spec,
                     _info_metadata=t8n._info_metadata,
+                    fill_metadata=fill_result.metadata or None,
                 )
 
                 output_subdir = resolve_fixture_subfolder(

--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -173,6 +173,7 @@ class BaseFixture(CamelModel):
         opcode_count: OpcodeCount | None,
         ref_spec: ReferenceSpec | None,
         _info_metadata: Dict[str, Any] | None,
+        fill_metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Fill the info field for this fixture."""
         if "comment" not in self.info:
@@ -182,6 +183,8 @@ class BaseFixture(CamelModel):
         self.info["url"] = fixture_source_url
         if opcode_count is not None:
             self.info["opcode_count"] = opcode_count.model_dump()
+        if fill_metadata:
+            self.info.update(fill_metadata)
         if ref_spec is not None:
             ref_spec.write_info(self.info)
         if _info_metadata:

--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -29,7 +29,6 @@ from pydantic import (
 from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from execution_testing.base_types import CamelModel, ReferenceSpec
-from execution_testing.client_clis.cli_types import OpcodeCount
 from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
 
@@ -170,10 +169,9 @@ class BaseFixture(CamelModel):
         t8n_version: str,
         test_case_description: str,
         fixture_source_url: str,
-        opcode_count: OpcodeCount | None,
         ref_spec: ReferenceSpec | None,
         _info_metadata: Dict[str, Any] | None,
-        fill_metadata: Dict[str, Any] | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Fill the info field for this fixture."""
         if "comment" not in self.info:
@@ -181,10 +179,8 @@ class BaseFixture(CamelModel):
         self.info["filling-transition-tool"] = t8n_version
         self.info["description"] = test_case_description
         self.info["url"] = fixture_source_url
-        if opcode_count is not None:
-            self.info["opcode_count"] = opcode_count.model_dump()
-        if fill_metadata:
-            self.info.update(fill_metadata)
+        if metadata:
+            self.info["metadata"] = metadata
         if ref_spec is not None:
             ref_spec.write_info(self.info)
         if _info_metadata:

--- a/packages/testing/src/execution_testing/fixtures/tests/test_base.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_base.py
@@ -149,7 +149,6 @@ def test_base_fixtures_parsing(fixture: BaseFixture) -> None:
         "t8n-version",
         "test_case_description",
         fixture_source_url="fixture_source_url",
-        opcode_count=None,
         ref_spec=None,
         _info_metadata={},
     )

--- a/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_collector.py
@@ -22,7 +22,6 @@ def _make_fixture(nonce: int = 0) -> TransactionFixture:
         f"test description {nonce}",
         fixture_source_url="http://example.com",
         ref_spec=None,
-        opcode_count=None,
         _info_metadata={},
     )
     return fixture

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Self
 
 from execution_testing.base_types import to_hex
@@ -96,6 +96,7 @@ class FillResult(BaseModel):
     benchmark_gas_used: int | None = None
     benchmark_opcode_count: OpcodeCount | None = None
     post_verifications: PostVerifications | None = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class BaseTest(BaseModel):

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -554,6 +554,11 @@ class BenchmarkTest(BaseTest):
                 self._verify_target_opcode_count(
                     fill_result.benchmark_opcode_count
                 )
+
+            # Embed target opcode in the fill result for fixture metadata
+            if self.target_opcode is not None:
+                fill_result.metadata["target_opcode"] = str(self.target_opcode)
+
             return fill_result
         else:
             raise Exception(f"Unsupported fixture format: {fixture_format}")

--- a/packages/testing/src/execution_testing/specs/benchmark.py
+++ b/packages/testing/src/execution_testing/specs/benchmark.py
@@ -555,7 +555,6 @@ class BenchmarkTest(BaseTest):
                     fill_result.benchmark_opcode_count
                 )
 
-            # Embed target opcode in the fill result for fixture metadata
             if self.target_opcode is not None:
                 fill_result.metadata["target_opcode"] = str(self.target_opcode)
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Add `target_opcode` field in the fixture, so that user could parse the benchmark target more easily from the fixture, instead of the test name.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Closes #2208 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
