### PR TITLE
chore(test-fill): don't collect tests for unsupported forks

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -615,6 +615,22 @@ def pytest_report_header(config: pytest.Config, start_path: Any) -> List[str]:
             + reset
         ),
     ]
+    if config.unsupported_forks:  # type: ignore[attr-defined]
+        t8n_name = config.t8n.__class__.__name__  # type: ignore[attr-defined]
+        excluded = ", ".join(
+            f.name()
+            for f in sorted(config.unsupported_forks)  # type: ignore[attr-defined]
+        )
+        header += [
+            (
+                bold
+                + warning
+                + f"Unsupported forks excluded from {t8n_name}: "
+                + excluded
+                + "."
+                + reset
+            )
+        ]
     if all(fork.is_deployed() for fork in config.selected_fork_set):  # type: ignore[attr-defined]
         header += [
             (
@@ -1093,6 +1109,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         return
 
     pytest_params: List[Any]
+    unsupported_forks: Set[Fork] = metafunc.config.unsupported_forks  # type: ignore
+    intersection_set -= unsupported_forks
+
     if not intersection_set:
         if metafunc.config.getoption("verbose") >= 2:
             pytest_params = [
@@ -1110,21 +1129,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             ]
             metafunc.parametrize("fork", pytest_params, scope="function")
     else:
-        unsupported_forks: Set[Fork] = metafunc.config.unsupported_forks  # type: ignore
         pytest_params = []
         for fork in sorted(intersection_set):
             marks: List[pytest.MarkDecorator | pytest.Mark] = fork_markers(
                 fork=fork,
             )
-            if fork in unsupported_forks:
-                marks.append(
-                    pytest.mark.skip(
-                        reason=(
-                            f"Fork '{fork}' unsupported by "
-                            f"{metafunc.config.t8n.__class__.__name__}."  # type: ignore
-                        )
-                    )
-                )
             pytest_params.append(ForkParametrizer(fork=fork, marks=marks))
         add_fork_covariant_parameters(metafunc, pytest_params)
         parametrize_fork(metafunc, pytest_params)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from execution_testing.client_clis.clis.execution_specs import (
+    ExecutionSpecsTransitionTool,
+)
 from execution_testing.fixtures import LabeledFixtureFormat
 from execution_testing.forks import (
     ArrowGlacier,
@@ -38,21 +41,17 @@ def test_no_options_no_validity_marker(pytester: pytest.Pytester) -> None:
     )
     result = pytester.runpytest("-c", "pytest-fill.ini", "-v")
     all_forks = get_deployed_forks()
+    t8n = ExecutionSpecsTransitionTool()
     forks_under_test = [
         f
         for f in forks_from_until(all_forks[0], all_forks[-1])
-        if not f.ignore()
+        if not f.ignore() and t8n.is_fork_supported(f)
     ]
-    expected_skipped = 2  # eels doesn't support Constantinople
-    expected_passed = (
-        len([f for f in forks_under_test if not f.ignore()])
-        * len(StateTest.supported_fixture_formats)
-        - expected_skipped
+    expected_passed = len(forks_under_test) * len(
+        StateTest.supported_fixture_formats
     )
     stdout = "\n".join(result.stdout.lines)
     for test_fork in forks_under_test:
-        if test_fork.ignore():
-            continue
         for fixture_format in StateTest.supported_fixture_formats:
             if isinstance(fixture_format, LabeledFixtureFormat):
                 fixture_format_label = fixture_format.label
@@ -77,7 +76,7 @@ def test_no_options_no_validity_marker(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(
         passed=expected_passed,
         failed=0,
-        skipped=expected_skipped,
+        skipped=0,
         errors=0,
     )
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -26,7 +26,7 @@ def test_case(state_test):
                 valid_until='"Cancun"',
             ),
             [],
-            {"passed": 10, "failed": 0, "skipped": 1, "errors": 0},
+            {"passed": 10, "failed": 0, "skipped": 0, "errors": 0},
             id="valid_until",
         ),
         pytest.param(


### PR DESCRIPTION
## 🗒️ Description

### Problem

Currently, `fill`, specifically the `forks` plugin:

1. Collects all tests for forks that are unsupported by a `t8n`.
2. Marks each test with `skip`.

This leads to redundant and noisy pytest reporting. For example, the original `Constantinople` fork will never be supported by EELS, which generates 1000s of skipped test cases.

Background: The `ExecutionSpecsTransitionTool` maps `ConstantinopleFix` to the `src/ethereum/forks/constantinople`. This is consistent with other transition tools.

### Solution

This PR excludes unsupported forks from test parametrization instead of marking them as skipped.

- `pytest_generate_tests` now subtracts `unsupported_forks` from the candidate set before building parameters.
- Forks unsupported by the current `t8n` tool (e.g., `Constantinople` for `execution-specs`) produce zero test cases rather than always-skipped ones.
- `pytest_report_header` now displays excluded forks in the session header for visibility.
- Other `t8n` tools that do support those forks are unaffected since `unsupported_forks` is computed per tool in `pytest_configure`.

### Before
<img width="2880" height="1130" alt="image" src="https://github.com/user-attachments/assets/927db3cb-d655-4ab4-b41f-29dc3d17446d" />

### After
<img width="2862" height="702" alt="image" src="https://github.com/user-attachments/assets/3cc6f5ed-fe19-4f46-9e4c-78038bb53048" />

## 🔗 Related Issues or PRs

Closes #1762:
- #1762

## ✅ Checklist

- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:bear: 