### PR TITLE
fix(test-benchmarks): gas accounting for `test_account_access` when nonzero value

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_account_query.py
+++ b/tests/benchmark/stateful/bloatnet/test_account_query.py
@@ -164,6 +164,7 @@ def test_account_query(
                 # Gas accounting
                 address_warm=access_warm,
                 new_memory_size=max(mem_size, 96),
+                value_transfer=value_sent > 0,
             )
         )
     elif opcode in (Op.STATICCALL, Op.DELEGATECALL):


### PR DESCRIPTION
## 🗒️ Description
Fixes the gas accounting for account_query, which before this fix made the account_query go OOG if value > 0, defeating the purpose of the stateful test.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
