### PR TITLE
feat(zkevm): harden witness state validation for malformed trie proofs

### DIFF
--- a/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
+++ b/packages/testing/src/execution_testing/test_types/execution_witness/modifiers.py
@@ -113,6 +113,19 @@ def reverse_codes() -> Callable[[ExecutionWitness], ExecutionWitness]:
     return transform
 
 
+def reverse_state_nodes() -> Callable[[ExecutionWitness], ExecutionWitness]:
+    """Reverse the order of witness state nodes."""
+
+    def transform(
+        witness: ExecutionWitness,
+    ) -> ExecutionWitness:
+        return witness.model_copy(
+            update={"state": list(reversed(witness.state))}
+        )
+
+    return transform
+
+
 def clear_headers() -> Callable[[ExecutionWitness], ExecutionWitness]:
     """Remove all header entries from the witness."""
 
@@ -201,6 +214,7 @@ __all__ = [
     "remove_code",
     "remove_code_at",
     "reverse_codes",
+    "reverse_state_nodes",
     "prepend_header",
     "remove_header_at",
     "reverse_headers",

--- a/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
+++ b/packages/testing/src/execution_testing/test_types/tests/test_execution_witness.py
@@ -20,6 +20,7 @@ from execution_testing.test_types.execution_witness.modifiers import (
     replace_header_at,
     reverse_codes,
     reverse_headers,
+    reverse_state_nodes,
 )
 
 
@@ -85,6 +86,9 @@ def test_execution_witness_state_modifiers_add_and_remove() -> None:
 
     restored = remove_state_node(Bytes(b"bb"))(modified)
     assert restored.state == [Bytes(b"aa")]
+
+    reversed_state = reverse_state_nodes()(modified)
+    assert reversed_state.state == [Bytes(b"bb"), Bytes(b"aa")]
 
 
 def test_execution_witness_code_modifiers() -> None:

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -903,9 +903,7 @@ def _resolve_child_ref(
             f"Unexpected child ref length: {len(ref_bytes)}"
         )
         if ref_bytes in node_db:
-            return _decode_witness_node(
-                node_db, node_db[ref_bytes], secured
-            )
+            return _decode_witness_node(node_db, node_db[ref_bytes], secured)
         return HashedNode(_hash=ref_bytes)
     else:
         return _decode_witness_node(node_db, rlp.encode(child_ref), secured)
@@ -925,6 +923,8 @@ def _decode_witness_node(
         Mapping from node hash to RLP-encoded node data.
     rlp_bytes :
         The RLP-encoded node to decode.
+    secured :
+        Whether the trie uses secured (hashed) keys.
 
     """
     node_hash: Optional[Bytes] = None

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -886,6 +886,7 @@ def compact_to_nibbles(compact: Bytes) -> Tuple[Bytes, bool]:
 def _resolve_child_ref(
     node_db: Dict[Bytes, Bytes],
     child_ref: Extended,
+    secured: bool,
 ) -> MutableNode:
     """
     Resolve a child reference from an RLP-decoded trie node.
@@ -902,15 +903,18 @@ def _resolve_child_ref(
             f"Unexpected child ref length: {len(ref_bytes)}"
         )
         if ref_bytes in node_db:
-            return _decode_witness_node(node_db, node_db[ref_bytes])
+            return _decode_witness_node(
+                node_db, node_db[ref_bytes], secured
+            )
         return HashedNode(_hash=ref_bytes)
     else:
-        return _decode_witness_node(node_db, rlp.encode(child_ref))
+        return _decode_witness_node(node_db, rlp.encode(child_ref), secured)
 
 
 def _decode_witness_node(
     node_db: Dict[Bytes, Bytes],
     rlp_bytes: Bytes,
+    secured: bool,
 ) -> MutableNode:
     """
     Decode an RLP-encoded trie node into a ``MutableNode``.
@@ -950,7 +954,11 @@ def _decode_witness_node(
                 _rlp=rlp_bytes,
             )
         else:
-            child = _resolve_child_ref(node_db, decoded[1])
+            assert len(nibbles) > 0 or not secured, (
+                "ExtensionNode must have a non-empty path "
+                "in state/storage trie"
+            )
+            child = _resolve_child_ref(node_db, decoded[1], secured)
             assert isinstance(child, (MutableBranchNode, HashedNode)), (
                 "ExtensionNode child must be a BranchNode"
             )
@@ -964,13 +972,15 @@ def _decode_witness_node(
     elif len(decoded) == 17:
         children: List[Optional[MutableNode]] = []
         for i in range(16):
-            children.append(_resolve_child_ref(node_db, decoded[i]))
+            children.append(_resolve_child_ref(node_db, decoded[i], secured))
         value_raw = decoded[16]
         if isinstance(value_raw, (bytes, bytearray)):
             value = Bytes(value_raw)
         else:
             value = b""
-        # TODO: value is always empty in practice; refactor
+        assert value == b"" or not secured, (
+            "BranchNode value must be empty in state/storage trie"
+        )
         occupied = 16 - children.count(None) + (value != b"")
         assert occupied >= 2, "BranchNode must have at least 2 children"
         return MutableBranchNode(
@@ -1022,7 +1032,7 @@ def decode_witness_to_mpt(
         )
 
     root_rlp = node_db[root_hash]
-    root_node = _decode_witness_node(node_db, root_rlp)
+    root_node = _decode_witness_node(node_db, root_rlp, secured)
 
     return IncrementalMPT(
         secured=secured,

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -973,7 +973,9 @@ def _decode_witness_node(
         else:
             value = b""
         occupied = 16 - children.count(None) + (value != b"")
-        assert occupied >= 2, "BranchNode must have at least 2 children"
+        assert occupied >= 2, (
+            "BranchNode must have at least 2 occupied entries"
+        )
         return MutableBranchNode(
             children=children,
             value=value,

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -886,7 +886,6 @@ def compact_to_nibbles(compact: Bytes) -> Tuple[Bytes, bool]:
 def _resolve_child_ref(
     node_db: Dict[Bytes, Bytes],
     child_ref: Extended,
-    secured: bool,
 ) -> MutableNode:
     """
     Resolve a child reference from an RLP-decoded trie node.
@@ -903,16 +902,15 @@ def _resolve_child_ref(
             f"Unexpected child ref length: {len(ref_bytes)}"
         )
         if ref_bytes in node_db:
-            return _decode_witness_node(node_db, node_db[ref_bytes], secured)
+            return _decode_witness_node(node_db, node_db[ref_bytes])
         return HashedNode(_hash=ref_bytes)
     else:
-        return _decode_witness_node(node_db, rlp.encode(child_ref), secured)
+        return _decode_witness_node(node_db, rlp.encode(child_ref))
 
 
 def _decode_witness_node(
     node_db: Dict[Bytes, Bytes],
     rlp_bytes: Bytes,
-    secured: bool,
 ) -> MutableNode:
     """
     Decode an RLP-encoded trie node into a ``MutableNode``.
@@ -923,9 +921,6 @@ def _decode_witness_node(
         Mapping from node hash to RLP-encoded node data.
     rlp_bytes :
         The RLP-encoded node to decode.
-    secured :
-        Whether the trie uses secured (hashed) keys.
-
     """
     node_hash: Optional[Bytes] = None
     if len(rlp_bytes) >= 32:
@@ -954,11 +949,10 @@ def _decode_witness_node(
                 _rlp=rlp_bytes,
             )
         else:
-            assert len(nibbles) > 0 or not secured, (
-                "ExtensionNode must have a non-empty path "
-                "in state/storage trie"
+            assert len(nibbles) > 0, (
+                "ExtensionNode must have a non-empty path"
             )
-            child = _resolve_child_ref(node_db, decoded[1], secured)
+            child = _resolve_child_ref(node_db, decoded[1])
             assert isinstance(child, (MutableBranchNode, HashedNode)), (
                 "ExtensionNode child must be a BranchNode"
             )
@@ -972,15 +966,12 @@ def _decode_witness_node(
     elif len(decoded) == 17:
         children: List[Optional[MutableNode]] = []
         for i in range(16):
-            children.append(_resolve_child_ref(node_db, decoded[i], secured))
+            children.append(_resolve_child_ref(node_db, decoded[i]))
         value_raw = decoded[16]
         if isinstance(value_raw, (bytes, bytearray)):
             value = Bytes(value_raw)
         else:
             value = b""
-        assert value == b"" or not secured, (
-            "BranchNode value must be empty in state/storage trie"
-        )
         occupied = 16 - children.count(None) + (value != b"")
         assert occupied >= 2, "BranchNode must have at least 2 children"
         return MutableBranchNode(
@@ -1032,7 +1023,7 @@ def decode_witness_to_mpt(
         )
 
     root_rlp = node_db[root_hash]
-    root_node = _decode_witness_node(node_db, root_rlp, secured)
+    root_node = _decode_witness_node(node_db, root_rlp)
 
     return IncrementalMPT(
         secured=secured,

--- a/src/ethereum/forks/amsterdam/incremental_mpt.py
+++ b/src/ethereum/forks/amsterdam/incremental_mpt.py
@@ -921,6 +921,7 @@ def _decode_witness_node(
         Mapping from node hash to RLP-encoded node data.
     rlp_bytes :
         The RLP-encoded node to decode.
+
     """
     node_hash: Optional[Bytes] = None
     if len(rlp_bytes) >= 32:
@@ -949,9 +950,7 @@ def _decode_witness_node(
                 _rlp=rlp_bytes,
             )
         else:
-            assert len(nibbles) > 0, (
-                "ExtensionNode must have a non-empty path"
-            )
+            assert len(nibbles) > 0, "ExtensionNode must have a non-empty path"
             child = _resolve_child_ref(node_db, decoded[1])
             assert isinstance(child, (MutableBranchNode, HashedNode)), (
                 "ExtensionNode child must be a BranchNode"

--- a/src/ethereum/forks/amsterdam/witness_state.py
+++ b/src/ethereum/forks/amsterdam/witness_state.py
@@ -21,8 +21,12 @@ from ethereum.state import (
 )
 
 from .incremental_mpt import (
+    HashedNode,
     IncrementalMPT,
-    compact_to_nibbles,
+    MutableBranchNode,
+    MutableExtensionNode,
+    MutableLeafNode,
+    MutableNode,
     decode_witness_to_mpt,
     mpt_root,
     mpt_set,
@@ -46,96 +50,56 @@ def build_code_db(code_entries: Tuple[Bytes, ...]) -> Dict[Hash32, Bytes]:
     return db
 
 
-def _resolve_node_ref(
-    node_db: Dict[Bytes, Bytes],
-    ref: object,
-) -> object:
-    """
-    Resolve a node reference to a decoded RLP object.
-
-    Handle inline nodes (lists), 32-byte hash references (look up
-    in node_db), and empty bytes (absent node).
-    """
-    if isinstance(ref, list):
-        return ref
-    if isinstance(ref, (bytes, bytearray)):
-        ref_bytes = Bytes(ref)
-        if len(ref_bytes) == 0:
-            return None
-        if len(ref_bytes) == 32:
-            if ref_bytes not in node_db:
-                return None
-            return rlp.decode(node_db[ref_bytes])
-        return rlp.decode(ref_bytes)
-    return None
-
-
 def _trie_lookup(
-    node_db: Dict[Bytes, Bytes],
-    root_hash: Root,
+    root_node: MutableNode,
     key_hash: Hash32,
 ) -> Optional[Bytes]:
     """
-    Walk MPT from root following nibblized key_hash.
+    Walk a decoded MPT from root following nibblized key_hash.
 
     Return leaf value or ``None`` if not found.
 
-    Parameters
-    ----------
-    node_db :
-        Mapping from node hash to RLP-encoded node data.
-    root_hash :
-        Root hash of the trie.
-    key_hash :
-        Hashed key to look up (will be nibblized).
-
     """
-    if root_hash == EMPTY_TRIE_ROOT:
-        return None
-    if root_hash not in node_db:
-        return None
-
     nibbles = bytearray()
     for byte in key_hash:
         nibbles.append(byte >> 4)
         nibbles.append(byte & 0x0F)
 
-    node = _resolve_node_ref(node_db, root_hash)
+    node = root_node
     pos = 0
 
     while node is not None:
-        if not isinstance(node, list):
+        if isinstance(node, HashedNode):
+            raise AssertionError(
+                "Encountered unresolved HashedNode during witness lookup"
+            )
+
+        if isinstance(node, MutableLeafNode):
+            if bytes(nibbles[pos:]) == node.rest_of_key:
+                return node.value
             return None
 
-        if len(node) == 2:
-            path = node[0]
-            assert isinstance(path, (bytes, bytearray))
-            segment, is_leaf = compact_to_nibbles(Bytes(path))
-            remaining = bytes(nibbles[pos:])
-
-            if is_leaf:
-                if remaining == segment:
-                    value = node[1]
-                    assert isinstance(value, (bytes, bytearray))
-                    return Bytes(value)
+        if isinstance(node, MutableExtensionNode):
+            segment = node.key_segment
+            if bytes(nibbles[pos : pos + len(segment)]) != segment:
                 return None
-            else:
-                if not remaining[: len(segment)] == segment:
-                    return None
-                pos += len(segment)
-                node = _resolve_node_ref(node_db, node[1])
+            pos += len(segment)
+            node = node.child
+            continue
 
-        elif len(node) == 17:
-            if pos >= len(nibbles):
-                value = node[16]
-                if isinstance(value, (bytes, bytearray)) and len(value) > 0:
-                    return Bytes(value)
-                return None
-            idx = nibbles[pos]
-            pos += 1
-            node = _resolve_node_ref(node_db, node[idx])
-        else:
-            return None
+        assert isinstance(node, MutableBranchNode), (
+            f"Unexpected node type {type(node)}"
+        )
+
+        assert pos <= len(nibbles), (
+            "BranchNode cannot appear past the end of a key "
+            "in state/storage trie"
+        )
+        if pos == len(nibbles):
+            return node.value or None
+        idx = nibbles[pos]
+        pos += 1
+        node = node.children[idx]
 
     return None
 
@@ -180,6 +144,25 @@ class WitnessState:
     _state_root: Root
     _code_db: Dict[Hash32, Bytes]
     _storage_root_cache: Dict[Address, Root] = field(default_factory=dict)
+    _decoded_secure_roots: Dict[Root, MutableNode] = field(
+        default_factory=dict
+    )
+
+    def _get_decoded_secure_root(self, root_hash: Root) -> MutableNode:
+        """Decode and cache a secured trie root for read-only lookups."""
+        if root_hash == EMPTY_TRIE_ROOT:
+            return None
+        if root_hash not in self._decoded_secure_roots:
+            decoded_mpt: IncrementalMPT[Bytes, Bytes] = (
+                decode_witness_to_mpt(
+                    self._node_db,
+                    root_hash,
+                    secured=True,
+                    default=b"",
+                )
+            )
+            self._decoded_secure_roots[root_hash] = decoded_mpt.root_node
+        return self._decoded_secure_roots[root_hash]
 
     def get_account_optional(self, address: Address) -> Optional[Account]:
         """
@@ -188,7 +171,9 @@ class WitnessState:
         Return ``None`` if there is no account at the address.
         """
         key_hash = keccak256(address)
-        leaf = _trie_lookup(self._node_db, self._state_root, key_hash)
+        leaf = _trie_lookup(
+            self._get_decoded_secure_root(self._state_root), key_hash
+        )
         if leaf is None:
             self._storage_root_cache[address] = EMPTY_TRIE_ROOT
             return None
@@ -209,7 +194,9 @@ class WitnessState:
             return U256(0)
 
         key_hash = keccak256(key)
-        leaf = _trie_lookup(self._node_db, storage_root, key_hash)
+        leaf = _trie_lookup(
+            self._get_decoded_secure_root(storage_root), key_hash
+        )
         if leaf is None:
             return U256(0)
 

--- a/src/ethereum/forks/amsterdam/witness_state.py
+++ b/src/ethereum/forks/amsterdam/witness_state.py
@@ -153,13 +153,11 @@ class WitnessState:
         if root_hash == EMPTY_TRIE_ROOT:
             return None
         if root_hash not in self._decoded_secure_roots:
-            decoded_mpt: IncrementalMPT[Bytes, Bytes] = (
-                decode_witness_to_mpt(
-                    self._node_db,
-                    root_hash,
-                    secured=True,
-                    default=b"",
-                )
+            decoded_mpt: IncrementalMPT[Bytes, Bytes] = decode_witness_to_mpt(
+                self._node_db,
+                root_hash,
+                secured=True,
+                default=b"",
             )
             self._decoded_secure_roots[root_hash] = decoded_mpt.root_node
         return self._decoded_secure_roots[root_hash]

--- a/src/ethereum/forks/amsterdam/witness_state.py
+++ b/src/ethereum/forks/amsterdam/witness_state.py
@@ -91,10 +91,6 @@ def _trie_lookup(
             f"Unexpected node type {type(node)}"
         )
 
-        assert pos <= len(nibbles), (
-            "BranchNode cannot appear past the end of a key "
-            "in state/storage trie"
-        )
         if pos == len(nibbles):
             return node.value or None
         idx = nibbles[pos]

--- a/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
+++ b/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
@@ -167,11 +167,11 @@ def _state_account(account: Account) -> StateAccount:
     )
 
 
-def _collect_account_node_set(
+def _collect_account_proof_node_rlps(
     alloc: Alloc,
     addresses: Sequence[StateAddress | bytes],
 ) -> set[bytes]:
-    """Collect hashed witness nodes for the given account proof paths."""
+    """Collect witness node RLPs for hashed account proof-path nodes."""
     storage_roots: dict[StateAddress, Root] = {}
     accounts: dict[StateAddress, StateAccount | None] = {}
 
@@ -202,7 +202,7 @@ def collect_account_proof_nodes(
     addresses: Sequence[StateAddress | bytes],
 ) -> list[Bytes]:
     """Collect account-trie proof nodes for the given addresses."""
-    return _nodes(_collect_account_node_set(alloc, addresses))
+    return _nodes(_collect_account_proof_node_rlps(alloc, addresses))
 
 
 def collect_account_path_only_nodes(
@@ -211,6 +211,8 @@ def collect_account_path_only_nodes(
     relative_to_addresses: Sequence[StateAddress | bytes],
 ) -> list[Bytes]:
     """Collect nodes unique to one account proof path relative to others."""
-    address_nodes = _collect_account_node_set(alloc, [address])
-    reference_nodes = _collect_account_node_set(alloc, relative_to_addresses)
+    address_nodes = _collect_account_proof_node_rlps(alloc, [address])
+    reference_nodes = _collect_account_proof_node_rlps(
+        alloc, relative_to_addresses
+    )
     return _nodes(address_nodes - reference_nodes)

--- a/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
+++ b/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
@@ -2,14 +2,24 @@
 
 from collections.abc import Mapping, Sequence
 
+from ethereum.crypto.hash import Hash32, keccak256
 from ethereum_types.bytes import Bytes32
-from ethereum_types.numeric import U256
-from execution_testing import Bytes, Storage
+from ethereum_types.numeric import U256, Uint
+from execution_testing import Account, Alloc, Bytes, Storage
+from execution_testing.forks import Amsterdam
 
 from ethereum.forks.amsterdam.incremental_mpt import (
     build_mpt,
     mpt_get,
+    mpt_root,
     mpt_set,
+)
+from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT
+from ethereum.state import (
+    EMPTY_CODE_HASH,
+    Account as StateAccount,
+    Address as StateAddress,
+    Root,
 )
 
 
@@ -102,3 +112,69 @@ def collect_storage_post_state_only_nodes(
         pre_storage, pre_state_reference_slots
     )
     return _nodes(post_state_nodes - pre_state_nodes)
+
+
+def merge_with_amsterdam_pre_alloc(pre: Alloc) -> Alloc:
+    """Merge test-local accounts with Amsterdam's implicit pre-allocation."""
+    return Alloc.merge(
+        Alloc.model_validate(Amsterdam.pre_allocation_blockchain()),
+        pre,
+    )
+
+
+def _storage_root_for_account(account: Account) -> Root:
+    """Compute the storage root for one execution-testing account."""
+    if not account.storage.root:
+        return EMPTY_TRIE_ROOT
+    storage_mpt = build_mpt(
+        {
+            _slot(int(slot)): U256(int(value))
+            for slot, value in account.storage.root.items()
+        },
+        secured=True,
+        default=U256(0),
+    )
+    return mpt_root(storage_mpt)
+
+
+def _state_account(account: Account) -> StateAccount:
+    """Convert an execution-testing account into the spec account type."""
+    code = bytes(account.code)
+    code_hash = (
+        EMPTY_CODE_HASH if len(code) == 0 else Hash32(keccak256(code))
+    )
+    return StateAccount(
+        nonce=Uint(int(account.nonce)),
+        balance=U256(int(account.balance)),
+        code_hash=code_hash,
+    )
+
+
+def collect_account_proof_nodes(
+    alloc: Alloc,
+    addresses: Sequence[StateAddress | bytes],
+) -> list[Bytes]:
+    """Collect account-trie proof nodes for the given addresses."""
+    storage_roots: dict[StateAddress, Root] = {}
+    accounts: dict[StateAddress, StateAccount | None] = {}
+
+    for address, account in alloc.items():
+        state_address = StateAddress(bytes(address))
+        if account is None:
+            accounts[state_address] = None
+            continue
+        storage_roots[state_address] = _storage_root_for_account(account)
+        accounts[state_address] = _state_account(account)
+
+    def get_storage_root(address: StateAddress) -> Root:
+        return storage_roots.get(address, EMPTY_TRIE_ROOT)
+
+    account_mpt = build_mpt(
+        accounts,
+        secured=True,
+        default=None,
+        get_storage_root=get_storage_root,
+    )
+    for address in addresses:
+        mpt_get(account_mpt, StateAddress(bytes(address)))
+    return _nodes(set(account_mpt.witness.accessed_nodes.values()))

--- a/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
+++ b/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
@@ -2,12 +2,12 @@
 
 from collections.abc import Mapping, Sequence
 
-from ethereum.crypto.hash import Hash32, keccak256
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256, Uint
 from execution_testing import Account, Address, Alloc, Bytes, Storage
 from execution_testing.forks import Amsterdam
 
+from ethereum.crypto.hash import Hash32, keccak256
 from ethereum.forks.amsterdam.incremental_mpt import (
     build_mpt,
     mpt_get,
@@ -17,9 +17,13 @@ from ethereum.forks.amsterdam.incremental_mpt import (
 from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT
 from ethereum.state import (
     EMPTY_CODE_HASH,
-    Account as StateAccount,
-    Address as StateAddress,
     Root,
+)
+from ethereum.state import (
+    Account as StateAccount,
+)
+from ethereum.state import (
+    Address as StateAddress,
 )
 
 
@@ -155,9 +159,7 @@ def _storage_root_for_account(account: Account) -> Root:
 def _state_account(account: Account) -> StateAccount:
     """Convert an execution-testing account into the spec account type."""
     code = bytes(account.code)
-    code_hash = (
-        EMPTY_CODE_HASH if len(code) == 0 else Hash32(keccak256(code))
-    )
+    code_hash = EMPTY_CODE_HASH if len(code) == 0 else Hash32(keccak256(code))
     return StateAccount(
         nonce=Uint(int(account.nonce)),
         balance=U256(int(account.balance)),
@@ -190,8 +192,8 @@ def _collect_account_node_set(
         default=None,
         get_storage_root=get_storage_root,
     )
-    for address in addresses:
-        mpt_get(account_mpt, StateAddress(bytes(address)))
+    for addr in addresses:
+        mpt_get(account_mpt, StateAddress(bytes(addr)))
     return set(account_mpt.witness.accessed_nodes.values())
 
 

--- a/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
+++ b/tests/amsterdam/eip8025_optional_proofs/state_helpers.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from ethereum.crypto.hash import Hash32, keccak256
 from ethereum_types.bytes import Bytes32
 from ethereum_types.numeric import U256, Uint
-from execution_testing import Account, Alloc, Bytes, Storage
+from execution_testing import Account, Address, Alloc, Bytes, Storage
 from execution_testing.forks import Amsterdam
 
 from ethereum.forks.amsterdam.incremental_mpt import (
@@ -114,6 +114,21 @@ def collect_storage_post_state_only_nodes(
     return _nodes(post_state_nodes - pre_state_nodes)
 
 
+def find_account_with_shared_secured_nibble(
+    target: Address,
+    excluded: set[Address],
+) -> Address:
+    """Return an occupied address that deepens one account absence proof."""
+    target_nibble = keccak256(bytes(target))[0] >> 4
+    for value in range(0x100, 0x1000):
+        address = Address(value)
+        if address in excluded:
+            continue
+        if (keccak256(bytes(address))[0] >> 4) == target_nibble:
+            return address
+    raise AssertionError("failed to find non-precompile sibling address")
+
+
 def merge_with_amsterdam_pre_alloc(pre: Alloc) -> Alloc:
     """Merge test-local accounts with Amsterdam's implicit pre-allocation."""
     return Alloc.merge(
@@ -150,11 +165,11 @@ def _state_account(account: Account) -> StateAccount:
     )
 
 
-def collect_account_proof_nodes(
+def _collect_account_node_set(
     alloc: Alloc,
     addresses: Sequence[StateAddress | bytes],
-) -> list[Bytes]:
-    """Collect account-trie proof nodes for the given addresses."""
+) -> set[bytes]:
+    """Collect hashed witness nodes for the given account proof paths."""
     storage_roots: dict[StateAddress, Root] = {}
     accounts: dict[StateAddress, StateAccount | None] = {}
 
@@ -177,4 +192,23 @@ def collect_account_proof_nodes(
     )
     for address in addresses:
         mpt_get(account_mpt, StateAddress(bytes(address)))
-    return _nodes(set(account_mpt.witness.accessed_nodes.values()))
+    return set(account_mpt.witness.accessed_nodes.values())
+
+
+def collect_account_proof_nodes(
+    alloc: Alloc,
+    addresses: Sequence[StateAddress | bytes],
+) -> list[Bytes]:
+    """Collect account-trie proof nodes for the given addresses."""
+    return _nodes(_collect_account_node_set(alloc, addresses))
+
+
+def collect_account_path_only_nodes(
+    alloc: Alloc,
+    address: StateAddress | bytes,
+    relative_to_addresses: Sequence[StateAddress | bytes],
+) -> list[Bytes]:
+    """Collect nodes unique to one account proof path relative to others."""
+    address_nodes = _collect_account_node_set(alloc, [address])
+    reference_nodes = _collect_account_node_set(alloc, relative_to_addresses)
+    return _nodes(address_nodes - reference_nodes)

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_headers.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_headers.py
@@ -15,6 +15,7 @@ from execution_testing import (
 )
 from execution_testing.client_clis import TransitionTool
 from execution_testing.fixtures import BlockchainFixture
+from execution_testing.fixtures.blockchain import FixtureBlock
 from execution_testing.forks import Amsterdam
 from execution_testing.test_types.execution_witness.modifiers import (
     prepend_header,
@@ -324,7 +325,9 @@ def test_witness_headers_extra_unused_older_ancestor(
         .fixture
     )
     assert isinstance(probe_fixture, BlockchainFixture)
-    extra_header = probe_fixture.blocks[0].header.rlp
+    probe_block = probe_fixture.blocks[0]
+    assert isinstance(probe_block, FixtureBlock)
+    extra_header = probe_block.header.rlp
 
     blocks = [Block(txs=[]) for _ in range(offset + 1)]
     blocks.append(

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
@@ -10,7 +10,6 @@ from execution_testing import (
     Op,
     Transaction,
 )
-from execution_testing.forks import Amsterdam
 
 from .state_helpers import (
     as_storage,

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
@@ -1,4 +1,4 @@
-"""Witness state collection scenarios for storage reads."""
+"""Witness state collection scenarios for state reads."""
 
 import pytest
 from execution_testing import (
@@ -10,12 +10,15 @@ from execution_testing import (
     Op,
     Transaction,
 )
+from execution_testing.forks import Amsterdam
 
 from .state_helpers import (
     as_storage,
     build_large_storage,
+    collect_account_proof_nodes,
     collect_storage_path_only_nodes,
     collect_storage_proof_nodes,
+    merge_with_amsterdam_pre_alloc,
 )
 
 pytestmark = pytest.mark.valid_from("Amsterdam")
@@ -130,6 +133,60 @@ def test_witness_state_reverted_inner_sload_still_contains_storage_proof(
         post={
             sender: Account(nonce=1),
             callee: Account(storage=storage),
+        },
+    )
+
+
+def test_witness_state_failed_call_still_contains_target_account_proof(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """A failed CALL should still include the target account proof."""
+    target = pre.fund_eoa()
+    caller_balance = 100
+    transfer_value = 1_000
+    caller_code = (
+        Op.SSTORE(
+            0,
+            Op.CALL(
+                Op.GAS,
+                target,
+                transfer_value,
+                0,
+                0,
+                0,
+                0,
+            ),
+        )
+        + Op.STOP
+    )
+    caller = pre.deploy_contract(
+        code=caller_code,
+        balance=caller_balance,
+        storage={0: 1},
+    )
+    sender = pre.fund_eoa()
+    full_alloc = merge_with_amsterdam_pre_alloc(pre)
+    proof_nodes = collect_account_proof_nodes(full_alloc, [target])
+    assert proof_nodes
+
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            caller: Account(balance=caller_balance, storage={0: 0}),
         },
     )
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py
@@ -94,6 +94,46 @@ def test_witness_state_reverted_sload_still_contains_storage_proof(
     )
 
 
+def test_witness_state_reverted_inner_sload_still_contains_storage_proof(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """
+    A reverted inner-call SLOAD should still leave its proof nodes in witness.
+    """
+    storage = build_large_storage([1])
+    proof_nodes = collect_storage_proof_nodes(storage, [1])
+    assert proof_nodes
+
+    callee = pre.deploy_contract(
+        code=Op.SLOAD(1) + Op.POP + Op.REVERT(0, 0),
+        storage=as_storage(storage),
+    )
+    caller = pre.deploy_contract(
+        code=Op.CALL(Op.GAS, callee, 0, 0, 0, 0, 0) + Op.POP + Op.STOP,
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    )
+                ),
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            callee: Account(storage=storage),
+        },
+    )
+
+
 def test_witness_state_sload_absent_slot_contains_storage_proof(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -24,8 +24,8 @@ from ethereum.forks.amsterdam.incremental_mpt import compact_to_nibbles
 
 from .state_helpers import (
     as_storage,
-    collect_account_path_only_nodes,
     build_large_storage,
+    collect_account_path_only_nodes,
     collect_account_proof_nodes,
     collect_storage_delete_auxiliary_nodes,
     collect_storage_proof_nodes,
@@ -331,7 +331,7 @@ def test_validation_state_missing_account_node_for_storage_resolution(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,
 ) -> None:
-    """Removing the account proof that gates storage-root lookup should fail."""
+    """Removing the account proof gating storage-root lookup fails."""
     read_slot = 1
     storage = build_large_storage([read_slot])
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -204,16 +204,22 @@ def test_validation_state_missing_delete_auxiliary_node(
     )
 
 
-def test_validation_state_missing_account_trie_proof_node(
+def test_validation_state_missing_sender_account_proof_leaf_node(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,
 ) -> None:
-    """Removing a required account proof node should fail a transfer."""
+    """Removing the sender account proof leaf should fail a transfer."""
     sender = pre.fund_eoa()
-    recipient = pre.fund_eoa(amount=0)
+    recipient = pre.fund_eoa(amount=1)
     full_alloc = merge_with_amsterdam_pre_alloc(pre)
     proof_nodes = collect_account_proof_nodes(full_alloc, [sender, recipient])
-    removed_node = _required_node(proof_nodes)
+    sender_only_nodes = collect_account_path_only_nodes(
+        full_alloc,
+        sender,
+        [recipient, *Amsterdam.execution_witness_implicit_code_addresses()],
+    )
+    assert len(sender_only_nodes) == 1
+    removed_node = _leaf_node(sender_only_nodes)
 
     tx = Transaction(sender=sender, to=recipient, value=1, gas_limit=21_000)
 
@@ -232,7 +238,7 @@ def test_validation_state_missing_account_trie_proof_node(
         ],
         post={
             sender: Account(nonce=1),
-            recipient: Account(balance=1),
+            recipient: Account(balance=2),
         },
     )
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -107,11 +107,29 @@ def test_validation_state_missing_absent_slot_proof_leaf_node(
     blockchain_test: BlockchainTestFiller,
 ) -> None:
     """Removing the absent-slot proof leaf should fail insertion."""
+    # The contract will insert a value to a non-existent slot 1.
+
     # These slots produce a multi-node absence proof for slot 1:
-    # keccak(1) and keccak(24) share the first two nibbles ("b1"), while
-    # keccak(14) shares only the first nibble ("b"). That yields an
-    # extension -> branch -> leaf path, so this test can remove the leaf,
-    # thus the proof of absence is invalid due to missing data.
+    #
+    #   keccak(1)  -> b1...
+    #   keccak(24) -> b1...
+    #   keccak(14) -> bx...  (x != 1)
+    #
+    #   ext("b") (root)
+    #     |
+    #   branch
+    #   /    \
+    # [x]    [1]
+    #  |      |
+    # leaf   leaf
+    # (14)   (24)
+    #         ^
+    #         |
+    #   absent slot 1 follows this edge, then diverges inside the leaf
+    #
+    # The proof for slot 1 is therefore `extension -> branch -> leaf`.
+    # Removing that leaf makes the absence proof invalid due to missing
+    # data.
     pre_storage = build_large_storage([14, 24])
     insert_slot = 1
     insert_value = large_storage_value(insert_slot)

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -1,29 +1,66 @@
 """Execution witness state validation tests."""
 
 import pytest
+from ethereum_rlp import rlp
+from ethereum_types.bytes import Bytes as TrieBytes
 from execution_testing import (
     Account,
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytes,
     ExecutionWitnessStateExpectation,
     Op,
     Transaction,
 )
+from execution_testing.forks import Amsterdam
 from execution_testing.test_types.execution_witness.modifiers import (
+    add_state_node,
     remove_state_node,
+    reverse_state_nodes,
 )
+
+from ethereum.forks.amsterdam.incremental_mpt import compact_to_nibbles
 
 from .state_helpers import (
     as_storage,
+    collect_account_path_only_nodes,
     build_large_storage,
+    collect_account_proof_nodes,
+    collect_storage_delete_auxiliary_nodes,
     collect_storage_proof_nodes,
+    find_account_with_shared_secured_nibble,
+    large_storage_value,
+    merge_with_amsterdam_pre_alloc,
 )
 
 pytestmark = pytest.mark.valid_from("Amsterdam")
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"
+
+
+def _required_node(nodes: list[Bytes]) -> Bytes:
+    """Pick one required trie node from a proof set."""
+    assert nodes
+    return sorted(nodes)[0]
+
+
+def _leaf_node(nodes: list[Bytes]) -> Bytes:
+    """Pick the unique leaf node from a proof set."""
+    leaves: list[Bytes] = []
+    for node in nodes:
+        decoded = rlp.decode(bytes(node))
+        if not isinstance(decoded, list) or len(decoded) != 2:
+            continue
+        path_bytes = decoded[0]
+        assert isinstance(path_bytes, (bytes, bytearray))
+        _, is_leaf = compact_to_nibbles(TrieBytes(path_bytes))
+        if is_leaf:
+            leaves.append(node)
+
+    assert len(leaves) == 1
+    return leaves[0]
 
 
 def test_validation_state_missing_storage_proof_node(
@@ -35,8 +72,7 @@ def test_validation_state_missing_storage_proof_node(
     write_slot = 2
     storage = build_large_storage([read_slot])
     proof_nodes = collect_storage_proof_nodes(storage, [read_slot])
-    assert proof_nodes
-    removed_node = sorted(proof_nodes)[0]
+    removed_node = _required_node(proof_nodes)
 
     contract = pre.deploy_contract(
         code=Op.SSTORE(write_slot, Op.SLOAD(read_slot)) + Op.STOP,
@@ -62,5 +98,355 @@ def test_validation_state_missing_storage_proof_node(
         post={
             sender: Account(nonce=1),
             contract: Account(storage=post_storage),
+        },
+    )
+
+
+def test_validation_state_missing_absent_slot_proof_leaf_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the absent-slot proof leaf should fail insertion."""
+    # These slots produce a multi-node absence proof for slot 1:
+    # keccak(1) and keccak(24) share the first two nibbles ("b1"), while
+    # keccak(14) shares only the first nibble ("b"). That yields an
+    # extension -> branch -> leaf path, so this test can remove the leaf,
+    # thus the proof of absence is invalid due to missing data.
+    pre_storage = build_large_storage([14, 24])
+    insert_slot = 1
+    insert_value = large_storage_value(insert_slot)
+    proof_nodes = collect_storage_proof_nodes(pre_storage, [insert_slot])
+    assert len(proof_nodes) == 3
+    removed_node = _leaf_node(proof_nodes)
+
+    contract = pre.deploy_contract(
+        code=Op.SSTORE(insert_slot, insert_value) + Op.STOP,
+        storage=as_storage(pre_storage),
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(
+                storage={**pre_storage, insert_slot: insert_value},
+            ),
+        },
+    )
+
+
+def test_validation_state_missing_delete_auxiliary_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the delete-collapse auxiliary node should fail."""
+    storage = build_large_storage([1, 2])
+    proof_nodes = collect_storage_proof_nodes(storage, [1])
+    auxiliary_nodes = collect_storage_delete_auxiliary_nodes(storage, 1)
+    assert len(auxiliary_nodes) == 1
+    removed_node = auxiliary_nodes[0]
+
+    contract = pre.deploy_contract(
+        code=Op.SSTORE(1, 0) + Op.STOP,
+        storage=as_storage(storage),
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes + auxiliary_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(storage={2: storage[2]}),
+        },
+    )
+
+
+def test_validation_state_missing_account_trie_proof_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing a required account proof node should fail a transfer."""
+    sender = pre.fund_eoa()
+    recipient = pre.fund_eoa(amount=0)
+    full_alloc = merge_with_amsterdam_pre_alloc(pre)
+    proof_nodes = collect_account_proof_nodes(full_alloc, [sender, recipient])
+    removed_node = _required_node(proof_nodes)
+
+    tx = Transaction(sender=sender, to=recipient, value=1, gas_limit=21_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            recipient: Account(balance=1),
+        },
+    )
+
+
+def test_validation_state_missing_absent_account_proof_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing a recipient-only absent-account proof node should fail."""
+    sender = pre.fund_eoa()
+    recipient = pre.empty_account()
+    # Add one untouched sibling under the recipient's secured-trie prefix so
+    # the absence proof extends below the shared root node.
+    sibling = find_account_with_shared_secured_nibble(
+        recipient,
+        {
+            sender,
+            recipient,
+            *Amsterdam.execution_witness_implicit_code_addresses(),
+        },
+    )
+    pre.fund_address(sibling, 1)
+    full_alloc = merge_with_amsterdam_pre_alloc(pre)
+    recipient_only_nodes = sorted(
+        collect_account_path_only_nodes(
+            full_alloc,
+            recipient,
+            [sender, *Amsterdam.execution_witness_implicit_code_addresses()],
+        )
+    )
+    assert len(recipient_only_nodes) == 1
+    proof_nodes = collect_account_proof_nodes(full_alloc, [recipient])
+    removed_node = recipient_only_nodes[0]
+
+    tx = Transaction(sender=sender, to=recipient, value=1, gas_limit=21_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            recipient: Account(balance=1),
+        },
+    )
+
+
+def test_validation_state_missing_failed_call_target_account_proof_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the failed CALL target proof should fail witness replay."""
+    target = pre.fund_eoa()
+    caller_balance = 100
+    transfer_value = 1_000
+    caller_code = (
+        Op.SSTORE(
+            0,
+            Op.CALL(
+                Op.GAS,
+                target,
+                transfer_value,
+                0,
+                0,
+                0,
+                0,
+            ),
+        )
+        + Op.STOP
+    )
+    caller = pre.deploy_contract(
+        code=caller_code,
+        balance=caller_balance,
+        storage={0: 1},
+    )
+    sender = pre.fund_eoa()
+    full_alloc = merge_with_amsterdam_pre_alloc(pre)
+    proof_nodes = collect_account_proof_nodes(full_alloc, [target])
+    assert proof_nodes
+    removed_node = _required_node(proof_nodes)
+
+    tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            caller: Account(balance=caller_balance, storage={0: 0}),
+        },
+    )
+
+
+def test_validation_state_missing_account_node_for_storage_resolution(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Removing the account proof that gates storage-root lookup should fail."""
+    read_slot = 1
+    storage = build_large_storage([read_slot])
+
+    contract = pre.deploy_contract(
+        code=Op.SLOAD(read_slot) + Op.POP + Op.STOP,
+        storage=as_storage(storage),
+    )
+    sender = pre.fund_eoa()
+    full_alloc = merge_with_amsterdam_pre_alloc(pre)
+    account_proof_nodes = collect_account_proof_nodes(full_alloc, [contract])
+    storage_proof_nodes = collect_storage_proof_nodes(storage, [read_slot])
+    reference_account_nodes = collect_account_proof_nodes(
+        full_alloc,
+        [
+            sender,
+            *Amsterdam.execution_witness_implicit_code_addresses(),
+        ],
+    )
+    contract_only_account_nodes = sorted(
+        set(account_proof_nodes) - set(reference_account_nodes)
+    )
+
+    # The contract remaining node in the MPT proof is the account leaf node.
+    assert len(contract_only_account_nodes) == 1
+    removed_node = contract_only_account_nodes[0]
+
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=(
+                            account_proof_nodes + storage_proof_nodes
+                        ),
+                    ).modify(remove_state_node(removed_node))
+                ),
+                expected_stateless_validation_success=False,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(storage=storage),
+        },
+    )
+
+
+def test_validation_state_extra_unused_trie_node(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Adding an unused state node should still validate."""
+    storage = build_large_storage([1])
+    proof_nodes = collect_storage_proof_nodes(storage, [1])
+
+    contract = pre.deploy_contract(
+        code=Op.SLOAD(1) + Op.POP + Op.STOP,
+        storage=as_storage(storage),
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(add_state_node(Bytes(b"\x81\x99")))
+                ),
+                expected_stateless_validation_success=True,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(storage=storage),
+        },
+    )
+
+
+def test_validation_state_unsorted_but_complete(
+    pre: Alloc,
+    blockchain_test: BlockchainTestFiller,
+) -> None:
+    """Reordering a complete state witness should still validate."""
+    storage = build_large_storage([1])
+    proof_nodes = collect_storage_proof_nodes(storage, [1])
+
+    contract = pre.deploy_contract(
+        code=Op.SLOAD(1) + Op.POP + Op.STOP,
+        storage=as_storage(storage),
+    )
+    sender = pre.fund_eoa()
+    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                expected_execution_witness_state=(
+                    ExecutionWitnessStateExpectation(
+                        nodes_present=proof_nodes,
+                    ).modify(reverse_state_nodes())
+                ),
+                expected_stateless_validation_success=True,
+            )
+        ],
+        post={
+            sender: Account(nonce=1),
+            contract: Account(storage=storage),
         },
     )

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -351,7 +351,6 @@ def test_validation_state_missing_failed_call_target_account_proof_node(
     )
 
 
-
 def test_validation_state_extra_unused_trie_node(
     pre: Alloc,
     blockchain_test: BlockchainTestFiller,

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -321,7 +321,7 @@ def test_validation_state_missing_failed_call_target_account_proof_node(
     full_alloc = merge_with_amsterdam_pre_alloc(pre)
     proof_nodes = collect_account_proof_nodes(full_alloc, [target])
     assert proof_nodes
-    removed_node = _required_node(proof_nodes)
+    removed_node = _leaf_node(proof_nodes)
 
     tx = Transaction(sender=sender, to=caller, gas_limit=500_000)
 

--- a/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
+++ b/tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py
@@ -351,60 +351,6 @@ def test_validation_state_missing_failed_call_target_account_proof_node(
     )
 
 
-def test_validation_state_missing_account_node_for_storage_resolution(
-    pre: Alloc,
-    blockchain_test: BlockchainTestFiller,
-) -> None:
-    """Removing the account proof gating storage-root lookup fails."""
-    read_slot = 1
-    storage = build_large_storage([read_slot])
-
-    contract = pre.deploy_contract(
-        code=Op.SLOAD(read_slot) + Op.POP + Op.STOP,
-        storage=as_storage(storage),
-    )
-    sender = pre.fund_eoa()
-    full_alloc = merge_with_amsterdam_pre_alloc(pre)
-    account_proof_nodes = collect_account_proof_nodes(full_alloc, [contract])
-    storage_proof_nodes = collect_storage_proof_nodes(storage, [read_slot])
-    reference_account_nodes = collect_account_proof_nodes(
-        full_alloc,
-        [
-            sender,
-            *Amsterdam.execution_witness_implicit_code_addresses(),
-        ],
-    )
-    contract_only_account_nodes = sorted(
-        set(account_proof_nodes) - set(reference_account_nodes)
-    )
-
-    # The contract remaining node in the MPT proof is the account leaf node.
-    assert len(contract_only_account_nodes) == 1
-    removed_node = contract_only_account_nodes[0]
-
-    tx = Transaction(sender=sender, to=contract, gas_limit=500_000)
-
-    blockchain_test(
-        pre=pre,
-        blocks=[
-            Block(
-                txs=[tx],
-                expected_execution_witness_state=(
-                    ExecutionWitnessStateExpectation(
-                        nodes_present=(
-                            account_proof_nodes + storage_proof_nodes
-                        ),
-                    ).modify(remove_state_node(removed_node))
-                ),
-                expected_stateless_validation_success=False,
-            )
-        ],
-        post={
-            sender: Account(nonce=1),
-            contract: Account(storage=storage),
-        },
-    )
-
 
 def test_validation_state_extra_unused_trie_node(
     pre: Alloc,

--- a/tests/json_infra/test_incremental_mpt.py
+++ b/tests/json_infra/test_incremental_mpt.py
@@ -319,7 +319,8 @@ class TestMalformedWitnessNodes:
     def test_branch_with_zero_occupied_entries(self) -> None:
         """A branch node must encode at least two occupied entries."""
         with pytest.raises(
-            AssertionError, match="BranchNode must have at least 2 children"
+            AssertionError,
+            match="BranchNode must have at least 2 occupied entries",
         ):
             _decode_root_from_rlp(Bytes(rlp.encode([b""] * 17)))
 
@@ -329,7 +330,8 @@ class TestMalformedWitnessNodes:
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"value"]
 
         with pytest.raises(
-            AssertionError, match="BranchNode must have at least 2 children"
+            AssertionError,
+            match="BranchNode must have at least 2 occupied entries",
         ):
             _decode_root_from_rlp(Bytes(rlp.encode(branch)))
 

--- a/tests/json_infra/test_incremental_mpt.py
+++ b/tests/json_infra/test_incremental_mpt.py
@@ -195,6 +195,21 @@ def _build_trie_and_collect_nodes(
     return expected_root, node_db
 
 
+def _decode_root_from_rlp(
+    root_rlp: Bytes,
+    *,
+    secured: bool = False,
+) -> IncrementalMPT[Bytes, Bytes]:
+    """Decode a single synthetic witness root from its RLP bytes."""
+    root_hash = Root(keccak256(root_rlp))
+    return decode_witness_to_mpt(
+        {Bytes(root_hash): root_rlp},
+        root_hash,
+        secured=secured,
+        default=b"",
+    )
+
+
 class TestDecodeWitnessToMpt:
     """Test decode_witness_to_mpt with synthetic witness data."""
 
@@ -218,6 +233,130 @@ class TestDecodeWitnessToMpt:
             node_db, expected_root, secured=False, default=b""
         )
         assert mpt_root(mpt) == expected_root
+
+
+class TestMalformedWitnessNodes:
+    """Test malformed witness node decoding failures."""
+
+    def test_malformed_rlp_bytes(self) -> None:
+        """Malformed RLP should fail before node-shape validation."""
+        with pytest.raises(rlp.DecodingError):
+            _decode_root_from_rlp(Bytes(b"\xc1"))
+
+    def test_nonempty_byte_string_node(self) -> None:
+        """A decoded byte string node must be the empty node only."""
+        with pytest.raises(AssertionError, match="Expected empty node"):
+            _decode_root_from_rlp(Bytes(rlp.encode(b"\x01")))
+
+    def test_invalid_rlp_node_length(self) -> None:
+        """Only 2-item and 17-item node lists are valid."""
+        with pytest.raises(
+            AssertionError, match="Invalid RLP node length: 3"
+        ):
+            _decode_root_from_rlp(Bytes(rlp.encode([b"\x01", b"\x02", b"\x03"])))
+
+    def test_extension_with_empty_child_ref(self) -> None:
+        """Extension nodes must point to a branch child."""
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b"\x01"), False), b""])
+        )
+
+        with pytest.raises(
+            AssertionError, match="ExtensionNode child must be a BranchNode"
+        ):
+            _decode_root_from_rlp(root_rlp)
+
+    def test_extension_pointing_to_leaf(self) -> None:
+        """Extensions may not point directly to leaf nodes."""
+        leaf = [nibble_list_to_compact(Bytes(b"\x02"), True), b"value"]
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b"\x01"), False), leaf])
+        )
+
+        with pytest.raises(
+            AssertionError, match="ExtensionNode child must be a BranchNode"
+        ):
+            _decode_root_from_rlp(root_rlp)
+
+    def test_extension_pointing_to_extension(self) -> None:
+        """Extensions may not point directly to other extensions."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x03"), True), b"left"]
+        branch[1] = [nibble_list_to_compact(Bytes(b"\x04"), True), b"right"]
+        inner_extension = [
+            nibble_list_to_compact(Bytes(b"\x02"), False),
+            branch,
+        ]
+        root_rlp = Bytes(
+            rlp.encode(
+                [
+                    nibble_list_to_compact(Bytes(b"\x01"), False),
+                    inner_extension,
+                ]
+            )
+        )
+
+        with pytest.raises(
+            AssertionError, match="ExtensionNode child must be a BranchNode"
+        ):
+            _decode_root_from_rlp(root_rlp)
+
+    def test_extension_child_raw_nonzero_non_hash_bytes(self) -> None:
+        """Non-empty byte refs inside extensions must be 32-byte hashes."""
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b"\x01"), False), b"\x01"])
+        )
+
+        with pytest.raises(AssertionError, match="Unexpected child ref length"):
+            _decode_root_from_rlp(root_rlp)
+
+    def test_branch_with_zero_occupied_entries(self) -> None:
+        """A branch node must encode at least two occupied entries."""
+        with pytest.raises(
+            AssertionError, match="BranchNode must have at least 2 children"
+        ):
+            _decode_root_from_rlp(Bytes(rlp.encode([b""] * 17)))
+
+    def test_branch_with_single_occupied_entry(self) -> None:
+        """A branch node with only one child is non-canonical."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"value"]
+
+        with pytest.raises(
+            AssertionError, match="BranchNode must have at least 2 children"
+        ):
+            _decode_root_from_rlp(Bytes(rlp.encode(branch)))
+
+    def test_secured_branch_with_value(self) -> None:
+        """Secured tries must not use the branch value slot."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[16] = b"terminal"
+
+        with pytest.raises(
+            AssertionError,
+            match="BranchNode value must be empty in state/storage trie",
+        ):
+            _decode_root_from_rlp(Bytes(rlp.encode(branch)), secured=True)
+
+    def test_secured_extension_with_empty_path(self) -> None:
+        """Secured tries must reject empty extension segments."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b""), False), branch])
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="ExtensionNode must have a non-empty path",
+        ):
+            _decode_root_from_rlp(root_rlp, secured=True)
+
+
+class TestDecodeWitnessToMptMore:
+    """Additional decode_witness_to_mpt roundtrip coverage."""
 
     def test_multiple_entries(self) -> None:
         """Decode a trie with multiple entries and verify root."""

--- a/tests/json_infra/test_incremental_mpt.py
+++ b/tests/json_infra/test_incremental_mpt.py
@@ -333,20 +333,8 @@ class TestMalformedWitnessNodes:
         ):
             _decode_root_from_rlp(Bytes(rlp.encode(branch)))
 
-    def test_secured_branch_with_value(self) -> None:
-        """Secured tries must not use the branch value slot."""
-        branch: list[Any] = [b""] * 17
-        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
-        branch[16] = b"terminal"
-
-        with pytest.raises(
-            AssertionError,
-            match="BranchNode value must be empty in state/storage trie",
-        ):
-            _decode_root_from_rlp(Bytes(rlp.encode(branch)), secured=True)
-
-    def test_secured_extension_with_empty_path(self) -> None:
-        """Secured tries must reject empty extension segments."""
+    def test_extension_with_empty_path(self) -> None:
+        """Tries must reject empty extension segments."""
         branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
@@ -358,7 +346,7 @@ class TestMalformedWitnessNodes:
             AssertionError,
             match="ExtensionNode must have a non-empty path",
         ):
-            _decode_root_from_rlp(root_rlp, secured=True)
+            _decode_root_from_rlp(root_rlp)
 
 
 class TestDecodeWitnessToMptMore:

--- a/tests/json_infra/test_incremental_mpt.py
+++ b/tests/json_infra/test_incremental_mpt.py
@@ -1,5 +1,7 @@
 """Tests for the incremental MPT witness decoding and HashedNode."""
 
+from typing import Any
+
 import pytest
 from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes
@@ -250,10 +252,10 @@ class TestMalformedWitnessNodes:
 
     def test_invalid_rlp_node_length(self) -> None:
         """Only 2-item and 17-item node lists are valid."""
-        with pytest.raises(
-            AssertionError, match="Invalid RLP node length: 3"
-        ):
-            _decode_root_from_rlp(Bytes(rlp.encode([b"\x01", b"\x02", b"\x03"])))
+        with pytest.raises(AssertionError, match="Invalid RLP node length: 3"):
+            _decode_root_from_rlp(
+                Bytes(rlp.encode([b"\x01", b"\x02", b"\x03"]))
+            )
 
     def test_extension_with_empty_child_ref(self) -> None:
         """Extension nodes must point to a branch child."""
@@ -280,10 +282,10 @@ class TestMalformedWitnessNodes:
 
     def test_extension_pointing_to_extension(self) -> None:
         """Extensions may not point directly to other extensions."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x03"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x04"), True), b"right"]
-        inner_extension = [
+        inner_extension: list[Any] = [
             nibble_list_to_compact(Bytes(b"\x02"), False),
             branch,
         ]
@@ -304,10 +306,14 @@ class TestMalformedWitnessNodes:
     def test_extension_child_raw_nonzero_non_hash_bytes(self) -> None:
         """Non-empty byte refs inside extensions must be 32-byte hashes."""
         root_rlp = Bytes(
-            rlp.encode([nibble_list_to_compact(Bytes(b"\x01"), False), b"\x01"])
+            rlp.encode(
+                [nibble_list_to_compact(Bytes(b"\x01"), False), b"\x01"]
+            )
         )
 
-        with pytest.raises(AssertionError, match="Unexpected child ref length"):
+        with pytest.raises(
+            AssertionError, match="Unexpected child ref length"
+        ):
             _decode_root_from_rlp(root_rlp)
 
     def test_branch_with_zero_occupied_entries(self) -> None:
@@ -319,7 +325,7 @@ class TestMalformedWitnessNodes:
 
     def test_branch_with_single_occupied_entry(self) -> None:
         """A branch node with only one child is non-canonical."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"value"]
 
         with pytest.raises(
@@ -329,7 +335,7 @@ class TestMalformedWitnessNodes:
 
     def test_secured_branch_with_value(self) -> None:
         """Secured tries must not use the branch value slot."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[16] = b"terminal"
 
@@ -341,7 +347,7 @@ class TestMalformedWitnessNodes:
 
     def test_secured_extension_with_empty_path(self) -> None:
         """Secured tries must reject empty extension segments."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
         root_rlp = Bytes(

--- a/tests/json_infra/test_witness_state.py
+++ b/tests/json_infra/test_witness_state.py
@@ -1,6 +1,6 @@
 """Tests for WitnessState."""
 
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 from ethereum_rlp import rlp
@@ -277,7 +277,7 @@ class TestCanonicalSecureTrieValidation:
 
     def test_account_trie_rejects_nonempty_branch_value(self) -> None:
         """Secured account tries must not use the branch value slot."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[16] = b"terminal"
         state_root, node_db = _root_witness(Bytes(rlp.encode(branch)))
@@ -295,10 +295,12 @@ class TestCanonicalSecureTrieValidation:
 
     def test_storage_trie_rejects_nonempty_branch_value(self) -> None:
         """Secured storage tries must not use the branch value slot."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[16] = b"terminal"
-        storage_root, storage_node_db = _root_witness(Bytes(rlp.encode(branch)))
+        storage_root, storage_node_db = _root_witness(
+            Bytes(rlp.encode(branch))
+        )
         state_root, state_node_db = _single_account_state_witness(
             storage_root=storage_root
         )
@@ -316,7 +318,7 @@ class TestCanonicalSecureTrieValidation:
 
     def test_account_trie_rejects_zero_length_extension_path(self) -> None:
         """Secured account tries must reject empty extension segments."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
         root_rlp = Bytes(
@@ -337,7 +339,7 @@ class TestCanonicalSecureTrieValidation:
 
     def test_storage_trie_rejects_zero_length_extension_path(self) -> None:
         """Secured storage tries must reject empty extension segments."""
-        branch = [b""] * 17
+        branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
         root_rlp = Bytes(

--- a/tests/json_infra/test_witness_state.py
+++ b/tests/json_infra/test_witness_state.py
@@ -275,49 +275,8 @@ class TestComputeStateRoot:
 class TestCanonicalSecureTrieValidation:
     """Test state/storage-trie canonicality checks in WitnessState."""
 
-    def test_account_trie_rejects_nonempty_branch_value(self) -> None:
-        """Secured account tries must not use the branch value slot."""
-        branch: list[Any] = [b""] * 17
-        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
-        branch[16] = b"terminal"
-        state_root, node_db = _root_witness(Bytes(rlp.encode(branch)))
-        witness_state = WitnessState(
-            _node_db=node_db,
-            _state_root=state_root,
-            _code_db={},
-        )
-
-        with pytest.raises(
-            AssertionError,
-            match="BranchNode value must be empty in state/storage trie",
-        ):
-            witness_state.get_account_optional(_ADDR1)
-
-    def test_storage_trie_rejects_nonempty_branch_value(self) -> None:
-        """Secured storage tries must not use the branch value slot."""
-        branch: list[Any] = [b""] * 17
-        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
-        branch[16] = b"terminal"
-        storage_root, storage_node_db = _root_witness(
-            Bytes(rlp.encode(branch))
-        )
-        state_root, state_node_db = _single_account_state_witness(
-            storage_root=storage_root
-        )
-        witness_state = WitnessState(
-            _node_db={**state_node_db, **storage_node_db},
-            _state_root=state_root,
-            _code_db={},
-        )
-
-        with pytest.raises(
-            AssertionError,
-            match="BranchNode value must be empty in state/storage trie",
-        ):
-            witness_state.get_storage(_ADDR1, _SLOT1)
-
     def test_account_trie_rejects_zero_length_extension_path(self) -> None:
-        """Secured account tries must reject empty extension segments."""
+        """Account tries must reject empty extension segments."""
         branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
@@ -338,7 +297,7 @@ class TestCanonicalSecureTrieValidation:
             witness_state.get_account_optional(_ADDR1)
 
     def test_storage_trie_rejects_zero_length_extension_path(self) -> None:
-        """Secured storage tries must reject empty extension segments."""
+        """Storage tries must reject empty extension segments."""
         branch: list[Any] = [b""] * 17
         branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
         branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]

--- a/tests/json_infra/test_witness_state.py
+++ b/tests/json_infra/test_witness_state.py
@@ -2,17 +2,24 @@
 
 from typing import Optional
 
+import pytest
+from ethereum_rlp import rlp
 from ethereum_types.bytes import Bytes, Bytes32
 from ethereum_types.numeric import U256, Uint
 
 from ethereum.crypto.hash import Hash32, keccak256
+from ethereum.forks.amsterdam.fork_types import encode_account
 from ethereum.forks.amsterdam.incremental_mpt import (
     IncrementalMPT,
     build_mpt,
     mpt_get,
     mpt_root,
 )
-from ethereum.forks.amsterdam.trie import EMPTY_TRIE_ROOT
+from ethereum.forks.amsterdam.trie import (
+    EMPTY_TRIE_ROOT,
+    bytes_to_nibble_list,
+    nibble_list_to_compact,
+)
 from ethereum.forks.amsterdam.witness_state import (
     WitnessState,
     build_code_db,
@@ -79,6 +86,25 @@ def _make_ws(
     return WitnessState(
         _node_db=node_db, _state_root=state_root, _code_db=code_db or {}
     )
+
+
+def _root_witness(root_rlp: Bytes) -> tuple[Root, dict[Bytes, Bytes]]:
+    """Build a synthetic witness DB keyed by one root node."""
+    root_hash = Root(keccak256(root_rlp))
+    return root_hash, {Bytes(root_hash): root_rlp}
+
+
+def _single_account_state_witness(
+    *,
+    address: Address = _ADDR1,
+    storage_root: Root = EMPTY_TRIE_ROOT,
+) -> tuple[Root, dict[Bytes, Bytes]]:
+    """Build a valid one-account state witness with a custom storage root."""
+    account_leaf = [
+        nibble_list_to_compact(bytes_to_nibble_list(keccak256(address)), True),
+        encode_account(_acct(), storage_root),
+    ]
+    return _root_witness(Bytes(rlp.encode(account_leaf)))
 
 
 class TestBuildNodeDb:
@@ -244,3 +270,138 @@ class TestComputeStateRoot:
         )
         new_root, _ = witness_state.compute_state_root_and_trie_changes({}, {})
         assert new_root == state_root
+
+
+class TestCanonicalSecureTrieValidation:
+    """Test state/storage-trie canonicality checks in WitnessState."""
+
+    def test_account_trie_rejects_nonempty_branch_value(self) -> None:
+        """Secured account tries must not use the branch value slot."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[16] = b"terminal"
+        state_root, node_db = _root_witness(Bytes(rlp.encode(branch)))
+        witness_state = WitnessState(
+            _node_db=node_db,
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="BranchNode value must be empty in state/storage trie",
+        ):
+            witness_state.get_account_optional(_ADDR1)
+
+    def test_storage_trie_rejects_nonempty_branch_value(self) -> None:
+        """Secured storage tries must not use the branch value slot."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[16] = b"terminal"
+        storage_root, storage_node_db = _root_witness(Bytes(rlp.encode(branch)))
+        state_root, state_node_db = _single_account_state_witness(
+            storage_root=storage_root
+        )
+        witness_state = WitnessState(
+            _node_db={**state_node_db, **storage_node_db},
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="BranchNode value must be empty in state/storage trie",
+        ):
+            witness_state.get_storage(_ADDR1, _SLOT1)
+
+    def test_account_trie_rejects_zero_length_extension_path(self) -> None:
+        """Secured account tries must reject empty extension segments."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b""), False), branch])
+        )
+        state_root, node_db = _root_witness(root_rlp)
+        witness_state = WitnessState(
+            _node_db=node_db,
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="ExtensionNode must have a non-empty path",
+        ):
+            witness_state.get_account_optional(_ADDR1)
+
+    def test_storage_trie_rejects_zero_length_extension_path(self) -> None:
+        """Secured storage tries must reject empty extension segments."""
+        branch = [b""] * 17
+        branch[0] = [nibble_list_to_compact(Bytes(b"\x01"), True), b"left"]
+        branch[1] = [nibble_list_to_compact(Bytes(b"\x02"), True), b"right"]
+        root_rlp = Bytes(
+            rlp.encode([nibble_list_to_compact(Bytes(b""), False), branch])
+        )
+        storage_root, storage_node_db = _root_witness(root_rlp)
+        state_root, state_node_db = _single_account_state_witness(
+            storage_root=storage_root
+        )
+        witness_state = WitnessState(
+            _node_db={**state_node_db, **storage_node_db},
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="ExtensionNode must have a non-empty path",
+        ):
+            witness_state.get_storage(_ADDR1, _SLOT1)
+
+    def test_account_trie_rejects_unresolved_hashed_node(self) -> None:
+        """Secured account lookups must not silently pass unresolved hashes."""
+        fake_hash = Bytes(b"\x11" * 32)
+        key_nibbles = bytes_to_nibble_list(keccak256(_ADDR1))
+        root_rlp = Bytes(
+            rlp.encode(
+                [nibble_list_to_compact(key_nibbles[:1], False), fake_hash]
+            )
+        )
+        state_root, node_db = _root_witness(root_rlp)
+        witness_state = WitnessState(
+            _node_db=node_db,
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="Encountered unresolved HashedNode during witness lookup",
+        ):
+            witness_state.get_account_optional(_ADDR1)
+
+    def test_storage_trie_rejects_unresolved_hashed_node(self) -> None:
+        """Secured storage lookups must not silently pass unresolved hashes."""
+        fake_hash = Bytes(b"\x22" * 32)
+        key_nibbles = bytes_to_nibble_list(keccak256(_SLOT1))
+        root_rlp = Bytes(
+            rlp.encode(
+                [nibble_list_to_compact(key_nibbles[:1], False), fake_hash]
+            )
+        )
+        storage_root, storage_node_db = _root_witness(root_rlp)
+        state_root, state_node_db = _single_account_state_witness(
+            storage_root=storage_root
+        )
+        witness_state = WitnessState(
+            _node_db={**state_node_db, **storage_node_db},
+            _state_root=state_root,
+            _code_db={},
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="Encountered unresolved HashedNode during witness lookup",
+        ):
+            witness_state.get_storage(_ADDR1, _SLOT1)


### PR DESCRIPTION
## 🗒️ Description
This PR:
- Added some extra execution witness completeness tests -- not main intention of this PR, but useful to add more coverage.
- Tighten Amsterdam `WitnessState` and incremental MPT witness decoding so stateless execution rejects malformed or incomplete trie proofs, including unresolved hashed nodes, and empty extension paths.
- Add execution-witness tests covering missing account and storage proof nodes, absent-slot and absent-account proofs, delete-collapse auxiliary nodes, and reverted or failed-call read scenarios.

The last bullet basically means testing invalid `ExecutionWitness.state` regarding missing information for correctly verifying the witness. 

I also believe eventually we need to also cover invalid `ExecutionWitness.state` test cases for "structurally invalid MPTs". I already added the checks for this in the spec in this PR. For an idea of which cases to add, I wrote a document [here](https://hackmd.io/@jsign/invalid-decoded-mpt-test-cases) -- I think this probably needs more helpers in the testing framework to construct these tests nicely.

```
> uv run fill --clean -m "blockchain_test" --fork Amsterdam ./tests/amsterdam/eip8025_optional_proofs     
===================================================================== test session starts ======================================================================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0
Generating fixtures for: BPO2ToAmsterdamAtTime15k, Amsterdam
2.19.0
Log file: logs/fill-20260330-164614-main.log
rootdir: /home/ignacio/code/execution-specs
configfile: packages/testing/src/execution_testing/cli/pytest_commands/pytest_ini_files/pytest-fill.ini
plugins: cov-4.1.0, metadata-3.1.1, json-report-1.5.0, xdist-3.8.0, regex-0.2.0, custom-report-1.0.1, html-4.1.1
collecting ...  pytest-regex selected 328 tests to run for regex: .*
collected 492 items / 164 deselected / 328 selected                                                                                                            

tests/amsterdam/eip8025_optional_proofs/test_witness_headers.py ..                                                                                    [  2/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_7702.py .................                                                                        [ 19/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_call_variants.py ........                                                              [ 27/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_contract_creation.py ..........                                                        [ 37/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_eoa_precompiles.py ...................                                                 [ 56/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_extcode.py ............................................                                [100/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_selfdestruct.py .......                                                                [107/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_bytecodes_system_contracts.py .                                                                  [108/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_headers.py ..............                                                                        [122/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_state_deletes.py .....                                                                           [127/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_state_invariants.py .                                                                            [128/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_state_reads.py .....                                                                             [133/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_state_replay_order.py ..                                                                         [135/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_state_writes.py ....                                                                             [139/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_validation_codes.py ...........                                                                  [150/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_validation_headers.py .....                                                                      [155/164]
tests/amsterdam/eip8025_optional_proofs/test_witness_validation_state.py .........                                                                    [164/164]

======================================================================= warnings summary =======================================================================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812
  /home/ignacio/code/execution-specs/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:812: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; execution_testing.cli.pytest_commands.plugins.filler.pre_alloc
    self.import_plugin(arg, consider_entry_points=True)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------------------------------- Log file: /home/ignacio/code/execution-specs/logs/fill-20260330-164614-main.log ----------------------------------------
------------------------------- Generated html report: file:///home/ignacio/code/execution-specs/fixtures/.meta/report_fill.html -------------------------------
================================================  T8n cache: 164 unique test groups, no cache sharing possible =================================================
=================================  No tests executed - the test fixtures in "fixtures/" may now be executed against a client  ==================================
======================================================= 164 passed, 164 deselected, 1 warning in 35.36s ========================================================
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
