### PR TITLE
feat(specs,tests): EIP-8037 state gas ordering and clarifications

### DIFF
--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3691,22 +3691,16 @@ class Amsterdam(BPO2):
             current_value = original_value
         new_value = metadata["new_value"]
 
-        gas_cost = (
-            0 if metadata["key_warm"] else gas_costs.GAS_COLD_STORAGE_ACCESS
-        )
+        cold_access = gas_costs.GAS_COLD_STORAGE_ACCESS
+        cold_write = gas_costs.GAS_COLD_STORAGE_WRITE
+        gas_cost = 0 if metadata["key_warm"] else cold_access
 
         if original_value == current_value and current_value != new_value:
             if original_value == 0:
                 # EIP-8037: regular portion + state gas
-                gas_cost += (
-                    gas_costs.GAS_COLD_STORAGE_WRITE
-                    - gas_costs.GAS_COLD_STORAGE_ACCESS
-                ) + (32 * cpsb)
+                gas_cost += (cold_write - cold_access) + (32 * cpsb)
             else:
-                gas_cost += (
-                    gas_costs.GAS_COLD_STORAGE_WRITE
-                    - gas_costs.GAS_COLD_STORAGE_ACCESS
-                )
+                gas_cost += cold_write - cold_access
         else:
             gas_cost += gas_costs.GAS_WARM_SLOAD
 

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -104,9 +104,10 @@ def sstore(evm: Evm) -> None:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
         gas_cost += GAS_COLD_STORAGE_ACCESS
 
+    needs_state_gas = False
     if original_value == current_value and current_value != new_value:
         if original_value == 0:
-            charge_state_gas(evm, state_gas_storage_set)
+            needs_state_gas = True
         # charge regular cost for the operation, even when we
         # already charge state gas for state creation
         gas_cost += GAS_STORAGE_UPDATE - GAS_COLD_STORAGE_ACCESS
@@ -144,7 +145,12 @@ def sstore(evm: Evm) -> None:
                     - GAS_WARM_ACCESS
                 )
 
+    # Charge regular gas before state gas so that a regular-gas OOG
+    # does not consume state gas that would inflate the parent's
+    # reservoir on frame failure.
     charge_gas(evm, gas_cost)
+    if needs_state_gas:
+        charge_state_gas(evm, state_gas_storage_set)
     set_storage(tx_state, evm.message.current_target, key, new_value)
 
     # PROGRAM COUNTER

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -436,15 +436,6 @@ def call(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(to)
 
-    # Charge state gas for new account creation (replaces GAS_NEW_ACCOUNT)
-    if value != 0 and not is_account_alive(tx_state, to):
-        cost_per_state_byte = state_gas_per_byte(
-            evm.message.block_env.block_gas_limit
-        )
-        charge_state_gas(
-            evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
-        )
-
     extra_gas = access_gas_cost + transfer_gas_cost
     (
         is_delegated,
@@ -462,14 +453,28 @@ def call(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # Charge regular overhead first, then state gas, before the
+    # child gas calculation. This ensures:
+    # 1. Regular-gas OOG does not consume state gas (no inflation).
+    # 2. State gas spill into gas_left reduces the child's gas
+    #    (matching reth's ordering).
+    charge_gas(evm, extra_gas + extend_memory.cost)
+    if value != 0 and not is_account_alive(tx_state, to):
+        cost_per_state_byte = state_gas_per_byte(
+            evm.message.block_env.block_gas_limit
+        )
+        charge_state_gas(
+            evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
+        )
+
     message_call_gas = calculate_message_call_gas(
         value,
         gas,
         Uint(evm.gas_left),
         extend_memory.cost,
-        extra_gas,
+        extra_gas=Uint(0),
     )
-    charge_gas(evm, message_call_gas.cost + extend_memory.cost)
+    charge_gas(evm, message_call_gas.cost)
     escrow_subcall_regular_gas(evm, message_call_gas.sub_call)
 
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -651,18 +656,22 @@ def selfdestruct(evm: Evm) -> None:
     if is_cold_access:
         evm.accessed_addresses.add(beneficiary)
 
-    if (
+    needs_state_gas = (
         not is_account_alive(tx_state, beneficiary)
         and get_account(tx_state, evm.message.current_target).balance != 0
-    ):
+    )
+
+    # Charge regular gas before state gas so that a regular-gas OOG
+    # does not consume state gas that would inflate the parent's
+    # reservoir on frame failure.
+    charge_gas(evm, gas_cost)
+    if needs_state_gas:
         cost_per_state_byte = state_gas_per_byte(
             evm.message.block_env.block_gas_limit
         )
         charge_state_gas(
             evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte
         )
-
-    charge_gas(evm, gas_cost)
 
     originator = evm.message.current_target
     originator_balance = get_account(tx_state, originator).balance

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -453,11 +453,6 @@ def call(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
-    # Charge regular overhead first, then state gas, before the
-    # child gas calculation. This ensures:
-    # 1. Regular-gas OOG does not consume state gas (no inflation).
-    # 2. State gas spill into gas_left reduces the child's gas
-    #    (matching reth's ordering).
     charge_gas(evm, extra_gas + extend_memory.cost)
     if value != 0 and not is_account_alive(tx_state, to):
         cost_per_state_byte = state_gas_per_byte(

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -453,6 +453,9 @@ def call(evm: Evm) -> None:
     code_hash = get_account(tx_state, code_address).code_hash
     code = get_code(tx_state, code_hash)
 
+    # TODO: Consider consolidating charge_gas + charge_state_gas into
+    # a single gas charge to avoid duplicate EVM trace entries.
+    # Applies here and in create, create2, selfdestruct. See #2526.
     charge_gas(evm, extra_gas + extend_memory.cost)
     if value != 0 and not is_account_alive(tx_state, to):
         cost_per_state_byte = state_gas_per_byte(

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -466,7 +466,7 @@ def call(evm: Evm) -> None:
         value,
         gas,
         Uint(evm.gas_left),
-        extend_memory.cost,
+        memory_cost=Uint(0),
         extra_gas=Uint(0),
     )
     charge_gas(evm, message_call_gas.cost)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -787,3 +787,82 @@ def test_call_stack_depth_returns_reservoir(
 
     post = {recursive: Account(storage=storage)}
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_call_pre_charged_costs_excluded_from_forwarding(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify pre-charged CALL costs do not reduce the 63/64 forwarding budget.
+
+    CALL charges access gas and memory expansion up front, before
+    computing the 63/64 sub-call gas.  Those costs must not be
+    subtracted again during the forwarding calculation.
+
+    A wrapper contract receives a precise gas budget and calls a child
+    with maximum gas and a large ret_size (triggering memory expansion).
+    The child does a cold zero-to-nonzero SSTORE as proof of execution.
+    The gas budget is tight enough that any double-counting of the
+    pre-charged costs (access gas, memory expansion, or both) causes
+    the child to OOG and the SSTORE to revert.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # Child: SSTORE(0, 1) as proof of execution
+    child_storage = Storage()
+    child_code = Op.SSTORE(child_storage.store_next(1, "child_ran"), 1)
+    child = pre.deploy_contract(child_code)
+
+    child_regular_gas = (
+        2 * gas_costs.GAS_VERY_LOW + gas_costs.GAS_COLD_STORAGE_WRITE
+    )
+
+    # Memory expansion triggered by ret_size on the wrapper's CALL
+    ret_size = 512 * 32  # 512 words
+    memory_cost = fork.memory_expansion_gas_calculator()(new_bytes=ret_size)
+
+    extra_gas = gas_costs.GAS_COLD_ACCOUNT_ACCESS  # cold call, value=0
+
+    # Wrapper: CALL child requesting max gas with memory expansion
+    wrapper_code = Op.CALL(
+        gas=0xFFFFFFFF,
+        address=child,
+        value=0,
+        args_offset=0,
+        args_size=0,
+        ret_offset=0,
+        ret_size=ret_size,
+    )
+    wrapper = pre.deploy_contract(wrapper_code)
+
+    wrapper_pushes = 7 * gas_costs.GAS_VERY_LOW  # 7 CALL args
+
+    # After the pre-charge of extra_gas + memory_cost, the wrapper has
+    # gas_remaining left.  The 63/64 rule should forward
+    # gas_remaining * 63/64 to the child — just enough for its SSTORE.
+    gas_remaining = child_regular_gas * 64 // 63 + memory_cost // 2
+
+    wrapper_gas = wrapper_pushes + extra_gas + memory_cost + gas_remaining
+
+    caller = pre.deploy_contract(
+        Op.POP(Op.CALL(gas=wrapper_gas, address=wrapper))
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+    )
+
+    post = {
+        child: Account(storage=child_storage),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -157,6 +157,7 @@ def test_calldata_floor_exceeding_tx_gas_limit_cap(
     """
     gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
 
     # calldata_floor = tokens * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE
     # For non-zero bytes: tokens = 4 per byte.
@@ -170,9 +171,6 @@ def test_calldata_floor_exceeding_tx_gas_limit_cap(
     max_tokens = (gas_limit_cap - tx_base) // floor_token
     max_bytes = max_tokens // tokens_per_nonzero
     num_bytes = max_bytes + (1 if exceeds_cap else 0)
-
-    actual_tokens = num_bytes * tokens_per_nonzero
-    actual_floor = actual_tokens * floor_token + tx_base
 
     calldata = b"\x01" * num_bytes
     contract = pre.deploy_contract(Op.STOP)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -20,6 +20,7 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
+    TransactionException,
 )
 from execution_testing.checklists import EIPChecklist
 
@@ -128,3 +129,63 @@ def test_calldata_floor_higher_than_execution_with_state_ops(
 
     post = {contract: Account(storage=storage)}
     state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "exceeds_cap",
+    [
+        pytest.param(False, id="at_cap"),
+        pytest.param(True, id="exceeds_cap", marks=pytest.mark.exception_test),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_calldata_floor_exceeding_tx_gas_limit_cap(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    exceeds_cap: bool,
+) -> None:
+    """
+    Verify calldata floor > TX_MAX_GAS_LIMIT rejects the transaction.
+
+    When the EIP-7623 calldata floor cost exceeds the EIP-7825 transaction
+    gas limit cap, the transaction must be rejected at validation —
+    even though the regular intrinsic gas may be within the cap.
+
+    at_cap: calldata floor exactly equals the cap — transaction accepted.
+    exceeds_cap: calldata floor exceeds the cap by 1 — transaction rejected.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+
+    # calldata_floor = tokens * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE
+    # For non-zero bytes: tokens = 4 per byte.
+    # Solve: num_bytes * 4 * floor_token + GAS_TX_BASE = target
+    floor_token = gas_costs.GAS_TX_DATA_TOKEN_FLOOR
+    tx_base = gas_costs.GAS_TX_BASE
+    tokens_per_nonzero = 4
+
+    # For at_cap: find max bytes where floor <= cap (floor division).
+    # For exceeds_cap: add 1 more byte so floor > cap.
+    max_tokens = (gas_limit_cap - tx_base) // floor_token
+    max_bytes = max_tokens // tokens_per_nonzero
+    num_bytes = max_bytes + (1 if exceeds_cap else 0)
+
+    actual_tokens = num_bytes * tokens_per_nonzero
+    actual_floor = actual_tokens * floor_token + tx_base
+
+    calldata = b"\x01" * num_bytes
+    contract = pre.deploy_contract(Op.STOP)
+
+    tx = Transaction(
+        to=contract,
+        data=calldata,
+        gas_limit=gas_limit_cap,
+        sender=pre.fund_eoa(),
+        error=TransactionException.INTRINSIC_GAS_TOO_LOW
+        if exceeds_cap
+        else None,
+    )
+
+    post = {contract: Account(code=Op.STOP)} if not exceeds_cap else {}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_calldata_floor.py
@@ -152,27 +152,33 @@ def test_calldata_floor_exceeding_tx_gas_limit_cap(
     gas limit cap, the transaction must be rejected at validation —
     even though the regular intrinsic gas may be within the cap.
 
-    at_cap: calldata floor exactly equals the cap — transaction accepted.
-    exceeds_cap: calldata floor exceeds the cap by 1 — transaction rejected.
+    at_cap: tightest calldata floor that fits within the cap —
+    transaction accepted.
+    exceeds_cap: one zero byte more tips the floor over the cap —
+    transaction rejected.
     """
     gas_costs = fork.gas_costs()
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
 
     # calldata_floor = tokens * GAS_TX_DATA_TOKEN_FLOOR + GAS_TX_BASE
-    # For non-zero bytes: tokens = 4 per byte.
-    # Solve: num_bytes * 4 * floor_token + GAS_TX_BASE = target
+    # Non-zero bytes contribute 4 tokens each, zero bytes 1 token.
+    # Exact equality with the cap is not always reachable because
+    # the floor advances in steps of GAS_TX_DATA_TOKEN_FLOOR.
+    # Use nonzero bytes for bulk tokens, then zero bytes (1 token
+    # each) to get as close to the cap as possible.
     floor_token = gas_costs.GAS_TX_DATA_TOKEN_FLOOR
     tx_base = gas_costs.GAS_TX_BASE
     tokens_per_nonzero = 4
 
-    # For at_cap: find max bytes where floor <= cap (floor division).
-    # For exceeds_cap: add 1 more byte so floor > cap.
     max_tokens = (gas_limit_cap - tx_base) // floor_token
-    max_bytes = max_tokens // tokens_per_nonzero
-    num_bytes = max_bytes + (1 if exceeds_cap else 0)
+    nonzero_bytes = max_tokens // tokens_per_nonzero
+    zero_bytes = max_tokens - nonzero_bytes * tokens_per_nonzero
 
-    calldata = b"\x01" * num_bytes
+    if exceeds_cap:
+        zero_bytes += 1
+
+    calldata = b"\x01" * nonzero_bytes + b"\x00" * zero_bytes
     contract = pre.deploy_contract(Op.STOP)
 
     tx = Transaction(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -480,23 +480,20 @@ def test_sstore_oog_no_reservoir_inflation(
     initcode = Initcode(deploy_code=Op.STOP)
     initcode_len = len(initcode)
 
-    factory_code = (
-        Op.CALLDATACOPY(
-            0,
-            0,
-            Op.CALLDATASIZE,
-            data_size=initcode_len,
-            new_memory_size=initcode_len,
-        )
-        + Op.SSTORE(
-            0,
-            Op.CREATE(
-                value=0,
-                offset=0,
-                size=Op.CALLDATASIZE,
-                init_code_size=initcode_len,
-            ),
-        )
+    factory_code = Op.CALLDATACOPY(
+        0,
+        0,
+        Op.CALLDATASIZE,
+        data_size=initcode_len,
+        new_memory_size=initcode_len,
+    ) + Op.SSTORE(
+        0,
+        Op.CREATE(
+            value=0,
+            offset=0,
+            size=Op.CALLDATASIZE,
+            init_code_size=initcode_len,
+        ),
     )
     factory = pre.deploy_contract(factory_code)
     create_address = compute_create_address(address=factory, nonce=1)
@@ -700,6 +697,7 @@ def test_create_no_double_charge_new_account(
     )
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=caller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -457,6 +457,100 @@ def test_nested_create_code_deposit_cannot_borrow_parent_gas(
         pytest.param(1, id="short_one_gas"),
     ],
 )
+@pytest.mark.valid_from("Amsterdam")
+def test_sstore_oog_no_reservoir_inflation(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_shortfall: int,
+) -> None:
+    """
+    Verify SSTORE state gas is not charged when regular gas OOGs.
+
+    With zero reservoir, all state gas spills into gas_left. A child
+    frame does CREATE (charging state gas from gas_left) followed by
+    SSTORE. When the factory is 1 gas short, SSTORE OOGs. If state
+    gas is incorrectly charged before regular gas, the extra state gas
+    inflates the parent's reservoir on frame failure, changing the
+    transaction's effective gas consumption.
+
+    Regression test for SSTORE gas ordering: regular gas must be
+    checked before state gas.
+    """
+    initcode = Initcode(deploy_code=Op.STOP)
+    initcode_len = len(initcode)
+
+    factory_code = (
+        Op.CALLDATACOPY(
+            0,
+            0,
+            Op.CALLDATASIZE,
+            data_size=initcode_len,
+            new_memory_size=initcode_len,
+        )
+        + Op.SSTORE(
+            0,
+            Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+    )
+    factory = pre.deploy_contract(factory_code)
+    create_address = compute_create_address(address=factory, nonce=1)
+
+    # Total gas includes both regular and state components since
+    # reservoir is zero — all state gas comes from gas_left.
+    factory_gas = (
+        factory_code.gas_cost(fork)
+        + initcode.execution_gas(fork)
+        + initcode.deployment_gas(fork)
+    )
+
+    # Caller forwards total gas (regular + state) through CALL.
+    # With zero reservoir, the CALL gas parameter is the only source.
+    caller = pre.deploy_contract(
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.CALL(
+            gas=factory_gas - gas_shortfall,
+            address=factory,
+            value=0,
+            args_offset=0,
+            args_size=Op.CALLDATASIZE,
+            ret_offset=0,
+            ret_size=0,
+        )
+    )
+
+    sender = pre.fund_eoa()
+    # gas_limit = cap → reservoir = 0
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        data=bytes(initcode),
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    created = not gas_shortfall
+    post = {
+        create_address: Account(code=Op.STOP)
+        if created
+        else Account.NONEXISTENT,
+        factory: Account(storage={0: create_address if created else 0}),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.parametrize(
+    "gas_shortfall",
+    [
+        pytest.param(0, id="exact_gas"),
+        pytest.param(1, id="short_one_gas"),
+    ],
+)
 @pytest.mark.with_all_create_opcodes()
 @pytest.mark.valid_from("Amsterdam")
 def test_max_initcode_size_gas_metering_via_create(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -525,7 +525,7 @@ def test_sstore_oog_no_reservoir_inflation(
     )
 
     sender = pre.fund_eoa()
-    # gas_limit = cap → reservoir = 0
+    # gas_limit = cap, reservoir = 0
     tx = Transaction(
         sender=sender,
         to=caller,
@@ -657,4 +657,58 @@ def test_max_initcode_size_gas_metering_via_create(
         factory: Account(storage={0: create_address if created else 0}),
     }
 
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_create_no_double_charge_new_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify CREATE does not double-charge new-account gas.
+
+    CREATE charges REGULAR_GAS_CREATE as regular gas and new-account
+    state gas separately. Provide exactly enough gas for both — if
+    GAS_NEW_ACCOUNT were charged twice (once in regular, once in
+    state), the CREATE would OOG.
+    """
+    create_state_gas = fork.create_state_gas(code_size=0)
+
+    # Child: just does CREATE(value=0, offset=0, size=0) and stores result.
+    # This creates an empty account (no code deposit).
+    child_code = Op.SSTORE(0, Op.CREATE(value=0, offset=0, size=0))
+    child = pre.deploy_contract(child_code)
+
+    # Compute exact gas: child bytecode + CREATE child frame.
+    # The child frame is empty (size=0) so only the CREATE opcode
+    # charges matter: regular (REGULAR_GAS_CREATE) + state (new account).
+    child_total = child_code.gas_cost(fork)
+
+    create_address = compute_create_address(address=child, nonce=1)
+
+    # Caller forwards exact regular gas via CALL. State gas for
+    # new account comes from the reservoir (gas_limit above the cap).
+    caller_storage = Storage()
+    regular_gas = child_total - create_state_gas
+    caller = pre.deploy_contract(
+        Op.SSTORE(
+            caller_storage.store_next(1, "create_succeeds"),
+            Op.CALL(gas=regular_gas, address=child),
+        )
+    )
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=caller,
+        gas_limit=gas_limit_cap + create_state_gas,
+    )
+
+    post = {
+        caller: Account(storage=caller_storage),
+        child: Account(storage={0: create_address}),
+        create_address: Account(nonce=1),
+    }
     state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -23,7 +23,6 @@ from execution_testing import (
     StateTestFiller,
     Storage,
     Transaction,
-    compute_create_address,
 )
 
 from .spec import ref_spec_8037
@@ -69,23 +68,20 @@ def test_sstore_oog_reservoir_inflation_detection(
     initcode = Initcode(deploy_code=Op.STOP)
     initcode_len = len(initcode)
 
-    factory_code = (
-        Op.CALLDATACOPY(
-            0,
-            0,
-            Op.CALLDATASIZE,
-            data_size=initcode_len,
-            new_memory_size=initcode_len,
-        )
-        + Op.SSTORE(
-            0,
-            Op.CREATE(
-                value=0,
-                offset=0,
-                size=Op.CALLDATASIZE,
-                init_code_size=initcode_len,
-            ),
-        )
+    factory_code = Op.CALLDATACOPY(
+        0,
+        0,
+        Op.CALLDATASIZE,
+        data_size=initcode_len,
+        new_memory_size=initcode_len,
+    ) + Op.SSTORE(
+        0,
+        Op.CREATE(
+            value=0,
+            offset=0,
+            size=Op.CALLDATASIZE,
+            init_code_size=initcode_len,
+        ),
     )
     factory = pre.deploy_contract(factory_code)
 
@@ -99,10 +95,7 @@ def test_sstore_oog_reservoir_inflation_detection(
     # correct reservoir (CREATE state gas only) but fits within the
     # inflated reservoir (CREATE + SSTORE state gas).
     probe = pre.deploy_contract(
-        Op.SSTORE(0, 1)
-        + Op.SSTORE(1, 1)
-        + Op.SSTORE(2, 1)
-        + Op.SSTORE(3, 1)
+        Op.SSTORE(0, 1) + Op.SSTORE(1, 1) + Op.SSTORE(2, 1) + Op.SSTORE(3, 1)
     )
 
     # Compute probe gas: enough for 4 SSTOREs' regular gas + pushes,
@@ -172,8 +165,13 @@ def test_call_oog_reservoir_inflation_detection(
 
     dead_address = 0xDEAD
     child_code = Op.CALL(
-        gas=0, address=dead_address, value=1,
-        args_offset=0, args_size=0, ret_offset=0, ret_size=0,
+        gas=0,
+        address=dead_address,
+        value=1,
+        args_offset=0,
+        args_size=0,
+        ret_offset=0,
+        ret_size=0,
     )
     pushes_gas = 7 * gas_costs.GAS_VERY_LOW
     call_regular_gas = (
@@ -277,22 +275,19 @@ def test_code_deposit_oog_reservoir_inflation_detection(
     initcode = Initcode(deploy_code=Op.STOP)
     initcode_len = len(initcode)
 
-    factory_code = (
-        Op.CALLDATACOPY(
-            0,
-            0,
-            Op.CALLDATASIZE,
-            data_size=initcode_len,
-            new_memory_size=initcode_len,
-        )
-        + Op.POP(
-            Op.CREATE(
-                value=0,
-                offset=0,
-                size=Op.CALLDATASIZE,
-                init_code_size=initcode_len,
-            ),
-        )
+    factory_code = Op.CALLDATACOPY(
+        0,
+        0,
+        Op.CALLDATASIZE,
+        data_size=initcode_len,
+        new_memory_size=initcode_len,
+    ) + Op.POP(
+        Op.CREATE(
+            value=0,
+            offset=0,
+            size=Op.CALLDATASIZE,
+            init_code_size=initcode_len,
+        ),
     )
     factory = pre.deploy_contract(factory_code)
 
@@ -366,9 +361,7 @@ def test_create_oog_reservoir_inflation_detection(
         pushes_gas = 4 * gas_costs.GAS_VERY_LOW
 
     create_regular_gas = gas_costs.GAS_CREATE - new_account_state_gas
-    child_gas = (
-        pushes_gas + create_regular_gas + new_account_state_gas - 1
-    )
+    child_gas = pushes_gas + create_regular_gas + new_account_state_gas - 1
     child = pre.deploy_contract(child_code)
 
     probe = pre.deploy_contract(Op.SSTORE(0, 1))

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_ordering.py
@@ -1,0 +1,394 @@
+"""
+Test state gas consumption ordering under EIP-8037.
+
+When an opcode charges both regular gas and state gas, regular gas MUST
+be charged first. If regular gas OOGs, state gas is not consumed. This
+prevents the parent's reservoir from being inflated on frame failure.
+
+Each test gives a child frame exactly 1 gas less than needed, then uses
+a probe contract to detect whether the parent's reservoir was inflated
+by incorrectly consumed state gas.
+
+Tests for [EIP-8037: State Creation Gas Cost Increase]
+(https://eips.ethereum.org/EIPS/eip-8037).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Fork,
+    Initcode,
+    Op,
+    StateTestFiller,
+    Storage,
+    Transaction,
+    compute_create_address,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+
+def _single_sstore_probe_gas(fork: Fork) -> int:
+    """
+    Return the gas for a single-SSTORE probe that OOGs by 1 when the
+    reservoir is 0 but succeeds when the reservoir holds any state gas.
+
+    The probe bytecode is Op.SSTORE(0, 1): two pushes + SSTORE.
+    """
+    gas_costs = fork.gas_costs()
+    sstore_regular = gas_costs.GAS_COLD_STORAGE_WRITE
+    sstore_state = fork.sstore_state_gas()
+    push_gas = 2 * gas_costs.GAS_VERY_LOW
+    return push_gas + sstore_regular + sstore_state - 1
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_sstore_oog_reservoir_inflation_detection(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Detect SSTORE state gas ordering via reservoir inflation.
+
+    A factory does CREATE + SSTORE where SSTORE OOGs (1 gas short).
+    After factory failure, the parent's reservoir should contain only
+    CREATE's state gas. A probe contract tests this by doing 4 SSTOREs
+    that need more total state gas than the correct reservoir but less
+    than the inflated one.
+
+    With correct ordering (regular gas first): probe OOGs on 4th SSTORE.
+    With wrong ordering (state gas first): reservoir is inflated,
+    probe succeeds.
+    """
+    gas_costs = fork.gas_costs()
+    initcode = Initcode(deploy_code=Op.STOP)
+    initcode_len = len(initcode)
+
+    factory_code = (
+        Op.CALLDATACOPY(
+            0,
+            0,
+            Op.CALLDATASIZE,
+            data_size=initcode_len,
+            new_memory_size=initcode_len,
+        )
+        + Op.SSTORE(
+            0,
+            Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+    )
+    factory = pre.deploy_contract(factory_code)
+
+    factory_gas = (
+        factory_code.gas_cost(fork)
+        + initcode.execution_gas(fork)
+        + initcode.deployment_gas(fork)
+    )
+
+    # Probe: 4 SSTOREs to cold slots. Total state gas exceeds the
+    # correct reservoir (CREATE state gas only) but fits within the
+    # inflated reservoir (CREATE + SSTORE state gas).
+    probe = pre.deploy_contract(
+        Op.SSTORE(0, 1)
+        + Op.SSTORE(1, 1)
+        + Op.SSTORE(2, 1)
+        + Op.SSTORE(3, 1)
+    )
+
+    # Compute probe gas: enough for 4 SSTOREs' regular gas + pushes,
+    # but after 4th regular charge, gas_left < the state gas spill.
+    sstore_regular = gas_costs.GAS_COLD_STORAGE_WRITE
+    sstore_state = fork.sstore_state_gas()
+    push_per_sstore = 2 * gas_costs.GAS_VERY_LOW
+    create_state_gas = fork.create_state_gas(
+        code_size=len(initcode.deploy_code)
+    )
+    spill = 4 * sstore_state - create_state_gas
+    probe_gas = 4 * (push_per_sstore + sstore_regular) + spill // 2
+
+    caller_storage = Storage()
+    caller = pre.deploy_contract(
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.POP(
+            Op.CALL(
+                gas=factory_gas - 1,
+                address=factory,
+                value=0,
+                args_offset=0,
+                args_size=Op.CALLDATASIZE,
+                ret_offset=0,
+                ret_size=0,
+            )
+        )
+        + Op.SSTORE(
+            caller_storage.store_next(0, "probe_must_fail"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        data=bytes(initcode),
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    post = {
+        caller: Account(storage=caller_storage),
+    }
+
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_call_oog_reservoir_inflation_detection(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Detect CALL state gas ordering via reservoir inflation.
+
+    A child does CALL(value=1) to a dead address with gas tuned so
+    the regular gas charge OOGs by 1. If state gas (new account) is
+    incorrectly charged first, the parent's reservoir is inflated.
+
+    A single-SSTORE probe detects the inflation: with correct reservoir
+    (0) it OOGs; with inflated reservoir it succeeds.
+    """
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    dead_address = 0xDEAD
+    child_code = Op.CALL(
+        gas=0, address=dead_address, value=1,
+        args_offset=0, args_size=0, ret_offset=0, ret_size=0,
+    )
+    pushes_gas = 7 * gas_costs.GAS_VERY_LOW
+    call_regular_gas = (
+        gas_costs.GAS_COLD_ACCOUNT_ACCESS + gas_costs.GAS_CALL_VALUE
+    )
+    child_gas = pushes_gas + call_regular_gas + new_account_state_gas - 1
+    child = pre.deploy_contract(child_code)
+
+    probe = pre.deploy_contract(Op.SSTORE(0, 1))
+    probe_gas = _single_sstore_probe_gas(fork)
+
+    caller_storage = Storage()
+    caller = pre.deploy_contract(
+        Op.POP(Op.CALL(gas=child_gas, address=child))
+        + Op.SSTORE(
+            caller_storage.store_next(0, "probe_must_fail"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    post = {caller: Account(storage=caller_storage)}
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_selfdestruct_oog_reservoir_inflation_detection(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Detect SELFDESTRUCT state gas ordering via reservoir inflation.
+
+    A child with non-zero balance does SELFDESTRUCT(dead_beneficiary)
+    with gas tuned so the regular gas charge OOGs by 1. If state gas
+    is incorrectly charged first, the parent's reservoir is inflated.
+
+    Single-SSTORE probe detects the inflation.
+    """
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    dead_beneficiary = 0xBEEF
+    child_code = Op.SELFDESTRUCT(dead_beneficiary)
+    pushes_gas = gas_costs.GAS_VERY_LOW
+    selfdestruct_regular_gas = (
+        gas_costs.GAS_SELF_DESTRUCT + gas_costs.GAS_COLD_ACCOUNT_ACCESS
+    )
+    child_gas = (
+        pushes_gas + selfdestruct_regular_gas + new_account_state_gas - 1
+    )
+    child = pre.deploy_contract(child_code, balance=1)
+
+    probe = pre.deploy_contract(Op.SSTORE(0, 1))
+    probe_gas = _single_sstore_probe_gas(fork)
+
+    caller_storage = Storage()
+    caller = pre.deploy_contract(
+        Op.POP(Op.CALL(gas=child_gas, address=child))
+        + Op.SSTORE(
+            caller_storage.store_next(0, "probe_must_fail"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    post = {caller: Account(storage=caller_storage)}
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_code_deposit_oog_reservoir_inflation_detection(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Detect code deposit state gas ordering via reservoir inflation.
+
+    A factory does CREATE where the child has enough gas for init code
+    execution and the code hash regular gas, but is 1 gas short for
+    code deposit state gas. If code deposit charges state gas before
+    regular gas (wrong ordering), the state gas is consumed and
+    inflates the parent's reservoir.
+
+    Single-SSTORE probe detects the inflation.
+    """
+    initcode = Initcode(deploy_code=Op.STOP)
+    initcode_len = len(initcode)
+
+    factory_code = (
+        Op.CALLDATACOPY(
+            0,
+            0,
+            Op.CALLDATASIZE,
+            data_size=initcode_len,
+            new_memory_size=initcode_len,
+        )
+        + Op.POP(
+            Op.CREATE(
+                value=0,
+                offset=0,
+                size=Op.CALLDATASIZE,
+                init_code_size=initcode_len,
+            ),
+        )
+    )
+    factory = pre.deploy_contract(factory_code)
+
+    factory_gas = (
+        factory_code.gas_cost(fork)
+        + initcode.execution_gas(fork)
+        + initcode.deployment_gas(fork)
+    )
+
+    probe = pre.deploy_contract(Op.SSTORE(0, 1))
+    probe_gas = _single_sstore_probe_gas(fork)
+
+    caller_storage = Storage()
+    caller = pre.deploy_contract(
+        Op.CALLDATACOPY(0, 0, Op.CALLDATASIZE)
+        + Op.POP(
+            Op.CALL(
+                gas=factory_gas - 1,
+                address=factory,
+                value=0,
+                args_offset=0,
+                args_size=Op.CALLDATASIZE,
+                ret_offset=0,
+                ret_size=0,
+            )
+        )
+        + Op.SSTORE(
+            caller_storage.store_next(0, "probe_must_fail"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        data=bytes(initcode),
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    post = {caller: Account(storage=caller_storage)}
+    state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("Amsterdam")
+def test_create_oog_reservoir_inflation_detection(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+) -> None:
+    """
+    Detect CREATE/CREATE2 state gas ordering via reservoir inflation.
+
+    A child does CREATE (or CREATE2) with size=0 and gas tuned so the
+    regular gas charge OOGs by 1. CREATE/CREATE2 already have the
+    correct ordering (regular before state), so this is a regression
+    test ensuring it stays that way.
+
+    Single-SSTORE probe detects potential inflation.
+    """
+    gas_costs = fork.gas_costs()
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    if create_opcode == Op.CREATE:
+        child_code = create_opcode(value=0, offset=0, size=0)
+        pushes_gas = 3 * gas_costs.GAS_VERY_LOW
+    else:
+        child_code = create_opcode(value=0, offset=0, size=0, salt=0)
+        pushes_gas = 4 * gas_costs.GAS_VERY_LOW
+
+    create_regular_gas = gas_costs.GAS_CREATE - new_account_state_gas
+    child_gas = (
+        pushes_gas + create_regular_gas + new_account_state_gas - 1
+    )
+    child = pre.deploy_contract(child_code)
+
+    probe = pre.deploy_contract(Op.SSTORE(0, 1))
+    probe_gas = _single_sstore_probe_gas(fork)
+
+    caller_storage = Storage()
+    caller = pre.deploy_contract(
+        Op.POP(Op.CALL(gas=child_gas, address=child))
+        + Op.SSTORE(
+            caller_storage.store_next(0, "probe_must_fail"),
+            Op.CALL(gas=probe_gas, address=probe),
+        )
+    )
+
+    sender = pre.fund_eoa()
+    tx = Transaction(
+        sender=sender,
+        to=caller,
+        gas_limit=fork.transaction_gas_limit_cap(),
+    )
+
+    post = {caller: Account(storage=caller_storage)}
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -398,7 +398,8 @@ def test_sstore_stipend_check_excludes_reservoir(
         Op.SSTORE(
             caller_storage.store_next(
                 1 if sstore_succeeds else 0,
-                "sstore_succeeds" if sstore_succeeds
+                "sstore_succeeds"
+                if sstore_succeeds
                 else "sstore_fails_stipend",
             ),
             Op.CALL(gas=child_gas, address=child),
@@ -406,6 +407,7 @@ def test_sstore_stipend_check_excludes_reservoir(
     )
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     tx = Transaction(
         sender=pre.fund_eoa(),
         to=caller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_sstore.py
@@ -343,3 +343,74 @@ def test_sstore_state_gas_all_tx_types(
 
     post = {contract: Account(storage=storage)}
     state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "gas_above_stipend",
+    [
+        pytest.param(-1, id="below_stipend"),
+        pytest.param(0, id="at_stipend"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_sstore_stipend_check_excludes_reservoir(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_above_stipend: int,
+) -> None:
+    """
+    Verify SSTORE stipend check uses gas_left only, not the reservoir.
+
+    A child frame has gas_left at or just below the stipend threshold
+    (GAS_CALL_STIPEND + 1) while the reservoir holds ample state gas.
+    The stipend check must fail when gas_left < stipend, regardless
+    of the reservoir balance.
+
+    With below_stipend: SSTORE fails (gas_left < 2301, reservoir ignored).
+    With at_stipend: SSTORE passes the stipend check and proceeds.
+    """
+    gas_costs = fork.gas_costs()
+    stipend = gas_costs.GAS_CALL_STIPEND + 1
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # Child: Op.SSTORE(0, 1) = 2 pushes + SSTORE opcode.
+    child_code = Op.SSTORE(0, 1)
+    child = pre.deploy_contract(child_code)
+
+    # Full regular gas for the child (pushes + SSTORE regular cost).
+    # State gas comes from the reservoir so it doesn't affect gas_left.
+    child_full_regular = child_code.gas_cost(fork) - sstore_state_gas
+
+    # below_stipend: give 1 less than stipend after pushes, fails check.
+    # at_stipend: give full regular gas, passes check and completes.
+    if gas_above_stipend < 0:
+        push_gas = 2 * gas_costs.GAS_VERY_LOW
+        child_gas = push_gas + stipend - 1
+    else:
+        child_gas = child_full_regular
+
+    # Caller forwards limited regular gas via CALL. State gas comes
+    # from the reservoir (gas_limit above the cap).
+    caller_storage = Storage()
+    sstore_succeeds = gas_above_stipend >= 0
+    caller = pre.deploy_contract(
+        Op.SSTORE(
+            caller_storage.store_next(
+                1 if sstore_succeeds else 0,
+                "sstore_succeeds" if sstore_succeeds
+                else "sstore_fails_stipend",
+            ),
+            Op.CALL(gas=child_gas, address=child),
+        )
+    )
+
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    tx = Transaction(
+        sender=pre.fund_eoa(),
+        to=caller,
+        gas_limit=gas_limit_cap + sstore_state_gas,
+    )
+
+    post = {caller: Account(storage=caller_storage)}
+    state_test(pre=pre, tx=tx, post=post)

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -334,9 +334,8 @@ def test_tstore_rollback_on_failed_create(
         gas_limit_cap = fork.transaction_gas_limit_cap() or gas_limit
         code_deposit_state = fork.code_deposit_state_gas(code_size=0x600A)
         new_account_state = fork.gas_costs().GAS_NEW_ACCOUNT
-        gas_limit = gas_limit_cap + 2 * (
-            code_deposit_state + new_account_state
-        )
+        state_gas = 2 * (code_deposit_state + new_account_state)
+        gas_limit = gas_limit_cap + state_gas
 
     sender = pre.fund_eoa()
     tx = Transaction(


### PR DESCRIPTION
## 🗒️ Description

Note: these changes are already added to `devnets/bal/3`, and this PR is to highlight key changes to the EIP.

Fix EIP-8037 state gas charging order and add detection/clarification tests. Includes `forks/amsterdam` rebase changes.

**Spec fix**: When an opcode charges both regular gas and state gas, regular gas must be charged first, EIPs PR: https://github.com/ethereum/EIPs/pull/11421. If regular gas OOGs, state gas is not consumed. The previous ordering (state before regular) allowed state gas spilled into `gas_left` to be lifted into the parent's reservoir via `incorporate_child_on_error`, inflating it and changing the transaction's effective gas consumption.

This was identified by @rakita (reth/revm) who found a failing test fixture on the `tests-bal@v5.3.0` tag. The revm implementation already charges regular gas before state gas across all opcodes.

**Opcodes fixed** (state gas moved after regular gas):
- `SSTORE` -- storage set (zero to non-zero)
- `CALL` -- value transfer to non-existent account
- `SELFDESTRUCT` -- dead beneficiary with non-zero balance

`CREATE`, `CREATE2`, and code deposit already had the correct order.

**CALL memory expansion double-charge fix**: `CALL` with value transfer to a new account was double-charging memory expansion costs — once in regular gas and again in state gas. Fixed to only charge memory costs in regular gas.

**1D to 2D gas accounting fix** (`test_sstore_oog_no_reservoir_inflation` in `test_state_gas_create.py`): The original `test_max_initcode_size_gas_metering_via_create` from `tests-bal@v5.3.0` used 1D gas accounting (all gas through CALL, zero reservoir). This test uses the same pattern with `reservoir=0`, verifying the gas accounting is correct in the fixture for both `exact_gas` and `short_one_gas` cases.

**Detection tests** (`test_state_gas_ordering.py`): Each test gives a child frame 1 gas less than needed, then probes the parent's reservoir with SSTOREs. Clients with wrong ordering produce different storage values (not just different gas accounting), causing fixture assertion failures.

**Edge case tests** for [ethereum/EIPs#11414](https://github.com/ethereum/EIPs/pull/11414) (EIP-8037 text clarifications by @nerolation ):
- SSTORE stipend check uses `gas_left` only, excluding reservoir
- CREATE does not double-charge `GAS_NEW_ACCOUNT`

**Edge case test** from @jwasinger (via @MariusVanDerWijden):
- Calldata floor exceeding `TX_MAX_GAS_LIMIT` rejects the transaction at validation

**Fixture format divergence fix:** The `blocks` fixture in `tests/prague/eip7002_el_triggerable_withdrawals/conftest.py` mutated `WithdrawalRequestContract.tx_gas_limit` in-place (`+=`) to add EIP-8037 state gas costs. Since pytest shares parameter objects across fixture format runs, the gas cost compounded, added once for `blockchain_test`, then again for `blockchain_test_engine` on the already-modified object, producing different transactions and block hashes between formats. Fixed by deep copying the parameters before mutation. Reported by @jangko (nimbus).

## 🔗 Related Issues or PRs

- [ethereum/EIPs#11421](https://github.com/ethereum/EIPs/pull/11421) -- EIP-8037 state gas charging ordering clarifications
- [ethereum/EIPs#11414](https://github.com/ethereum/EIPs/pull/11414) -- EIP-8037 text clarifications (stipend, CREATE formula)

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.bEhlibEXxFZblETuJ7TsvAHaH3%3Fpid%3DApi&f=1&ipt=a13b4f2ff8f521c1f1df6d7a63b9db4592788c0bf8d2517be50c5b856b5bc199&ipo=images)