### PR TITLE
feat(test-fill): add `--post-verifications` flag to capture fill time post state checks

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -796,6 +796,17 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Only creates debug output when explicitly specified."
         ),
     )
+    debug_group.addoption(
+        "--post-verifications",
+        action="store_true",
+        dest="post_verifications",
+        default=False,
+        help=(
+            "Include a postVerifications field in fixture output "
+            "that records which post-state checks were "
+            "performed during filling."
+        ),
+    )
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -1767,6 +1778,11 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         )
                 assert fill_result is not None
                 fixture = fill_result.fixture
+                if (
+                    request.config.getoption("post_verifications")
+                    and fill_result.post_verifications is not None
+                ):
+                    fixture.post_verifications = fill_result.post_verifications
                 # If operation mode is benchmarking, check the gas used.
                 self.validate_benchmark_gas(
                     benchmark_gas_used=fill_result.benchmark_gas_used,

--- a/packages/testing/src/execution_testing/fixtures/__init__.py
+++ b/packages/testing/src/execution_testing/fixtures/__init__.py
@@ -22,6 +22,7 @@ from .collector import (
     merge_partial_fixture_files,
 )
 from .consume import FixtureConsumer
+from .post_verifications import AccountCheck, PostVerifications
 from .pre_alloc_groups import (
     PreAllocGroup,
     PreAllocGroupBuilder,
@@ -43,11 +44,13 @@ __all__ = [
     "FixtureCollector",
     "FixtureConsumer",
     "FixtureFillingPhase",
+    "AccountCheck",
     "FixtureFormat",
     "LabeledFixtureFormat",
     "PreAllocGroup",
     "PreAllocGroupBuilder",
     "PreAllocGroupBuilders",
+    "PostVerifications",
     "PreAllocGroups",
     "StateFixture",
     "strip_fixture_format_from_node",

--- a/packages/testing/src/execution_testing/fixtures/base.py
+++ b/packages/testing/src/execution_testing/fixtures/base.py
@@ -30,6 +30,7 @@ from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from execution_testing.base_types import CamelModel, ReferenceSpec
 from execution_testing.client_clis.cli_types import OpcodeCount
+from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
 
 
@@ -73,6 +74,9 @@ class BaseFixture(CamelModel):
 
     info: Dict[str, Dict[str, Any] | str] = Field(
         default_factory=dict, alias="_info"
+    )
+    post_verifications: PostVerifications | None = Field(
+        default=None, alias="postVerifications"
     )
 
     # Fixture format properties

--- a/packages/testing/src/execution_testing/fixtures/post_verifications.py
+++ b/packages/testing/src/execution_testing/fixtures/post_verifications.py
@@ -1,0 +1,78 @@
+"""Post-state verification model for tracking fill-time checks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Mapping
+
+from execution_testing.base_types import (
+    Address,
+    Bytes,
+    CamelModel,
+    ZeroPaddedHexNumber,
+)
+
+if TYPE_CHECKING:
+    from execution_testing.base_types import Alloc
+
+
+class AccountCheck(CamelModel):
+    """
+    Capture which fields are verified for a single account.
+
+    A ``None`` value means the field is not checked (it was not
+    explicitly set by the test author).  A present value records the
+    expected value that ``check_alloc`` would assert against.
+    """
+
+    nonce: ZeroPaddedHexNumber | None = None
+    balance: ZeroPaddedHexNumber | None = None
+    code: Bytes | None = None
+    storage: Mapping[ZeroPaddedHexNumber, ZeroPaddedHexNumber] | None = None
+
+
+class PostVerifications(CamelModel):
+    """
+    Record every post-state check performed during a fill session.
+
+    Accounts mapped to ``None`` represent *should-not-exist* checks.
+    """
+
+    accounts: Dict[Address, AccountCheck | None]
+
+    @classmethod
+    def from_alloc(cls, alloc: Alloc) -> PostVerifications:
+        """
+        Derive verification checks from an expected post ``Alloc``.
+
+        Walk each address/account pair and inspect
+        ``model_fields_set`` to determine which fields will actually
+        be compared by ``Account.check_alloc``.
+        """
+        accounts: Dict[Address, AccountCheck | None] = {}
+        for address, account in alloc.root.items():
+            if account is None:
+                accounts[address] = None
+                continue
+            accounts[address] = AccountCheck(
+                nonce=(
+                    account.nonce
+                    if "nonce" in account.model_fields_set
+                    else None
+                ),
+                balance=(
+                    account.balance
+                    if "balance" in account.model_fields_set
+                    else None
+                ),
+                code=(
+                    account.code
+                    if "code" in account.model_fields_set
+                    else None
+                ),
+                storage=(
+                    dict(account.storage.root)
+                    if "storage" in account.model_fields_set
+                    else None
+                ),
+            )
+        return cls(accounts=accounts)

--- a/packages/testing/src/execution_testing/specs/base.py
+++ b/packages/testing/src/execution_testing/specs/base.py
@@ -33,6 +33,7 @@ from execution_testing.fixtures import (
     FixtureFormat,
     LabeledFixtureFormat,
 )
+from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.forks.base_fork import BaseFork
 from execution_testing.test_types import Environment, Withdrawal
@@ -94,6 +95,7 @@ class FillResult(BaseModel):
     gas_optimization: int | None
     benchmark_gas_used: int | None = None
     benchmark_opcode_count: OpcodeCount | None = None
+    post_verifications: PostVerifications | None = None
 
 
 class BaseTest(BaseModel):

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -74,6 +74,7 @@ from execution_testing.fixtures.common import (
     FixtureBlobSchedule,
     FixtureTransactionReceipt,
 )
+from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
 from execution_testing.test_types import (
     Alloc,
@@ -930,6 +931,7 @@ class BlockchainTest(BaseTest):
             gas_optimization=None,
             benchmark_gas_used=benchmark_gas_used,
             benchmark_opcode_count=benchmark_opcode_count,
+            post_verifications=PostVerifications.from_alloc(self.post),
         )
 
     def make_hive_fixture(
@@ -1075,6 +1077,7 @@ class BlockchainTest(BaseTest):
             gas_optimization=None,
             benchmark_gas_used=benchmark_gas_used,
             benchmark_opcode_count=benchmark_opcode_count,
+            post_verifications=PostVerifications.from_alloc(self.post),
         )
 
     def generate(

--- a/packages/testing/src/execution_testing/specs/state.py
+++ b/packages/testing/src/execution_testing/specs/state.py
@@ -38,6 +38,7 @@ from execution_testing.fixtures import (
     StateFixture,
 )
 from execution_testing.fixtures.common import FixtureBlobSchedule
+from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.fixtures.state import (
     FixtureConfig,
     FixtureEnvironment,
@@ -511,6 +512,7 @@ class StateTest(BaseTest):
             gas_optimization=gas_optimization,
             benchmark_gas_used=transition_tool_output.result.gas_used,
             benchmark_opcode_count=transition_tool_output.result.opcode_count,
+            post_verifications=PostVerifications.from_alloc(self.post),
         )
 
     def get_genesis_environment(self) -> Environment:

--- a/packages/testing/src/execution_testing/specs/static_state/expect_section.py
+++ b/packages/testing/src/execution_testing/specs/static_state/expect_section.py
@@ -293,10 +293,9 @@ class ResultInFiller(EthereumTestRootModel, TagDependentData):
             else:
                 resolved_address = Address(address)
 
-            if account is None:
-                continue
-
-            post[resolved_address] = account.resolve(tags)
+            post[resolved_address] = (
+                account.resolve(tags) if account is not None else account
+            )
         return post
 
     def __contains__(self, address: Address) -> bool:


### PR DESCRIPTION
## 🗒️ Description

Adds a PostVerifications Pydantic model that records exactly which post-state checks are performed during a fill session. When `--post-verifications` is passed, a `postVerifications` field is included in the fixture JSON output, capturing which account fields (nonce, balance, code, storage) are verified and their expected values. This enables diffing verification coverage between two fill runs via `hasher compare` to detect silently lost assertions.

This is added to help aid with #2514, so that we can check where we lose post state verification checks from the static test ports to python.

Note when running fill with `--post-verifications` the new field is included within the info hash calculation for the fixture.

We might want not even merge this given its redundant in the future.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.oZr8dTF82ch1NOFRVjcl9QHaEo%3Fpid%3DApi&f=1&ipt=433f93623861ff39ed104dd292171a3230db6c56afc562fe7347ba1bae911c15&ipo=images)