### PR TITLE
fix(test-fill): fix filling pre-Byzantium forks with geth

### DIFF
--- a/packages/testing/src/execution_testing/test_types/receipt_types.py
+++ b/packages/testing/src/execution_testing/test_types/receipt_types.py
@@ -45,9 +45,18 @@ class TransactionReceipt(CamelModel):
     def strip_extra_fields(cls, data: Any) -> Any:
         """Strip extra fields from t8n tool output not part of model."""
         if isinstance(data, dict):
+            data = dict(data)
             # geth (1.16+) returns extra fields in receipts
             data.pop("type", None)
             data.pop("blockNumber", None)
+            root = data.get("root")
+            root_is_empty = root in (None, "", "0x", b"", bytearray())
+            if not root_is_empty:
+                # geth's t8n JSON uses `root` for pre-Byzantium receipts while
+                # also populating `status`. For fixture re-encoding, a
+                # non-empty root must take precedence over status.
+                data.setdefault("post_state", root)
+                data.pop("status", None)
         return data
 
     transaction_hash: Hash | None = None

--- a/packages/testing/src/execution_testing/test_types/tests/test_types.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_types.py
@@ -21,6 +21,7 @@ from ..block_types import (
     Environment,
     Withdrawal,
 )
+from ..receipt_types import TransactionReceipt
 from ..transaction_types import (
     AuthorizationTuple,
     Transaction,
@@ -91,6 +92,31 @@ def test_storage() -> None:
         "0x01": ("0x0200"),
         "0x02": ("0x0300"),
     }
+
+
+def test_transaction_receipt_maps_non_empty_root_to_post_state() -> None:
+    """Non-empty `root` from geth should be treated as pre-Byzantium state."""
+    receipt = TransactionReceipt.model_validate(
+        {
+            "root": "0x" + "11" * 32,
+            "status": "0x1",
+        }
+    )
+    assert str(receipt.post_state) == "0x" + "11" * 32
+    assert receipt.status is None
+
+
+def test_transaction_receipt_keeps_status_when_root_is_empty() -> None:
+    """Empty `root` should not override Byzantium-style receipt status."""
+    receipt = TransactionReceipt.model_validate(
+        {
+            "root": "0x",
+            "status": "0x1",
+        }
+    )
+    assert receipt.post_state is None
+    assert receipt.status is not None
+    assert int(receipt.status) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 🗒️ Description
Fixes compatibility with geth evm t8n for pre-Byzantium state tests. geth emits receipt JSON with a non-empty root field, and we were rebuilding those receipts as if `status` should take precedence, which caused receipt-root mismatches during `fill`. the parser now treats a non-empty geth JSON root as pre-Byzantium `post_state` and ignores `status` in that case, while preserving Byzantium-and-later behavior when root is empty.

Also added a few tests covering both pre-Byzantium (`root`) and Byzantium+ (`status`) receipt parsing behavior.

## How to run
Before applying this PR u can run `uv run fill --fork Frontier --evm-bin=/home/user/Documents/go-ethereum/build/bin/evm --clean tests/frontier/touch/test_touch.py::test_zero_gas_price_and_touching` using latest geth master and one of the two tests will fail with a receipt-root mismatch. After applying the PR both tests pass (like they always would when filling with eels).

## 🔗 Related Issues or PRs
This fix was originally part of #2548 but was split into its own PR for cleaner commit history.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
