### PR TITLE
chore(doc,ci): don't include `ported_static` tests in mkdocs

### DIFF
--- a/docs/scripts/gen_test_case_reference.py
+++ b/docs/scripts/gen_test_case_reference.py
@@ -58,6 +58,7 @@ args = [
     f"--until={GENERATE_UNTIL_FORK}",
     "--checklist-doc-gen",
     "--skip-index",
+    "--ignore=tests/ported_static",
     "-m",
     "not blockchain_test_engine and not benchmark",
     "-s",


### PR DESCRIPTION
## 🗒️ Description

Skip inclusion of the `ported_static` tests in the Test Case Reference; this caused a 6x increase in the time to generate docs. It's currently taking ~25 mins to run the Test Docs workflow: https://github.com/ethereum/execution-specs/actions/workflows/test-docs.yaml.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to:
- #2455

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
