### PR TITLE
refactor(tests): replace runtime skips with upfront parametrize filtering

### DIFF
--- a/tests/benchmark/compute/instruction/test_account_query.py
+++ b/tests/benchmark/compute/instruction/test_account_query.py
@@ -265,7 +265,10 @@ def test_ext_account_query_cold(
     Benchmark stateful opcodes accessing cold accounts.
     """
     if fixed_opcode_count:
-        pytest.skip("Fixed opcode count is not supported for this test")
+        pytest.skip(
+            "Cold-account queries need one unique account per opcode, "
+            "so the iteration count is gas-driven, not fixed"
+        )
 
     attack_gas_limit = gas_benchmark_value
 

--- a/tests/benchmark/compute/instruction/test_arithmetic.py
+++ b/tests/benchmark/compute/instruction/test_arithmetic.py
@@ -214,7 +214,10 @@ def test_mod(
     # sign bits.
     # The result stays negative.
     if fixed_opcode_count is not None:
-        pytest.skip("fixed-opcode-count not supported in test_mode")
+        pytest.skip(
+            "test_mod uses a data-dependent chain length, "
+            "incompatible with --fixed-opcode-count"
+        )
     should_negate = opcode == Op.SMOD
 
     num_numerators = 15

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -232,8 +232,8 @@ def test_calldatacopy_from_call(
     min_gas = intrinsic_gas_calculator(calldata=data)
     if min_gas > tx_gas_limit:
         pytest.skip(
-            "Minimum gas required for calldata ({min_gas}) is greater "
-            "than the gas limit"
+            f"Intrinsic gas for calldata ({min_gas}) exceeds "
+            f"tx gas limit ({tx_gas_limit})"
         )
 
     # We create the contract that will be doing the CALLDATACOPY multiple

--- a/tests/benchmark/compute/instruction/test_call_context.py
+++ b/tests/benchmark/compute/instruction/test_call_context.py
@@ -203,15 +203,13 @@ def test_calldatacopy_from_origin(
     ],
 )
 @pytest.mark.parametrize(
-    "non_zero_data",
+    "calldata_size,non_zero_data",
     [
-        True,
-        False,
+        (size, nzd)
+        for size in [0, 32, 256, 1024]
+        for nzd in [True, False]
+        if not (size == 0 and nzd)
     ],
-)
-@pytest.mark.parametrize(
-    "calldata_size",
-    [0, 32, 256, 1024],
 )
 def test_calldatacopy_from_call(
     benchmark_test: BenchmarkTestFiller,
@@ -222,12 +220,8 @@ def test_calldatacopy_from_call(
     tx_gas_limit: int,
 ) -> None:
     """Benchmark CALLDATACOPY instruction."""
-    if calldata_size == 0 and non_zero_data:
-        pytest.skip("Non-zero data with size 0 is not applicable.")
-
     # If `non_zero_data` is True, we fill the calldata with deterministic
-    # random data. Note that if `size == 0` and `non_zero_data` is a skipped
-    # case.
+    # random data.
     data = (
         Bytes([i % 256 for i in range(calldata_size)])
         if non_zero_data

--- a/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
+++ b/tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py
@@ -361,9 +361,16 @@ def test_clz_fork_transition(
 
 
 @pytest.mark.valid_from("Osaka")
-@pytest.mark.parametrize("opcode", [Op.JUMPI, Op.JUMP])
+@pytest.mark.parametrize(
+    "opcode,jumpi_condition",
+    [
+        (op, cond)
+        for op in [Op.JUMPI, Op.JUMP]
+        for cond in [True, False]
+        if not (op == Op.JUMP and not cond)
+    ],
+)
 @pytest.mark.parametrize("valid_jump", [True, False])
-@pytest.mark.parametrize("jumpi_condition", [True, False])
 @pytest.mark.parametrize("bits", [0, 16, 64, 128, 255])
 @pytest.mark.json_loader
 def test_clz_jump_operation(
@@ -375,9 +382,6 @@ def test_clz_jump_operation(
     bits: int,
 ) -> None:
     """Test CLZ opcode with valid and invalid jump."""
-    if opcode == Op.JUMP and not jumpi_condition:
-        pytest.skip("Duplicate case for JUMP.")
-
     code = Op.PUSH32(1 << bits)
 
     if opcode == Op.JUMPI:


### PR DESCRIPTION
## 🗒️ Description

This PR removes avoidable runtime pytest "skip" calls by refactoring the affected test parametrization to not generate invalid test cases at all. This was possible in two tests:

| Test | Before | After | Skips removed | Fixture parity |
|------|--------|-------|---------------|----------------|
| `osaka/.../test_count_leading_zeros.py::test_clz_jump_operation` | 90 passed + 30 skipped | 90 passed | 30 (10/fork) | Identical (normalized IDs) |
| `benchmark/.../test_call_context.py::test_calldatacopy_from_call` | 56 passed + 8 skipped | 56 passed | 8 (4/fork) | Identical (direct hasher) |

I validated that the same fixtures are generated via hasher.

It also improves the skip reasons for other test cases.

### Parametrize refactors

#### `tests/osaka/eip7939_count_leading_zeros/test_count_leading_zeros.py::test_clz_jump_operation`

Merged `opcode` and `jumpi_condition` into a single parametrize with a filter excluding `(JUMP, jumpi_condition=False)` (duplicate of `(JUMP, jumpi_condition=True)` since JUMP ignores the condition). Removed the runtime skip.

**Note:** Merging two separate parametrize decorators into one changes the parameter ordering in test IDs (e.g., `bits_0-jumpi_condition_True-valid_jump_False-opcode_JUMPI` becomes `bits_0-valid_jump_False-opcode_JUMPI-jumpi_condition_True`). Fixture content is verified identical via normalized hash comparison.

#### `tests/benchmark/compute/instruction/test_call_context.py::test_calldatacopy_from_call`

Merged `calldata_size` and `non_zero_data` into a single parametrize with a filter excluding `(0, True)` (non-zero data with zero-length calldata is nonsensical). Removed the runtime skip. Kept the second skip (intrinsic gas > tx gas limit) since it depends on runtime fork calculations.

Fixture content verified identical via `hasher compare` (filled with `--evm-bin=evmone-t8n --gas-benchmark-values=1`). No test ID reordering in this case.

### Runtime-dependent skips (not removed)

These skips depend on values computed at runtime and cannot be easily converted to upfront parametrize filtering:

| File | Reason |
|------|--------|
| `tests/prague/eip7702_set_code_tx/test_set_code_txs.py` | `chain_id` edge case (runtime fixture). |
| `tests/benchmark/compute/instruction/test_call_context.py` | `min_gas > tx_gas_limit` (runtime gas calc). |
| `tests/benchmark/compute/eip7928_block_level_access_lists/test_block_access_list.py` | `group_size > gas budget` (runtime gas calc). |

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/).
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

Like this PR, which removes unnecessary parametrize "bread" from around test cases, this cat has been breaded. Unlike the skipped tests, the cat wears it well.

![breaded_cat_512](https://github.com/user-attachments/assets/86b4468f-5921-4a9e-b04b-066ed748147b)
