### PR TITLE
chore(test-client-clis): update BAL exceptions for nethermind

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -431,8 +431,9 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
         ),
-        # BAL Exceptions — each specific exception uses a unique pattern.
-        # INVALID_BLOCK_ACCESS_LIST is the generic catch-all for all BAL errors.
+        # BAL Exceptions — specific exceptions have unique patterns, but
+        # INVALID_BLOCK_ACCESS_LIST and INCORRECT_BLOCK_FORMAT intentionally
+        # overlap because the test framework requires `want in got` matching.
         BlockException.INVALID_BAL_HASH: (
             r"InvalidBlockLevelAccessListHash:"
         ),

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -397,6 +397,9 @@ class NethermindExceptionMapper(ExceptionMapper):
             "InvalidStateRoot: State root in header does not match"
         ),
         BlockException.GAS_USED_OVERFLOW: ("Block gas limit exceeded"),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            "BlockAccessListGasLimitExceeded:"
+        ),
     }
     mapping_regex = {
         TransactionException.INSUFFICIENT_ACCOUNT_FUNDS: (

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -431,21 +431,30 @@ class NethermindExceptionMapper(ExceptionMapper):
         BlockException.SYSTEM_CONTRACT_CALL_FAILED: (
             r"(Withdrawals|Consolidations)Failed: Contract execution failed\."
         ),
-        # BAL Exceptions: TODO - review once all clients completed.
-        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
-            r"could not be parsed as a block: "
-            r"Could not decode block access list."
+        # BAL Exceptions — each specific exception uses a unique pattern.
+        # INVALID_BLOCK_ACCESS_LIST is the generic catch-all for all BAL errors.
+        BlockException.INVALID_BAL_HASH: (
+            r"InvalidBlockLevelAccessListHash:"
         ),
-        BlockException.INVALID_BAL_HASH: (r"InvalidBlockLevelAccessListRoot:"),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
-            r"InvalidBlockLevelAccessListRoot:"
+            r"InvalidBlockLevelAccessList:.*missing account"
+        ),
+        BlockException.INVALID_BAL_EXTRA_ACCOUNT: (
+            r"InvalidBlockLevelAccessList:.*surplus changes"
+            r"|could not be parsed as a block: "
+            r"Error decoding block access list:"
         ),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
-            r"InvalidBlockLevelAccessListRoot:|could not be parsed as a "
-            r"block: Could not decode block access list."
+            r"InvalidBlockLevelAccessListHash:"
+            r"|InvalidBlockLevelAccessList:"
+            r"|could not be parsed as a block: "
+            r"Error decoding block access list:"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (
             r"could not be parsed as a block: "
-            r"Could not decode block access list."
+            r"Error decoding block access list:"
+        ),
+        TransactionException.GAS_ALLOWANCE_EXCEEDED: (
+            r"TxGasLimitCapExceeded:"
         ),
     }

--- a/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/nethermind.py
@@ -437,9 +437,7 @@ class NethermindExceptionMapper(ExceptionMapper):
         # BAL Exceptions — specific exceptions have unique patterns, but
         # INVALID_BLOCK_ACCESS_LIST and INCORRECT_BLOCK_FORMAT intentionally
         # overlap because the test framework requires `want in got` matching.
-        BlockException.INVALID_BAL_HASH: (
-            r"InvalidBlockLevelAccessListHash:"
-        ),
+        BlockException.INVALID_BAL_HASH: (r"InvalidBlockLevelAccessListHash:"),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             r"InvalidBlockLevelAccessList:.*missing account"
         ),


### PR DESCRIPTION
## 🗒️ Description

Update Nethermind BAL related exceptions.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

