### PR TITLE
fix(test-tests): restore `execute` chain-id defaults after in-process pytest runs

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
@@ -75,5 +75,15 @@ def pytest_configure(config: pytest.Config) -> None:
             "flags or the CHAIN_ID/RPC_CHAIN_ID environment variables."
         )
 
+    setattr(config, "_original_chain_id_default", ChainConfigDefaults.chain_id)
+
     # write to config
     ChainConfigDefaults.chain_id = chain_id
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore the previous chain-id default after the session ends."""
+    if hasattr(config, "_original_chain_id_default"):
+        ChainConfigDefaults.chain_id = getattr(
+            config, "_original_chain_id_default"
+        )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
@@ -75,7 +75,9 @@ def pytest_configure(config: pytest.Config) -> None:
             "flags or the CHAIN_ID/RPC_CHAIN_ID environment variables."
         )
 
-    setattr(config, "_original_chain_id_default", ChainConfigDefaults.chain_id)
+    setattr(  # noqa: B010
+        config, "_original_chain_id_default", ChainConfigDefaults.chain_id
+    )
 
     # write to config
     ChainConfigDefaults.chain_id = chain_id
@@ -84,4 +86,6 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Restore the previous chain-id default after the session ends."""
     if hasattr(config, "_original_chain_id_default"):
-        ChainConfigDefaults.chain_id = getattr(config, "_original_chain_id_default")
+        ChainConfigDefaults.chain_id = getattr(  # noqa: B009
+            config, "_original_chain_id_default"
+        )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/execute_flags/execute_flags.py
@@ -84,6 +84,4 @@ def pytest_configure(config: pytest.Config) -> None:
 def pytest_unconfigure(config: pytest.Config) -> None:
     """Restore the previous chain-id default after the session ends."""
     if hasattr(config, "_original_chain_id_default"):
-        ChainConfigDefaults.chain_id = getattr(
-            config, "_original_chain_id_default"
-        )
+        ChainConfigDefaults.chain_id = getattr(config, "_original_chain_id_default")

--- a/packages/testing/src/execution_testing/cli/tests/test_pytest_execute_command.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_pytest_execute_command.py
@@ -6,12 +6,12 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from ..pytest_commands.execute import execute
 from ...test_types.chain_config_types import (
     DEFAULT_CHAIN_ID,
     ChainConfigDefaults,
 )
 from ...test_types.transaction_types import Transaction
+from ..pytest_commands.execute import execute
 
 
 @pytest.fixture
@@ -126,7 +126,12 @@ def test_execute_remote_leaks_chain_id_into_later_defaults(
     inner_test.write_text(
         "\n".join(
             [
-                "from execution_testing import Account, Environment, TestAddress, Transaction",
+                "from execution_testing import (",
+                "    Account,",
+                "    Environment,",
+                "    TestAddress,",
+                "    Transaction,",
+                ")",
                 "",
                 "def test_noop(state_test) -> None:",
                 "    state_test(",

--- a/packages/testing/src/execution_testing/cli/tests/test_pytest_execute_command.py
+++ b/packages/testing/src/execution_testing/cli/tests/test_pytest_execute_command.py
@@ -1,9 +1,17 @@
 """Tests for execute command click CLI."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
 from ..pytest_commands.execute import execute
+from ...test_types.chain_config_types import (
+    DEFAULT_CHAIN_ID,
+    ChainConfigDefaults,
+)
+from ...test_types.transaction_types import Transaction
 
 
 @pytest.fixture
@@ -108,3 +116,45 @@ def test_all_execute_subcommands_help_no_conflicts(runner: CliRunner) -> None:
             f"execute {subcommand} --help has conflicting option string\n"
             f"Output: {result.output}"
         )
+
+
+def test_execute_remote_leaks_chain_id_into_later_defaults(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Demonstrate that an in-process execute session leaks chain ID."""
+    inner_test = tmp_path / "test_inner.py"
+    inner_test.write_text(
+        "\n".join(
+            [
+                "from execution_testing import Account, Environment, TestAddress, Transaction",
+                "",
+                "def test_noop(state_test) -> None:",
+                "    state_test(",
+                "        env=Environment(),",
+                "        pre={TestAddress: Account(balance=1_000_000)},",
+                "        post={},",
+                "        tx=Transaction(),",
+                "    )",
+            ]
+        )
+    )
+
+    ChainConfigDefaults.chain_id = DEFAULT_CHAIN_ID
+    with patch(
+        "execution_testing.cli.pytest_commands.plugins.execute.rpc.remote.EthRPC"
+    ) as mock_eth_rpc:
+        mock_eth_rpc.return_value.chain_id.return_value = 12345
+        result = runner.invoke(
+            execute,
+            [
+                "remote",
+                "--rpc-endpoint=http://localhost:12345",
+                "--chain-id=12345",
+                "--collect-only",
+                "-q",
+                str(inner_test),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert Transaction().chain_id == DEFAULT_CHAIN_ID


### PR DESCRIPTION
## 🗒️ Description
Continuing the search for potential in-process state leaks a potential leak in the `execute` command path was found. `execute_flags.py` was mutating `ChainConfigDefaults.chain_id` during `pytest_configure`, and because `execute` runs `pytest.main(...)` in-process, a nested `execute` session could leave that non-default chain ID behind for later tests in the same outer process. 

Note: This issue was fixed before it ever occured, the first commit is a unit test that would fail without the second commit (that fixes the underlying issue).

The fix preserves `execute` behavior during the nested session but restores the previous `chain-id` default in `pytest_unconfigure`. The added unit test reproduces the leak via CliRunner by running `execute remote --chain-id=12345 --collect-only` and then asserting that a later default `Transaction()` still uses the canonical default chain ID.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://cdn.discordapp.com/attachments/1349696533922320478/1482020877246926998/IMG_0182.png?ex=69c5e9bf&is=69c4983f&hm=300f79eb3a9822425cb81c32515a779f3e41606d127e099dc79002e26ebef414&"
  alt="Cute Animal Picture"
  width="320">
