### PR TITLE
feat(spec-specs, tests): remove per-tx state gas pre-check and add 2D block gas validity test

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -546,21 +546,16 @@ def check_transaction(
         is empty.
 
     """
-    # Both regular gas and state gas have their own limits
+    # Regular gas is capped at TX_MAX_GAS_LIMIT per EIP-7825.
+    # State gas is not checked per-tx; block-end validation enforces
+    # max(block_regular_gas_used, block_state_gas_used) <= gas_limit.
     regular_gas_available = (
         block_env.block_gas_limit - block_output.block_gas_used
     )
-    state_gas_available = (
-        block_env.block_gas_limit - block_output.block_state_gas_used
-    )
     blob_gas_available = MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used
 
-    # Regular gas is capped at TX_MAX_GAS_LIMIT; state gas can use all
-    # of tx.gas (gas_left can be drawn for state gas when reservoir is empty)
     if min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available:
         raise GasUsedExceedsLimitError("regular gas used exceeds limit")
-    if tx.gas > state_gas_available:
-        raise GasUsedExceedsLimitError("state gas used exceeds limit")
 
     tx_blob_gas_used = calculate_total_blob_gas(tx)
     if tx_blob_gas_used > blob_gas_available:

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -242,64 +242,6 @@ def test_block_regular_gas_limit(
     blockchain_test(pre=pre, post={}, blocks=[block])
 
 
-@pytest.mark.parametrize(
-    "exceed_block_gas_limit",
-    [
-        pytest.param(True, marks=pytest.mark.exception_test),
-        pytest.param(False),
-    ],
-)
-@pytest.mark.valid_from("Amsterdam")
-def test_block_state_gas_limit(
-    blockchain_test: BlockchainTestFiller,
-    pre: Alloc,
-    exceed_block_gas_limit: bool,
-) -> None:
-    """
-    Test check_transaction enforcement of state gas against block limit.
-
-    The block-level state gas check compares tx.gas against remaining
-    state gas capacity. The first tx performs an SSTORE (consuming
-    state gas from its reservoir), which increases block_state_gas_used.
-    A second tx with gas_limit equal to block_gas_limit then exceeds
-    the remaining state gas capacity.
-    """
-    env = Environment()
-    high_gas = env.gas_limit
-
-    # Contract that performs a single SSTORE (consumes state gas)
-    state_gas_spender = pre.deploy_contract(
-        code=Op.SSTORE(0, 1),
-    )
-
-    txs = [
-        Transaction(
-            to=state_gas_spender,
-            sender=pre.fund_eoa(),
-            gas_limit=high_gas,
-        ),
-    ]
-
-    if exceed_block_gas_limit:
-        txs.append(
-            Transaction(
-                to=state_gas_spender,
-                sender=pre.fund_eoa(),
-                gas_limit=high_gas,
-                error=TransactionException.GAS_ALLOWANCE_EXCEEDED,
-            ),
-        )
-
-    block = Block(
-        txs=txs,
-        exception=TransactionException.GAS_ALLOWANCE_EXCEEDED
-        if exceed_block_gas_limit
-        else None,
-    )
-
-    blockchain_test(pre=pre, post={}, blocks=[block])
-
-
 @pytest.mark.valid_from("Amsterdam")
 def test_block_gas_used_no_state_ops(
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_reservoir.py
@@ -305,6 +305,73 @@ def test_block_gas_used_with_state_ops(
     )
 
 
+@pytest.mark.valid_from("Amsterdam")
+def test_block_2d_gas_valid_when_cumulative_exceeds_limit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block validity under 2D gas when sum(txGasUsed) > gas_limit.
+
+    EIP-8037 block validity: max(regular, state) <= gas_limit.
+    Receipt cumulative_gas_used sums both dimensions per-tx, so it
+    can legitimately exceed gas_limit. Clients must not use the 1D
+    cumulative check for block validation.
+    """
+    gas_costs = fork.gas_costs()
+    sstore_state_gas = fork.sstore_state_gas()
+
+    tx_regular = (
+        gas_costs.GAS_TX_BASE
+        + 2 * gas_costs.GAS_VERY_LOW
+        + gas_costs.GAS_COLD_STORAGE_WRITE
+    )
+    tx_state = sstore_state_gas
+    tx_gas_used = tx_regular + tx_state
+    num_txs = 5
+
+    # 2D bound < gas_limit < 1D bound
+    two_d_bound = num_txs * max(tx_regular, tx_state)
+    one_d_bound = num_txs * tx_gas_used
+    block_gas_limit = (two_d_bound + one_d_bound) // 2
+    assert two_d_bound < block_gas_limit < one_d_bound
+
+    env = Environment(gas_limit=block_gas_limit)
+    tx_limit = tx_gas_used + 1000
+
+    txs = []
+    post = {}
+    for _ in range(num_txs):
+        storage = Storage()
+        contract = pre.deploy_contract(
+            code=Op.SSTORE(storage.store_next(1), 1),
+        )
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=tx_limit,
+                sender=pre.fund_eoa(),
+            ),
+        )
+        post[contract] = Account(storage=storage)
+
+    blockchain_test(
+        genesis_environment=env,
+        pre=pre,
+        blocks=[
+            Block(
+                txs=txs,
+                gas_limit=block_gas_limit,
+                header_verify=Header(
+                    gas_used=num_txs * tx_state,
+                ),
+            ),
+        ],
+        post=post,
+    )
+
+
 @pytest.mark.parametrize(
     "gas_above_cap",
     [


### PR DESCRIPTION
## 🗒️ Description

Remove the per-tx state gas reservation check from `check_transaction`. The check `tx.gas > block_gas_limit - block_state_gas_used` double-counts a tx's single gas budget across both dimensions, undermining the 2D gas model. Block-end validation (`max(block_regular_gas_used, block_state_gas_used) <= gas_limit`) already catches state gas overflow.

Also adds a test (credit @qu0b) verifying 2D block gas validity when `sum(tx_gas_used) > gas_limit`.

## 🔗 Related Issues or PRs

- Closes #2578
- Related: #2581