### PR TITLE
feat(tests): Add 2D block gas validity EIP-8037 test for multi-tx state-heavy blocks

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -363,6 +363,73 @@ def test_block_gas_used_with_state_ops(
     )
 
 
+@pytest.mark.valid_from("Amsterdam")
+def test_block_2d_gas_valid_when_cumulative_exceeds_limit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block validity under 2D gas when sum(txGasUsed) > gas_limit.
+
+    EIP-8037 block validity: max(regular, state) <= gas_limit.
+    Receipt cumulative_gas_used sums both dimensions per-tx, so it
+    can legitimately exceed gas_limit. Clients must not use the 1D
+    cumulative check for block validation.
+    """
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = fork.sstore_state_gas()
+
+    tx_regular = (
+        gas_costs.GAS_TX_BASE
+        + 2 * gas_costs.GAS_VERY_LOW
+        + gas_costs.GAS_STORAGE_UPDATE
+    )
+    tx_state = sstore_state_gas
+    tx_gas_used = tx_regular + tx_state
+    num_txs = 5
+
+    # 2D bound < gas_limit < 1D bound
+    two_d_bound = num_txs * max(tx_regular, tx_state)
+    one_d_bound = num_txs * tx_gas_used
+    block_gas_limit = (two_d_bound + one_d_bound) // 2
+    assert two_d_bound < block_gas_limit < one_d_bound
+
+    env = Environment(gas_limit=block_gas_limit)
+    tx_limit = tx_gas_used + 1000
+
+    txs = []
+    post = {}
+    for _ in range(num_txs):
+        storage = Storage()
+        contract = pre.deploy_contract(
+            code=Op.SSTORE(storage.store_next(1), 1),
+        )
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=tx_limit,
+                sender=pre.fund_eoa(),
+            ),
+        )
+        post[contract] = Account(storage=storage)
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        blocks=[
+            Block(
+                txs=txs,
+                gas_limit=block_gas_limit,
+                header_verify=Header(
+                    gas_used=num_txs * tx_state,
+                ),
+            ),
+        ],
+        post=post,
+    )
+
+
 @pytest.mark.parametrize(
     "gas_above_cap",
     [


### PR DESCRIPTION
## Summary

- Adds `test_block_2d_gas_valid_when_cumulative_exceeds_limit` to the EIP-8037 reservoir test suite
- Tests that a block with 5 SSTORE zero-to-nonzero transactions is valid under 2D gas accounting (`max(regular, state) <= gas_limit`) even when the receipt `cumulative_gas_used` exceeds `gas_limit`
- Block header `gas_used = 187,840` (state dimension bottleneck) vs `gas_limit = 252,855`, while `sum(tx_gas_used) = 317,870`

## Motivation

EIP-8037 specifies block validity as:
```python
gas_used = max(block_output.block_regular_gas_used, block_output.block_state_gas_used)
assert gas_used <= block.gas_limit
```

Multiple clients retain a pre-8037 invariant (`sum(tx_gas_used) <= gas_limit`) in their gasPool / block processing code, which incorrectly rejects valid blocks when state gas dominates. This test surfaces that bug.

Currently fails against:
- **go-ethereum** (`bal-devnet-3`): `SubGas` returns `ErrGasLimitReached`
- **nimbus-eth1** (`bal-devnet-3`): `commitOrRollbackDependingOnGasUsed` rejects with "block header gasLimit reached"

Fills successfully against the EELS reference implementation.

## Test plan

- [x] `uv run fill` passes (blockchain_test + blockchain_test_engine)
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] `header_verify` confirms `gas_used = 5 * sstore_state_gas`
- [x] Confirmed INVALID on geth and nimbus via hive `consume-engine-local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)