### PR TITLE
fix(tests): prevent `tx_gas_limit` double-accumulation across fixture format runs in withdrawal request contract tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1148,6 +1148,44 @@ def pytest_html_results_table_row(report: Any, cells: Any) -> None:
 
 
 @pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item: Any) -> Generator[None, None, None]:
+    """
+    Snapshot parametrize values before fixture setup to detect unintended
+    mutations of shared pytest parameter objects across fixture format runs.
+    """
+    if hasattr(item, "callspec"):
+        item._param_repr_snapshot = {
+            key: repr(value) for key, value in item.callspec.params.items()
+        }
+    yield
+
+
+def pytest_runtest_teardown(item: Any) -> None:
+    """
+    Compare parametrize values after test teardown to the pre-setup snapshot.
+
+    Warn if any fixture mutated shared parameter objects — these mutations
+    persist across fixture format runs and can cause subtle bugs (e.g.
+    block hash mismatches between blockchain_test and blockchain_engine_test).
+    """
+    snapshot = getattr(item, "_param_repr_snapshot", None)
+    if snapshot is None:
+        return
+    for key, original_repr in snapshot.items():
+        current_repr = repr(item.callspec.params[key])
+        if current_repr != original_repr:
+            warnings.warn(
+                f"Shared pytest parameter '{key}' was mutated during "
+                f"test '{item.nodeid}'. Mutations on parametrize values "
+                f"persist across fixture format runs and can cause "
+                f"divergent test results. Avoid mutating these objects "
+                f"in fixtures; compute derived values locally instead.",
+                stacklevel=1,
+            )
+    del item._param_repr_snapshot
+
+
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(
     item: Any, call: Any
 ) -> Generator[None, None, None]:

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -3691,17 +3691,21 @@ class Amsterdam(BPO2):
             current_value = original_value
         new_value = metadata["new_value"]
 
-        gas_cost = 0 if metadata["key_warm"] else gas_costs.GAS_COLD_STORAGE_ACCESS
+        gas_cost = (
+            0 if metadata["key_warm"] else gas_costs.GAS_COLD_STORAGE_ACCESS
+        )
 
         if original_value == current_value and current_value != new_value:
             if original_value == 0:
                 # EIP-8037: regular portion + state gas
                 gas_cost += (
-                    gas_costs.GAS_COLD_STORAGE_WRITE - gas_costs.GAS_COLD_STORAGE_ACCESS
+                    gas_costs.GAS_COLD_STORAGE_WRITE
+                    - gas_costs.GAS_COLD_STORAGE_ACCESS
                 ) + (32 * cpsb)
             else:
                 gas_cost += (
-                    gas_costs.GAS_COLD_STORAGE_WRITE - gas_costs.GAS_COLD_STORAGE_ACCESS
+                    gas_costs.GAS_COLD_STORAGE_WRITE
+                    - gas_costs.GAS_COLD_STORAGE_ACCESS
                 )
         else:
             gas_cost += gas_costs.GAS_WARM_SLOAD

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -526,9 +526,10 @@ def test_max_initcode_size_gas_metering_via_create(
         + initcode.execution_gas(fork)
         + initcode.deployment_gas(fork)
     )
-    factory_state_gas = fork.create_state_gas(
-        code_size=len(initcode.deploy_code)
-    ) + fork.sstore_state_gas()
+    factory_state_gas = (
+        fork.create_state_gas(code_size=len(initcode.deploy_code))
+        + fork.sstore_state_gas()
+    )
     factory_regular_gas = factory_gas - factory_state_gas
 
     caller = pre.deploy_contract(

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -546,6 +546,7 @@ def test_max_initcode_size_gas_metering_via_create(
     )
 
     gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     tx = Transaction(
         sender=alice,
         to=caller,

--- a/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py
@@ -334,7 +334,9 @@ def test_tstore_rollback_on_failed_create(
         gas_limit_cap = fork.transaction_gas_limit_cap() or gas_limit
         code_deposit_state = fork.code_deposit_state_gas(code_size=0x600A)
         new_account_state = fork.gas_costs().GAS_NEW_ACCOUNT
-        gas_limit = gas_limit_cap + 2 * (code_deposit_state + new_account_state)
+        gas_limit = gas_limit_cap + 2 * (
+            code_deposit_state + new_account_state
+        )
 
     sender = pre.fund_eoa()
     tx = Transaction(

--- a/tests/istanbul/eip152_blake2/common.py
+++ b/tests/istanbul/eip152_blake2/common.py
@@ -1,7 +1,5 @@
 """Common classes used in the BLAKE2b precompile tests."""
 
-from dataclasses import dataclass
-
 from execution_testing import Bytes, TestParameterGroup
 
 from .spec import Spec, SpecTestVectors
@@ -63,7 +61,6 @@ class Blake2bInput(TestParameterGroup):
         return _rounds + self.h + self.m + _t_0 + _t_1 + _f
 
 
-@dataclass(kw_only=True, frozen=True, repr=False)
 class ExpectedOutput(TestParameterGroup):
     """
     Expected test result.

--- a/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
@@ -98,7 +98,12 @@ def blocks(
                 if isinstance(r, WithdrawalRequestContract):
                     # Each withdrawal request writes 3 new storage slots
                     # in the system contract queue (source, pubkey, amount).
-                    r.tx_gas_limit += (
+                    # Store the base gas limit to avoid accumulating the
+                    # extra cost on repeated fixture format runs that share
+                    # the same pytest parameter object.
+                    if not hasattr(r, "_base_tx_gas_limit"):
+                        r._base_tx_gas_limit = r.tx_gas_limit  # type: ignore[attr-defined]
+                    r.tx_gas_limit = r._base_tx_gas_limit + (  # type: ignore[attr-defined]
                         len(r.requests) * 3 * gas_costs.GAS_STORAGE_SET
                     )
 

--- a/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
@@ -5,11 +5,9 @@ from typing import List
 
 import pytest
 from execution_testing import Alloc, Block, Fork, Header, Requests
-from execution_testing.forks import Amsterdam
 
 from .helpers import (
     WithdrawalRequest,
-    WithdrawalRequestContract,
     WithdrawalRequestInteractionBase,
 )
 from .spec import Spec
@@ -91,22 +89,6 @@ def blocks(
     timestamp: int,
 ) -> List[Block]:
     """Return the list of blocks that should be included in the test."""
-    if fork >= Amsterdam:
-        gas_costs = fork.gas_costs()
-        for block_requests in blocks_withdrawal_requests:
-            for r in block_requests:
-                if isinstance(r, WithdrawalRequestContract):
-                    # Each withdrawal request writes 3 new storage slots
-                    # in the system contract queue (source, pubkey, amount).
-                    # Store the base gas limit to avoid accumulating the
-                    # extra cost on repeated fixture format runs that share
-                    # the same pytest parameter object.
-                    if not hasattr(r, "_base_tx_gas_limit"):
-                        r._base_tx_gas_limit = r.tx_gas_limit  # type: ignore[attr-defined]
-                    r.tx_gas_limit = r._base_tx_gas_limit + (  # type: ignore[attr-defined]
-                        len(r.requests) * 3 * gas_costs.GAS_STORAGE_SET
-                    )
-
     blocks: List[Block] = []
 
     for block_requests, block_included_requests in zip_longest(  # type: ignore
@@ -128,7 +110,7 @@ def blocks(
             assert not block_included_requests
         blocks.append(
             Block(
-                txs=sum((r.transactions() for r in block_requests), []),
+                txs=sum((r.transactions(fork) for r in block_requests), []),
                 header_verify=header_verify,
                 timestamp=timestamp,
             )

--- a/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/helpers.py
@@ -10,12 +10,14 @@ from execution_testing import (
     Address,
     Alloc,
     Bytecode,
+    Fork,
     Op,
     Transaction,
 )
 from execution_testing import (
     WithdrawalRequest as WithdrawalRequestBase,
 )
+from execution_testing.forks import Amsterdam
 
 from .spec import Spec
 
@@ -80,7 +82,7 @@ class WithdrawalRequestInteractionBase:
     requests: List[WithdrawalRequest]
     """Withdrawal request to be included in the block."""
 
-    def transactions(self) -> List[Transaction]:
+    def transactions(self, fork: Fork | None = None) -> List[Transaction]:
         """Return a transaction for the withdrawal request."""
         raise NotImplementedError
 
@@ -105,8 +107,9 @@ class WithdrawalRequestTransaction(WithdrawalRequestInteractionBase):
     owned account.
     """
 
-    def transactions(self) -> List[Transaction]:
+    def transactions(self, fork: Fork | None = None) -> List[Transaction]:
         """Return a transaction for the withdrawal request."""
+        del fork
         assert self.sender_account is not None, (
             "Sender account not initialized"
         )
@@ -190,12 +193,18 @@ class WithdrawalRequestContract(WithdrawalRequestInteractionBase):
             current_offset += len(r.calldata)
         return code + self.extra_code
 
-    def transactions(self) -> List[Transaction]:
+    def transactions(self, fork: Fork | None = None) -> List[Transaction]:
         """Return a transaction for the withdrawal request."""
         assert self.entry_address is not None, "Entry address not initialized"
+        gas_limit = self.tx_gas_limit
+        if fork is not None and fork >= Amsterdam:
+            # Each withdrawal request writes 3 new storage slots
+            # in the system contract queue (source, pubkey, amount).
+            gas_costs = fork.gas_costs()
+            gas_limit += len(self.requests) * 3 * gas_costs.GAS_STORAGE_SET
         return [
             Transaction(
-                gas_limit=self.tx_gas_limit,
+                gas_limit=gas_limit,
                 gas_price=1_000_000_000,
                 to=self.entry_address,
                 value=0,


### PR DESCRIPTION
jangko from nimbus notified us that in our bal 5.5.1 fixtures there is a block hash mismatch between `blockchain_test ` and `blockchain_test_engine` for `test_withdrawal_requests`.


## Cause of `block_hash` mismatches

Since pytest runs the blocks fixture separately for each fixture format (once for `blockchain_test`, once for `blockchain_test_engine`), and the `WithdrawalRequestContract` objects are shared across those runs (they're pytest parameter objects), the gas limit was accumulated twice — adding `121404` each time. This made the transaction RLP differ between formats, which changed the `transactions_trie`, which changed the `block_hash`.

Why only contract tests were affected: Only `WithdrawalRequestContract` had this gas adjustment. EOA-based tests (`WithdrawalRequestTransaction`) didn't get the adjustment, so their hashes were consistent.


## Fix
Save the original gas limit before the first adjustment and always compute from that base value.


## How to reproduce 

Before applying this PR's fix run:
`uv run fill --clean -k "test_withdrawal_requests" tests/prague/eip7002_el_triggerable_withdrawals/test_withdrawal_requests.py --fork=Amsterdam -s`

and then verify issue via:
	
```
import json

bt = json.load(
    open(
        "fixtures/blockchain_tests/for_amsterdam/prague/eip7002_el_triggerable_withdrawals/withdrawal_requests/withdrawal_requests.json"
    )
)

be = json.load(
    open(
        "fixtures/blockchain_tests_engine/for_amsterdam/prague/eip7002_el_triggerable_withdrawals/withdrawal_requests/withdrawal_requests.json"
    )
)


def n(k):
    return k.replace("blockchain_test_engine", "X").replace(
        "blockchain_test", "X"
    )


bm = {n(k): k for k in bt}
em = {n(k): k for k in be}

d = [
    (
        nk,
        bt[bm[nk]]["blocks"][-1]["blockHeader"]["hash"],
        be[em[nk]]["lastblockhash"],
    )
    for nk in sorted(bm.keys() & em.keys())
    if bt[bm[nk]]["blocks"][-1]["blockHeader"]["hash"]
    != be[em[nk]]["lastblockhash"]
]

print(
    f"{len(d)}/{len(bm.keys() & em.keys())} tests have mismatched block hashes"
)

for nk, bh, eh in d:
    print(f"  {nk.split('X-')[-1][:70]}")

```

then apply the fix from this PR and re-run the script above. You will see that pre-fix shows `14/26` tests have mismatched block hashes, after-fix `0/26` mismatches.


#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1349696533922320478/1482020876227711177/IMG_0179.png?ex=69bcaf3f&is=69bb5dbf&hm=4e97d4007de61b63f69c409c1a5dfe927d4ed389eb66d15686b3fbc6b8ca506f&"
  alt="Cute Animal Picture"
  width="320">
