### PR TITLE
refactor(test-benchmark): generic erc20 benchmark

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -273,6 +273,97 @@ def test_sload_erc20_balanceof(
     benchmark_test(pre=pre, blocks=blocks, skip_gas_used_validation=True)
 
 
+@pytest.mark.parametrize("token_name", SSTORE_TOKENS)
+def test_sstore_erc20_generic(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+) -> None:
+    """Benchmark SSTORE using ERC20 approve."""
+    sender = pre.fund_eoa()
+
+    threshold = 100_000
+
+    # Stub Account
+    erc20_address = pre.deploy_contract(
+        code=Bytecode(),
+        stub=f"test_sstore_erc20_approve_{token_name}",
+    )
+
+    # MEM[0] = function selector
+    # MEM[32] = starting address offset
+    setup = Op.MSTORE(
+        0,
+        APPROVE_SELECTOR,
+    ) + Op.MSTORE(
+        32,
+        Op.SLOAD(0),  # Address Offset
+    )
+
+    call_approve = Op.MSTORE(
+        64,
+        Op.ADD(1, Op.MLOAD(32)),
+    ) + Op.POP(
+        Op.CALL(
+            address=erc20_address,
+            args_offset=28,
+            args_size=68,
+        )
+    )
+
+    loop = While(
+        body=call_approve + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        condition=Op.GT(Op.GAS, threshold),
+    )
+
+    teardown = Op.SSTORE(0, Op.MLOAD(32))
+
+    # Contract Deployment
+    code = setup + loop + teardown
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Transaction Loops
+    gas_remaining = gas_benchmark_value
+
+    # Collect tx params first, then build Transaction objects
+    # so that nonces are allocated contiguously per block.
+    tx_gas: list[int] = []
+    while gas_remaining > intrinsic_gas:
+        gas_available = min(gas_remaining, tx_gas_limit)
+
+        if gas_available < intrinsic_gas:
+            break
+
+        tx_gas.append(gas_available)
+
+        gas_remaining -= gas_available
+
+    txs = []
+    with TestPhaseManager.execution():
+        for gas_available in tx_gas:
+            txs.append(
+                Transaction(
+                    gas_limit=gas_available,
+                    to=attack_contract_address,
+                    sender=sender,
+                )
+            )
+
+    blocks = [Block(txs=txs)]
+
+    benchmark_test(
+        pre=pre,
+        blocks=blocks,
+        skip_gas_used_validation=True,
+        expected_receipt_status=True,
+    )
+
+
 @pytest.mark.repricing
 @pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 @pytest.mark.parametrize("token_name", SSTORE_TOKENS)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -60,6 +60,93 @@ START_SLOT = (
     % (2**160)
 )
 
+
+@pytest.mark.parametrize("token_name", SLOAD_TOKENS)
+def test_sload_erc20_generic(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+) -> None:
+    """Benchmark SLOAD using ERC20 balanceOf on bloatnet."""
+    # Stub Account
+    erc20_address = pre.deploy_contract(
+        code=Bytecode(),
+        stub=f"test_sload_empty_erc20_balanceof_{token_name}",
+    )
+    threshold = 100000
+
+    # MEM[0] = function selector
+    # MEM[32] = starting address offset
+    setup = Op.MSTORE(
+        0,
+        BALANCEOF_SELECTOR,
+        # gas accounting
+        old_memory_size=0,
+        new_memory_size=32,
+    ) + Op.MSTORE(
+        32,
+        Op.SLOAD(0),  # Address Offset
+        # gas accounting
+        old_memory_size=32,
+        new_memory_size=64,
+    )
+
+    call_balance_of = Op.POP(
+        Op.CALL(
+            address=erc20_address,
+            args_offset=32 - 4,
+            args_size=32 + 4,
+        )
+    )
+
+    loop = While(
+        body=call_balance_of + Op.MSTORE(32, Op.ADD(Op.MLOAD(32), 1)),
+        condition=Op.GT(Op.GAS, threshold),
+    )
+
+    teardown = Op.SSTORE(0, Op.MLOAD(32))
+
+    # Contract Deployment
+    code = setup + loop + teardown
+    attack_contract_address = pre.deploy_contract(code=code)
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+
+    # Transaction Loops
+    txs = []
+    gas_remaining = gas_benchmark_value
+
+    sender = pre.fund_eoa()
+
+    while gas_remaining > intrinsic_gas:
+        gas_available = min(gas_remaining, tx_gas_limit)
+
+        if gas_available < intrinsic_gas:
+            break
+
+        with TestPhaseManager.execution():
+            txs.append(
+                Transaction(
+                    gas_limit=gas_available,
+                    to=attack_contract_address,
+                    sender=sender,
+                )
+            )
+
+        gas_remaining -= gas_available
+
+    blocks = [Block(txs=txs)]
+    benchmark_test(
+        pre=pre,
+        blocks=blocks,
+        skip_gas_used_validation=True,
+        expected_receipt_status=True,
+    )
+
+
 # SLOAD BENCHMARK ARCHITECTURE:
 #
 #   [Pre-deployed ERC20 Contract] ──── Storage slots for balances


### PR DESCRIPTION
## 🗒️ Description
Adds generic SSTORE/SLOAD tests targeting contracts with an ERC20 interface. Gas check is in the loop, threshold is 100_000, should be sufficient. Explicitly checks receipts to see if transaction succeeded.

CC @CPerezz 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
