### PR TITLE
feat(benchmarks): add runtime delegated EIP-7702 benchmarks

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -35,6 +35,7 @@ from execution_testing import (
     keccak256,
 )
 from execution_testing.base_types.base_types import Number
+from execution_testing.rpc import EthRPC
 
 from tests.benchmark.stateful.helpers import (
     ALLOWANCE_SELECTOR,
@@ -42,8 +43,10 @@ from tests.benchmark.stateful.helpers import (
     BALANCEOF_SELECTOR,
     DECREMENT_COUNTER_CONDITION,
     MINT_SELECTOR,
+    STORAGE_BLOATED_EOAS,
     CacheStrategy,
     build_cache_strategy_blocks,
+    get_storage_bloated_eoa,
 )
 
 REFERENCE_SPEC_GIT_PATH = "DUMMY/bloatnet.md"
@@ -56,6 +59,209 @@ START_SLOT = (
     0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
     % (2**160)
 )
+
+
+def _deploy_slot0_setter(pre: Alloc) -> Address:
+    """Deploy a contract that writes CALLDATALOAD(0) into storage slot 0."""
+    return pre.deploy_contract(code=Op.SSTORE(0, Op.CALLDATALOAD(0)))
+
+
+def _delegate_and_set_slot0(
+    pre: Alloc,
+    authority: EOA,
+    setter_address: Address,
+    slot_0_value: Hash,
+) -> Transaction:
+    """
+    Create a tx that delegates the authority to the setter and calls
+    it with slot_0_value as calldata, writing it into slot 0.
+
+    The authority nonce is incremented in-place.
+    """
+    tx = Transaction(
+        gas_limit=100_000,
+        to=authority,
+        value=0,
+        data=slot_0_value,
+        sender=pre.fund_eoa(),
+        authorization_list=[
+            AuthorizationTuple(
+                chain_id=0,
+                address=setter_address,
+                nonce=authority.nonce,
+                signer=authority,
+            ),
+        ],
+    )
+    authority.nonce = Number(authority.nonce + 1)
+    return tx
+
+
+def _run_bloated_eoa_benchmark(
+    *,
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+    existing_slots: bool,
+    runtime_code: Bytecode,
+    eth_rpc: EthRPC | None = None,
+) -> None:
+    """
+    Run a bloated-EOA benchmark with the given runtime delegation code.
+
+    Handles authority setup, slot 0 initialization, delegation to
+    runtime code, benchmark tx generation, and test invocation.
+    """
+    authority = get_storage_bloated_eoa(token_name, eth_rpc=eth_rpc)
+    slot_0_value = Hash(1) if existing_slots else Hash(START_SLOT)
+    setter_address = _deploy_slot0_setter(pre)
+
+    runtime_address = pre.deploy_contract(code=runtime_code)
+
+    init_tx = _delegate_and_set_slot0(
+        pre, authority, setter_address, slot_0_value
+    )
+    runtime_tx = _delegate_and_set_slot0(
+        pre, authority, runtime_address, Hash(0)
+    )
+
+    blocks: list[Block] = [Block(txs=[init_tx, runtime_tx])]
+
+    gas_available = gas_benchmark_value
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    sender = pre.fund_eoa()
+
+    txs: list[Transaction] = []
+    while gas_available >= intrinsic_gas:
+        tx_gas = min(gas_available, tx_gas_limit)
+        txs.append(
+            Transaction(
+                gas_limit=tx_gas,
+                to=authority,
+                sender=sender,
+            )
+        )
+        gas_available -= tx_gas
+    blocks.append(Block(txs=txs))
+
+    benchmark_test(
+        pre=pre,
+        blocks=blocks,
+        skip_gas_used_validation=True,
+        expected_receipt_status=True,
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("token_name", STORAGE_BLOATED_EOAS)
+@pytest.mark.parametrize("existing_slots", [False, True])
+def test_sload_bloated(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+    existing_slots: bool,
+    eth_rpc: EthRPC | None = None,
+) -> None:
+    """
+    Benchmark SLOAD opcodes targeting an EOA with storage bloated.
+
+    The storage is assumed to be filled from 0-N linearly, where
+    each slot has the value of the key. If this is not the
+    storage layout of the target account, then the existing_slots
+    parameter will not be correct.
+    """
+    runtime_code = (
+        Op.SLOAD(Op.PUSH0)
+        + While(
+            body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
+            condition=Op.GT(Op.GAS, 0xFFFF),
+        )
+        + Op.PUSH0
+        + Op.SSTORE
+    )
+
+    _run_bloated_eoa_benchmark(
+        benchmark_test=benchmark_test,
+        pre=pre,
+        fork=fork,
+        gas_benchmark_value=gas_benchmark_value,
+        tx_gas_limit=tx_gas_limit,
+        token_name=token_name,
+        existing_slots=existing_slots,
+        runtime_code=runtime_code,
+        eth_rpc=eth_rpc,
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("token_name", STORAGE_BLOATED_EOAS)
+@pytest.mark.parametrize("write_new_value", [False, True])
+@pytest.mark.parametrize("existing_slots", [True, False])
+def test_sstore_bloated(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+    write_new_value: bool,
+    existing_slots: bool,
+    eth_rpc: EthRPC | None = None,
+) -> None:
+    """
+    Benchmark SSTORE opcodes targeting an EOA with storage bloated.
+
+    The storage is assumed to be filled from 0-N linearly, where
+    each slot has the value of the key. Except slot 0, this is the
+    pointer to the next free (empty) storage slot.
+
+    For this test to work correctly under all parameters then above
+    has to be true. If this is not the case then some tests will not
+    test what they claim to do. For instance, for `write_new_value`
+    set to False we need to know the current value of the slots.
+    """
+    stack_init = Op.DUP1 + (
+        Op.PUSH1(1) + Op.ADD + Op.SWAP1 if write_new_value else Bytecode()
+    )
+
+    runtime_code = (
+        Op.SLOAD(Op.PUSH0)
+        + stack_init
+        + While(
+            body=(
+                Op.DUP2
+                + Op.DUP2
+                + Op.SSTORE
+                + Op.PUSH1(1)
+                + Op.ADD
+                + Op.SWAP1
+                + Op.PUSH1(1)
+                + Op.ADD
+                + Op.SWAP1
+            ),
+            condition=Op.GT(Op.GAS, 0xFFFF),
+        )
+        + Op.PUSH0
+        + Op.SSTORE
+    )
+
+    _run_bloated_eoa_benchmark(
+        benchmark_test=benchmark_test,
+        pre=pre,
+        fork=fork,
+        gas_benchmark_value=gas_benchmark_value,
+        tx_gas_limit=tx_gas_limit,
+        token_name=token_name,
+        existing_slots=existing_slots,
+        runtime_code=runtime_code,
+        eth_rpc=eth_rpc,
+    )
 
 
 @pytest.mark.stub_parametrize(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -61,12 +61,7 @@ START_SLOT = (
 )
 
 
-def _deploy_slot0_setter(pre: Alloc) -> Address:
-    """Deploy a contract that writes CALLDATALOAD(0) into storage slot 0."""
-    return pre.deploy_contract(code=Op.SSTORE(0, Op.CALLDATALOAD(0)))
-
-
-def _delegate_and_set_slot0(
+def delegate_and_set_slot0(
     pre: Alloc,
     authority: EOA,
     setter_address: Address,
@@ -97,7 +92,7 @@ def _delegate_and_set_slot0(
     return tx
 
 
-def _run_bloated_eoa_benchmark(
+def run_bloated_eoa_benchmark(
     *,
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -117,14 +112,14 @@ def _run_bloated_eoa_benchmark(
     """
     authority = get_storage_bloated_eoa(token_name, eth_rpc=eth_rpc)
     slot_0_value = Hash(1) if existing_slots else Hash(START_SLOT)
-    setter_address = _deploy_slot0_setter(pre)
 
+    setter_address = pre.deploy_contract(code=Op.SSTORE(0, Op.CALLDATALOAD(0)))
     runtime_address = pre.deploy_contract(code=runtime_code)
 
-    init_tx = _delegate_and_set_slot0(
+    init_tx = delegate_and_set_slot0(
         pre, authority, setter_address, slot_0_value
     )
-    runtime_tx = _delegate_and_set_slot0(
+    runtime_tx = delegate_and_set_slot0(
         pre, authority, runtime_address, Hash(0)
     )
 
@@ -186,7 +181,7 @@ def test_sload_bloated(
         + Op.SSTORE
     )
 
-    _run_bloated_eoa_benchmark(
+    run_bloated_eoa_benchmark(
         benchmark_test=benchmark_test,
         pre=pre,
         fork=fork,
@@ -251,7 +246,7 @@ def test_sstore_bloated(
         + Op.SSTORE
     )
 
-    _run_bloated_eoa_benchmark(
+    run_bloated_eoa_benchmark(
         benchmark_test=benchmark_test,
         pre=pre,
         fork=fork,

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,9 +1,7 @@
 """Shared constants and helpers for stateful benchmark tests."""
 
-import json
 from collections.abc import Callable
 from enum import Enum
-from pathlib import Path
 
 from execution_testing import (
     EOA,
@@ -25,25 +23,21 @@ APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
 ALLOWANCE_SELECTOR = 0xDD62ED3E  # allowance(address,address)
 MINT_SELECTOR = 0x40C10F19  # mint(address,uint256)
 
-# Load token names from stubs_bloatnet.json for test parametrization
-_STUBS_FILE = Path(__file__).parent / "bloatnet" / "stubs_bloatnet.json"
-with open(_STUBS_FILE) as f:
-    _STUBS = json.load(f)
+# Storage-bloated EOA private keys, keyed by bloat size identifier.
+# Addresses derived via: keccak256(utf8ToBytes("stateBloaters{N}"))
+_STORAGE_BLOATED_EOA_KEYS: dict[str, str] = {
+    "1GB": (
+        "0xc618d7bcd54de2f0dcf86e4ced86ccf07926619a74ee10432c3d1c60743e3427"
+    ),
+    "10GB": (
+        "0x4da32d29f6dcffa26e09dc4e102033f2d105de1444fb893493ae703289275e0e"
+    ),
+    "20GB": (
+        "0xc025d5a1aa0f5eee1f50687901c5dc9a8e97a2be91aa381e4c938dc309105059"
+    ),
+}
 
-# Extract storage-bloated EOA names (keyed by bloat size identifier).
-# Each entry in the JSON has {"private_key": ..., "address": ...}.
-STORAGE_BLOATED_EOAS: list[str] = []
-for _key, _entry in (
-    (k, _STUBS[k]) for k in _STUBS if k.startswith("storage_bloated_eoa_")
-):
-    _eoa = EOA(key=_entry["private_key"])
-    if Address(_eoa) != Address(_entry["address"]):
-        raise ValueError(
-            f"Address mismatch for {_key}: "
-            f"private key derives {Address(_eoa)}, "
-            f"but JSON specifies {_entry['address']}"
-        )
-    STORAGE_BLOATED_EOAS.append(_key.replace("storage_bloated_eoa_", ""))
+STORAGE_BLOATED_EOAS: list[str] = list(_STORAGE_BLOATED_EOA_KEYS.keys())
 
 
 def get_storage_bloated_eoa(
@@ -51,8 +45,7 @@ def get_storage_bloated_eoa(
     eth_rpc: EthRPC | None = None,
 ) -> EOA:
     """Return an EOA for a storage-bloated account with its on-chain nonce."""
-    entry = _STUBS[f"storage_bloated_eoa_{name}"]
-    eoa = EOA(key=entry["private_key"])
+    eoa = EOA(key=_STORAGE_BLOATED_EOA_KEYS[name])
     if eth_rpc is not None:
         nonce = eth_rpc.get_transaction_count(Address(eoa))
         eoa.nonce = Number(nonce)

--- a/tests/benchmark/stateful/helpers.py
+++ b/tests/benchmark/stateful/helpers.py
@@ -1,9 +1,12 @@
 """Shared constants and helpers for stateful benchmark tests."""
 
+import json
 from collections.abc import Callable
 from enum import Enum
+from pathlib import Path
 
 from execution_testing import (
+    EOA,
     AccessList,
     Address,
     Alloc,
@@ -13,12 +16,48 @@ from execution_testing import (
     Op,
     Transaction,
 )
+from execution_testing.base_types import Number
+from execution_testing.rpc import EthRPC
 
 # ERC20 function selectors
 BALANCEOF_SELECTOR = 0x70A08231  # balanceOf(address)
 APPROVE_SELECTOR = 0x095EA7B3  # approve(address,uint256)
 ALLOWANCE_SELECTOR = 0xDD62ED3E  # allowance(address,address)
 MINT_SELECTOR = 0x40C10F19  # mint(address,uint256)
+
+# Load token names from stubs_bloatnet.json for test parametrization
+_STUBS_FILE = Path(__file__).parent / "bloatnet" / "stubs_bloatnet.json"
+with open(_STUBS_FILE) as f:
+    _STUBS = json.load(f)
+
+# Extract storage-bloated EOA names (keyed by bloat size identifier).
+# Each entry in the JSON has {"private_key": ..., "address": ...}.
+STORAGE_BLOATED_EOAS: list[str] = []
+for _key, _entry in (
+    (k, _STUBS[k]) for k in _STUBS if k.startswith("storage_bloated_eoa_")
+):
+    _eoa = EOA(key=_entry["private_key"])
+    if Address(_eoa) != Address(_entry["address"]):
+        raise ValueError(
+            f"Address mismatch for {_key}: "
+            f"private key derives {Address(_eoa)}, "
+            f"but JSON specifies {_entry['address']}"
+        )
+    STORAGE_BLOATED_EOAS.append(_key.replace("storage_bloated_eoa_", ""))
+
+
+def get_storage_bloated_eoa(
+    name: str,
+    eth_rpc: EthRPC | None = None,
+) -> EOA:
+    """Return an EOA for a storage-bloated account with its on-chain nonce."""
+    entry = _STUBS[f"storage_bloated_eoa_{name}"]
+    eoa = EOA(key=entry["private_key"])
+    if eth_rpc is not None:
+        nonce = eth_rpc.get_transaction_count(Address(eoa))
+        eoa.nonce = Number(nonce)
+    return eoa
+
 
 # Standard While-loop decrement-and-test condition.
 #

--- a/tests/benchmark/stateful/stubs/stubs_bloatnet.json
+++ b/tests/benchmark/stateful/stubs/stubs_bloatnet.json
@@ -36,5 +36,20 @@
   "bloatnet_factory_2kb": "0x88c159584059308C4B466bafC82c45d52De9951D",
   "bloatnet_factory_5kb": "0x3f59809dac4b33e251e518acDadf923184151334",
   "bloatnet_factory_10kb": "0xf90E8a6Ce32A949Ce5F58803BBa07476404cD89F",
-  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef"
+  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef",
+  "storage_bloated_eoa_1GB": {
+    "private_key": "0xc618d7bcd54de2f0dcf86e4ced86ccf07926619a74ee10432c3d1c60743e3427",
+    "address": "0x3f8074692982594c1936bd27433a8b6e5d77e0f0",
+    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters0\"))"
+  },
+  "storage_bloated_eoa_10GB": {
+    "private_key": "0x4da32d29f6dcffa26e09dc4e102033f2d105de1444fb893493ae703289275e0e",
+    "address": "0x87a6314da5ac8832f6e7a176c8fb133b19f5be04",
+    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters1\"))"
+  },
+  "storage_bloated_eoa_20GB": {
+    "private_key": "0xc025d5a1aa0f5eee1f50687901c5dc9a8e97a2be91aa381e4c938dc309105059",
+    "address": "0x772604ee92ebc9afa5b6ce561f6f6a4c4cdd214a",
+    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters2\"))"
+  }
 }

--- a/tests/benchmark/stateful/stubs/stubs_bloatnet.json
+++ b/tests/benchmark/stateful/stubs/stubs_bloatnet.json
@@ -36,20 +36,5 @@
   "bloatnet_factory_2kb": "0x88c159584059308C4B466bafC82c45d52De9951D",
   "bloatnet_factory_5kb": "0x3f59809dac4b33e251e518acDadf923184151334",
   "bloatnet_factory_10kb": "0xf90E8a6Ce32A949Ce5F58803BBa07476404cD89F",
-  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef",
-  "storage_bloated_eoa_1GB": {
-    "private_key": "0xc618d7bcd54de2f0dcf86e4ced86ccf07926619a74ee10432c3d1c60743e3427",
-    "address": "0x3f8074692982594c1936bd27433a8b6e5d77e0f0",
-    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters0\"))"
-  },
-  "storage_bloated_eoa_10GB": {
-    "private_key": "0x4da32d29f6dcffa26e09dc4e102033f2d105de1444fb893493ae703289275e0e",
-    "address": "0x87a6314da5ac8832f6e7a176c8fb133b19f5be04",
-    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters1\"))"
-  },
-  "storage_bloated_eoa_20GB": {
-    "private_key": "0xc025d5a1aa0f5eee1f50687901c5dc9a8e97a2be91aa381e4c938dc309105059",
-    "address": "0x772604ee92ebc9afa5b6ce561f6f6a4c4cdd214a",
-    "comment": "Address is generated from key (JS): keccak_256(utf8ToBytes(\"stateBloaters2\"))"
-  }
+  "bloatnet_factory_24kb": "0x091988Afd81E0a2A3E20530A2510c089fF4bfAef"
 }


### PR DESCRIPTION
## 🗒️ Description
This adds benchmarks plus a template for future use. On perf-devnet-3, there are (so far) three EOAs being targeted with their bytecode being delegated to: 

`0x5f541515600b5760015f555b5f54805b818155600101906001019061ffff5a11600f575f55`

This (22866e06568ba74ddbdd7dec3811de0a5d0d5948):

> This is example code to delegate to (runtime code):
    0x5f541515600b5760015f555b5f54805b818155600101906001019061ffff5a11600f575f55
    This works even on empty accounts: if the first slot is 0, set it to 1,
    then: initialize stack to SLOAD(0) and proceed to write stack key as value
    to that slot. It will keep looping until the gasleft is lower than or equal
    to 0xffff (65535), i.e. currently enough to write to an empty slot (about
    22100 gas as of Fusaka)
    The cleanup phase at the end of the loop writes next key to slot 0.
    Note that this key is either already dirty (initial call on empty storage)
    or is already set. So the max gas cost of
    cleanup is 5000 + 2100 as of Fusaka.
    
We now use the fact that we have pkey of these accounts to overwrite runtime bytecode via EIP-7702 to target these for our needs. The bloatnet/perf-devnet-3 accounts are thus bloated with a range from 1-N (1/10/20Gb currently) which we can now target for storage related benchmarks.
So far this PR accounts for the NO-CACHE variant with existing/non-existing keys in the case we run the setup bytecode as provided and then start the attack block.

To add:

- The SLOAD variant which does not do SSTORE, only SLOAD
- The CACHE_TX variant which does SLOAD before either SSTORE/SLOAD of the target
- The CACHE_PREVIOUS_BLOCK variant which does **ONLY** SLOADs before the attack block. This also resets the start slot to the same key it started before doing the cache initialization.

Draft, but want to finish this ASAP as we are super interested in the benchmark results.


## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
