### PR TITLE
feat(testing): add TemporalHarness for deterministic timestamp injection in tests

### DIFF
--- a/src/ethereum/utils/temporal_harness.py
+++ b/src/ethereum/utils/temporal_harness.py
@@ -1,0 +1,94 @@
+"""
+Temporal Harness for Timestamp Injection in Tests.
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Optional test infrastructure for injecting and validating external time
+sources in execution-spec timestamp tests.
+
+Follows the opt-in pattern established by ``TransitionConfig`` (#2449):
+existing tests are completely unaffected unless a ``TemporalHarness``
+instance is explicitly constructed and passed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+
+@dataclass
+class TemporalHarness:
+    """
+    Optional harness for injecting and validating external time sources
+    in execution-specs timestamp tests.
+
+    Follows the TransitionConfig opt-in pattern (#2449).
+    All fields have safe defaults — existing tests are unaffected unless
+    a TemporalHarness instance is explicitly passed.
+
+    Parameters
+    ----------
+    time_source :
+        A zero-argument callable returning the current time in milliseconds
+        (Unix epoch, integer). Defaults to system time via ``time.time_ns``.
+        Can be replaced with any deterministic mock, NTP client, or
+        GPS-synchronized time source for test isolation.
+    max_drift_ms :
+        Maximum acceptable drift in milliseconds between the block timestamp
+        and the value returned by ``time_source``.
+        Default: 15000 ms (15 seconds), per EIP-1482.
+    attestation_hook :
+        Optional callable invoked before drift validation.
+        Receives ``(block_timestamp_ms: int, source_timestamp_ms: int)
+        -> None``. Intended for integration with external attestation
+        systems (e.g., satellite time verification). No-op when ``None``.
+    """
+
+    time_source: Callable[[], int] = field(
+        default_factory=lambda: (
+            lambda: __import__("time").time_ns() // 1_000_000
+        )
+    )
+    max_drift_ms: int = 15_000  # EIP-1482: ±15 seconds
+    attestation_hook: Optional[Callable[[int, int], None]] = None
+
+    def validate(self, block_timestamp_s: int) -> None:
+        """
+        Validate that ``block_timestamp_s`` does not exceed ``max_drift_ms``
+        relative to the injected time source.
+
+        Parameters
+        ----------
+        block_timestamp_s :
+            Block timestamp in seconds, as stored on-chain.
+
+        Raises
+        ------
+        TimestampDriftError
+            If the absolute drift exceeds ``max_drift_ms``.
+        """
+        source_ms = self.time_source()
+        block_ms = block_timestamp_s * 1_000
+        drift_ms = abs(source_ms - block_ms)
+
+        if self.attestation_hook is not None:
+            self.attestation_hook(block_ms, source_ms)
+
+        if drift_ms > self.max_drift_ms:
+            raise TimestampDriftError(
+                f"block.timestamp drift {drift_ms} ms exceeds "
+                f"EIP-1482 limit of {self.max_drift_ms} ms "
+                f"(block={block_ms} ms, source={source_ms} ms)"
+            )
+
+
+class TimestampDriftError(Exception):
+    """Raised when block.timestamp drift exceeds the configured threshold."""
+
+    pass

--- a/tests/utils/test_temporal_harness.py
+++ b/tests/utils/test_temporal_harness.py
@@ -1,0 +1,118 @@
+"""
+Tests for TemporalHarness — deterministic timestamp injection utility.
+
+These tests verify the harness itself, not any fork-specific logic.
+All existing tests are unaffected: TemporalHarness is never imported
+unless explicitly instantiated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ethereum.utils.temporal_harness import TemporalHarness, TimestampDriftError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+PINNED_MS = 1_700_000_000_000  # fixed reference: 2023-11-14 ~22:13 UTC
+PINNED_S = PINNED_MS // 1_000
+
+
+# ---------------------------------------------------------------------------
+# Basic drift validation
+# ---------------------------------------------------------------------------
+
+
+def test_within_drift_passes() -> None:
+    """Block timestamp 5 s ahead of source is within EIP-1482 tolerance."""
+    harness = TemporalHarness(time_source=lambda: PINNED_MS)
+    harness.validate(block_timestamp_s=PINNED_S + 5)
+
+
+def test_exact_drift_boundary_passes() -> None:
+    """Block timestamp exactly at the 15 s boundary must pass."""
+    harness = TemporalHarness(time_source=lambda: PINNED_MS)
+    harness.validate(block_timestamp_s=PINNED_S + 15)
+
+
+def test_exceeds_drift_raises() -> None:
+    """Block timestamp 20 s ahead of source exceeds EIP-1482 limit."""
+    harness = TemporalHarness(time_source=lambda: PINNED_MS)
+    with pytest.raises(TimestampDriftError):
+        harness.validate(block_timestamp_s=PINNED_S + 20)
+
+
+def test_block_behind_source_raises() -> None:
+    """Block timestamp 20 s behind source also exceeds the limit."""
+    harness = TemporalHarness(time_source=lambda: PINNED_MS)
+    with pytest.raises(TimestampDriftError):
+        harness.validate(block_timestamp_s=PINNED_S - 20)
+
+
+def test_custom_max_drift() -> None:
+    """Custom max_drift_ms overrides the EIP-1482 default."""
+    harness = TemporalHarness(
+        time_source=lambda: PINNED_MS,
+        max_drift_ms=5_000,
+    )
+    # 3 s drift — within custom 5 s window
+    harness.validate(block_timestamp_s=PINNED_S + 3)
+    # 6 s drift — exceeds custom 5 s window
+    with pytest.raises(TimestampDriftError):
+        harness.validate(block_timestamp_s=PINNED_S + 6)
+
+
+# ---------------------------------------------------------------------------
+# Attestation hook
+# ---------------------------------------------------------------------------
+
+
+def test_attestation_hook_invoked() -> None:
+    """Attestation hook is called with (block_ms, source_ms) before check."""
+    log: list[tuple[int, int]] = []
+
+    harness = TemporalHarness(
+        time_source=lambda: PINNED_MS,
+        attestation_hook=lambda block_ms, src_ms: log.append(
+            (block_ms, src_ms)
+        ),
+    )
+
+    harness.validate(block_timestamp_s=PINNED_S + 3)
+
+    assert len(log) == 1
+    block_ms_recorded, src_ms_recorded = log[0]
+    assert block_ms_recorded == (PINNED_S + 3) * 1_000
+    assert src_ms_recorded == PINNED_MS
+
+
+def test_attestation_hook_invoked_before_raise() -> None:
+    """Hook fires even when drift is out of bounds."""
+    log: list[tuple[int, int]] = []
+
+    harness = TemporalHarness(
+        time_source=lambda: PINNED_MS,
+        attestation_hook=lambda block_ms, src_ms: log.append(
+            (block_ms, src_ms)
+        ),
+    )
+
+    with pytest.raises(TimestampDriftError):
+        harness.validate(block_timestamp_s=PINNED_S + 30)
+
+    assert len(log) == 1
+
+
+# ---------------------------------------------------------------------------
+# Default time source (smoke test — does not assert exact value)
+# ---------------------------------------------------------------------------
+
+
+def test_default_time_source_returns_int() -> None:
+    """Default time_source returns a positive integer (ms since epoch)."""
+    harness = TemporalHarness()
+    result = harness.time_source()
+    assert isinstance(result, int)
+    assert result > 0


### PR DESCRIPTION
## 🗒️ Description

Add a lightweight, opt-in test helper (`TemporalHarness`) to `src/ethereum/utils/` that allows time-sensitive execution-spec tests to inject a deterministic time source and assert EIP-1482 drift bounds without hardcoding absolute timestamps.

Follows the same backwards-compatible extension pattern as `TransitionConfig` (#2449): no existing test file is modified or imports this class.

### Problem

L2 sequencers (Optimism, Arbitrum, Starknet, zkSync, etc.) have unilateral control over `block.timestamp`. The current test infrastructure has no standard mechanism to:

1. Inject external time sources into timestamp validation during testing
2. Assert timestamp boundary conditions without hardcoding absolute values
3. Simulate sequencer timestamp drift against a known reference

EIP-1482 defined a ±15-second drift tolerance in 2018 but provided no enforcement or verification mechanism. Peer-reviewed research (arXiv:2505.05328, "SUUM attack") confirmed timestamp manipulation in 4 mining pools, resulting in a −11.85% reduction in honest validator rewards.

### Solution

`TemporalHarness` is a dataclass with three fields:

- `time_source`: zero-argument callable returning current time in ms (defaults to `time.time_ns`)
- `max_drift_ms`: acceptable drift window in ms (default 15 000, per EIP-1482)
- `attestation_hook`: optional callback invoked before drift check, for external verification workflows

A single `validate(block_timestamp_s)` method raises `TimestampDriftError` when drift exceeds the configured threshold.

### Files changed

```
src/ethereum/utils/temporal_harness.py   # new: TemporalHarness + TimestampDriftError
tests/utils/__init__.py                  # new: package marker
tests/utils/test_temporal_harness.py     # new: 8 unit tests
```

No existing files are modified.

## 🔗 Related Issues or PRs

Closes #1601
Related: #2449 (TransitionConfig opt-in pattern)

## ✅ Checklist

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![A small cat sitting next to a clock](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat_03.jpg/320px-Cat_03.jpg)