### PR TITLE
Replace `Uint(len(...))` with `ulen(...)`

### DIFF
--- a/src/ethereum/forks/amsterdam/block_access_lists.py
+++ b/src/ethereum/forks/amsterdam/block_access_lists.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Set, Tuple, TypeAlias
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U32, U64, U256, Uint
+from ethereum_types.numeric import U32, U64, U256, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.state import EMPTY_CODE_HASH, Account, Address, PreState
@@ -760,7 +760,7 @@ def validate_block_access_list_gas_limit(
             unique_slots.add(slot)
 
         # Count each unique storage key as one item
-        bal_items += Uint(len(unique_slots))
+        bal_items += ulen(unique_slots)
 
     if bal_items > block_gas_limit // GasCosts.BLOCK_ACCESS_LIST_ITEM:
         raise BlockAccessListGasLimitExceededError(

--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Tuple
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
 from ethereum_types.frozen import slotted_freezable
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.exceptions import (
@@ -850,7 +850,7 @@ def apply_body(
 
     # EIP-7928: Post-execution operations use index N+1
     block_env.block_access_list_builder.block_access_index = BlockAccessIndex(
-        Uint(len(transactions)) + Uint(1)
+        ulen(transactions) + Uint(1)
     )
 
     process_withdrawals(block_env, block_output, withdrawals)

--- a/src/ethereum/forks/amsterdam/vm/gas.py
+++ b/src/ethereum/forks/amsterdam/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.forks.bpo5.blocks import Header as PreviousHeader
 from ethereum.trace import GasAndRefund, evm_trace
@@ -311,7 +311,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/amsterdam/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/amsterdam/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/arrow_glacier/vm/gas.py
+++ b/src/ethereum/forks/arrow_glacier/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/arrow_glacier/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/berlin/vm/gas.py
+++ b/src/ethereum/forks/berlin/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/berlin/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/berlin/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/berlin/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/berlin/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/berlin/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/berlin/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/berlin/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/berlin/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/bpo1/vm/gas.py
+++ b/src/ethereum/forks/bpo1/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/bpo1/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/bpo1/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/bpo1/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/bpo1/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/bpo1/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/bpo1/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/bpo1/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/bpo1/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/bpo2/vm/gas.py
+++ b/src/ethereum/forks/bpo2/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/bpo2/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/bpo2/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/bpo2/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/bpo2/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -32,7 +32,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/bpo2/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/bpo2/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -35,7 +35,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/bpo2/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/bpo2/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -34,7 +34,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/bpo3/vm/gas.py
+++ b/src/ethereum/forks/bpo3/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/bpo3/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/bpo3/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/bpo3/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/bpo3/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/bpo3/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/bpo3/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/bpo3/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/bpo3/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/bpo4/vm/gas.py
+++ b/src/ethereum/forks/bpo4/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/bpo4/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/bpo4/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/bpo4/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/bpo4/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/bpo4/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/bpo4/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/bpo4/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/bpo4/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/bpo5/vm/gas.py
+++ b/src/ethereum/forks/bpo5/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/bpo5/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/bpo5/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/bpo5/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/bpo5/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/bpo5/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/bpo5/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/bpo5/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/bpo5/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/byzantium/vm/gas.py
+++ b/src/ethereum/forks/byzantium/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -255,7 +255,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/byzantium/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/byzantium/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/byzantium/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/byzantium/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -32,7 +32,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/byzantium/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/byzantium/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -35,7 +35,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/byzantium/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/byzantium/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -34,7 +34,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/cancun/vm/gas.py
+++ b/src/ethereum/forks/cancun/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -276,7 +276,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/cancun/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/cancun/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/cancun/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/cancun/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -32,7 +32,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/cancun/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/cancun/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -35,7 +35,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/cancun/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/cancun/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -34,7 +34,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/constantinople/vm/gas.py
+++ b/src/ethereum/forks/constantinople/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -259,7 +259,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/constantinople/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/constantinople/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/constantinople/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/constantinople/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/constantinople/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/constantinople/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/constantinople/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/constantinople/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/dao_fork/vm/gas.py
+++ b/src/ethereum/forks/dao_fork/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.state import Address
 from ethereum.trace import GasAndRefund, evm_trace
@@ -248,7 +248,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/dao_fork/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/dao_fork/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/dao_fork/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/dao_fork/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/dao_fork/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/dao_fork/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/frontier/vm/gas.py
+++ b/src/ethereum/forks/frontier/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.state import Address
 from ethereum.trace import GasAndRefund, evm_trace
@@ -246,7 +246,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/frontier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/frontier/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/frontier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/frontier/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/frontier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/frontier/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/gray_glacier/vm/gas.py
+++ b/src/ethereum/forks/gray_glacier/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/gray_glacier/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/homestead/vm/gas.py
+++ b/src/ethereum/forks/homestead/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.state import Address
 from ethereum.trace import GasAndRefund, evm_trace
@@ -248,7 +248,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/homestead/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/homestead/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/homestead/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/homestead/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/homestead/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/homestead/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/istanbul/vm/gas.py
+++ b/src/ethereum/forks/istanbul/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/istanbul/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/istanbul/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/istanbul/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/istanbul/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/istanbul/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/istanbul/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/istanbul/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/istanbul/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/london/vm/gas.py
+++ b/src/ethereum/forks/london/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/london/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/london/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/london/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/london/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/london/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/london/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/london/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/london/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/muir_glacier/vm/gas.py
+++ b/src/ethereum/forks/muir_glacier/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/muir_glacier/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/osaka/vm/gas.py
+++ b/src/ethereum/forks/osaka/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -290,7 +290,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/osaka/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/osaka/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/paris/vm/gas.py
+++ b/src/ethereum/forks/paris/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -262,7 +262,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/paris/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/paris/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/paris/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/paris/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/paris/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/paris/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/paris/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/paris/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/prague/vm/gas.py
+++ b/src/ethereum/forks/prague/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U64, U256, Uint
+from ethereum_types.numeric import U64, U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32, taylor_exponential
@@ -285,7 +285,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/prague/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/prague/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/prague/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/prague/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/prague/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/prague/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/prague/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/prague/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/shanghai/vm/gas.py
+++ b/src/ethereum/forks/shanghai/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -264,7 +264,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/shanghai/vm/precompiled_contracts/alt_bn128.py
+++ b/src/ethereum/forks/shanghai/vm/precompiled_contracts/alt_bn128.py
@@ -12,7 +12,7 @@ Implementation of the ALT_BN128 precompiled contracts.
 """
 
 from ethereum_types.bytes import Bytes
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 from py_ecc.optimized_bn128.optimized_curve import (
     FQ,
     FQ2,
@@ -207,7 +207,7 @@ def alt_bn128_pairing_check(evm: Evm) -> None:
     # GAS
     charge_gas(
         evm,
-        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * Uint(len(data) // 192)
+        GasCosts.PRECOMPILE_ECPAIRING_PER_POINT * (ulen(data) // Uint(192))
         + GasCosts.PRECOMPILE_ECPAIRING_BASE,
     )
 

--- a/src/ethereum/forks/shanghai/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/shanghai/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -32,7 +32,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/shanghai/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/shanghai/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -35,7 +35,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/shanghai/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/shanghai/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -34,7 +34,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/spurious_dragon/vm/gas.py
+++ b/src/ethereum/forks/spurious_dragon/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -248,7 +248,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/spurious_dragon/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum/forks/tangerine_whistle/vm/gas.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/gas.py
@@ -14,7 +14,7 @@ EVM gas constants and calculators.
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from ethereum_types.numeric import U256, Uint
+from ethereum_types.numeric import U256, Uint, ulen
 
 from ethereum.trace import GasAndRefund, evm_trace
 from ethereum.utils.numeric import ceil32
@@ -248,7 +248,7 @@ def calculate_gas_extend_memory(
     """
     size_to_extend = Uint(0)
     to_be_paid = Uint(0)
-    current_size = Uint(len(memory))
+    current_size = ulen(memory)
     for start_position, size in extensions:
         if size == 0:
             continue

--- a/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/identity.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/identity.py
@@ -11,7 +11,7 @@ Introduction
 Implementation of the `IDENTITY` precompiled contract.
 """
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -35,7 +35,7 @@ def identity(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_IDENTITY_BASE

--- a/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/ripemd160.py
@@ -13,7 +13,7 @@ Implementation of the `RIPEMD160` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.byte import left_pad_zero_bytes
 from ethereum.utils.numeric import ceil32
@@ -38,7 +38,7 @@ def ripemd160(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_RIPEMD160_BASE

--- a/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/sha256.py
+++ b/src/ethereum/forks/tangerine_whistle/vm/precompiled_contracts/sha256.py
@@ -13,7 +13,7 @@ Implementation of the `SHA256` precompiled contract.
 
 import hashlib
 
-from ethereum_types.numeric import Uint
+from ethereum_types.numeric import Uint, ulen
 
 from ethereum.utils.numeric import ceil32
 
@@ -37,7 +37,7 @@ def sha256(evm: Evm) -> None:
     data = evm.message.data
 
     # GAS
-    word_count = ceil32(Uint(len(data))) // Uint(32)
+    word_count = ceil32(ulen(data)) // Uint(32)
     charge_gas(
         evm,
         GasCosts.PRECOMPILE_SHA256_BASE

--- a/src/ethereum_spec_tools/lint/lints/uint_len.py
+++ b/src/ethereum_spec_tools/lint/lints/uint_len.py
@@ -1,0 +1,68 @@
+"""
+Uint(len(...)) Lint.
+
+Ensures that `Uint(len(...))` is replaced with `ulen(...)`.
+"""
+
+import ast
+from typing import List, Sequence
+
+from ethereum_spec_tools.forks import Hardfork
+from ethereum_spec_tools.lint import Diagnostic, Lint, walk_sources
+
+
+class UintLenHygiene(Lint):
+    """
+    Ensure `ulen(...)` is used instead of `Uint(len(...))`.
+    """
+
+    def lint(
+        self, forks: List[Hardfork], position: int
+    ) -> Sequence[Diagnostic]:
+        """
+        Walk the sources for each hardfork and emit Diagnostic messages.
+        """
+        fork = forks[position]
+        diagnostics: List[Diagnostic] = []
+
+        for name, source in walk_sources(fork):
+            visitor = self._parse(source, _Visitor())
+            for lineno in visitor.violations:
+                diagnostics.append(
+                    Diagnostic(
+                        message=(
+                            f"`Uint(len(...))` at line {lineno} in"
+                            f" `{name}` should be `ulen(...)`"
+                        )
+                    )
+                )
+
+        return diagnostics
+
+
+class _Visitor(ast.NodeVisitor):
+    """
+    Visit call nodes and detect `Uint(len(...))` patterns.
+    """
+
+    violations: List[int]
+
+    def __init__(self) -> None:
+        self.violations = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """
+        Visit a Call node.
+        """
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "Uint"
+            and len(node.args) == 1
+            and not node.keywords
+            and isinstance(node.args[0], ast.Call)
+            and isinstance(node.args[0].func, ast.Name)
+            and node.args[0].func.id == "len"
+        ):
+            self.violations.append(node.lineno)
+
+        self.generic_visit(node)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -28,6 +28,7 @@ from ethereum_spec_tools.lint.lints.glacier_forks_hygiene import (
     GlacierForksHygiene,
 )
 from ethereum_spec_tools.lint.lints.import_hygiene import ImportHygiene
+from ethereum_spec_tools.lint.lints.uint_len import UintLenHygiene
 from ethereum_spec_tools.new_fork.codemod.comment import CommentReplaceCommand
 from ethereum_spec_tools.new_fork.codemod.constant import SetConstantCommand
 from ethereum_spec_tools.new_fork.codemod.string_replace import (
@@ -111,6 +112,9 @@ Trace.returnData
 Trace.refund
 Trace.opName
 FinalTrace.gasUsed
+
+# src/ethereum_spec_tools/lint/lints/uint_len.py
+UintLenHygiene
 
 # src/ethereum_spec_tools/lint/lints/glacier_forks_hygiene.py
 GlacierForksHygiene


### PR DESCRIPTION
#### Prompt

> Using libcst (you can find some examples in src/ethereum_spec_tools/new_fork if you need them), write a                                                                                                                                                                         
 codemod to transform `Uint(len(...))` into `ulen(...)` from ethereum/ethereum-types, and then apply the codemod to the whole repository.

#### Codemod

```python
from pathlib import Path

import libcst as cst
import libcst.matchers as m
from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
from libcst.codemod.visitors import AddImportsVisitor, RemoveImportsVisitor
from typing_extensions import override


class UintLenToUlen(VisitorBasedCodemodCommand):
    """
    Replace `Uint(len(...))` with `ulen(...)`.
    """

    DESCRIPTION: str = "Replace Uint(len(...)) with ulen(...)."

    _transformed: bool

    def __init__(self, context: CodemodContext) -> None:
        super().__init__(context)
        self._transformed = False

    @override
    def leave_Call(
        self, original_node: cst.Call, updated_node: cst.Call
    ) -> cst.BaseExpression:
        # Match Uint(len(...))
        if not m.matches(
            updated_node,
            m.Call(
                func=m.Name("Uint"),
                args=[
                    m.Arg(
                        value=m.Call(func=m.Name("len")),
                        keyword=None,
                        star="",
                    )
                ],
            ),
        ):
            return updated_node

        if not self._transformed:
            self._transformed = True
            AddImportsVisitor.add_needed_import(
                self.context, "ethereum_types.numeric", "ulen"
            )
            RemoveImportsVisitor.remove_unused_import(
                self.context, "ethereum_types.numeric", "Uint"
            )

        # Extract the inner len() call's arguments
        inner_call = updated_node.args[0].value
        assert isinstance(inner_call, cst.Call)

        # Build ulen(...) preserving the inner arguments
        return updated_node.with_changes(
            func=cst.Name("ulen"),
            args=inner_call.args,
        )


def main() -> None:
    src_dir = Path("src/ethereum")
    files = sorted(src_dir.rglob("*.py"))

    for path in files:
        source = path.read_text()

        context = CodemodContext()
        tree = cst.parse_module(source)
        new_tree = UintLenToUlen(context).transform_module(tree)
        new_source = new_tree.code

        if new_source != source:
            path.write_text(new_source)
            print(f"  Modified: {path}")


if __name__ == "__main__":
    main()
```

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pixey.org/storage/m/_v2/785209519431136764/a1431798c-70628a/KNkc8b0VeVd6/bJHCR9pJ7nE4C1xklLKRB0tPMmgnj2NADem4RP1e.jpg)
