### PR TITLE
chore(test-client-clis): update erigon exception mapper for EIP-8037/7928 errors

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/erigon.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/erigon.py
@@ -112,8 +112,11 @@ class ErigonExceptionMapper(ExceptionMapper):
             r"invalid block access list"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list"),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list too large"
+        ),
         TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM: (
-            r"invalid block, txnIdx=\d+,.*gas limit too high"
+            r"gas limit too high"
         ),
         BlockException.INCORRECT_BLOB_GAS_USED: (
             r"blobGasUsed by execution: \d+, in header: \d+"


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Add `BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED` regex mapping for erigon's "block access list too large" validation error.

Update `GAS_LIMIT_EXCEEDS_MAXIMUM` regex to match erigon's current error format ("gas limit too high").

Now passes the following tests on hive:
- test_bal_gas_limit_boundary[below_boundary]
- test_tx_gas_above_cap_at_transition[above_cap]

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
