### PR TITLE
fix(ci): remove stale client Docker images before benchmark genesis build

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -37,6 +37,12 @@ runs:
         tar -xzf "${{ inputs.fixtures_path }}"
         echo "Fixtures extracted successfully"
 
+    - name: Remove stale client Docker images
+      shell: bash
+      run: |
+        echo "Removing stale Hive client images to force fresh builds..."
+        docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^(hive/clients/|.*/(client-go|besu|nethermind))' | xargs -r docker rmi -f || true
+
     - name: Start Hive in dev mode
       id: start-hive
       uses: ./.github/actions/start-hive-dev

--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -41,7 +41,14 @@ runs:
       shell: bash
       run: |
         echo "Removing stale Hive client images to force fresh builds..."
-        docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^(hive/clients/|.*/(client-go|besu|nethermind))' | xargs -r docker rmi -f || true
+        images_to_remove=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^(hive/clients/|.*/(client-go|besu|nethermind))' || true)
+        if [ -n "$images_to_remove" ]; then
+          echo "Found the following images to remove:"
+          echo "$images_to_remove"
+          echo "$images_to_remove" | xargs docker rmi -f
+        else
+          echo "No matching Hive client images found to remove."
+        fi
 
     - name: Start Hive in dev mode
       id: start-hive


### PR DESCRIPTION
## 🗒️ Description

Hotfix for the "Build Benchmark Fixture Artifact"` job which has been failing since 24th Feb :grimacing: e.g.
https://github.com/ethereum/execution-specs/actions/runs/23477679952/job/68319008639


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
