### PR TITLE
feat(zkevm): add invalid execution witness test support

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -1078,7 +1078,8 @@ def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
     assert stateless_output.successful_validation is False
     assert len(stateless_input.witness.headers) == 1
     assert [
-        "0x" + bytes(header).hex() for header in stateless_input.witness.headers
+        "0x" + bytes(header).hex()
+        for header in stateless_input.witness.headers
     ] == block["executionWitness"]["headers"]
 
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -769,6 +769,152 @@ test_module_execution_witness = textwrap.dedent(
     """
 )
 
+test_module_execution_witness_soundness = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Account,
+        Alloc,
+        Block,
+        BlockchainTestFiller,
+        ExecutionWitnessHeadersExpectation,
+        Op,
+        Transaction,
+    )
+    from execution_testing.test_types.execution_witness.modifiers import (
+        remove_header_at,
+    )
+
+    @pytest.mark.valid_at("Amsterdam")
+    def test_execution_witness_soundness(
+        pre: Alloc,
+        blockchain_test: BlockchainTestFiller,
+    ) -> None:
+        offset = 2
+        contract = pre.deploy_contract(
+            code=Op.BLOCKHASH(Op.SUB(Op.NUMBER, offset)) + Op.POP + Op.STOP
+        )
+        sender = pre.fund_eoa()
+        tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+        blocks = [Block(txs=[]) for _ in range(offset)]
+        blocks.append(
+            Block(
+                txs=[tx],
+                expected_execution_witness_headers=(
+                    ExecutionWitnessHeadersExpectation(
+                        expected_count=offset,
+                    ).modify(remove_header_at(-1))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        )
+
+        blockchain_test(
+            pre=pre,
+            blocks=blocks,
+            post={sender: Account(nonce=1)},
+        )
+    """
+)
+
+test_module_execution_witness_expected_true = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Account,
+        Alloc,
+        Block,
+        BlockchainTestFiller,
+        ExecutionWitnessHeadersExpectation,
+        Op,
+        Transaction,
+    )
+
+    @pytest.mark.valid_at("Amsterdam")
+    def test_execution_witness_expected_true(
+        pre: Alloc,
+        blockchain_test: BlockchainTestFiller,
+    ) -> None:
+        offset = 2
+        contract = pre.deploy_contract(
+            code=Op.BLOCKHASH(Op.SUB(Op.NUMBER, offset)) + Op.POP + Op.STOP
+        )
+        sender = pre.fund_eoa()
+        tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+        blocks = [Block(txs=[]) for _ in range(offset)]
+        blocks.append(
+            Block(
+                txs=[tx],
+                expected_execution_witness_headers=(
+                    ExecutionWitnessHeadersExpectation(
+                        expected_count=offset,
+                    )
+                ),
+                expected_stateless_validation_success=True,
+            )
+        )
+
+        blockchain_test(
+            pre=pre,
+            blocks=blocks,
+            post={sender: Account(nonce=1)},
+        )
+    """
+)
+
+test_module_execution_witness_missing_expected = textwrap.dedent(
+    """\
+    import pytest
+
+    from execution_testing import (
+        Account,
+        Alloc,
+        Block,
+        BlockchainTestFiller,
+        ExecutionWitnessHeadersExpectation,
+        Op,
+        Transaction,
+    )
+    from execution_testing.test_types.execution_witness.modifiers import (
+        remove_header_at,
+    )
+
+    @pytest.mark.valid_at("Amsterdam")
+    def test_execution_witness_missing_expected(
+        pre: Alloc,
+        blockchain_test: BlockchainTestFiller,
+    ) -> None:
+        offset = 2
+        contract = pre.deploy_contract(
+            code=Op.BLOCKHASH(Op.SUB(Op.NUMBER, offset)) + Op.POP + Op.STOP
+        )
+        sender = pre.fund_eoa()
+        tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+        blocks = [Block(txs=[]) for _ in range(offset)]
+        blocks.append(
+            Block(
+                txs=[tx],
+                expected_execution_witness_headers=(
+                    ExecutionWitnessHeadersExpectation(
+                        expected_count=offset,
+                    ).modify(remove_header_at(-1))
+                ),
+            )
+        )
+
+        blockchain_test(
+            pre=pre,
+            blocks=blocks,
+            post={sender: Account(nonce=1)},
+        )
+    """
+)
+
 
 def test_execution_witness_in_blockchain_fixture(
     testdir: pytest.Testdir,
@@ -826,6 +972,139 @@ def test_execution_witness_in_blockchain_fixture(
     assert "statelessOutputBytes" in block
     sob = block["statelessOutputBytes"]
     assert isinstance(sob, str) and sob.startswith("0x") and len(sob) > 2
+
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+    )
+    from ethereum_types.bytes import Bytes as EthereumBytes
+
+    stateless_output = deserialize_stateless_output(
+        EthereumBytes(bytes.fromhex(sob[2:]))
+    )
+    assert stateless_output.successful_validation is True
+
+
+def test_execution_witness_expected_true_reuses_canonical_stateless_result(
+    testdir: pytest.Testdir,
+) -> None:
+    """Explicit True expectation should preserve the canonical success path."""
+    tests_dir = testdir.mkdir("tests")
+    amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
+    test_module = amsterdam_tests_dir.join(
+        "test_module_execution_witness_expected_true.py"
+    )
+    test_module.write(test_module_execution_witness_expected_true)
+
+    testdir.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = ["-c", "pytest-fill.ini", "-v", "--until=Amsterdam", "--no-html"]
+    result = testdir.runpytest(*args)
+    assert result.ret == 0
+
+    fixture_path = Path(
+        "fixtures/blockchain_tests/for_amsterdam/amsterdam/"
+        "module_execution_witness_expected_true/"
+        "execution_witness_expected_true.json"
+    )
+    assert fixture_path.exists(), f"{fixture_path} does not exist"
+
+    with open(fixture_path, "r") as f:
+        fixture_data = json.load(f)
+
+    fixture = next(iter(fixture_data.values()))
+    block = fixture["blocks"][-1]
+
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+    )
+    from ethereum_types.bytes import Bytes as EthereumBytes
+
+    stateless_output = deserialize_stateless_output(
+        EthereumBytes(bytes.fromhex(block["statelessOutputBytes"][2:]))
+    )
+
+    assert stateless_output.successful_validation is True
+
+
+def test_execution_witness_soundness_rewrites_stateless_fixture_bytes(
+    testdir: pytest.Testdir,
+) -> None:
+    """Mutated witness fixtures should carry mutated stateless bytes."""
+    tests_dir = testdir.mkdir("tests")
+    amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
+    test_module = amsterdam_tests_dir.join(
+        "test_module_execution_witness_soundness.py"
+    )
+    test_module.write(test_module_execution_witness_soundness)
+
+    testdir.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = ["-c", "pytest-fill.ini", "-v", "--until=Amsterdam", "--no-html"]
+    result = testdir.runpytest(*args)
+    assert result.ret == 0
+
+    fixture_path = Path(
+        "fixtures/blockchain_tests/for_amsterdam/amsterdam/"
+        "module_execution_witness_soundness/"
+        "execution_witness_soundness.json"
+    )
+    assert fixture_path.exists(), f"{fixture_path} does not exist"
+
+    with open(fixture_path, "r") as f:
+        fixture_data = json.load(f)
+
+    fixture = next(iter(fixture_data.values()))
+    block = fixture["blocks"][-1]
+
+    assert len(block["executionWitness"]["headers"]) == 1
+
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+    )
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+    )
+    from ethereum_types.bytes import Bytes as EthereumBytes
+
+    stateless_input = deserialize_stateless_input(
+        EthereumBytes(bytes.fromhex(block["statelessInputBytes"][2:]))
+    )
+    stateless_output = deserialize_stateless_output(
+        EthereumBytes(bytes.fromhex(block["statelessOutputBytes"][2:]))
+    )
+
+    assert stateless_output.successful_validation is False
+    assert len(stateless_input.witness.headers) == 1
+    assert [
+        "0x" + bytes(header).hex() for header in stateless_input.witness.headers
+    ] == block["executionWitness"]["headers"]
+
+
+def test_execution_witness_modifier_requires_explicit_guest_expectation(
+    testdir: pytest.Testdir,
+) -> None:
+    """Mutated witness tests should declare the expected guest result."""
+    tests_dir = testdir.mkdir("tests")
+    amsterdam_tests_dir = tests_dir.mkdir("amsterdam")
+    test_module = amsterdam_tests_dir.join(
+        "test_module_execution_witness_missing_expected.py"
+    )
+    test_module.write(test_module_execution_witness_missing_expected)
+
+    testdir.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+    args = ["-c", "pytest-fill.ini", "-v", "--until=Amsterdam", "--no-html"]
+    result = testdir.runpytest(*args)
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(
+        [
+            "*Mutated execution witness tests must set "
+            "expected_stateless_validation_success explicitly*"
+        ]
+    )
 
 
 test_module_environment_variables = textwrap.dedent(

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -213,6 +213,102 @@ def with_execution_witness_implicit_codes(
     return expectation.model_copy(update={"codes_present": codes_present})
 
 
+def rerun_amsterdam_stateless_guest_with_witness(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    original_stateless_input_bytes: Bytes,
+    execution_witness: ExecutionWitness,
+) -> tuple[Bytes, Bytes, bool]:
+    """
+    Rebuild the stateless input with the emitted witness and rerun the guest.
+
+    Amsterdam is currently the only fork with stateless guest support in this
+    repository, so the rerun path is kept Amsterdam-specific.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam":
+        raise Exception(
+            "Execution witness guest rerun is only supported for Amsterdam"
+        )
+
+    from ethereum.forks.amsterdam.stateless import (
+        ExecutionWitness as AmsterdamExecutionWitness,
+        StatelessInput as AmsterdamStatelessInput,
+    )
+    from ethereum.forks.amsterdam.stateless_guest import (
+        deserialize_stateless_input,
+        run_stateless_guest,
+    )
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+        serialize_stateless_input,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    original_input = deserialize_stateless_input(
+        AmsterdamBytes(bytes(original_stateless_input_bytes))
+    )
+    rebuilt_witness = AmsterdamExecutionWitness(
+        state=tuple(
+            AmsterdamBytes(bytes(node)) for node in execution_witness.state
+        ),
+        codes=tuple(
+            AmsterdamBytes(bytes(code)) for code in execution_witness.codes
+        ),
+        headers=tuple(
+            AmsterdamBytes(bytes(header))
+            for header in execution_witness.headers
+        ),
+    )
+    rebuilt_input = AmsterdamStatelessInput(
+        new_payload_request=original_input.new_payload_request,
+        witness=rebuilt_witness,
+        chain_config=original_input.chain_config,
+        public_keys=original_input.public_keys,
+    )
+    rebuilt_input_bytes = serialize_stateless_input(rebuilt_input)
+    rebuilt_output_bytes = run_stateless_guest(rebuilt_input_bytes)
+    rebuilt_output = deserialize_stateless_output(rebuilt_output_bytes)
+
+    return (
+        Bytes(bytes(rebuilt_input_bytes)),
+        Bytes(bytes(rebuilt_output_bytes)),
+        rebuilt_output.successful_validation,
+    )
+
+
+def deserialize_amsterdam_stateless_output_success(
+    *,
+    fork: Fork,
+    block_number: int,
+    timestamp: int,
+    stateless_output_bytes: Bytes,
+) -> bool:
+    """
+    Decode the canonical t8n stateless output and return success status.
+
+    Amsterdam is currently the only fork with stateless guest support in this
+    repository, so the decode path is kept Amsterdam-specific.
+    """
+    active_fork = fork.fork_at(block_number=block_number, timestamp=timestamp)
+    if active_fork.name() != "Amsterdam":
+        raise Exception(
+            "Stateless output decoding is only supported for Amsterdam"
+        )
+
+    from ethereum.forks.amsterdam.stateless_host import (
+        deserialize_stateless_output,
+    )
+    from ethereum_types.bytes import Bytes as AmsterdamBytes
+
+    stateless_output = deserialize_stateless_output(
+        AmsterdamBytes(bytes(stateless_output_bytes))
+    )
+    return stateless_output.successful_validation
+
+
 class Header(CamelModel):
     """Header type used to describe block header properties in test specs."""
 
@@ -360,6 +456,11 @@ class Block(Header):
     """
     If set, the execution witness headers will be verified and potentially
     modified for invalid tests.
+    """
+    expected_stateless_validation_success: bool | None = None
+    """
+    If set, assert the stateless guest result matches this expectation. This
+    must be set explicitly for tests that mutate the emitted execution witness.
     """
     exception: BLOCK_EXCEPTION_TYPE = None
     # If set, the block is expected to be rejected by the client.
@@ -912,6 +1013,85 @@ class BlockchainTest(BaseTest):
                 execution_witness
             )
 
+        has_witness_modifier = (
+            (
+                block.expected_execution_witness_state is not None
+                and block.expected_execution_witness_state._modifier is not None
+            )
+            or (
+                block.expected_execution_witness_codes is not None
+                and block.expected_execution_witness_codes._modifier
+                is not None
+            )
+            or (
+                block.expected_execution_witness_headers is not None
+                and block.expected_execution_witness_headers._modifier
+                is not None
+            )
+        )
+        stateless_input_bytes = transition_tool_output.result.stateless_input_bytes
+        stateless_output_bytes = (
+            transition_tool_output.result.stateless_output_bytes
+        )
+        expected_success = block.expected_stateless_validation_success
+        if has_witness_modifier and expected_success is None:
+            raise AssertionError(
+                "Mutated execution witness tests must set "
+                "expected_stateless_validation_success explicitly"
+            )
+        canonical_successful_validation: bool | None = None
+        if has_witness_modifier or expected_success is not None:
+            if stateless_output_bytes is None:
+                raise Exception(
+                    "Stateless guest verification requires stateless output "
+                    "bytes"
+                )
+            canonical_successful_validation = (
+                deserialize_amsterdam_stateless_output_success(
+                    fork=self.fork,
+                    block_number=int(env.number),
+                    timestamp=int(env.timestamp),
+                    stateless_output_bytes=stateless_output_bytes,
+                )
+            )
+
+        should_rerun_stateless_guest = has_witness_modifier
+        if should_rerun_stateless_guest:
+            if execution_witness is None or stateless_input_bytes is None:
+                raise Exception(
+                    "Stateless guest rerun requires execution witness and "
+                    "stateless input bytes"
+                )
+            (
+                stateless_input_bytes,
+                stateless_output_bytes,
+                successful_validation,
+            ) = rerun_amsterdam_stateless_guest_with_witness(
+                fork=self.fork,
+                block_number=int(env.number),
+                timestamp=int(env.timestamp),
+                original_stateless_input_bytes=stateless_input_bytes,
+                execution_witness=execution_witness,
+            )
+            if (
+                expected_success is not None
+                and successful_validation != expected_success
+            ):
+                raise AssertionError(
+                    "Stateless guest validation result mismatch: "
+                    f"got {successful_validation}, "
+                    f"want {expected_success}"
+                )
+        elif (
+            expected_success is not None
+            and canonical_successful_validation != expected_success
+        ):
+            raise AssertionError(
+                "Canonical stateless guest validation result mismatch: "
+                f"got {canonical_successful_validation}, "
+                f"want {expected_success}"
+            )
+
         built_block = BuiltBlock(
             header=header,
             alloc=transition_tool_output.alloc,
@@ -927,12 +1107,8 @@ class BlockchainTest(BaseTest):
             fork=self.fork,
             block_access_list=bal,
             execution_witness=execution_witness,
-            stateless_input_bytes=(
-                transition_tool_output.result.stateless_input_bytes
-            ),
-            stateless_output_bytes=(
-                transition_tool_output.result.stateless_output_bytes
-            ),
+            stateless_input_bytes=stateless_input_bytes,
+            stateless_output_bytes=stateless_output_bytes,
         )
 
         try:
@@ -948,25 +1124,17 @@ class BlockchainTest(BaseTest):
                     block.expected_block_access_list is not None
                     and block.expected_block_access_list._modifier is not None
                 )
-                and not (
-                    block.expected_execution_witness_state is not None
-                    and block.expected_execution_witness_state._modifier
-                    is not None
-                )
-                and not (
-                    block.expected_execution_witness_codes is not None
-                    and block.expected_execution_witness_codes._modifier
-                    is not None
-                )
+                and not has_witness_modifier
             ):
                 # Only verify block level exception if: - No transaction
                 # exception was raised, because these are not reported as block
                 # exceptions. - No RLP modifier was specified, because the
                 # modifier is what normally produces the block exception. - No
                 # requests were specified, because modified requests are also
-                # what normally produces the block exception. - No BAL or
-                # witness modifier was specified, because modified BAL/witness
-                # also produces block exceptions.
+                # what normally produces the block exception. - No BAL
+                # modifier was specified, because modified BAL produces block
+                # exceptions. - No witness modifier was specified, because
+                # witness soundness is verified separately via the guest rerun.
                 built_block.verify_block_exception(
                     transition_tool_exceptions_reliable=t8n.exception_mapper.reliable,
                 )

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -235,6 +235,8 @@ def rerun_amsterdam_stateless_guest_with_witness(
 
     from ethereum.forks.amsterdam.stateless import (
         ExecutionWitness as AmsterdamExecutionWitness,
+    )
+    from ethereum.forks.amsterdam.stateless import (
         StatelessInput as AmsterdamStatelessInput,
     )
     from ethereum.forks.amsterdam.stateless_guest import (
@@ -1016,7 +1018,10 @@ class BlockchainTest(BaseTest):
         has_witness_modifier = (
             (
                 block.expected_execution_witness_state is not None
-                and block.expected_execution_witness_state._modifier is not None
+                and (
+                    block.expected_execution_witness_state._modifier
+                    is not None
+                )
             )
             or (
                 block.expected_execution_witness_codes is not None
@@ -1029,7 +1034,9 @@ class BlockchainTest(BaseTest):
                 is not None
             )
         )
-        stateless_input_bytes = transition_tool_output.result.stateless_input_bytes
+        stateless_input_bytes = (
+            transition_tool_output.result.stateless_input_bytes
+        )
         stateless_output_bytes = (
             transition_tool_output.result.stateless_output_bytes
         )

--- a/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
@@ -80,9 +80,64 @@ def remove_code(
     return transform
 
 
+def clear_headers() -> Callable[[ExecutionWitness], ExecutionWitness]:
+    """Remove all header entries from the witness."""
+
+    def transform(
+        witness: ExecutionWitness,
+    ) -> ExecutionWitness:
+        return witness.model_copy(update={"headers": []})
+
+    return transform
+
+
+def remove_header_at(
+    index: int,
+) -> Callable[[ExecutionWitness], ExecutionWitness]:
+    """Remove the header entry at `index` from the witness."""
+
+    def transform(
+        witness: ExecutionWitness,
+    ) -> ExecutionWitness:
+        new_headers = list(witness.headers)
+        try:
+            new_headers.pop(index)
+        except IndexError as exc:
+            raise IndexError(
+                f"Header index {index} out of range for witness headers"
+            ) from exc
+        return witness.model_copy(update={"headers": new_headers})
+
+    return transform
+
+
+def replace_header_at(
+    index: int,
+    header: Bytes,
+) -> Callable[[ExecutionWitness], ExecutionWitness]:
+    """Replace the header entry at `index` with `header`."""
+
+    def transform(
+        witness: ExecutionWitness,
+    ) -> ExecutionWitness:
+        new_headers = list(witness.headers)
+        try:
+            new_headers[index] = header
+        except IndexError as exc:
+            raise IndexError(
+                f"Header index {index} out of range for witness headers"
+            ) from exc
+        return witness.model_copy(update={"headers": new_headers})
+
+    return transform
+
+
 __all__ = [
     "add_state_node",
     "add_code",
+    "clear_headers",
     "remove_state_node",
     "remove_code",
+    "remove_header_at",
+    "replace_header_at",
 ]

--- a/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
@@ -11,8 +11,8 @@ from execution_testing.test_types.execution_witness import (
 from execution_testing.test_types.execution_witness.modifiers import (
     add_state_node,
     clear_headers,
-    remove_state_node,
     remove_header_at,
+    remove_state_node,
     replace_header_at,
 )
 

--- a/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
@@ -10,7 +10,10 @@ from execution_testing.test_types.execution_witness import (
 )
 from execution_testing.test_types.execution_witness.modifiers import (
     add_state_node,
+    clear_headers,
     remove_state_node,
+    remove_header_at,
+    replace_header_at,
 )
 
 
@@ -76,3 +79,21 @@ def test_execution_witness_state_modifiers_add_and_remove() -> None:
 
     restored = remove_state_node(Bytes(b"bb"))(modified)
     assert restored.state == [Bytes(b"aa")]
+
+
+def test_execution_witness_header_modifiers() -> None:
+    """Header modifiers should update witness headers predictably."""
+    witness = ExecutionWitness(
+        state=[],
+        codes=[],
+        headers=[Bytes(b"aa"), Bytes(b"bb")],
+    )
+
+    removed = remove_header_at(-1)(witness)
+    assert removed.headers == [Bytes(b"aa")]
+
+    replaced = replace_header_at(0, Bytes(b"cc"))(witness)
+    assert replaced.headers == [Bytes(b"cc"), Bytes(b"bb")]
+
+    cleared = clear_headers()(witness)
+    assert cleared.headers == []

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_soundness.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_soundness.py
@@ -1,0 +1,139 @@
+"""Execution witness soundness tests."""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytes,
+    ExecutionWitnessCodesExpectation,
+    ExecutionWitnessHeadersExpectation,
+    ExecutionWitnessStateExpectation,
+    Op,
+    Transaction,
+)
+from execution_testing.test_types.execution_witness.modifiers import (
+    remove_code,
+    remove_header_at,
+    remove_state_node,
+)
+
+from .state_helpers import (
+    as_storage,
+    build_large_storage,
+    collect_storage_proof_nodes,
+)
+
+pytestmark = pytest.mark.valid_from("Amsterdam")
+
+REFERENCE_SPEC_GIT_PATH = "N/A"
+REFERENCE_SPEC_VERSION = "N/A"
+
+
+def test_witness_soundness_missing_required_header(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the parent header from the witness should fail the guest."""
+    offset = 2
+    code = Op.BLOCKHASH(Op.SUB(Op.NUMBER, offset)) + Op.POP + Op.STOP
+    contract = pre.deploy_contract(code=code)
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blocks = [Block(txs=[]) for _ in range(offset)]
+    blocks.append(
+        Block(
+            txs=[tx],
+            expected_execution_witness_headers=(
+                ExecutionWitnessHeadersExpectation(
+                    expected_count=offset,
+                ).modify(remove_header_at(-1))
+            ),
+            expected_stateless_validation_success=False,
+        )
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=blocks,
+        post={sender: Account(nonce=1)},
+    )
+
+
+def test_witness_soundness_missing_caller_code(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the caller bytecode should fail guest re-execution."""
+    target_code = Op.PUSH1(0x42) + Op.POP + Op.STOP
+    target = pre.deploy_contract(code=target_code)
+
+    caller_code = Op.EXTCODESIZE(target) + Op.POP + Op.STOP
+    caller = pre.deploy_contract(code=caller_code)
+
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+    caller_code_bytes = Bytes(bytes(caller_code))
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_codes=(
+                    ExecutionWitnessCodesExpectation(
+                        codes_present=[
+                            caller_code_bytes,
+                            Bytes(bytes(target_code)),
+                        ],
+                    ).modify(remove_code(caller_code_bytes))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+        },
+    )
+
+
+def test_witness_soundness_missing_storage_proof_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing a required storage proof node should fail the guest."""
+    read_slot = 1
+    write_slot = 2
+    storage = build_large_storage([read_slot])
+    proof_nodes = collect_storage_proof_nodes(storage, [read_slot])
+    assert proof_nodes
+    removed_node = sorted(proof_nodes)[0]
+
+    contract = pre.deploy_contract(
+        code=Op.SSTORE(write_slot, Op.SLOAD(read_slot)) + Op.STOP,
+        storage=as_storage(storage),
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+    post_storage = storage | {write_slot: storage[read_slot]}
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(storage=post_storage),
+        },
+    )


### PR DESCRIPTION
## 🗒️ Description
This PR adds some machinery and basic tests to start focusing on covering guest program failing to execute in invalid `ExecutionWitness`.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
