### PR TITLE
chore(ci): [Experiment] split py3 job into 6 pytest-split groups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,8 +56,13 @@ jobs:
           uvx --from actionlint-py actionlint
 
   py3:
+    name: py3 (${{ matrix.group }}/6)
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -66,8 +71,8 @@ jobs:
         with:
           python-version: "3.14"
       - uses: ./.github/actions/setup-env
-      - name: Run py3 tests
-        run: tox -e py3
+      - name: Run py3 tests (group ${{ matrix.group }}/6)
+        run: tox -e py3 -- --splits 6 --group ${{ matrix.group }} --splitting-algorithm least_duration --durations-path .test_durations_py3
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ test = [
     "requests-cache>=1.2.1,<2",
     "libcst>=1.8,<2",
     "ethereum-execution-testing",
+    "pytest-split>=0.11.0",
 ]
 lint = [
     "codespell==2.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,6 @@ commands =
         --clean \
         --until Amsterdam \
         --durations=50 \
-        --ignore=tests/ported_static \
         {posargs} \
         tests
 

--- a/uv.lock
+++ b/uv.lock
@@ -886,6 +886,7 @@ dev = [
     { name = "pyspelling" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "requests-cache" },
@@ -933,6 +934,7 @@ test = [
     { name = "libcst" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "requests-cache" },
@@ -994,6 +996,7 @@ dev = [
     { name = "pyspelling", specifier = ">=2.8.2,<3" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
+    { name = "pytest-split", specifier = ">=0.11.0" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "requests" },
     { name = "requests-cache", specifier = ">=1.2.1,<2" },
@@ -1041,6 +1044,7 @@ test = [
     { name = "libcst", specifier = ">=1.8,<2" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = ">=4.1.0,<5" },
+    { name = "pytest-split", specifier = ">=0.11.0" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "requests" },
     { name = "requests-cache", specifier = ">=1.2.1,<2" },
@@ -2350,6 +2354,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/67/e3f3700e8f95fc9e80ab83d589346c117de4e6d01e6b922f7300282e7fc9/pytest-regex-0.2.0.tar.gz", hash = "sha256:f4076c49abece2503815c8b2e282a8fd22d330f06f9bf91d620b3ef02de7a353", size = 4097, upload-time = "2023-05-29T22:08:11.071Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/72/d4143c66c1806599358c119c0af530bab92ef0c48129f17522dfd5a7ff6a/pytest_regex-0.2.0-py3-none-any.whl", hash = "sha256:c97e9c49e8c7e7482bd1fa701e3a5cccd18eb78d263752e32dba4937d8cee6d9", size = 3824, upload-time = "2023-05-29T22:08:09.551Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗒️ Description

Experimental: split the `py3` CI job into 6 parallel matrix groups using `pytest-split` with `least_duration` balancing. Codecov merges the per-group coverage reports automatically.

It enables `./tests/static_ported/`.

Note: this approach won't work for enginex fixture fills since `pytest-split` doesn't support per-runner grouping (unlike xdist's per-worker grouping).

I don't think the pytest-split approach is it tbh, it should provide very good grouping per worker, see https://jerry-git.github.io/pytest-split/#splitting-algorithms. But I think a simple split by fork would be best as this:
1. Plays well with our new fixture dir layout `for_cancun` (we can now trivially merge the fixture output for releases).
2. Per-fork split works for EngineXFixtures as tests from different groups will never get split across runners; each fork gets at least one new pre-alloc group anyway (you can't group across forks).

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![cute animal](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg)