### PR TITLE
chore(ci): enable ported static in py3 and split into 5 parallel fork-range runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,8 +56,28 @@ jobs:
           uvx --from actionlint-py actionlint
 
   py3:
+    name: py3 (${{ matrix.label }})
     runs-on: [self-hosted-ghr, size-xl-x64]
     needs: static
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: pre-cancun
+            from_fork: Frontier
+            until_fork: Shanghai
+          - label: cancun
+            from_fork: Cancun
+            until_fork: Cancun
+          - label: prague
+            from_fork: Prague
+            until_fork: Prague
+          - label: osaka
+            from_fork: Osaka
+            until_fork: Osaka
+          - label: amsterdam
+            from_fork: Amsterdam
+            until_fork: Amsterdam
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -66,8 +86,8 @@ jobs:
         with:
           python-version: "3.14"
       - uses: ./.github/actions/setup-env
-      - name: Run py3 tests
-        run: tox -e py3
+      - name: Run py3 tests (${{ matrix.label }})
+        run: tox -e py3 -- --from ${{ matrix.from_fork }} --until ${{ matrix.until_fork }}
         env:
           PYTEST_XDIST_AUTO_NUM_WORKERS: auto
       - name: Upload coverage reports to Codecov

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,6 @@ commands =
         --clean \
         --until Amsterdam \
         --durations=50 \
-        --ignore=tests/ported_static \
         {posargs} \
         tests
 


### PR DESCRIPTION
## 🗒️ Description

The `py3` CI job would run ~419 minutes of `fill` test time (if ran sequentially with `./tests/ported_static`) on a single runner. This PR splits it into 5 parallel matrix runners grouped by fork duration, using the existing `--from`/`--until` CLI flags:

| Group | Forks | Est. duration |
|-------|-------|---------------|
| `pre-cancun` | Frontier → Shanghai | ~61m |
| `cancun` | Cancun | ~72m |
| `prague` | Prague | ~104m |
| `osaka` | Osaka | ~86m |
| `amsterdam` | Amsterdam | ~97m |

Durations were derived from `.test_durations_py3` (this was generated with the help of the pytest-switch plugin which I was experimenting with cf #2528, it's not required for this PR). The pre-Cancun forks (Frontier through Shanghai) total ~61m combined — light enough for a single runner. Each post-Shanghai fork needs its own runner due to the volume of tests and transition fork coverage.

Prague is the bottleneck at ~104m despite having fewer tests than Amsterdam (39k vs 44k), because ported static tests marked `valid_until("Prague")` — particularly `test_create_oo_gafter_max_codesize` (~14.3m across 4 variants) — don't run in later forks.

Coverage reports are auto-merged by Codecov via the shared `unittests` flag. Running `tox -e py3` locally without posargs still fills all forks (existing behavior unchanged).

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img width="217" height="236" alt="image" src="https://github.com/user-attachments/assets/824c4f16-8537-4475-b635-5e51359fb203" />
