### PR TITLE
feat(tooling): added a smoke test for devs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -105,7 +105,7 @@ checklist *args:
 
 # Static checks plus minimal test suite for quick validation
 [group('development')]
-smoke *args: typecheck lint-spec lock-check lint-actions format-check
+smoke-quick *args: typecheck lint-spec lock-check lint-actions format-check
     @mkdir -p "{{ output_dir }}/smoke/tmp"
     uv run fill \
         -m "not slow" \
@@ -123,6 +123,20 @@ smoke *args: typecheck lint-spec lock-check lint-actions format-check
         tests/prague/eip7702_set_code_tx/test_gas.py \
         tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py \
         tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+
+[group('development')]
+smoke *args: typecheck lint-spec lock-check lint-actions format-check
+    @mkdir -p "{{ output_dir }}/smoke/tmp"
+    uv run fill \
+        -m "eels_base_coverage and not derived_test" \
+        -x \
+        --skip-index \
+        --clean \
+        --generate-all-formats \
+        --until {{ latest_fork }} \
+        --basetemp="{{ output_dir }}/smoke/tmp" \
+        "$@" \
+        tests
 
 # --- Fill Tests ---
 

--- a/Justfile
+++ b/Justfile
@@ -96,10 +96,35 @@ lint-actions:
 coverage:
     uv run coverage html -d "{{ output_dir }}/fill/coverage-html"
 
-# Generate EIP test checklists from eip_checklist markers                                                                         
-[group('consensus tests')] 
+# Generate EIP test checklists from eip_checklist markers
+[group('consensus tests')]
 checklist *args:
     uv run checklist --output tmp/checklist "$@"
+
+# --- Development ---
+
+# Static checks plus minimal test suite for quick validation
+[group('development')]
+smoke *args: typecheck lint-spec lock-check lint-actions format-check
+    @mkdir -p "{{ output_dir }}/smoke/tmp"
+    uv run fill \
+        -m "not slow" \
+        -x \
+        --skip-index \
+        --clean \
+        --until {{ latest_fork }} \
+        --basetemp="{{ output_dir }}/smoke/tmp" \
+        "$@" \
+        tests/frontier/opcodes/test_all_opcodes.py \
+        tests/frontier/scenarios/test_scenarios.py \
+        tests/frontier/validation/test_transaction.py \
+        tests/berlin/eip2929_gas_cost_increases/test_call.py \
+        tests/cancun/eip1153_tstore/test_tstorage.py \
+        tests/prague/eip7702_set_code_tx/test_gas.py \
+        tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py \
+        tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
+
+# --- Fill Tests ---
 
 # Fill the consensus tests using EELS (with Python)
 [group('consensus tests')]

--- a/Justfile
+++ b/Justfile
@@ -105,30 +105,11 @@ checklist *args:
 
 # Static checks plus minimal test suite for quick validation
 [group('development')]
-smoke-quick *args: typecheck lint-spec lock-check lint-actions format-check
-    @mkdir -p "{{ output_dir }}/smoke/tmp"
-    uv run fill \
-        -m "not slow" \
-        -x \
-        --skip-index \
-        --clean \
-        --until {{ latest_fork }} \
-        --basetemp="{{ output_dir }}/smoke/tmp" \
-        "$@" \
-        tests/frontier/opcodes/test_all_opcodes.py \
-        tests/frontier/scenarios/test_scenarios.py \
-        tests/frontier/validation/test_transaction.py \
-        tests/berlin/eip2929_gas_cost_increases/test_call.py \
-        tests/cancun/eip1153_tstore/test_tstorage.py \
-        tests/prague/eip7702_set_code_tx/test_gas.py \
-        tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists.py \
-        tests/amsterdam/eip7928_block_level_access_lists/test_block_access_lists_opcodes.py
-
-[group('development')]
 smoke *args: typecheck lint-spec lock-check lint-actions format-check
     @mkdir -p "{{ output_dir }}/smoke/tmp"
     uv run fill \
         -m "eels_base_coverage and not derived_test" \
+        -n 14 \
         -x \
         --skip-index \
         --clean \


### PR DESCRIPTION
## 🗒️ Description

Adds a `smoke` job to `just` that runs some of the static analysis checks with a minimal test suite. It's intended for quick development validation during big changes such as large refactors without running the full test suite.

The smoke suite runs tests from 8 files from Frontier through Amsterdam. I chose tests that were not slow, and that covered as large a set of fragile and critical paths as possible.

### Test Coverage

| Test | Fork | Features Covered |
|------|------|-----------------|
| `test_all_opcodes.py` | Frontier+ | All opcodes, static gas costs, stack validation |
| `test_scenarios.py` | Frontier+ | SSTORE/SLOAD, CALL, CREATE, DELEGATECALL, SELFDESTRUCT, REVERT |
| `test_transaction.py` | Frontier+ | Transaction validation, intrinsic gas, nonce, balance |
| `test_call.py` | Berlin+ | Warm/cold account access, EIP-2929 gas costs |
| `test_tstorage.py` | Cancun+ | Transient storage (TLOAD/TSTORE), warm access |
| `test_gas.py` | Prague+ | EIP-7702 authorisation gas, TX intrinsic costs, cold/warm access |
| `test_block_access_lists.py` | Amsterdam | BAL core state changes |
| `test_block_access_lists_opcodes.py` | Amsterdam | BAL tracking across all opcodes |

## 🔗 Related Issues or PRs

None

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).