### PR TITLE
refactor(tests,test-fill): rename `json_loader` pytest marker to `eels_base_coverage`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/execute_fill.py
@@ -199,8 +199,8 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "json_loader: tests forming a minimized test set that is used by "
-        "tests/json_loader/",
+        "eels_base_coverage: Minimized subset selected to preserve high "
+        "EELS line-coverage parity.",
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,7 +289,7 @@ markers = [
     "json_blockchain_tests: marks tests as json_blockchain_tests (deselect with '-m \"not json_blockchain_tests\"')",
     "json_state_tests: marks tests as json_state_tests (deselect with '-m \"not json_state_tests\"')",
     "vm_test: marks tests as vm_test (deselect with '-m \"not vm_test\"')",
-    "json_loader: marks tests as minimal set for json_loader coverage (select with '-m json_loader')",
+    "eels_base_coverage: Minimized subset selected to preserve high EELS line-coverage parity (select with '-m eels_base_coverage')",
 ]
 
 [tool.coverage.run]

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py
@@ -1985,7 +1985,7 @@ def test_bal_multiple_storage_writes_same_slot(
         pytest.param([2, 3, 4], id="depth_3"),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_bal_nested_delegatecall_storage_writes_net_zero(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+++ b/tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
@@ -538,7 +538,7 @@ def test_bal_call_no_delegation_and_oog_before_target_access(
 @pytest.mark.parametrize(
     "memory_expansion", [False, True], ids=["no_memory", "with_memory"]
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_bal_call_no_delegation_oog_after_target_access(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,

--- a/tests/berlin/eip2929_gas_cost_increases/test_call.py
+++ b/tests/berlin/eip2929_gas_cost_increases/test_call.py
@@ -17,7 +17,7 @@ REFERENCE_SPEC_VERSION = "0e11417265a623adb680c527b15d0cb6701b870b"
 
 
 @pytest.mark.valid_from("Berlin")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_call_insufficient_balance(
     state_test: StateTestFiller, pre: Alloc, env: Environment, fork: Fork
 ) -> None:

--- a/tests/berlin/eip2930_access_list/test_acl.py
+++ b/tests/berlin/eip2930_access_list/test_acl.py
@@ -219,7 +219,7 @@ def test_account_storage_warm_cold_state(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_transaction_intrinsic_gas_cost(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/byzantium/eip196_ec_add_mul/test_ecadd.py
+++ b/tests/byzantium/eip196_ec_add_mul/test_ecadd.py
@@ -305,7 +305,7 @@ def test_valid(
         "https://github.com/ethereum/execution-specs/pull/2477",
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/byzantium/eip198_modexp_precompile/test_modexp.py
+++ b/tests/byzantium/eip198_modexp_precompile/test_modexp.py
@@ -453,7 +453,7 @@ REFERENCE_SPEC_VERSION = "5c8f066acb210c704ef80c1033a941aa5374aac5"
     ids=lambda param: param.__repr__(),  # only required to remove parameter
     # names (input/output)
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_modexp(
     state_test: StateTestFiller,
     mod_exp_input: ModExpInput | Bytes,

--- a/tests/byzantium/eip214_staticcall/test_staticcall.py
+++ b/tests/byzantium/eip214_staticcall/test_staticcall.py
@@ -105,7 +105,7 @@ def bal_expectation_for_contract_with_markers(
     "stStaticFlagEnabled/StaticcallForPrecompilesIssue683Filler.yml"
 )
 @pytest.mark.valid_from("Byzantium")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_staticcall_reentrant_call_to_precompile(
     pre: Alloc,
     state_test: StateTestFiller,

--- a/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_execution_contexts.py
@@ -368,7 +368,7 @@ def post(  # noqa: D103
 
 
 @CallContextTestCases.parametrize()
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_subcall(
     state_test: StateTestFiller,
     env: Environment,

--- a/tests/cancun/eip4844_blobs/test_blob_txs.py
+++ b/tests/cancun/eip4844_blobs/test_blob_txs.py
@@ -498,7 +498,7 @@ def generate_invalid_tx_max_fee_per_blob_gas_tests(
     [1_000_000_000],
 )  # Extra balance to cover block blob gas cost
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_tx_max_fee_per_blob_gas(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -564,7 +564,7 @@ def test_invalid_tx_max_fee_per_blob_gas_state(
 )
 @pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_normal_gas(
     state_test: StateTestFiller,
     state_env: Environment,
@@ -605,7 +605,7 @@ def test_invalid_normal_gas(
 )
 @pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_block_blob_count(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -937,7 +937,7 @@ def generate_invalid_tx_blob_count_tests(
 )
 @pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_tx_blob_count(
     state_test: StateTestFiller,
     state_env: Environment,
@@ -1053,7 +1053,7 @@ def test_invalid_blob_hash_versioning_single_tx(
 )
 @pytest.mark.exception_test
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_blob_hash_versioning_multiple_txs(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
+++ b/tests/cancun/eip4844_blobs/test_blobhash_opcode.py
@@ -306,7 +306,7 @@ def test_blobhash_scenarios(
         "invalid_calls",
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_blobhash_invalid_blob_index(
     pre: Alloc,
     fork: Fork,

--- a/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
+++ b/tests/cancun/eip4844_blobs/test_excess_blob_gas_fork_transition.py
@@ -453,7 +453,7 @@ def test_invalid_post_fork_block_without_blob_fields(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_fork_transition_excess_blob_gas_at_blob_genesis(
     blockchain_test: BlockchainTestFiller,
     genesis_environment: Environment,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile.py
@@ -353,7 +353,7 @@ def test_valid_inputs(
 )
 @pytest.mark.parametrize("result", [Result.FAILURE])
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_inputs(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
+++ b/tests/cancun/eip4844_blobs/test_point_evaluation_precompile_gas.py
@@ -203,7 +203,7 @@ def post(
 )
 @pytest.mark.parametrize("proof", ["correct", "incorrect"])
 @pytest.mark.valid_from("Cancun")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_point_evaluation_precompile_gas_usage(
     state_test: StateTestFiller,
     pre: Dict,

--- a/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
+++ b/tests/constantinople/eip1052_extcodehash/test_extcodehash.py
@@ -39,7 +39,7 @@ pytestmark = [
     ],
     pr=["https://github.com/ethereum/execution-specs/pull/2249"],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_extcodehash_self(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/constantinople/eip145_bitwise_shift/test_shift_combinations.py
+++ b/tests/constantinople/eip145_bitwise_shift/test_shift_combinations.py
@@ -59,7 +59,7 @@ combinations = list(itertools.product(list_of_args, repeat=2))
     ],
     pr=["https://github.com/ethereum/execution-spec-tests/pull/1683"],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_combinations(
     state_test: StateTestFiller, pre: Alloc, opcode: Op, operation: Callable
 ) -> None:

--- a/tests/frontier/create/test_create_deposit_oog.py
+++ b/tests/frontier/create/test_create_deposit_oog.py
@@ -21,7 +21,7 @@ SLOT_CREATE_RESULT_PRE = 0xDEADBEEF
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.parametrize("enough_gas", [True, False])
 @pytest.mark.with_all_create_opcodes
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_create_deposit_oog(
     state_test: StateTestFiller,
     fork: Fork,

--- a/tests/frontier/create/test_create_one_byte.py
+++ b/tests/frontier/create/test_create_one_byte.py
@@ -32,7 +32,7 @@ from execution_testing.forks import London
 )
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.with_all_create_opcodes
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_create_one_byte(
     state_test: StateTestFiller,
     fork: Fork,

--- a/tests/frontier/create/test_create_suicide_during_init.py
+++ b/tests/frontier/create/test_create_suicide_during_init.py
@@ -44,7 +44,7 @@ class Operation(Enum):
     "operation",
     [Operation.SUICIDE, Operation.SUICIDE_TO_ITSELF],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_create_suicide_during_transaction_create(
     state_test: StateTestFiller,
     fork: Fork,

--- a/tests/frontier/create/test_create_suicide_store.py
+++ b/tests/frontier/create/test_create_suicide_store.py
@@ -41,7 +41,7 @@ class Operation(IntEnum):
 )
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.with_all_create_opcodes
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_create_suicide_store(
     state_test: StateTestFiller,
     fork: Fork,

--- a/tests/frontier/identity_precompile/test_identity.py
+++ b/tests/frontier/identity_precompile/test_identity.py
@@ -113,7 +113,7 @@ from .common import CallArgs, generate_identity_call_bytecode
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_call_identity_precompile(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/opcodes/test_all_opcodes.py
+++ b/tests/frontier/opcodes/test_all_opcodes.py
@@ -66,7 +66,7 @@ def prepare_suffix(opcode: Opcode) -> Bytecode:
     pr=["https://github.com/ethereum/execution-spec-tests/pull/748"],
 )
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_all_opcodes(
     state_test: StateTestFiller, pre: Alloc, fork: Fork
 ) -> None:
@@ -152,7 +152,7 @@ def fork_opcodes_increasing_stack(
 
 @pytest.mark.parametrize_by_fork("opcode", fork_opcodes_increasing_stack)
 @pytest.mark.parametrize("fails", [True, False])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_stack_overflow(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -229,7 +229,7 @@ def constant_gas_opcodes(fork: Fork) -> Generator[ParameterSet, None, None]:
 
 @pytest.mark.valid_from("Berlin")
 @pytest.mark.parametrize_by_fork("opcode", constant_gas_opcodes)
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_constant_gas(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
+++ b/tests/frontier/opcodes/test_call_and_callcode_gas_calculation.py
@@ -318,7 +318,7 @@ def test_value_transfer_gas_calculation(
 @pytest.mark.parametrize("gas_shortage", [0, 1])
 @pytest.mark.valid_from("Byzantium")
 @pytest.mark.valid_until("Berlin")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_value_transfer_gas_calculation_byzantium(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/opcodes/test_calldatacopy.py
+++ b/tests/frontier/opcodes/test_calldatacopy.py
@@ -154,7 +154,7 @@ from execution_testing import (
         "sec",
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_calldatacopy(
     state_test: StateTestFiller,
     code: Bytecode,

--- a/tests/frontier/opcodes/test_swap.py
+++ b/tests/frontier/opcodes/test_swap.py
@@ -108,7 +108,7 @@ def test_swap(
     ids=lambda op: str(op),
 )
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_stack_underflow(
     state_test: StateTestFiller,
     fork: Fork,

--- a/tests/frontier/precompiles/test_ecrecover.py
+++ b/tests/frontier/precompiles/test_ecrecover.py
@@ -394,7 +394,7 @@ from execution_testing.vm import Opcodes as Op
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_precompiles(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/precompiles/test_precompiles.py
+++ b/tests/frontier/precompiles/test_precompiles.py
@@ -57,7 +57,7 @@ def precompile_addresses(fork: Fork) -> Iterator[Tuple[Address, bool]]:
 @pytest.mark.parametrize_by_fork(
     "address,precompile_exists", precompile_addresses
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_precompiles(
     state_test: StateTestFiller,
     address: Address,

--- a/tests/frontier/precompiles/test_ripemd.py
+++ b/tests/frontier/precompiles/test_ripemd.py
@@ -141,7 +141,7 @@ from execution_testing.vm import Opcodes as Op
     ],
 )
 @pytest.mark.parametrize("oog", [True, False])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_precompiles(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -13,7 +13,7 @@ from execution_testing import (
 
 @pytest.mark.valid_from("Frontier")
 @pytest.mark.valid_until("Berlin")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_zero_gas_price_and_touching(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/frontier/validation/test_transaction.py
+++ b/tests/frontier/validation/test_transaction.py
@@ -15,7 +15,7 @@ from execution_testing.test_types.transaction_types import TransactionDefaults
 
 
 @pytest.mark.exception_test
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_tx_gas_limit(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -66,7 +66,7 @@ def test_tx_gas_limit(
     ],
 )
 @pytest.mark.pre_alloc_mutable
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_tx_nonce(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -108,7 +108,7 @@ def test_tx_nonce(
         (1, None),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_sender_balance(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/istanbul/eip152_blake2/test_blake2.py
+++ b/tests/istanbul/eip152_blake2/test_blake2.py
@@ -508,7 +508,7 @@ def test_blake2b(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_blake2b_invalid_gas(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -633,7 +633,7 @@ def tx_gas_limits(fork: Fork) -> List[int]:
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_blake2b_gas_limit(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
+++ b/tests/osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py
@@ -342,7 +342,7 @@ def total_cost_floor_per_token(fork: Fork) -> int:
 )
 @pytest.mark.parametrize("zero_byte", [True, False])
 @pytest.mark.valid_from("Osaka")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_tx_gas_limit_cap_full_calldata(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
+++ b/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py
@@ -392,7 +392,7 @@ def test_modexp_gas_usage_contract_wrapper(
 @EIPChecklist.Precompile.Test.CallContexts.TxEntry()
 @EIPChecklist.Precompile.Test.ValueTransfer.NoFee()
 @pytest.mark.valid_from("Berlin")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_modexp_used_in_transaction_entry_points(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -786,7 +786,7 @@ def create_modexp_variable_gas_test_cases() -> Generator:
 @EIPChecklist.Precompile.Test.InputLengths.Zero()
 @EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
 @pytest.mark.valid_from("Berlin")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_modexp_variable_gas_cost(
     state_test: StateTestFiller,
     precompile_gas: int,

--- a/tests/osaka/eip7918_blob_reserve_price/test_blob_base_fee.py
+++ b/tests/osaka/eip7918_blob_reserve_price/test_blob_base_fee.py
@@ -232,7 +232,7 @@ def get_boundary_scenarios(fork: Fork) -> Iterator[Any]:
     "parent_excess_blobs,block_base_fee_per_gas_delta",
     get_boundary_scenarios,
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_reserve_price_boundary(
     blockchain_test: BlockchainTestFiller,
     env: Environment,

--- a/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
+++ b/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py
@@ -693,7 +693,7 @@ def test_block_at_rlp_size_limit_boundary(
 @pytest.mark.with_all_typed_transactions
 @pytest.mark.verify_sync
 @pytest.mark.valid_from("Osaka")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_block_rlp_size_at_limit_with_all_typed_transactions(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -365,7 +365,7 @@ def test_clz_fork_transition(
 @pytest.mark.parametrize("valid_jump", [True, False])
 @pytest.mark.parametrize("jumpi_condition", [True, False])
 @pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_clz_jump_operation(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
+++ b/tests/osaka/eip7951_p256verify_precompiles/test_p256verify.py
@@ -43,7 +43,7 @@ pytestmark = [
 @EIPChecklist.Precompile.Test.CallContexts.Normal()
 @EIPChecklist.Precompile.Test.Inputs.Valid()
 @EIPChecklist.Precompile.Test.Inputs.MaxValues()
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_wycheproof_valid(
     state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transaction
 ) -> None:
@@ -969,7 +969,7 @@ def test_valid(
 @EIPChecklist.Precompile.Test.InputLengths.Static.TooLong()
 @EIPChecklist.Precompile.Test.OutOfBounds.Max()
 @EIPChecklist.Precompile.Test.OutOfBounds.MaxPlusOne()
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller, pre: Alloc, post: dict, tx: Transaction
 ) -> None:

--- a/tests/paris/eip7610_create_collision/test_initcollision.py
+++ b/tests/paris/eip7610_create_collision/test_initcollision.py
@@ -61,7 +61,7 @@ pytestmark = [
 
 
 @pytest.mark.with_all_contract_creating_tx_types
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_init_collision_create_tx(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/paris/eip7610_create_collision/test_revert_in_create.py
+++ b/tests/paris/eip7610_create_collision/test_revert_in_create.py
@@ -102,7 +102,7 @@ def test_collision_with_create2_revert_in_initcode(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_create2_collision_storage(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py
@@ -470,7 +470,7 @@ def test_gas(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_call_types(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
@@ -243,7 +243,7 @@ def test_valid(
     "precompile_gas_modifier", [100_000], ids=[""]
 )  # Add gas so that won't be the cause of failure
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1mul.py
@@ -425,7 +425,7 @@ def test_gas(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_call_types(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py
@@ -218,7 +218,7 @@ pytestmark = [
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2msm.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2msm.py
@@ -254,7 +254,7 @@ def test_valid(
     "precompile_gas_modifier", [100_000], ids=[""]
 )  # Add gas so that won't be the cause of failure
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -293,7 +293,7 @@ def test_invalid(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_call_types(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_map_fp2_to_g2.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_map_fp2_to_g2.py
@@ -79,7 +79,7 @@ G2_POINT_ZERO_FP = PointG2(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_map_fp_to_g1.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_map_fp_to_g1.py
@@ -64,7 +64,7 @@ G1_POINT_ZERO_FP = PointG1(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -139,7 +139,7 @@ def test_isogeny_kernel_values(
     ],
 )
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_pairing.py
@@ -127,7 +127,7 @@ pytestmark = [
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -394,7 +394,7 @@ def test_valid_multi_inf(
     ],
 )
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_variable_length_input_contracts.py
@@ -355,7 +355,7 @@ def test_invalid_zero_gas_g1msm(
 )
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
 @pytest.mark.parametrize("precompile_address", [Spec.G1MSM])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_gas_g1msm(
     state_test: StateTestFiller,
     env: Environment,
@@ -514,7 +514,7 @@ def test_invalid_zero_gas_g2msm(
 )
 @pytest.mark.parametrize("expected_output", [Spec.INVALID], ids=[""])
 @pytest.mark.parametrize("precompile_address", [Spec.G2MSM])
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_gas_g2msm(
     state_test: StateTestFiller,
     env: Environment,

--- a/tests/prague/eip2537_bls_12_381_precompiles/test_eip_mainnet.py
+++ b/tests/prague/eip2537_bls_12_381_precompiles/test_eip_mainnet.py
@@ -75,7 +75,7 @@ pytestmark = [pytest.mark.valid_at("Prague"), pytest.mark.mainnet]
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_eip_2537(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
+++ b/tests/prague/eip2935_historical_block_hashes_from_state/test_block_hashes.py
@@ -243,7 +243,7 @@ def test_block_hashes_history_at_transition(
     ],
 )
 @pytest.mark.valid_from("Prague")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_block_hashes_history(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip6110_deposits/test_modified_contract.py
+++ b/tests/prague/eip6110_deposits/test_modified_contract.py
@@ -183,7 +183,7 @@ def test_extra_logs(
     ],
 )
 @pytest.mark.exception_test
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_layout(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -234,7 +234,7 @@ def test_invalid_layout(
 
 @pytest.mark.parametrize("slice_bytes", [True, False])
 @pytest.mark.exception_test
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_invalid_log_length(
     blockchain_test: BlockchainTestFiller, pre: Alloc, slice_bytes: bool
 ) -> None:

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_contract_deployment.py
@@ -25,7 +25,7 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_7002.git_path
 REFERENCE_SPEC_VERSION = ref_spec_7002.version
 
 
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 @generate_system_contract_deploy_test(
     fork=Prague,
     tx_json_path=Path(realpath(__file__)).parent / "contract_deploy_tx.json",

--- a/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/test_modified_withdrawal_contract.py
@@ -147,7 +147,7 @@ def test_extra_withdrawals(
 @generate_system_contract_error_test(  # type: ignore[arg-type]
     max_gas_limit=Spec_EIP7002.SYSTEM_CALL_GAS_LIMIT,
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_system_contract_errors() -> None:
     """
     Test system contract raising different errors when called by the system

--- a/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
+++ b/tests/prague/eip7685_general_purpose_el_requests/test_multi_type_requests.py
@@ -336,7 +336,7 @@ def get_contract_permutations(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid_multi_type_requests(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_gas.py
+++ b/tests/prague/eip7702_set_code_tx/test_gas.py
@@ -946,7 +946,7 @@ def test_gas_cost(
 @pytest.mark.parametrize(
     **gas_test_parameter_args(include_many=False, include_data=False)
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_account_warming(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs.py
@@ -836,7 +836,7 @@ def test_set_code_to_self_caller(
 
 
 @pytest.mark.execute(pytest.mark.skip(reason="excessive gas"))
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_set_code_max_depth_call_stack(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -905,7 +905,7 @@ def test_set_code_max_depth_call_stack(
     "value",
     [0, 1],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_set_code_call_set_code(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -2407,7 +2407,7 @@ def test_set_code_using_valid_synthetic_signatures(
         ),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_valid_tx_invalid_auth_signature(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -2697,7 +2697,7 @@ def test_nonce_validity(
 
 
 @pytest.mark.pre_alloc_mutable()
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_nonce_overflow_after_first_authorization(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3351,7 +3351,7 @@ def test_reset_code(
 
 
 @pytest.mark.exception_test
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_contract_create(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3380,7 +3380,7 @@ def test_contract_create(
 
 
 @pytest.mark.exception_test
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_empty_authorization_list(
     state_test: StateTestFiller,
     pre: Alloc,
@@ -3989,7 +3989,7 @@ def test_authorization_reusing_nonce(
 )
 @pytest.mark.exception_test
 @pytest.mark.pre_alloc_mutable
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_set_code_from_account_with_non_delegating_code(
     state_test: StateTestFiller,
     pre: Alloc,

--- a/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
+++ b/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py
@@ -1864,7 +1864,7 @@ def test_double_auth(
 
 @pytest.mark.xdist_group(name="bigmem")
 @pytest.mark.valid_from("Prague")
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_pointer_resets_an_empty_code_account_with_storage(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/shanghai/eip3860_initcode/test_initcode.py
+++ b/tests/shanghai/eip3860_initcode/test_initcode.py
@@ -122,7 +122,7 @@ def initcode(fork: Fork, initcode_name: str) -> Initcode:
         pytest.param("over_limit_ones", marks=pytest.mark.exception_test),
     ],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_contract_creating_tx(
     state_test: StateTestFiller,
     env: Environment,

--- a/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
+++ b/tests/shanghai/eip4895_withdrawals/test_withdrawals.py
@@ -607,7 +607,7 @@ class ZeroAmountTestCases(Enum):  # noqa: D101
     list(ZeroAmountTestCases),
     ids=[case.value for case in ZeroAmountTestCases],
 )
-@pytest.mark.json_loader
+@pytest.mark.eels_base_coverage
 def test_zero_amount(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ dependency_groups =
     test
 commands =
     fill \
-        -m "json_loader and not derived_test" \
+        -m "eels_base_coverage and not derived_test" \
         --until Amsterdam \
         -n {env:PYTEST_XDIST_AUTO_NUM_WORKERS:6} --dist=loadgroup \
         --skip-index \
@@ -144,7 +144,7 @@ commands =
         --tb=no \
         --show-capture=no \
         --disable-warnings \
-        -m "json_loader and not derived_test" \
+        -m "eels_base_coverage and not derived_test" \
         -n auto --maxprocesses 7 \
         # loadgroup: serialize xdist_group("bigmem") tests onto one worker to limit peak memory
         --dist=loadgroup \


### PR DESCRIPTION
## 🗒️ Description

Rename the `json_loader` pytest marker to `eels_base_coverage` to better reflect that this minimized test subset is selected to preserve high EELS line-coverage parity.

The neutral name `eels_base_coverage` was intentionally chosen to avoid insinuating that selecting this marker achieves "good" or full coverage — it represents a baseline, not a target.

Only the pytest marker is renamed:

- Update marker registration in `pyproject.toml` and `execute_fill.py`.
- Update `-m` filter expressions in `tox.ini`.
- Replace all `@pytest.mark.json_loader` decorators across 58 test files (80 occurrences).

Infrastructure that shares the `json_loader` name (tox environment, `tests/json_loader/` directory, CI job) is left unchanged.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.

#### Cute Animal Picture
![960px-Quokka](https://github.com/user-attachments/assets/859aaadb-2ed5-4d5b-8c06-5da39f974892)

Source: https://commons.wikimedia.org/wiki/Setonix_brachyurus#/media/File:Quokka.jpg