### PR TITLE
feat(spec-specs): EIP-8037 - move CREATE state gas charge after initcode size validation

### DIFF
--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -90,6 +90,12 @@ def generic_create(
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
 
+    # Charge state gas for account creation after initcode validation
+    cost_per_state_byte = state_gas_per_byte(
+        evm.message.block_env.block_gas_limit
+    )
+    charge_state_gas(evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte)
+
     tx_state = evm.message.tx_env.state
 
     call_data = memory_read_bytes(
@@ -184,11 +190,7 @@ def create(evm: Evm) -> None:
         evm.memory, [(memory_start_position, memory_size)]
     )
     init_code_gas = init_code_cost(Uint(memory_size))
-    cost_per_state_byte = state_gas_per_byte(
-        evm.message.block_env.block_gas_limit
-    )
     charge_gas(evm, REGULAR_GAS_CREATE + extend_memory.cost + init_code_gas)
-    charge_state_gas(evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by
@@ -236,9 +238,6 @@ def create2(evm: Evm) -> None:
     )
     call_data_words = ceil32(Uint(memory_size)) // Uint(32)
     init_code_gas = init_code_cost(Uint(memory_size))
-    cost_per_state_byte = state_gas_per_byte(
-        evm.message.block_env.block_gas_limit
-    )
     charge_gas(
         evm,
         REGULAR_GAS_CREATE
@@ -246,7 +245,6 @@ def create2(evm: Evm) -> None:
         + extend_memory.cost
         + init_code_gas,
     )
-    charge_state_gas(evm, STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte)
 
     # OPERATION
     evm.memory += b"\x00" * extend_memory.expand_by

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -82,10 +82,6 @@ def generic_create(
         process_create_message,
     )
 
-    # Check static context first
-    if evm.message.is_static:
-        raise WriteInStaticContext
-
     # Check max init code size early before memory read
     if memory_size > U256(MAX_INIT_CODE_SIZE):
         raise OutOfGasError
@@ -180,6 +176,9 @@ def create(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)
@@ -226,6 +225,9 @@ def create2(evm: Evm) -> None:
         The current EVM frame.
 
     """
+    if evm.message.is_static:
+        raise WriteInStaticContext
+
     # STACK
     endowment = pop(evm.stack)
     memory_start_position = pop(evm.stack)


### PR DESCRIPTION
## 🗒️ Description

### Spec Fix 1: State gas after initcode size check

Move `charge_state_gas(STATE_BYTES_PER_NEW_ACCOUNT)` from `create()/create2()` into `generic_create()`, after the `MAX_INIT_CODE_SIZE` validation.

Previously, state gas was charged before the initcode size check, so a CREATE with oversized initcode would persist `state_gas_used` equal to the account creation state gas cost (`STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte`) even though no account was ever created and no state was touched.

### Spec Fix 2: Static context check before gas charging

Move the `is_static` check from `generic_create()` into `create()` and `create2()`, before stack pops and `charge_gas()`. Previously, regular and state gas were charged before checking static context. This is now consistent with SSTORE, CALL, and SELFDESTRUCT which all check static context before any gas charging.

### Tests

Existing `test_max_initcode_size_via_create[over_max]` cases (CREATE and CREATE2) in `tests/amsterdam/eip7954_increase_max_contract_size/test_max_initcode_size.py` already cover the state gas ordering fix. They only need a re-fill after this spec fix, no test code changes required.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).