### PR TITLE
chore(test-client-clis): update besu exception mapper

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/besu.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/besu.py
@@ -424,11 +424,13 @@ class BesuExceptionMapper(ExceptionMapper):
             r"exceeds transaction sender account balance 0x[0-9a-f]+"
         ),
         TransactionException.INTRINSIC_GAS_TOO_LOW: (
-            r"transaction invalid intrinsic gas cost \d+ "
+            r"transaction invalid intrinsic gas cost \d+"
+            r"(?: \(regular \d+ \+ state \d+\))? "
             r"exceeds gas limit \d+"
         ),
         TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
-            r"transaction invalid intrinsic gas cost \d+ "
+            r"transaction invalid intrinsic gas cost \d+"
+            r"(?: \(regular \d+ \+ state \d+\))? "
             r"exceeds gas limit \d+"
         ),
         TransactionException.SENDER_NOT_EOA: (


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Update besu exception mapper to handle EIP-8037 intrinsic gas error format.

Besu now includes `(regular X + state Y)` in intrinsic gas errors for EIP-8037 transactions:
```
intrinsic gas cost 161488 (regular 30000 + state 131488) exceeds gas limit 161487
```

The existing regex only matched `intrinsic gas cost \d+ exceeds gas limit \d+`, missing the optional breakdown.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).