### PR TITLE
chores(consume): rename `--bin` flag of consume direct to `--evm-bin` to be consistent with fill's `--evm-bin`

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/direct/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/direct/conftest.py
@@ -58,7 +58,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # noqa: D103
     )
 
     consume_group.addoption(
-        "--bin",
+        "--evm-bin",
         action="append",
         dest="fixture_consumer_bin",
         type=Path,
@@ -110,8 +110,8 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: D103
             (
                 "No fixture consumer binaries provided; using a dummy "
                 "consumer for collect-only; all possible fixture formats "
-                "will be collected. Specify fixture consumer(s) via `--bin` "
-                "to see actual collection results."
+                "will be collected. Specify fixture consumer(s) via "
+                "`--evm-bin` to see actual collection results."
             ),
             stacklevel=1,
         )
@@ -119,7 +119,7 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: D103
     elif not fixture_consumers:
         pytest.exit(
             "No fixture consumer binaries provided; please specify a binary "
-            "path via `--bin`."
+            "path via `--evm-bin`."
         )
     config.fixture_consumers = fixture_consumers  # type: ignore[attr-defined]
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_consume_args.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/tests/test_consume_args.py
@@ -232,3 +232,27 @@ def test_consume_simlimit_collectonly(
         if expected_filter_pattern.search(line)
     ]
     assert set(collected_test_ids) == set(expected_collected_test_ids)
+
+
+def test_direct_consume_requires_evm_bin(
+    pytester: Pytester,
+    fixtures_dir: Path,
+) -> None:
+    """Test that direct consume references --evm-bin in its usage error."""
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-consume.ini"
+    )
+    consume_test_path = (
+        "src/execution_testing/cli/pytest_commands/plugins/"
+        "consume/direct/test_via_direct.py"
+    )
+    result = pytester.runpytest_subprocess(
+        "-c",
+        "pytest-consume.ini",
+        "--input",
+        str(fixtures_dir),
+        consume_test_path,
+    )
+    assert result.ret != pytest.ExitCode.OK
+    output = "\n".join(result.stdout.lines + result.stderr.lines)
+    assert "path via `--evm-bin`." in output

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -570,7 +570,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help=(
             "Path to an evm executable (or name of an executable in the "
-            "PATH) that provides `t8n`. Default: `ethereum-spec-evm-resolver`."
+            "PATH) that provides `t8n`. Default: use the configured default "
+            "transition tool."
         ),
     )
     evm_group.addoption(

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -21,7 +21,7 @@ from execution_testing.test_types import Alloc, Environment, Transaction
 
 CURRENT_FOLDER = Path(realpath(__file__)).parent
 FIXTURES_ROOT = CURRENT_FOLDER / "fixtures"
-DEFAULT_EVM_T8N_BINARY_NAME = "ethereum-spec-evm-resolver"
+DEFAULT_EVM_T8N_BINARY_NAME = "ethereum-spec-evm"
 
 
 @pytest.fixture(autouse=True)
@@ -35,8 +35,8 @@ def monkeypatch_path_for_entry_points(
     This would typically be in the venv in which pytest is running these tests
     and fill, which, with uv, is `./.venv/bin`.
 
-    This is required in order for fill to locate the ethereum-spec-evm-resolver
-    "binary" (entrypoint) when being executed using pytester.
+    This is required so pytester-based invocations can locate the
+    execution-specs transition tool entrypoint while running in tests.
     """
     bin_dir = sysconfig.get_path("scripts")
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -5,8 +5,7 @@ import os
 import sysconfig
 from os.path import realpath
 from pathlib import Path
-from shutil import which
-from typing import Dict, List, Type
+from typing import Dict, List
 
 import pytest
 from pydantic import TypeAdapter

--- a/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_execution_specs.py
@@ -21,7 +21,6 @@ from execution_testing.test_types import Alloc, Environment, Transaction
 
 CURRENT_FOLDER = Path(realpath(__file__)).parent
 FIXTURES_ROOT = CURRENT_FOLDER / "fixtures"
-DEFAULT_EVM_T8N_BINARY_NAME = "ethereum-spec-evm"
 
 
 @pytest.fixture(autouse=True)
@@ -36,7 +35,7 @@ def monkeypatch_path_for_entry_points(
     and fill, which, with uv, is `./.venv/bin`.
 
     This is required so pytester-based invocations can locate the
-    execution-specs transition tool entrypoint while running in tests.
+    `ethereum-spec-evm t8n` entrypoint while running in tests.
     """
     bin_dir = sysconfig.get_path("scripts")
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
@@ -94,39 +93,6 @@ def test_calc_state_root(
 ) -> None:
     """Test calculation of the state root against expected hash."""
     assert Alloc(alloc).state_root().startswith(expected_hash)
-
-
-@pytest.mark.parametrize("evm_tool", [ExecutionSpecsTransitionTool])
-@pytest.mark.parametrize(
-    "binary_arg", ["no_binary_arg", "path_type", "str_type"]
-)
-@pytest.mark.skip(
-    reason="ExecutionSpecsTransitionTool through binary path is not supported"
-)
-def test_evm_tool_binary_arg(
-    evm_tool: Type[ExecutionSpecsTransitionTool], binary_arg: str
-) -> None:
-    """Test the `evm_tool` binary argument."""
-    if binary_arg == "no_binary_arg":
-        evm_tool().version()
-        return
-    elif binary_arg == "path_type":
-        evm_bin = which(DEFAULT_EVM_T8N_BINARY_NAME)
-        if not evm_bin:
-            # typing: Path can not take None; but if None, we may
-            # as well fail explicitly.
-            raise Exception(
-                f"Failed to find `{DEFAULT_EVM_T8N_BINARY_NAME}` "
-                "in the PATH via which"
-            )
-        evm_tool(binary=Path(evm_bin)).version()
-        return
-    elif binary_arg == "str_type":
-        evm_bin_str = which(DEFAULT_EVM_T8N_BINARY_NAME)
-        if evm_bin_str:
-            evm_tool(binary=Path(evm_bin_str)).version()
-        return
-    raise Exception("unknown test parameter")
 
 
 transaction_type_adapter = TypeAdapter(List[Transaction])


### PR DESCRIPTION
## 🗒️ Description
Renames `consume direct`'s `--bin` flag to `--evm-bin` so the binary flag is consistent with `fill --evm-bin`, and it removes stale references to `ethereum-spec-evm-resolver` now that the weld is completed.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
