### PR TITLE
chore(fill): guard type-only `pre_alloc` import behind `TYPE_CHECKING`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -6,6 +6,8 @@ and that modifies pytest hooks in order to fill test specs for all tests
 and writes the generated fixtures to file.
 """
 
+from __future__ import annotations
+
 import atexit
 import configparser
 import datetime
@@ -19,7 +21,7 @@ import time
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Self, Set, Type
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Self, Set, Type
 
 import pytest
 import xdist
@@ -91,7 +93,9 @@ from ..shared.helpers import (
 from ..spec_version_checker.spec_version_checker import (
     get_ref_spec_from_module,
 )
-from .pre_alloc import Alloc
+
+if TYPE_CHECKING:
+    from .pre_alloc import Alloc
 
 # Fixture output dir for keyboard interrupt cleanup (set in pytest_configure).
 # Used by _merge_on_exit to merge partial JSONL files on Ctrl+C or SIGTERM.


### PR DESCRIPTION
## Description

This PR fixes this warning (again):
<img width="1893" height="394" alt="image" src="https://github.com/user-attachments/assets/f6dacf50-97fb-4820-8ff8-fcd57fa0b486" />

Guard the `Alloc` import in `filler.py` behind `TYPE_CHECKING` so that `pre_alloc` is not imported before pytest can register it for assertion rewriting.

- `filler` plugin loads before `pre_alloc` in `pytest-fill.ini`, and its top-level `from .pre_alloc import Alloc` triggers an early import.
- `Alloc` is only used as a type annotation (`pre: Alloc`), not at runtime.
- Added `from __future__ import annotations` to keep the annotation lazy.

## Related Issues or PRs

N/A.

## Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

![exotic ultra face persian cat](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/%27Exotic_ultra_face_Persian_cat%27_at_%27Mumbai_cat_show-2014%27.JPG/500px-%27Exotic_ultra_face_Persian_cat%27_at_%27Mumbai_cat_show-2014%27.JPG)