### PR TITLE
fix(tests): resolve transition fork blob methods in EIP-4844 conftest

### DIFF
--- a/tests/cancun/eip4844_blobs/conftest.py
+++ b/tests/cancun/eip4844_blobs/conftest.py
@@ -26,25 +26,25 @@ def block_base_fee_per_gas() -> int:
 @pytest.fixture
 def target_blobs_per_block(fork: Fork) -> int:
     """Return default number of blobs to be included in the block."""
-    return fork.target_blobs_per_block()
+    return fork.transitions_to().target_blobs_per_block()
 
 
 @pytest.fixture
 def max_blobs_per_block(fork: Fork) -> int:
     """Return default number of blobs to be included in the block."""
-    return fork.max_blobs_per_block()
+    return fork.transitions_to().max_blobs_per_block()
 
 
 @pytest.fixture
 def max_blobs_per_tx(fork: Fork) -> int:
     """Return max number of blobs per transaction."""
-    return fork.max_blobs_per_tx()
+    return fork.transitions_to().max_blobs_per_tx()
 
 
 @pytest.fixture
 def blob_gas_per_blob(fork: Fork) -> int:
     """Return default blob gas cost per blob."""
-    return fork.blob_gas_per_blob()
+    return fork.transitions_to().blob_gas_per_blob()
 
 
 @pytest.fixture(autouse=True)
@@ -97,7 +97,7 @@ def excess_blob_gas(
     """
     if parent_excess_blobs is None or parent_blobs is None:
         return None
-    return fork.excess_blob_gas_calculator()(
+    return fork.transitions_to().excess_blob_gas_calculator()(
         parent_excess_blobs=parent_excess_blobs,
         parent_blob_count=parent_blobs,
         parent_base_fee_per_gas=block_base_fee_per_gas,
@@ -119,7 +119,7 @@ def correct_excess_blob_gas(
     """
     if parent_excess_blobs is None or parent_blobs is None:
         return 0
-    return fork.excess_blob_gas_calculator()(
+    return fork.transitions_to().excess_blob_gas_calculator()(
         parent_excess_blobs=parent_excess_blobs,
         parent_blob_count=parent_blobs,
         parent_base_fee_per_gas=block_base_fee_per_gas,
@@ -132,7 +132,7 @@ def block_fee_per_blob_gas(
     correct_excess_blob_gas: int,
 ) -> int:
     """Calculate the blob gas price for the current block."""
-    get_blob_gas_price = fork.blob_gas_price_calculator()
+    get_blob_gas_price = fork.transitions_to().blob_gas_price_calculator()
     return get_blob_gas_price(excess_blob_gas=correct_excess_blob_gas)
 
 
@@ -145,7 +145,7 @@ def blob_gas_price(
     if excess_blob_gas is None:
         return None
 
-    get_blob_gas_price = fork.blob_gas_price_calculator()
+    get_blob_gas_price = fork.transitions_to().blob_gas_price_calculator()
     return get_blob_gas_price(
         excess_blob_gas=excess_blob_gas,
     )


### PR DESCRIPTION
## 🗒️ Description

Transition forks like `ShanghaiToCancunAtTime15k` inherit from `TransitionBaseClass`, not `BaseFork`, so they lack blob-related methods (`blob_gas_per_blob`, `target_blobs_per_block`, etc.). Calling these methods on a transition fork in the EIP-4844 conftest fixtures causes an `AttributeError`.

Fix: chain `.transitions_to()` before each blob method call — a no-op for regular forks, resolves to the target fork for transition forks. This is the established pattern used 30+ times across the codebase.

This bug is not caught in CI because `test_blob_type_tx_pre_fork` is marked `@pytest.mark.slow` and `tox -e py3` runs with `-m "not slow"`.

## 🔗 Related Issues or PRs

Blocks:
- #2592
- A new fixture release.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="990" height="451" alt="image" src="https://github.com/user-attachments/assets/3d4a59df-52d8-434c-8d42-1214c2c708f0" />
