### PR TITLE
feat(test-benchmark): verify transaction status

### DIFF
--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -36,6 +36,9 @@ from execution_testing.fixtures import (
 from execution_testing.forks import Fork
 from execution_testing.forks.base_fork import BaseFork
 from execution_testing.test_types import Environment, Withdrawal
+from execution_testing.test_types.receipt_types import (
+    TransactionReceipt,
+)
 
 
 class HashMismatchExceptionError(Exception):
@@ -109,6 +112,7 @@ class BaseTest(BaseModel):
     gas_optimization_max_gas_limit: int | None = None
     expected_benchmark_gas_used: int | None = None
     skip_gas_used_validation: bool = False
+    expected_receipt_status: int | None = None
     is_tx_gas_heavy_test: bool = False
     is_exception_test: bool = False
 
@@ -287,6 +291,33 @@ class BaseTest(BaseModel):
             "benchmark gas allowed for this configuration: "
             f"{gas_benchmark_value}"
         )
+
+    def validate_receipt_status(
+        self,
+        *,
+        receipts: List[TransactionReceipt],
+        block_number: int,
+    ) -> None:
+        """
+        Validate receipt status for every transaction in a block.
+
+        When expected_receipt_status is set, verify that all
+        receipts match. Catches silent OOG failures that roll
+        back state and invalidate benchmarks.
+        """
+        if self.expected_receipt_status is None:
+            return
+        for i, receipt in enumerate(receipts):
+            if receipt.status is not None and (
+                int(receipt.status) != self.expected_receipt_status
+            ):
+                raise Exception(
+                    f"Transaction {i} in block "
+                    f"{block_number} has receipt "
+                    f"status {int(receipt.status)}, "
+                    f"expected "
+                    f"{self.expected_receipt_status}."
+                )
 
 
 TestSpec = Callable[[Fork], Generator[BaseTest, None, None]]

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -305,7 +305,7 @@ class BaseTest(BaseModel):
         receipts match. Catches silent OOG failures that roll
         back state and invalidate benchmarks.
         """
-        if self.expected_receipt_status is None:
+        if "expected_receipt_status" not in self.model_fields_set:
             return
         for i, receipt in enumerate(receipts):
             if receipt.status is not None and (

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -174,7 +174,7 @@ class BaseTest(BaseModel):
     ) -> Self:
         """Create a test in a different format from a base test."""
         for k in BaseTest.model_fields.keys():
-            if k not in kwargs:
+            if k not in kwargs and k in base_test.model_fields_set:
                 kwargs[k] = getattr(base_test, k)
         return cls(**kwargs)
 

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -870,6 +870,11 @@ class BlockchainTest(BaseTest):
             if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
+            if built_block.result.receipts:
+                self.validate_receipt_status(
+                    receipts=built_block.result.receipts,
+                    block_number=i,
+                )
             include_receipts = (
                 block.include_receipts_in_output
                 if block.include_receipts_in_output is not None
@@ -962,6 +967,11 @@ class BlockchainTest(BaseTest):
             if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
+            if built_block.result.receipts:
+                self.validate_receipt_status(
+                    receipts=built_block.result.receipts,
+                    block_number=i,
+                )
             fixture_payloads.append(
                 built_block.get_fixture_engine_new_payload()
             )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -856,7 +856,6 @@ class BlockchainTest(BaseTest):
         invalid_blocks = 0
         benchmark_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
-        last_block = self.blocks[-1]
         for block in self.blocks:
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
@@ -868,10 +867,8 @@ class BlockchainTest(BaseTest):
                 previous_alloc=alloc,
             )
             block_number = int(built_block.header.number)
-            if (
-                block is last_block
-                and self.operation_mode == OpMode.BENCHMARKING
-            ):
+            is_last_block = block is self.blocks[-1]
+            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:
@@ -960,7 +957,6 @@ class BlockchainTest(BaseTest):
         invalid_blocks = 0
         benchmark_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
-        last_block = self.blocks[-1]
         for block in self.blocks:
             built_block = self.generate_block_data(
                 t8n=t8n,
@@ -969,10 +965,8 @@ class BlockchainTest(BaseTest):
                 previous_alloc=alloc,
             )
             block_number = int(built_block.header.number)
-            if (
-                block is last_block
-                and self.operation_mode == OpMode.BENCHMARKING
-            ):
+            is_last_block = block is self.blocks[-1]
+            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -856,8 +856,8 @@ class BlockchainTest(BaseTest):
         invalid_blocks = 0
         benchmark_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
-        for i, block in enumerate(self.blocks):
-            is_last_block = i == len(self.blocks) - 1
+        last_block = self.blocks[-1]
+        for block in self.blocks:
             # This is the most common case, the RLP needs to be constructed
             # based on the transactions to be included in the block.
             # Set the environment according to the block to execute.
@@ -867,13 +867,17 @@ class BlockchainTest(BaseTest):
                 previous_env=env,
                 previous_alloc=alloc,
             )
-            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
+            block_number = int(built_block.header.number)
+            if (
+                block is last_block
+                and self.operation_mode == OpMode.BENCHMARKING
+            ):
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:
                 self.validate_receipt_status(
                     receipts=built_block.result.receipts,
-                    block_number=i,
+                    block_number=block_number,
                 )
             include_receipts = (
                 block.include_receipts_in_output
@@ -956,21 +960,25 @@ class BlockchainTest(BaseTest):
         invalid_blocks = 0
         benchmark_gas_used: int | None = None
         benchmark_opcode_count: OpcodeCount | None = None
-        for i, block in enumerate(self.blocks):
-            is_last_block = i == len(self.blocks) - 1
+        last_block = self.blocks[-1]
+        for block in self.blocks:
             built_block = self.generate_block_data(
                 t8n=t8n,
                 block=block,
                 previous_env=env,
                 previous_alloc=alloc,
             )
-            if is_last_block and self.operation_mode == OpMode.BENCHMARKING:
+            block_number = int(built_block.header.number)
+            if (
+                block is last_block
+                and self.operation_mode == OpMode.BENCHMARKING
+            ):
                 benchmark_gas_used = int(built_block.result.gas_used)
                 benchmark_opcode_count = built_block.result.opcode_count
             if built_block.result.receipts:
                 self.validate_receipt_status(
                     receipts=built_block.result.receipts,
-                    block_number=i,
+                    block_number=block_number,
                 )
             fixture_payloads.append(
                 built_block.get_fixture_engine_new_payload()


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

We use `expected_benchmark_gas_used` to verify that benchmarks behave as expected. For more complex scenarios, such as complex gas accounting cases or stub account interactions, we may apply `skip_gas_used_validation` to bypass validation. However, this makes it harder to confirm correct benchmark behavior. That said, for certain scenarios, particularly storage-related benchmarks, we still need to know whether a transaction runs out of gas (OOG). If a transaction hits OOG, we cannot accurately measure storage write performance.

In this PR, we add a new verification approach, such that we ensure each transaction is not OOG.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
