### PR TITLE
fix(ci): use master client builds for benchmark genesis extraction

### DIFF
--- a/.github/actions/build-benchmark-genesis/action.yaml
+++ b/.github/actions/build-benchmark-genesis/action.yaml
@@ -55,7 +55,7 @@ runs:
       uses: ./.github/actions/start-hive-dev
       with:
         clients: besu,go-ethereum,nethermind
-        client-file: .github/configs/hive/latest.yaml
+        client-file: .github/configs/hive/master.yaml
         hive-path: hive
 
     - name: Extract genesis configs


### PR DESCRIPTION
## 🗒️ Description

Switch the benchmark genesis build action from `latest.yaml` to `master.yaml` client configuration.

The latest Besu release (`v26.2.0`) does not support the `TESTING` RPC API namespace that the Hive client wrapper passes via `--rpc-http-api`. This causes Besu to fail to start during benchmark genesis extraction. The ethpandaops master branch build includes `TESTING` API support.

More generally, it's better to use `master.yaml` here to get the latest master branch client builds which match the configuration options expected by ethereum/hive.

## 🔗 Related Issues or PRs

Fixes #2553:
- #2553 

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img width="485" height="564" alt="image" src="https://github.com/user-attachments/assets/74dc75f1-8af8-425b-91f4-bf864ba8a801" />
