### PR TITLE
feat(tooling,docs): add pytester best practices skill and docs

### DIFF
--- a/.claude/commands/pytester.md
+++ b/.claude/commands/pytester.md
@@ -1,0 +1,36 @@
+# Pytester
+
+Guide for pytester-based plugin/CLI tests. Run before writing or modifying these tests.
+
+## Which execution mode to use
+
+- **`runpytest()`** — default. In-process, fast, full `RunResult` API (`assert_outcomes()`, `fnmatch_lines()`).
+- **`runpytest_subprocess()`** — use only when in-process causes state leakage (Pydantic cache pollution, global mutation in `pytest_configure`). Same `RunResult` API.
+- **Raw `subprocess.run()`** — never use alongside pytester. Use `runpytest_subprocess()` instead.
+
+Subprocess isolation masks bugs rather than fixing them. Prefer fixing the root cause and use subprocess as defense-in-depth.
+
+## Expected inner failures
+
+`runpytest_subprocess()` replays inner output to outer stdout (by design). Suppress with `capsys.readouterr()`:
+
+```python
+def test_expected_failure(pytester: Any, capsys: Any, pytestconfig: Any) -> None:
+    result = pytester.runpytest_subprocess(...)
+    capsys.readouterr()  # suppress inner failure bleed
+    assert result.ret != 0
+    output = "\n".join(result.outlines + result.errlines)
+    # conditional print for -s debugging
+    if pytestconfig.getoption("capture") == "no":
+        with capsys.disabled():
+            print(output)
+```
+
+## RunResult API
+
+Prefer `assert_outcomes()` and `fnmatch_lines()` over manual `any(... in line ...)` — better failure messages.
+
+- `result.ret` — exit code
+- `result.outlines` / `result.errlines` — line lists
+- `result.assert_outcomes(passed=N, failed=N)`
+- `result.stdout.fnmatch_lines(["*pattern*"])`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ When reviewing PRs that implement or test EIPs:
 ## When to Use Skills
 
 - Writing or modifying tests → run `/write-test` first
+- Writing or modifying pytester-based plugin tests → run `/pytester` first
 - Filling test fixtures → run `/fill-tests` first
 - Implementing an EIP or modifying fork code in `src/` → run `/implement-eip` first
 - Modifying GitHub Actions workflows → run `/edit-workflow` first
@@ -53,6 +54,7 @@ When reviewing PRs that implement or test EIPs:
 ## Available Skills
 
 - `/write-test` — test writing patterns, fixtures, markers, bytecode helpers
+- `/pytester` — pytester execution modes, isolation, output handling for plugin tests
 - `/fill-tests` — `fill` CLI reference, flags, debugging, benchmark tests
 - `/implement-eip` — fork structure, import rules, adding opcodes/precompiles/tx types
 - `/edit-workflow` — GitHub Actions conventions and version pinning

--- a/docs/getting_started/code_standards_details.md
+++ b/docs/getting_started/code_standards_details.md
@@ -91,6 +91,18 @@ uvx pre-commit install
 
 For more information, see [Pre-commit Hooks Documentation](../dev/precommit.md).
 
+## Testing Framework Plugins with Pytester
+
+Use pytest's `pytester` fixture when writing tests for our pytest plugins and CLI commands.
+
+`runpytest()` is the default. It runs the inner session in-process, is fast, and gives access to helpers like `assert_outcomes()` and `fnmatch_lines()`.
+
+`runpytest_subprocess()` runs the inner session in a separate process. Use it only when in-process mode causes state leakage (e.g., Pydantic `ModelMetaclass` cache pollution or global mutation in `pytest_configure`). Subprocess isolation masks these bugs rather than fixing them, so prefer fixing the root cause and use subprocess mode as defense-in-depth.
+
+Don't use raw `subprocess.run()` in pytester-based tests. If you need process isolation, use `runpytest_subprocess()`.
+
+Both methods return a `RunResult` with `.ret`, `.outlines`, `.errlines`, `assert_outcomes()`, and `fnmatch_lines()`. When the inner test is expected to fail, use `capsys.readouterr()` after `runpytest_subprocess()` to suppress the inner failure output that pytester replays to stdout.
+
 ## Formatting and Line Length
 
 The Python code in @ethereum/execution-spec-tests is formatted with `ruff` with a line length of 100 characters.

--- a/docs/getting_started/code_standards_details.md
+++ b/docs/getting_started/code_standards_details.md
@@ -103,24 +103,6 @@ Don't use raw `subprocess.run()` in pytester-based tests. If you need process is
 
 Both methods return a `RunResult` with `.ret`, `.outlines`, `.errlines`, `assert_outcomes()`, and `fnmatch_lines()`. When the inner test is expected to fail, use `capsys.readouterr()` after `runpytest_subprocess()` to suppress the inner failure output that pytester replays to stdout.
 
-## Formatting and Line Length
-
-The Python code in @ethereum/execution-spec-tests is formatted with `ruff` with a line length of 100 characters.
-
-### Ignoring Bulk Change Commits
-
-The maximum line length was changed from 80 to 100 in Q2 2023. To ignore this bulk change commit in git blame output, use the `.git-blame-ignore-revs` file:
-
-```console
-git blame --ignore-revs-file .git-blame-ignore-revs docs/gen_test_case_reference.py
-```
-
-To use the revs file persistently with `git blame`:
-
-```console
-git config blame.ignoreRevsFile .git-blame-ignore-revs
-```
-
 ## Building and Verifying Docs Locally
 
 To quickly build and browse the HTML documentation locally run:


### PR DESCRIPTION
## 🗒️ Description
Help humans and bots write pytest plugin tests via pytester.

## 🔗 Related Issues or PRs
- Follow-up to a discussion in #2551.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

:baby_chick:  