### PR TITLE
refactor(specs): add `has_access_list` fn for transaction types

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -77,7 +77,6 @@ from .state_tracker import (
     set_account_balance,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -86,6 +85,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -998,15 +998,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -622,15 +633,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -891,3 +894,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/amsterdam/transactions.py
+++ b/src/ethereum/forks/amsterdam/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -900,14 +906,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo1/fork.py
+++ b/src/ethereum/forks/bpo1/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo1/transactions.py
+++ b/src/ethereum/forks/bpo1/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/bpo2/fork.py
+++ b/src/ethereum/forks/bpo2/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo2/transactions.py
+++ b/src/ethereum/forks/bpo2/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/bpo3/fork.py
+++ b/src/ethereum/forks/bpo3/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo3/transactions.py
+++ b/src/ethereum/forks/bpo3/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/bpo4/fork.py
+++ b/src/ethereum/forks/bpo4/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo4/transactions.py
+++ b/src/ethereum/forks/bpo4/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/bpo5/fork.py
+++ b/src/ethereum/forks/bpo5/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/bpo5/transactions.py
+++ b/src/ethereum/forks/bpo5/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/osaka/fork.py
+++ b/src/ethereum/forks/osaka/fork.py
@@ -63,7 +63,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -72,6 +71,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -916,15 +916,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -488,7 +488,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -893,14 +899,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )

--- a/src/ethereum/forks/osaka/transactions.py
+++ b/src/ethereum/forks/osaka/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -481,6 +481,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -615,15 +626,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -884,3 +887,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/prague/fork.py
+++ b/src/ethereum/forks/prague/fork.py
@@ -62,7 +62,6 @@ from .state import (
     state_root,
 )
 from .transactions import (
-    AccessListTransaction,
     BlobTransaction,
     FeeMarketTransaction,
     LegacyTransaction,
@@ -71,6 +70,7 @@ from .transactions import (
     decode_transaction,
     encode_transaction,
     get_transaction_hash,
+    has_access_list,
     recover_sender,
     validate_transaction,
 )
@@ -899,15 +899,7 @@ def process_transaction(
     access_list_addresses = set()
     access_list_storage_keys = set()
     access_list_addresses.add(block_env.coinbase)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_addresses.add(access.account)
             for slot in access.slots:

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -5,7 +5,7 @@ transactions are the events that move between states.
 """
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeGuard
 
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes0, Bytes32
@@ -475,6 +475,17 @@ Union type representing any valid transaction type.
 """
 
 
+AccessListCapableTransaction = (
+    AccessListTransaction
+    | FeeMarketTransaction
+    | BlobTransaction
+    | SetCodeTransaction
+)
+"""
+Union type representing transaction variants that include access list.
+"""
+
+
 def encode_transaction(tx: Transaction) -> LegacyTransaction | Bytes:
     """
     Encode a transaction into its RLP or typed transaction format.
@@ -607,15 +618,7 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         create_cost = Uint(0)
 
     access_list_cost = Uint(0)
-    if isinstance(
-        tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
-    ):
+    if has_access_list(tx):
         for access in tx.access_list:
             access_list_cost += GAS_TX_ACCESS_LIST_ADDRESS
             access_list_cost += (
@@ -876,3 +879,20 @@ def get_transaction_hash(tx: Bytes | LegacyTransaction) -> Hash32:
         return keccak256(rlp.encode(tx))
     else:
         return keccak256(tx)
+
+
+def has_access_list(
+    tx: Transaction,
+) -> TypeGuard[AccessListCapableTransaction]:
+    """
+    Return whether the transaction has an access list.
+    """
+    return isinstance(
+        tx,
+        (
+            AccessListTransaction,
+            FeeMarketTransaction,
+            BlobTransaction,
+            SetCodeTransaction,
+        ),
+    )

--- a/src/ethereum/forks/prague/transactions.py
+++ b/src/ethereum/forks/prague/transactions.py
@@ -482,7 +482,13 @@ AccessListCapableTransaction = (
     | SetCodeTransaction
 )
 """
-Union type representing transaction variants that include access list.
+Transaction types that include an [EIP-2930]-style access list.
+
+See [`has_access_list`][hal] and [`Access`][a] for more details.
+
+[EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
+[hal]: ref:ethereum.forks.amsterdam.transactions.has_access_list
+[a]: ref:ethereum.forks.amsterdam.transactions.Access
 """
 
 
@@ -885,14 +891,11 @@ def has_access_list(
     tx: Transaction,
 ) -> TypeGuard[AccessListCapableTransaction]:
     """
-    Return whether the transaction has an access list.
+    Return whether the transaction has an [EIP-2930]-style access list.
+
+    [EIP-2930]: https://eips.ethereum.org/EIPS/eip-2930
     """
     return isinstance(
         tx,
-        (
-            AccessListTransaction,
-            FeeMarketTransaction,
-            BlobTransaction,
-            SetCodeTransaction,
-        ),
+        AccessListCapableTransaction,
     )


### PR DESCRIPTION
## 🗒️ Description
Add `has_access_list` fn for transaction types instead of inline check with `isinstance(tx, (...)`

## 🔗 Related Issues or PRs
closes: #2521

## ✅ Checklist
- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/9cac95d0-9e63-4415-8e12-28a5af51f6bc" />
