### PR TITLE
eip-8037: refund execution state gas on top-level failure

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -1050,6 +1050,26 @@ def process_transaction(
 
     tx_output = process_message_call(message)
 
+    # EIP-8037: On top-level revert or exceptional halt, restore all
+    # execution state gas to the reservoir.  State changes are fully
+    # reverted so no state was actually grown — the sender should not
+    # pay for state gas.  This mirrors incorporate_child_on_error for
+    # child frames.
+    if tx_output.error:
+        tx_output = MessageCallOutput(
+            gas_left=tx_output.gas_left,
+            state_gas_left=(
+                tx_output.state_gas_left + tx_output.state_gas_used
+            ),
+            refund_counter=tx_output.refund_counter,
+            logs=tx_output.logs,
+            accounts_to_delete=tx_output.accounts_to_delete,
+            error=tx_output.error,
+            return_data=tx_output.return_data,
+            regular_gas_used=tx_output.regular_gas_used,
+            state_gas_used=Uint(0),
+        )
+
     tx_gas_used_before_refund = (
         tx.gas - tx_output.gas_left - tx_output.state_gas_left
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_top_level_state_gas_refund.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_top_level_state_gas_refund.py
@@ -1,0 +1,94 @@
+"""
+Opposite of ethereum/execution-specs#2595: state gas refunded on
+top-level failure (ethereum/EIPs#11476).
+
+TX1 pushes block_state above block_regular via large deploy.
+TX2 is a failing CREATE whose initcode state gas (GAS_NEW_ACCOUNT)
+must NOT count in block_state_gas_used.
+
+Tests for [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037).
+See: ethereum/EIPs#11476
+"""
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Fork,
+    Op,
+    Transaction,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+
+@pytest.mark.parametrize(
+    "state_op",
+    [
+        pytest.param(
+            Op.POP(Op.CALL(gas=100_000, address=0xDEAD, value=1)),
+            id="call_new_account",
+        ),
+        pytest.param(
+            Op.POP(Op.CREATE(value=0, offset=0, size=1)),
+            id="inner_create",
+        ),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_top_level_failure_refunds_execution_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    state_op: bytes,
+) -> None:
+    """
+    TX1 makes state gas the binding dimension. TX2's initcode state
+    gas (GAS_NEW_ACCOUNT) must not count in block_state_gas_used
+    after code deposit failure.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    # --- TX1: Deploy a 14 KiB contract (high state gas) ---
+    deploy_size = 14_000
+    tx1_create_state = fork.create_state_gas(code_size=deploy_size)
+    tx1_gas_limit = gas_limit_cap + tx1_create_state
+
+    sender1 = pre.fund_eoa(10**21)
+    tx1 = Transaction(
+        to=None,
+        data=Op.RETURN(0, deploy_size),
+        gas_limit=tx1_gas_limit,
+        sender=sender1,
+    )
+
+    # --- TX2: Failing CREATE with initcode state ops ---
+    oversized = fork.max_code_size() + 232
+    initcode = state_op + Op.RETURN(0, oversized)
+
+    sender2 = pre.fund_eoa(10**21)
+    tx2 = Transaction(
+        to=None,
+        data=initcode,
+        value=10**18,
+        gas_limit=gas_limit_cap,
+        sender=sender2,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=100_000_000),
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx1, tx2],
+                gas_limit=100_000_000,
+            ),
+        ],
+        post={},
+    )


### PR DESCRIPTION
## Summary

**Note this is a consideration for `bal-devnet-4` and requires more discussion async based on EIPs#11476.**


The opposite of #2595. Where #2595 tests that state gas IS counted at the top level on failure (#11468), this PR tests that state gas is NOT counted (#11476) — the parent frame refunds state gas just like child frames do.

## Changes

**`fork.py`**: On top-level error, move `state_gas_used` back into `state_gas_left` and reset to zero — mirroring `incorporate_child_on_error`.

**`test_top_level_state_gas_refund.py`**: 2-tx blockchain test at 100M:
- TX1: deploys 14 KiB contract → state gas becomes the binding dimension
- TX2: failing CREATE whose initcode does CALL to new account then returns oversized code

The execution state gas from TX2 (`GAS_NEW_ACCOUNT = 112 * cpsb = 131,488`) is the delta between the two spec interpretations:
- **#2595 / #11468** (unpatched EELS): `gasUsed = 0x100D000` — state gas counted
- **This PR / #11476** (patched EELS): `gasUsed = 0xFECE60` — state gas refunded

Spec change: ethereum/EIPs#11476

## Fill results

- [x] EELS fill: PASS (4/4)
- [x] Fixtures differ from unpatched EELS by exactly GAS_NEW_ACCOUNT (131,488)

🤖 Generated with [Claude Code](https://claude.com/claude-code)