### PR TITLE
chore(test-client-clis): update geth exception mapper for BAL devnet-3

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/geth.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/geth.py
@@ -164,13 +164,21 @@ class GethExceptionMapper(ExceptionMapper):
         BlockException.INVALID_BAL_HASH: (r"invalid block access list:"),
         BlockException.INVALID_BAL_MISSING_ACCOUNT: (
             r"computed state diff contained mutated accounts "
-            r"which weren't reported in BAL"
+            r"which weren't reported in BAL|"
+            r"invalid block access list:"
         ),
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             r"difference between computed state diff and "
             r"BAL entry for account|invalid block access list:"
         ),
         BlockException.INCORRECT_BLOCK_FORMAT: (r"invalid block access list:"),
+        BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: (
+            r"block access list exceeds gas limit"
+        ),
+        BlockException.GAS_USED_OVERFLOW: (r"gas limit reached"),
+        TransactionException.INTRINSIC_GAS_TOO_LOW: (
+            r"insufficient gas for floor data gas cost"
+        ),
     }
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->
Add regex mappings for new geth error strings from bal-devnet-3:
- INVALID_BAL_MISSING_ACCOUNT: add "invalid block access list:" for the parallel processor's mismatch error format
- BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED: new entry for EIP-7928 ValidateGasLimit check
- GAS_USED_OVERFLOW: "gas limit reached" from the parallel processor's 2D gas check (matches EELS GasUsedExceedsLimitError)
- INTRINSIC_GAS_TOO_LOW: "insufficient gas for floor data gas cost" matches EELS InsufficientTransactionGasError which uses one error type for both intrinsic gas and calldata floor failures

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).