### PR TITLE
refactor(test-vm): optimize `Bytecode.__mul__` and `__add__` performance 

### DIFF
--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -227,7 +227,7 @@ class Bytecode:
         )
 
         return Bytecode(
-            bytes(self) + bytes(other),
+            self._bytes_ + other._bytes_,
             popped_stack_items=c_pop,
             pushed_stack_items=c_push,
             min_stack_height=c_min,
@@ -256,10 +256,32 @@ class Bytecode:
             raise ValueError("Cannot multiply by a negative number")
         if other == 0:
             return Bytecode()
-        output = self
-        for _ in range(other - 1):
-            output += self
-        return output
+        if other == 1:
+            return Bytecode(self)
+
+        result_bytes = self._bytes_ * other
+
+        a_pop = self.popped_stack_items
+        a_push = self.pushed_stack_items
+        a_min = self.min_stack_height
+        a_max = self.max_stack_height
+        net = a_push - a_pop
+        repeats = other - 1
+
+        c_pop = a_pop + max(0, -net) * repeats
+        c_push = a_push + max(0, net) * repeats
+        c_min = a_min + max(0, -net) * repeats
+        c_max = a_max + abs(net) * repeats
+
+        return Bytecode(
+            result_bytes,
+            popped_stack_items=c_pop,
+            pushed_stack_items=c_push,
+            min_stack_height=c_min,
+            max_stack_height=c_max,
+            terminating=self.terminating,
+            opcode_list=self.opcode_list * other,
+        )
 
     def hex(self) -> str:
         """

--- a/packages/testing/src/execution_testing/vm/bytecode.py
+++ b/packages/testing/src/execution_testing/vm/bytecode.py
@@ -238,7 +238,7 @@ class Bytecode:
 
     def __radd__(self, other: "Bytecode | int | None") -> "Bytecode":
         """
-        Concatenate the opcode byte representation with another bytes object.
+        Repeat the bytecode a given number of times.
         """
         if other is None or (isinstance(other, int) and other == 0):
             # Edge case for sum() function


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

From my understanding, we had this loop:

```python
  output = self                                                                                                            
  for _ in range(other - 1):                                                                                               
      output += self 
```

Each `output += self` calls `__add__`, which creates a new bytes object via bytes(self) + bytes(other). 

Since python bytes are  immutable, each concatenation allocates a new buffer and copies all previous bytes into it.

So:

  For `self * n` where `len(self) = k`:                                                                                        
  - Iteration 1: copies k + k = 2k bytes
  - Iteration 2: copies 2k + k = 3k bytes                                                                                  
  - ...                                                           
  - Iteration n-1: copies nk bytes  


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

:cat2: 
