### PR TITLE
fix(ci,test-benchmark): do not generate stateful benchmarks

### DIFF
--- a/.github/configs/feature.yaml
+++ b/.github/configs/feature.yaml
@@ -9,11 +9,11 @@ develop:
 
 benchmark:
   evm-type: benchmark
-  fill-params: --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark --maxprocesses=30 --dist=worksteal
+  fill-params: --fork=Osaka --gas-benchmark-values 1,5,10,30,60,100,150 ./tests/benchmark/compute --maxprocesses=30 --dist=worksteal
 
 benchmark_fast:
   evm-type: benchmark
-  fill-params: --fork=Osaka --gas-benchmark-values 100 ./tests/benchmark
+  fill-params: --fork=Osaka --gas-benchmark-values 100 ./tests/benchmark/compute
   feature_only: true
 
 bal:


### PR DESCRIPTION
## 🗒️ Description
This PR modifies the benchmark release config to only generate compute benchmarks.

Both Benchmark artifact and release generation is currently failing as its trying to `fill` stateful tests. I think this is due to the a change in behavior from https://github.com/ethereum/execution-specs/pull/2496.

Example fail from https://github.com/ethereum/execution-specs/actions/runs/23786501432/job/69312825598
```
FAILED tests/benchmark/stateful/bloatnet/test_multi_opcode.py::test_mixed_sload_sstore[fork_Osaka-blockchain_test_engine_x-30-70-token_name_4_23MB_ERC20-benchmark-gas-value_100M]@t8n-cache-a4b843a8 - ValueError: Stub 'test_mixed_sload_sstore_4_23MB_ERC20' not found in address stubs. Provide --address-stubs with a mapping file.
```

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
Follow-up to:
- #2496

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).


#### Cute Animal Picture

<img width="256" alt="image" src="https://github.com/user-attachments/assets/60007355-e873-4cc7-91e7-80f9749cf56d" />

