### PR TITLE
fix(test-logging): don't store empty logs

### DIFF
--- a/packages/testing/src/execution_testing/cli/tests/test_pytest_fill_command.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_pytest_fill_command.py
@@ -209,6 +209,26 @@ class TestFillPytester:
         run_fill(*fill_args)
         assert not default_html_path.exists()
 
+    def test_fill_pytest_help_does_not_create_empty_log_file(
+        self, pytester: Pytester
+    ) -> None:
+        """Help-mode startup should not leave behind an empty log file."""
+        log_dir = pytester.path / "logs"
+        pytester.copy_example(
+            name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+        )
+
+        result = pytester.runpytest(
+            "-c",
+            "pytest-fill.ini",
+            "--help",
+            "--log-to",
+            str(log_dir),
+        )
+
+        assert result.ret == pytest.ExitCode.OK
+        assert not list(log_dir.glob("*.log"))
+
     def test_generate_pre_alloc_groups_preserves_chain_id_for_valid_from(
         self,
         pytester: Pytester,

--- a/packages/testing/src/execution_testing/logging/logger.py
+++ b/packages/testing/src/execution_testing/logging/logger.py
@@ -215,7 +215,9 @@ def configure_logging(
         log_path = Path(log_file)
         log_path.parent.mkdir(exist_ok=True, parents=True)
 
-        file_handler_instance = logging.FileHandler(log_path, mode="w")
+        file_handler_instance = logging.FileHandler(
+            log_path, mode="w", delay=True
+        )
         file_handler_instance.setFormatter(UTCFormatter(fmt=log_format))
         root_logger.addHandler(file_handler_instance)
 

--- a/packages/testing/src/execution_testing/logging/tests/test_logging.py
+++ b/packages/testing/src/execution_testing/logging/tests/test_logging.py
@@ -169,13 +169,14 @@ class TestStandaloneConfiguration:
                 # Should return a file handler
                 assert isinstance(handler, logging.FileHandler)
 
-                # Should create the log file
-                assert log_file.exists()
+                # Delay file creation until the first record is emitted.
+                assert not log_file.exists()
 
                 # Log a message and check it appears in the file
                 logger = get_logger("test_config")
                 logger.info("Test log message")
 
+                assert log_file.exists()
                 with open(log_file, "r") as f:
                     log_content = f.read()
                     assert "Test log message" in log_content
@@ -258,11 +259,14 @@ class TestPytestIntegration:
                 # Find the log file handler's file
                 log_file = Path(file_handlers[0].baseFilename)
 
-                # Check that the log file was created
-                assert log_file.exists()
-
                 # Verify the file is in the logs directory
                 assert log_file.parent.resolve() == log_dir.resolve()
+
+                # Delay file creation until the first record is emitted.
+                assert not log_file.exists()
+
+                get_logger("test_pytest_configure").info("Test log message")
+                assert log_file.exists()
 
                 # Clean up the test log file
                 log_file.unlink()


### PR DESCRIPTION
## 🗒️ Description
Before this PR, when u run e.g.  `uv run fill --pytest-help` it will create an empty log file. I have noticed empty log files in the past and this is just a minimal example to demonstrate it.

The PR fixes it so that no completely empty log files are created. Writing non-empty logs still works, e.g. run `uv run fill -v -s --no-html --clean 'tests/frontier/touch/test_touch.py::test_zero_gas_price_and_touching[fork_Frontier-state_test]'` after applying the PR.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
