### PR TITLE
feat(test-types): improve error messages for invalid tx fields

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
@@ -1,7 +1,5 @@
 """Regression tests for fill error messages."""
 
-import subprocess
-import sys
 import textwrap
 from typing import Any
 
@@ -23,7 +21,9 @@ invalid_fee_payment_test_module = textwrap.dedent(
 )
 
 
-def test_fill_reports_conflicting_fee_fields(pytester: Any) -> None:
+def test_fill_reports_conflicting_fee_fields(
+    pytester: Any, capsys: Any, pytestconfig: Any
+) -> None:
     """Test that fill surfaces the conflicting fee fields in failures."""
     tests_dir = pytester.mkdir("tests")
     berlin_tests_dir = tests_dir / "berlin"
@@ -37,30 +37,24 @@ def test_fill_reports_conflicting_fee_fields(pytester: Any) -> None:
         name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
     )
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "-c",
-            "pytest-fill.ini",
-            "--fork",
-            "Berlin",
-            "-m",
-            "state_test",
-            "--no-html",
-            "--output=stdout",
-            str(test_module),
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        cwd=pytester.path,
+    result = pytester.runpytest_subprocess(
+        "-c",
+        "pytest-fill.ini",
+        "--fork",
+        "Berlin",
+        "-m",
+        "state_test",
+        "--no-html",
+        "--output=stdout",
+        str(test_module.relative_to(pytester.path)),
     )
+    # Suppress the expected inner pytest failure output from the outer test
+    # When using subprocess directly this would not be necessary
+    capsys.readouterr()
 
-    assert result.returncode != 0, "Fill command was expected to fail"
+    assert result.ret != 0, "Fill command was expected to fail"
 
-    output = "\n".join((result.stdout, result.stderr))
+    output = "\n".join(result.outlines + result.errlines)
     expected_message = (
         "cannot mix fee fields in a single tx: "
         "'gas_price' (legacy/type-1), 'max_fee_per_gas' (type-2+)"
@@ -70,4 +64,7 @@ def test_fill_reports_conflicting_fee_fields(pytester: Any) -> None:
     error_line = next(
         line for line in output.splitlines() if expected_message in line
     )
-    print(error_line)
+    # show print but only when -s is passed
+    if pytestconfig.getoption("capture") == "no":
+        with capsys.disabled():
+            print(error_line)

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
@@ -62,8 +62,8 @@ def test_fill_reports_conflicting_fee_fields(pytester: Any) -> None:
 
     output = "\n".join((result.stdout, result.stderr))
     expected_message = (
-        "cannot mix legacy/type-1 fee field 'gas_price' with type-2+ fee "
-        "field 'max_fee_per_gas'"
+        "cannot mix fee fields in a single tx: "
+        "'gas_price' (legacy/type-1), 'max_fee_per_gas' (type-2+)"
     )
     assert expected_message in output
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py
@@ -1,0 +1,73 @@
+"""Regression tests for fill error messages."""
+
+import subprocess
+import sys
+import textwrap
+from typing import Any
+
+invalid_fee_payment_test_module = textwrap.dedent(
+    """\
+    from execution_testing import Transaction
+
+
+    def test_invalid_fee_payment_error(state_test, pre) -> None:
+        tx = Transaction(
+            to=0,
+            gas_limit=21_000,
+            sender=pre.fund_eoa(),
+            gas_price=1,
+            max_fee_per_gas=2,
+        )
+        state_test(pre=pre, post={}, tx=tx)
+    """
+)
+
+
+def test_fill_reports_conflicting_fee_fields(pytester: Any) -> None:
+    """Test that fill surfaces the conflicting fee fields in failures."""
+    tests_dir = pytester.mkdir("tests")
+    berlin_tests_dir = tests_dir / "berlin"
+    berlin_tests_dir.mkdir()
+    fee_test_dir = berlin_tests_dir / "invalid_fee_payment_module"
+    fee_test_dir.mkdir()
+    test_module = fee_test_dir / "test_invalid_fee_payment_error.py"
+    test_module.write_text(invalid_fee_payment_test_module)
+
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-c",
+            "pytest-fill.ini",
+            "--fork",
+            "Berlin",
+            "-m",
+            "state_test",
+            "--no-html",
+            "--output=stdout",
+            str(test_module),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=pytester.path,
+    )
+
+    assert result.returncode != 0, "Fill command was expected to fail"
+
+    output = "\n".join((result.stdout, result.stderr))
+    expected_message = (
+        "cannot mix legacy/type-1 fee field 'gas_price' with type-2+ fee "
+        "field 'max_fee_per_gas'"
+    )
+    assert expected_message in output
+
+    error_line = next(
+        line for line in output.splitlines() if expected_message in line
+    )
+    print(error_line)

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -690,20 +690,33 @@ class TestPydanticModelConversion:
         pytest.param(
             {"gas_price": 1, "max_fee_per_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "only one type of fee payment field can be used",
+            "with type-2+ fee field 'max_fee_per_gas'",
             id="gas-price-and-max-fee-per-gas",
         ),
         pytest.param(
             {"gas_price": 1, "max_priority_fee_per_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "only one type of fee payment field can be used",
+            "with type-2+ fee field 'max_priority_fee_per_gas'",
             id="gas-price-and-max-priority-fee-per-gas",
         ),
         pytest.param(
             {"gas_price": 1, "max_fee_per_blob_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "only one type of fee payment field can be used",
+            "with type-2+ fee field 'max_fee_per_blob_gas'",
             id="gas-price-and-max-fee-per-blob-gas",
+        ),
+        pytest.param(
+            {
+                "gas_price": 1,
+                "max_fee_per_gas": 2,
+                "max_priority_fee_per_gas": 3,
+            },
+            Transaction.InvalidFeePaymentError,
+            (
+                "with type-2+ fee fields 'max_fee_per_gas' and "
+                "'max_priority_fee_per_gas'"
+            ),
+            id="gas-price-and-multiple-dynamic-fee-fields",
         ),
         pytest.param(
             {"ty": 0, "v": 1, "secret_key": 2},
@@ -725,6 +738,17 @@ def test_transaction_post_init_invalid_arg_combinations(  # noqa: D103
     with pytest.raises(expected_exception) as exc_info:
         Transaction(**invalid_tx_args)
     assert expected_exception_substring in str(exc_info.value)
+
+
+def test_invalid_fee_payment_error_message() -> None:
+    """Test the exact error message for mixed legacy and type-2+ fee fields."""
+    with pytest.raises(Transaction.InvalidFeePaymentError) as exc_info:
+        Transaction(gas_price=1, max_fee_per_gas=2)
+
+    error_msg = f"\n\t{str(exc_info.value)}"
+    print(error_msg)
+
+    assert "cannot mix" in error_msg
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -690,19 +690,22 @@ class TestPydanticModelConversion:
         pytest.param(
             {"gas_price": 1, "max_fee_per_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "with type-2+ fee field 'max_fee_per_gas'",
+            "'gas_price' (legacy/type-1), 'max_fee_per_gas' (type-2+)",
             id="gas-price-and-max-fee-per-gas",
         ),
         pytest.param(
             {"gas_price": 1, "max_priority_fee_per_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "with type-2+ fee field 'max_priority_fee_per_gas'",
+            (
+                "'gas_price' (legacy/type-1), "
+                "'max_priority_fee_per_gas' (type-2+)"
+            ),
             id="gas-price-and-max-priority-fee-per-gas",
         ),
         pytest.param(
             {"gas_price": 1, "max_fee_per_blob_gas": 2},
             Transaction.InvalidFeePaymentError,
-            "with type-2+ fee field 'max_fee_per_blob_gas'",
+            "'gas_price' (legacy/type-1), 'max_fee_per_blob_gas' (type-3+)",
             id="gas-price-and-max-fee-per-blob-gas",
         ),
         pytest.param(
@@ -713,8 +716,9 @@ class TestPydanticModelConversion:
             },
             Transaction.InvalidFeePaymentError,
             (
-                "with type-2+ fee fields 'max_fee_per_gas' and "
-                "'max_priority_fee_per_gas'"
+                "'gas_price' (legacy/type-1), "
+                "'max_fee_per_gas' (type-2+), "
+                "'max_priority_fee_per_gas' (type-2+)"
             ),
             id="gas-price-and-multiple-dynamic-fee-fields",
         ),

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -343,6 +343,13 @@ class Transaction(
     class InvalidFeePaymentError(Exception):
         """Transaction described more than one fee payment type."""
 
+        FEE_FIELD_LABELS = {
+            "gas_price": "legacy/type-1",
+            "max_fee_per_gas": "type-2+",
+            "max_priority_fee_per_gas": "type-2+",
+            "max_fee_per_blob_gas": "type-3+",
+        }
+
         def __init__(self, *conflicting_fields: str) -> None:
             """Store the conflicting fee fields used in the transaction."""
             self.conflicting_fields = conflicting_fields
@@ -350,41 +357,12 @@ class Transaction(
         def __str__(self) -> str:
             """Print exception string."""
             if not self.conflicting_fields:
-                return (
-                    "cannot mix legacy/type-1 and type-2+ fee fields in a "
-                    "single tx"
-                )
-
-            typed_fee_fields = tuple(
-                field_name
-                for field_name in self.conflicting_fields
-                if field_name != "gas_price"
+                return "cannot mix fee fields in a single tx"
+            labels = ", ".join(
+                f"'{f}' ({self.FEE_FIELD_LABELS[f]})"
+                for f in self.conflicting_fields
             )
-            formatted_typed_fields = [
-                f"'{field_name}'"
-                for field_name in self.conflicting_fields
-                if field_name != "gas_price"
-            ]
-            if len(formatted_typed_fields) == 1:
-                conflict_description = formatted_typed_fields[0]
-            elif len(formatted_typed_fields) == 2:
-                conflict_description = " and ".join(formatted_typed_fields)
-            else:
-                conflict_description = (
-                    ", ".join(formatted_typed_fields[:-1])
-                    + f", and {formatted_typed_fields[-1]}"
-                )
-            typed_field_label = (
-                "field" if len(typed_fee_fields) == 1 else "fields"
-            )
-
-            return (
-                "cannot mix legacy/type-1 fee field 'gas_price' with "
-                f"type-2+ fee {typed_field_label} {conflict_description}; "
-                "'gas_price' is for legacy/type-1 txs, while "
-                "'max_priority_fee_per_gas' and 'max_fee_per_gas' are for "
-                "type-2+ txs"
-            )
+            return f"cannot mix fee fields in a single tx: {labels}"
 
     class InvalidSignaturePrivateKeyError(Exception):
         """

--- a/packages/testing/src/execution_testing/test_types/transaction_types.py
+++ b/packages/testing/src/execution_testing/test_types/transaction_types.py
@@ -343,10 +343,47 @@ class Transaction(
     class InvalidFeePaymentError(Exception):
         """Transaction described more than one fee payment type."""
 
+        def __init__(self, *conflicting_fields: str) -> None:
+            """Store the conflicting fee fields used in the transaction."""
+            self.conflicting_fields = conflicting_fields
+
         def __str__(self) -> str:
             """Print exception string."""
+            if not self.conflicting_fields:
+                return (
+                    "cannot mix legacy/type-1 and type-2+ fee fields in a "
+                    "single tx"
+                )
+
+            typed_fee_fields = tuple(
+                field_name
+                for field_name in self.conflicting_fields
+                if field_name != "gas_price"
+            )
+            formatted_typed_fields = [
+                f"'{field_name}'"
+                for field_name in self.conflicting_fields
+                if field_name != "gas_price"
+            ]
+            if len(formatted_typed_fields) == 1:
+                conflict_description = formatted_typed_fields[0]
+            elif len(formatted_typed_fields) == 2:
+                conflict_description = " and ".join(formatted_typed_fields)
+            else:
+                conflict_description = (
+                    ", ".join(formatted_typed_fields[:-1])
+                    + f", and {formatted_typed_fields[-1]}"
+                )
+            typed_field_label = (
+                "field" if len(typed_fee_fields) == 1 else "fields"
+            )
+
             return (
-                "only one type of fee payment field can be used in a single tx"
+                "cannot mix legacy/type-1 fee field 'gas_price' with "
+                f"type-2+ fee {typed_field_label} {conflict_description}; "
+                "'gas_price' is for legacy/type-1 txs, while "
+                "'max_priority_fee_per_gas' and 'max_fee_per_gas' are for "
+                "type-2+ txs"
             )
 
     class InvalidSignaturePrivateKeyError(Exception):
@@ -363,12 +400,18 @@ class Transaction(
         """Ensure transaction has no conflicting properties."""
         super().model_post_init(__context)
 
-        if self.gas_price is not None and (
-            self.max_fee_per_gas is not None
-            or self.max_priority_fee_per_gas is not None
-            or self.max_fee_per_blob_gas is not None
-        ):
-            raise Transaction.InvalidFeePaymentError()
+        conflicting_fee_fields = [
+            field_name
+            for field_name in (
+                "gas_price",
+                "max_fee_per_gas",
+                "max_priority_fee_per_gas",
+                "max_fee_per_blob_gas",
+            )
+            if getattr(self, field_name) is not None
+        ]
+        if self.gas_price is not None and len(conflicting_fee_fields) > 1:
+            raise Transaction.InvalidFeePaymentError(*conflicting_fee_fields)
 
         if "ty" not in self.model_fields_set:
             # Try to deduce transaction type from included fields


### PR DESCRIPTION
## 🗒️ Description
while writing tests i sometimes mess up when defining a tx and i think that `Transaction.InvalidFeePaymentError()` currently gives u a fairly unhelpful error message when u accidentally define a legacy tx field + 1559 field at the same time. this PR improves the logging (it tells u which fields that u defined are conflicting with regards to which tx type they belong to). also adds unit tests to ensure we don't break this accidentally.

## Command to showcase new logged error
`uv run pytest -v -s packages/testing/src/execution_testing/test_types/tests/test_types.py -k test_invalid_fee_payment_error_message`

and

`uv run pytest -v -s packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_error_messages.py`

now show you e.g. `cannot mix legacy/type-1 fee field 'gas_price' with type-2+ fee field 'max_fee_per_gas'; 'gas_price' is for legacy/type-1 txs, while 'max_priority_fee_per_gas' and 'max_fee_per_gas' are for type-2+ txs` which is much more helpful than the error u saw before that (`only one type of fee can be set`).

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
