### PR TITLE
fix(test-tests,ci): fix flakiness due to mutated `EnvironmentDefaults.gas_limit` with xdist

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute.py
@@ -26,6 +26,7 @@ from ..shared.helpers import (
     get_spec_format_for_item,
     is_help_or_collectonly_mode,
     labeled_format_parameter_set,
+    option_was_explicitly_set,
 )
 from ..spec_version_checker.spec_version_checker import EIPSpecTestItem
 from .pre_alloc import Alloc
@@ -200,8 +201,9 @@ def pytest_configure(config: pytest.Config) -> None:
        called before the pytest-html plugin's pytest_configure to ensure that
        it uses the modified `htmlpath` option.
     """
-    # Modify the block gas limit if specified.
-    if config.getoption("transaction_gas_limit"):
+    # Keep execute-mode overrides working, but avoid rewriting the global
+    # default when this plugin is merely imported into nested pytest sessions.
+    if option_was_explicitly_set(config, "--transaction-gas-limit"):
         EnvironmentDefaults.gas_limit = config.getoption(
             "transaction_gas_limit"
         )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/tests/test_execute.py
@@ -1,0 +1,57 @@
+"""Regression tests for execute plugin configuration."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from execution_testing.test_types.block_types import EnvironmentDefaults
+
+from ..execute import pytest_configure
+
+
+class FakeConfig:
+    """Minimal config object for exercising execute plugin setup."""
+
+    engine_rpc_supported: bool
+
+    def __init__(self, *args: str) -> None:
+        self.invocation_params = SimpleNamespace(args=args)
+        self.option = SimpleNamespace(help=True)
+        self.pluginmanager = SimpleNamespace(has_plugin=lambda _name: False)
+
+    def getoption(self, name: str, default: Any = None) -> Any:
+        """Return configured option values used by pytest_configure."""
+        options = {
+            "transaction_gas_limit": 7,
+            "disable_html": False,
+            "htmlpath": None,
+            "markers": False,
+            "collectonly": False,
+            "show_ported_from": False,
+            "links_as_filled": False,
+            "help": True,
+        }
+        return options.get(name, default)
+
+
+def test_pytest_configure_ignores_default_transaction_gas_limit() -> None:
+    """Default execute options must not rewrite the global block gas limit."""
+    original_gas_limit = EnvironmentDefaults.gas_limit
+
+    config = FakeConfig()
+    pytest_configure(config)  # type: ignore[arg-type]
+
+    assert EnvironmentDefaults.gas_limit == original_gas_limit
+    assert config.engine_rpc_supported is False
+
+
+def test_pytest_configure_applies_explicit_transaction_gas_limit() -> None:
+    """An explicit execute gas-limit override still updates the default."""
+    original_gas_limit = EnvironmentDefaults.gas_limit
+
+    config = FakeConfig("--transaction-gas-limit=7")
+    pytest_configure(config)  # type: ignore[arg-type]
+
+    assert EnvironmentDefaults.gas_limit == 7
+    assert config.engine_rpc_supported is False
+
+    EnvironmentDefaults.gas_limit = original_gas_limit

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -89,6 +89,7 @@ from ..shared.helpers import (
     get_spec_format_for_item,
     is_help_or_collectonly_mode,
     labeled_format_parameter_set,
+    option_was_explicitly_set,
 )
 from ..spec_version_checker.spec_version_checker import (
     get_ref_spec_from_module,
@@ -827,7 +828,7 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     # Register custom markers
     # Modify the block gas limit if specified.
-    if config.getoption("block_gas_limit"):
+    if option_was_explicitly_set(config, "--block-gas-limit"):
         EnvironmentDefaults.gas_limit = config.getoption("block_gas_limit")
 
     # Initialize fixture output configuration

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/conftest.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/conftest.py
@@ -5,15 +5,20 @@ from typing import Generator
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def restore_environment_defaults() -> Generator[None, None, None]:
     """
-    Restore EnvironmentDefaults.gas_limit after tests.
+    Reset EnvironmentDefaults.gas_limit around each test.
 
-    Restore the gas limit after the test run to prevent side effects.
+    Reset the gas limit to DEFAULT_BLOCK_GAS_LIMIT before and after each test
+    run to prevent side effects from nested in-process pytest sessions leaking
+    into later tests on the same worker.
     """
-    from execution_testing.test_types.block_types import EnvironmentDefaults
+    from execution_testing.test_types.block_types import (
+        DEFAULT_BLOCK_GAS_LIMIT,
+        EnvironmentDefaults,
+    )
 
-    original_gas_limit = EnvironmentDefaults.gas_limit
+    EnvironmentDefaults.gas_limit = DEFAULT_BLOCK_GAS_LIMIT
     yield
-    EnvironmentDefaults.gas_limit = original_gas_limit
+    EnvironmentDefaults.gas_limit = DEFAULT_BLOCK_GAS_LIMIT

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_filler.py
@@ -872,7 +872,6 @@ test_module_environment_variables = textwrap.dedent(
         ),
     ],
 )
-@pytest.mark.usefixtures("restore_environment_defaults")
 def test_fill_variables(
     testdir: pytest.Testdir,
     args: list[str],

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/helpers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/helpers.py
@@ -16,6 +16,18 @@ from execution_testing.fixtures import (
 from execution_testing.specs import BaseTest
 
 
+def option_was_explicitly_set(config: pytest.Config, option_name: str) -> bool:
+    """Return whether a long CLI option was passed explicitly."""
+    normalized_option = option_name.strip()
+    if not normalized_option.startswith("--"):
+        normalized_option = f"--{normalized_option}"
+
+    for arg in config.invocation_params.args:
+        if arg == normalized_option or arg.startswith(f"{normalized_option}="):
+            return True
+    return False
+
+
 def is_help_or_collectonly_mode(config: pytest.Config) -> bool:
     """Check if pytest is running in a help or collectonly mode."""
     return (


### PR DESCRIPTION
## Summary
Fixes unit tests that 'sometimes' would be failing, due to a flaky `pytest -n auto` failure caused by worker-local leakage of `EnvironmentDefaults.gas_limit`.

You can reproduce the problem (before applying the PR) by navigating to:
`cd packages/testing`

and then repeatedly running:
	
`uv run pytest -n auto -p no:cacheprovider --ignore=src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_benchmarking.py src -v -s`

e.g:
* 1. try: `29 failed, 1416 passed`
* 2. try: `14 failed, 1431 passed`
* 3. try: `22 failed, 1423 passed`
* 4. try: `29 failed, 1416 passed`

after applying the PR you consistently get:
	
* `1447 passed` (the PR also adds two new unit tests so that this is detected before it can happen again)


## Problem
Some pytest plugins were mutating the global `EnvironmentDefaults.gas_limit` during `pytest_configure`, even when the corresponding CLI option had not been explicitly passed by the user.

That was mostly harmless in a fresh process, but it became a problem in nested in-process pytest runs and under xdist:

* a nested pytest session could rewrite the global gas limit
* later tests on the same worker would inherit the mutated value
* depending on worker scheduling, this produced different numbers of failures under `-n auto`

In practice this showed up as occasional unit test CI failures with bogus tiny gas limits and errors like `gas used exceeds limit`.

## Root Cause
Both `fill` and `execute` use config.getoption(...) to decide whether to override the global gas limit.

That meant the override happened not only for explicit flags like `--transaction-gas-limit` or `--block-gas-limit`, but also when pytest was just returning the option default value.

In `execute` mode this was especially bad because the default transaction gas limit is derived from the current global block gas limit, so repeated nested sessions could keep shrinking the global value.

## Fix
Make it explicit-only:

* add a shared helper to detect whether a long CLI option was actually passed on the command line
* only override `EnvironmentDefaults.gas_limit` in `execute` when `--transaction-gas-limit` was explicitly provided
* only override `EnvironmentDefaults.gas_limit` in `fill` when `--block-gas-limit` was explicitly provided
* reset `EnvironmentDefaults.gas_limit` to the canonical default before and after each filler test to avoid cross-test worker contamination
* add regression tests covering the explicit-vs-default execute behavior

Note: The user-facing feature is preserved:

* `--transaction-gas-limit` still overrides the default when explicitly requested
* `--block-gas-limit` still overrides the default when explicitly requested

What changes is only the accidental behavior where merely loading a plugin or using default option values could mutate global state.

## 🔗 Related Issues or PRs
I originally started this work when looking into why a [harmless exeception mapper update PR](https://github.com/ethereum/execution-specs/pull/2550) had py3 failures. The problem with silencing those failures with 'rebasing' is that it does not fix the underlying issue, it re-runs CI and when you get a lucky (or rather unlucky) worker distribution you might pass the tests without noticing the sleeper bug.

The fix is also related to ongoing work started with [#2534](https://github.com/ethereum/execution-specs/issues/2534) which recognized that there is a problem in our codebase where we modify shared objects and end up with subtle / sometimes hard-to-reproduce failures.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1349696533922320478/1482020876726702130/IMG_0181.png?ex=69c5e9bf&is=69c4983f&hm=ed4214b22d8683438662ca34d81c1cb42ab9f5e00b752de7077e41c50c52c374&"
  alt="Cute Animal Picture"
  width="320">


