### PR TITLE
feat(cli): Add --until option for checklist generation

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -22,7 +22,16 @@ from .fill import FillCommand
     multiple=True,
     help="Generate checklist only for specific EIP(s)",
 )
-def checklist(output: str, eip: tuple[int, ...], **kwargs: Any) -> None:
+@click.option(
+    "--until",
+    "-u",
+    type=str,
+    default=None,
+    help="Include upcoming forks up to and including this fork",
+)
+def checklist(
+    output: str, eip: tuple[int, ...], until: str | None, **kwargs: Any
+) -> None:
     """
     Generate EIP test checklists based on pytest.mark.eip_checklist markers.
 
@@ -39,6 +48,9 @@ def checklist(output: str, eip: tuple[int, ...], **kwargs: Any) -> None:
         # Generate checklists for specific test path
         uv run checklist tests/prague/eip7702*
 
+        # Include upcoming forks
+        uv run checklist --eip 8037 --until Amsterdam
+
         # Specify output directory
         uv run checklist --output ./my-checklists
 
@@ -51,6 +63,10 @@ def checklist(output: str, eip: tuple[int, ...], **kwargs: Any) -> None:
     # Add EIP filter if specified
     for eip_num in eip:
         args.extend(["--checklist-eip", str(eip_num)])
+
+    # Add --until fork if specified
+    if until:
+        args.extend(["--until", until])
 
     command = FillCommand(
         plugins=[

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -4,7 +4,14 @@ from typing import Any
 
 import click
 
+from ...forks import get_development_forks
 from .fill import FillCommand
+
+
+def _last_development_fork() -> str | None:
+    """Return the name of the last development fork, if any."""
+    dev_forks = get_development_forks()
+    return dev_forks[-1].name() if dev_forks else None
 
 
 @click.command()
@@ -38,6 +45,9 @@ def checklist(
     This command scans test files for eip_checklist markers and generates
     filled checklists showing which checklist items have been implemented.
 
+    By default, includes all development forks so that checklists for
+    upcoming EIPs are generated without needing --until.
+
     Examples:
         # Generate checklists for all EIPs
         uv run checklist
@@ -48,8 +58,8 @@ def checklist(
         # Generate checklists for specific test path
         uv run checklist tests/prague/eip7702*
 
-        # Include upcoming forks
-        uv run checklist --eip 8037 --until Amsterdam
+        # Limit to a specific fork
+        uv run checklist --until Prague
 
         # Specify output directory
         uv run checklist --output ./my-checklists
@@ -64,7 +74,10 @@ def checklist(
     for eip_num in eip:
         args.extend(["--checklist-eip", str(eip_num)])
 
-    # Add --until fork if specified
+    # Default --until to the last development fork so checklists for
+    # upcoming EIPs are generated without requiring the flag explicitly.
+    if until is None:
+        until = _last_development_fork()
     if until:
         args.extend(["--until", until])
 


### PR DESCRIPTION
## 🗒️ Description
The checklist CLI command wraps `fill`, and so checklist generation wasn't picking up EIPs in a future fork. Added the `--until` option.


## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).



#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.nps.gov/thro/learn/nature/images/20210718_Prairie_Dog_Tristin.jpg)
