### PR TITLE
fix(test-forks): exclude transition target fork from `--until` boundary

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
@@ -273,12 +273,11 @@ def test_transition_fork_until_excludes_target(
     pytester: pytest.Pytester,
 ) -> None:
     """
-    Test that `--until` with a transition fork does not collect tests
-    for the transition's target fork.
+    Test that `--until` with a transition fork excludes the
+    transition's target fork from the selected fork set.
 
-    `--from OsakaToBPO1AtTime15k --until BPO2ToAmsterdamAtTime15k`
-    should include `fork_BPO1`, `fork_BPO2`, and
-    `fork_BPO2ToAmsterdamAtTime15k` but not `fork_Amsterdam`.
+    The "Generating fixtures for:" header printed by
+    `pytest_report_header` reflects `config.selected_fork_set`.
     """
     pytester.makepyfile(
         f"""
@@ -293,16 +292,28 @@ def test_transition_fork_until_excludes_target(
     result = pytester.runpytest(
         "-c",
         "pytest-fill.ini",
-        "--collect-only",
-        "-q",
+        "-v",
         "--from",
         "OsakaToBPO1AtTime15k",
         "--until",
         "BPO2ToAmsterdamAtTime15k",
     )
     stdout = "\n".join(result.stdout.lines)
-    assert f"fork_{Amsterdam}" not in stdout
-    assert f"fork_{BPO1}" in stdout
-    assert f"fork_{BPO2}" in stdout
-    assert f"fork_{BPO2ToAmsterdamAtTime15k}" in stdout
-    assert f"fork_{OsakaToBPO1AtTime15k}" in stdout
+    # The header line lists the selected fork set; parse it.
+    assert "Generating fixtures for:" in stdout
+    header_line = [
+        line
+        for line in result.stdout.lines
+        if "Generating fixtures for:" in line
+    ][0]
+    fork_names = [
+        name.strip()
+        for name in header_line.split("Generating fixtures for:")[1].split(",")
+    ]
+    # Strip ANSI codes from the last element.
+    fork_names[-1] = fork_names[-1].split("\x1b")[0]
+    assert Amsterdam.name() not in fork_names
+    assert BPO1.name() in fork_names
+    assert BPO2.name() in fork_names
+    assert BPO2ToAmsterdamAtTime15k.name() in fork_names
+    assert OsakaToBPO1AtTime15k.name() in fork_names

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_forks.py
@@ -7,11 +7,18 @@ from execution_testing.client_clis.clis.execution_specs import (
 )
 from execution_testing.fixtures import LabeledFixtureFormat
 from execution_testing.forks import (
+    BPO1,
+    BPO2,
+    Amsterdam,
     ArrowGlacier,
     Fork,
     forks_from_until,
     get_deployed_forks,
     get_forks,
+)
+from execution_testing.forks.forks.transition import (
+    BPO2ToAmsterdamAtTime15k,
+    OsakaToBPO1AtTime15k,
 )
 from execution_testing.specs import StateTest
 
@@ -260,3 +267,42 @@ def test_from_paris_until_paris_option_no_validity_marker(
         skipped=0,
         errors=0,
     )
+
+
+def test_transition_fork_until_excludes_target(
+    pytester: pytest.Pytester,
+) -> None:
+    """
+    Test that `--until` with a transition fork does not collect tests
+    for the transition's target fork.
+
+    `--from OsakaToBPO1AtTime15k --until BPO2ToAmsterdamAtTime15k`
+    should include `fork_BPO1`, `fork_BPO2`, and
+    `fork_BPO2ToAmsterdamAtTime15k` but not `fork_Amsterdam`.
+    """
+    pytester.makepyfile(
+        f"""
+        def test_fork_range({StateTest.pytest_parameter_name()}):
+            pass
+        """
+    )
+    pytester.copy_example(
+        name="src/execution_testing/cli/pytest_commands/"
+        "pytest_ini_files/pytest-fill.ini"
+    )
+    result = pytester.runpytest(
+        "-c",
+        "pytest-fill.ini",
+        "--collect-only",
+        "-q",
+        "--from",
+        "OsakaToBPO1AtTime15k",
+        "--until",
+        "BPO2ToAmsterdamAtTime15k",
+    )
+    stdout = "\n".join(result.stdout.lines)
+    assert f"fork_{Amsterdam}" not in stdout
+    assert f"fork_{BPO1}" in stdout
+    assert f"fork_{BPO2}" in stdout
+    assert f"fork_{BPO2ToAmsterdamAtTime15k}" in stdout
+    assert f"fork_{OsakaToBPO1AtTime15k}" in stdout

--- a/packages/testing/src/execution_testing/forks/helpers.py
+++ b/packages/testing/src/execution_testing/forks/helpers.py
@@ -221,6 +221,12 @@ def get_selected_fork_set(
         selected_fork_set |= get_from_until_fork_set(
             ALL_FORKS, forks_from, forks_until
         )
+        # Transition fork comparison operators resolve to
+        # transitions_to(), so an --until transition fork boundary
+        # incorrectly includes its target in the normal fork set.
+        for fork_until in forks_until:
+            if issubclass(fork_until, TransitionBaseClass):
+                selected_fork_set.discard(fork_until.transitions_to())
     selected_fork_set_with_transitions: Set[
         Type[BaseFork | TransitionBaseClass]
     ] = set() | selected_fork_set
@@ -228,6 +234,12 @@ def get_selected_fork_set(
         for normal_fork in list(selected_fork_set):
             transition_fork_set = transition_fork_to(normal_fork)
             selected_fork_set_with_transitions |= transition_fork_set
+        # Explicitly add transition fork boundaries whose target fork
+        # was removed above (transition_fork_to won't find them).
+        if not single_fork:
+            for fork in forks_from | forks_until:
+                if issubclass(fork, TransitionBaseClass):
+                    selected_fork_set_with_transitions.add(fork)
     return selected_fork_set_with_transitions
 
 

--- a/packages/testing/src/execution_testing/forks/tests/test_forks.py
+++ b/packages/testing/src/execution_testing/forks/tests/test_forks.py
@@ -27,6 +27,7 @@ from ..forks.forks import (
 from ..forks.transition import (
     BerlinToLondonAt5,
     BPO1ToBPO2AtTime15k,
+    BPO2ToAmsterdamAtTime15k,
     BPO2ToBPO3AtTime15k,
     BPO3ToBPO4AtTime15k,
     CancunToPragueAtTime15k,
@@ -45,6 +46,7 @@ from ..helpers import (
     forks_from_until,
     get_deployed_forks,
     get_forks,
+    get_selected_fork_set,
     transition_fork_from_to,
     transition_fork_to,
 )
@@ -604,3 +606,77 @@ def test_fork_adapters() -> None:  # noqa: D103
     assert {Osaka} == ForkSetAdapter.validate_python("Osaka")
     assert {Osaka} == ForkSetAdapter.validate_python({Osaka})
     assert set() == ForkSetAdapter.validate_python("")
+
+
+class TestSelectedForkSetWithTransitionBoundaries:
+    """Test `get_selected_fork_set` with transition fork boundaries."""
+
+    @staticmethod
+    def _normal_forks(fork_set: set) -> set:
+        """Return the set of normal (non-transition) forks."""
+        return {f for f in fork_set if not issubclass(f, TransitionBaseClass)}
+
+    @staticmethod
+    def _transition_forks(fork_set: set) -> set:
+        """Return the set of transition forks."""
+        return {f for f in fork_set if issubclass(f, TransitionBaseClass)}
+
+    def test_transition_from_and_until(self) -> None:
+        """Test range with transition forks as both boundaries."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={OsakaToBPO1AtTime15k},  # type: ignore[arg-type]
+            forks_until={BPO2ToAmsterdamAtTime15k},  # type: ignore[arg-type]
+        )
+        assert self._normal_forks(result) == {BPO1, BPO2}
+        assert self._transition_forks(result) == {
+            OsakaToBPO1AtTime15k,
+            BPO1ToBPO2AtTime15k,
+            BPO2ToAmsterdamAtTime15k,
+        }
+
+    def test_transition_until_excludes_target(self) -> None:
+        """Transition fork `--until` must not include `transitions_to()`."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={OsakaToBPO1AtTime15k},  # type: ignore[arg-type]
+            forks_until={BPO2ToAmsterdamAtTime15k},  # type: ignore[arg-type]
+        )
+        assert Amsterdam not in result
+
+    def test_non_bpo_transition_boundaries(self) -> None:
+        """Test non-BPO transition fork boundaries."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={CancunToPragueAtTime15k},  # type: ignore[arg-type]
+            forks_until={PragueToOsakaAtTime15k},  # type: ignore[arg-type]
+        )
+        assert self._normal_forks(result) == {Prague}
+        assert self._transition_forks(result) == {
+            CancunToPragueAtTime15k,
+            PragueToOsakaAtTime15k,
+        }
+        assert Osaka not in result
+
+    def test_normal_boundaries_unchanged(self) -> None:
+        """Normal fork boundaries still work as before."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={Prague},
+            forks_until={Osaka},
+        )
+        assert self._normal_forks(result) == {Prague, Osaka}
+        assert CancunToPragueAtTime15k in result
+        assert PragueToOsakaAtTime15k in result
+
+    def test_transition_from_normal_until(self) -> None:
+        """Test transition `--from` with normal `--until`."""
+        result = get_selected_fork_set(
+            single_fork=set(),
+            forks_from={OsakaToBPO1AtTime15k},  # type: ignore[arg-type]
+            forks_until={BPO2},
+        )
+        assert self._normal_forks(result) == {BPO1, BPO2}
+        assert OsakaToBPO1AtTime15k in result
+        assert BPO1ToBPO2AtTime15k in result
+        assert BPO2ToAmsterdamAtTime15k not in result


### PR DESCRIPTION
## 🗒️ Description

When `--until` is a transition fork (e.g., `BPO2ToAmsterdamAtTime15k`),
`get_selected_fork_set()` incorrectly includes the `transitions_to()`
target fork (`Amsterdam`) in the selected fork set.

This happens because transition fork comparison operators resolve to
`transitions_to()`, so `Amsterdam <= BPO2ToAmsterdamAtTime15k` evaluates
as `Amsterdam <= Amsterdam` (True).

The fix:

- Discard `transitions_to()` from the normal fork set when `--until` is
  a transition fork.
- Explicitly add boundary transition forks that `transition_fork_to()`
  can no longer discover after the target removal.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="512" alt="image" src="https://github.com/user-attachments/assets/12892a51-46d8-41b6-9d6b-fef3a1b81dcb" />
