### PR TITLE
feat(ci): cache mypy results in the static analysis job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,8 +50,9 @@ jobs:
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: .mypy_cache
-          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}
+          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}-${{ github.sha }}
           restore-keys: |
+            mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}-
             mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-
       - name: Run static checks
         run: tox -e static
@@ -60,7 +61,7 @@ jobs:
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
         with:
           path: .mypy_cache
-          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}
+          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}-${{ github.sha }}
       - name: Validate workflow config variables
         run: |
           cat >> .github/actionlint.yaml << 'EOF'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,25 @@ jobs:
       - name: Install build dependencies
         shell: bash
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes build-essential pkg-config
+      - name: Detect Python version
+        id: python
+        shell: bash
+        run: echo "version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" >> "$GITHUB_OUTPUT"
+      - name: Restore mypy cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+        with:
+          path: .mypy_cache
+          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-
       - name: Run static checks
         run: tox -e static
+      - name: Save mypy cache
+        if: always()
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+        with:
+          path: .mypy_cache
+          key: mypy-${{ runner.os }}-py${{ steps.python.outputs.version }}-${{ hashFiles('uv.lock') }}
       - name: Validate workflow config variables
         run: |
           cat >> .github/actionlint.yaml << 'EOF'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ uv run mypy              # Verifies type annotations.
 > mypy cache across all of them and avoid cold-start delays:
 >
 > ```bash
-> export MYPY_CACHE_DIR=~/.cache/mypy/execution-specs
+> export MYPY_CACHE_DIR=~/path/to/execution-specs/.mypy_cache
 > ```
 
 It is recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) to keep your system Python installation clean.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,14 @@ uv run ruff format       # Formats code.
 uv run mypy              # Verifies type annotations.
 ```
 
+> [!TIP]
+> If you use multiple git worktrees, set `MYPY_CACHE_DIR` to share a single
+> mypy cache across all of them and avoid cold-start delays:
+>
+> ```bash
+> export MYPY_CACHE_DIR=~/.cache/mypy/execution-specs
+> ```
+
 It is recommended to use a [virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) to keep your system Python installation clean.
 
 A trace of the EVM execution for any test case can be obtained by providing the `--evm-trace` argument to pytest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,6 +490,7 @@ exclude = [
     "^site/",
     "^tests/json_loader/fixtures/",
 ]
+cache_fine_grained = true
 plugins = ["pydantic.mypy"]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -490,7 +490,6 @@ exclude = [
     "^site/",
     "^tests/json_loader/fixtures/",
 ]
-cache_fine_grained = true
 plugins = ["pydantic.mypy"]
 
 [tool.uv]


### PR DESCRIPTION
## 🗒️ Description

#2455 ported ~2250 static test files into `tests/ported_static/`, more than doubling what mypy checks:

| | Files | Lines |
|---|---:|---:|
| `src/` | 1,108 | 230,874 |
| `packages/` | 360 | 92,757 |
| `tests/` (excl. ported) | 381 | 95,950 |
| **Before** | **1,849** | **419,581** |
| `tests/ported_static/` | 2,250 | 567,356 |
| **After** | **4,099** | **986,937** |

Cold mypy went from ~20s to 60–90s. Since `static` gates every other CI job, this hits overall pipeline latency.

This PR caches `.mypy_cache/` using the split restore/save pattern already established in the repo (`actions/cache` v5.0.3).

### Cache strategy

**Key:** `mypy-{OS}-py{version}-{hash of uv.lock}-{commit SHA}`

- Commit SHA in the key ensures each run saves a fresh cache (GitHub Actions cache keys are immutable).
- Restore falls back via prefix matching: same lockfile (any commit) → same Python version (any lockfile).
- Cross-branch: PRs restore from their base branch + the default branch (built-in GitHub Actions scoping).
- ~6MB compressed per entry; ~105 CI runs/week ≈ 630MB — well within GitHub's 10GB budget. Entries not accessed in 7 days are evicted automatically.

Also documents the `MYPY_CACHE_DIR` env var in CONTRIBUTING.md for developers using multiple git worktrees.

## 🔗 Related Issues or PRs

- #2455 (root cause of the mypy slowdown).

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="658" height="363" alt="image" src="https://github.com/user-attachments/assets/42d014ea-f3f4-4517-89b6-ecd0f6d725c5" />