### PR TITLE
fix(ci): separate Hive client build from dev mode startup; increase timeout

### DIFF
--- a/.github/workflows/hive-consume.yaml
+++ b/.github/workflows/hive-consume.yaml
@@ -139,6 +139,16 @@ jobs:
             --sim.limit="${{ matrix.sim_limit }}" \
             --docker.output
 
+      - name: Build Hive client images
+        if: matrix.mode == 'dev'
+        run: |
+          cd hive
+          ./hive \
+            --client go-ethereum \
+            --client-file ../execution-specs/.github/configs/hive/latest.yaml \
+            --docker.buildoutput
+        timeout-minutes: 10
+
       - name: Start Hive in dev mode
         if: matrix.mode == 'dev'
         id: start-hive
@@ -147,7 +157,7 @@ jobs:
           clients: go-ethereum
           client-file: execution-specs/.github/configs/hive/latest.yaml
           hive-path: hive
-          timeout: "120"
+          timeout: "30"
 
       - name: Run consume in dev mode
         if: matrix.mode == 'dev'


### PR DESCRIPTION
## 🗒️ Description

The "Hive Consume Dev" step upon push to forks/amsterdam has been flaky and been failing in ~40% of runs. This PR pulls out the go-ethereum build to it's own step and increases the timeout for that step.

For example: https://github.com/ethereum/execution-specs/actions/runs/23460438823/job/68260815976

Flakiness: https://github.com/ethereum/execution-specs/actions/workflows/hive-consume.yaml?query=branch%3Aforks%2Famsterdam

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="512" alt="image" src="https://github.com/user-attachments/assets/8a67d576-9566-4596-98c3-771d05a6b60e" />
