### PR TITLE
feat(tests): block-level 2D gas accounting tests for EIP-8037

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -1,12 +1,9 @@
 """
-Block-level 2D gas accounting tests for EIP-8037.
+Test block-level two-dimensional gas accounting under EIP-8037.
 
-EIP-8037 introduces two-dimensional gas metering: each transaction
-contributes to both ``block_gas_used`` (regular gas) and
-``block_state_gas_used`` (state gas).  The block header's ``gas_used``
-field is ``max(block_gas_used, block_state_gas_used)``.
-
-These tests target inter-client disagreements observed on BAL devnet-3.
+Verify that the block header gas_used equals
+max(block_regular_gas_used, block_state_gas_used) across
+single-block, multi-block, and mixed-transaction scenarios.
 
 Tests for [EIP-8037: State Creation Gas Cost Increase]
 (https://eips.ethereum.org/EIPS/eip-8037).
@@ -33,81 +30,67 @@ REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
 
 
-# -- Helpers --
-
-
-def _sstore_tx_gas(fork, num_sstores=1):
-    """Return (regular, state) gas for a tx with N SSTOREs."""
-    gc = fork.gas_costs()
-    evm = num_sstores * (
-        2 * gc.GAS_VERY_LOW + gc.GAS_COLD_STORAGE_WRITE
-    )
+def sstore_tx_gas(fork: Fork, num_sstores: int = 1) -> tuple[int, int]:
+    """Return (regular, state) gas for a tx with N cold SSTOREs."""
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    evm_total = num_sstores * Op.SSTORE(0, 1).gas_cost(fork)
     state = num_sstores * fork.sstore_state_gas()
-    return gc.GAS_TX_BASE + evm, state
+    return intrinsic_gas + evm_total - state, state
 
 
-def _stop_tx_gas(fork):
-    """Return per-tx regular gas for a STOP transaction."""
-    return fork.transaction_intrinsic_cost_calculator()()
-
-
-def _make_sstore_txs(pre, fork, n, num_sstores=1,
-                     tx_gas_limit=None):
-    """
-    Build n txs each doing num_sstores zero-to-nonzero SSTOREs.
-
-    Return (txs, post).
-    """
+def sstore_txs(
+    pre: Alloc,
+    fork: Fork,
+    n: int,
+    num_sstores: int = 1,
+    tx_gas_limit: int | None = None,
+) -> tuple[list[Transaction], dict]:
+    """Build n txs each doing num_sstores zero-to-nonzero SSTOREs."""
     if tx_gas_limit is None:
-        cap = fork.transaction_gas_limit_cap()
-        assert cap is not None
-        tx_gas_limit = (
-            cap + num_sstores * fork.sstore_state_gas()
-        )
+        gas_limit_cap = fork.transaction_gas_limit_cap()
+        assert gas_limit_cap is not None
+        tx_gas_limit = gas_limit_cap + num_sstores * fork.sstore_state_gas()
     txs, post = [], {}
     for _ in range(n):
         storage = Storage()
-        code = Bytecode()
+        code = Bytecode(Op.STOP)
         for _ in range(num_sstores):
-            code += Op.SSTORE(storage.store_next(1), 1)
+            code = Op.SSTORE(storage.store_next(1), 1) + code
         contract = pre.deploy_contract(code=code)
-        txs.append(Transaction(
-            to=contract,
-            gas_limit=tx_gas_limit,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
-            sender=pre.fund_eoa(),
-        ))
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=tx_gas_limit,
+                sender=pre.fund_eoa(),
+            )
+        )
         post[contract] = Account(storage=storage)
     return txs, post
 
 
-def _make_stop_txs(pre, fork, n):
-    """Build n STOP transactions. Return list of txs."""
-    gas = _stop_tx_gas(fork)
+def stop_txs(pre: Alloc, fork: Fork, n: int) -> list[Transaction]:
+    """Build n STOP transactions."""
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     txs = []
     for _ in range(n):
         contract = pre.deploy_contract(code=Op.STOP)
-        txs.append(Transaction(
-            to=contract,
-            gas_limit=gas,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
-            sender=pre.fund_eoa(),
-        ))
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=intrinsic_gas,
+                sender=pre.fund_eoa(),
+            )
+        )
     return txs
-
-
-# -- Tests --
 
 
 @pytest.mark.parametrize(
     "num_txs,num_sstores",
     [
-        pytest.param(5, 1, id="5tx_1sstore"),
-        pytest.param(20, 1, id="20tx_1sstore"),
-        pytest.param(2, 3, id="2tx_3sstore_spillover"),
-        pytest.param(10, 5, id="10tx_5sstore"),
+        pytest.param(5, 1, id="single_sstore"),
+        pytest.param(20, 1, id="single_sstore_many_txs"),
+        pytest.param(2, 3, id="multi_sstore_spillover"),
+        pytest.param(10, 5, id="multi_sstore_many_txs"),
     ],
 )
 @pytest.mark.valid_from("Amsterdam")
@@ -121,32 +104,33 @@ def test_block_gas_used_state_dominates(
     """
     Verify block.gas_used = block_state_gas when state > regular.
 
-    Each tx does ``num_sstores`` zero-to-nonzero SSTOREs.  Since
-    state gas per SSTORE exceeds regular gas, block_state_gas exceeds
+    Each tx performs zero-to-nonzero SSTOREs. Since state gas per
+    SSTORE exceeds regular gas, block_state_gas exceeds
     block_regular_gas and becomes the header gas_used.
 
-    The spillover variant (2tx_3sstore) provides reservoir for only
-    one SSTORE per tx; the remaining state gas spills into gas_left.
+    The spillover variant provides reservoir for only one SSTORE
+    per tx; the remaining state gas spills into gas_left.
     Block-level accounting must still separate the two dimensions.
-
-    Catches: clients ignoring state gas, summing instead of max,
-    or conflating spillover gas with the regular dimension.
     """
-    tx_regular, tx_state = _sstore_tx_gas(fork, num_sstores)
+    tx_regular, tx_state = sstore_tx_gas(fork, num_sstores)
     block_regular = num_txs * tx_regular
     block_state = num_txs * tx_state
     assert block_state > block_regular
-    expected = block_state
 
-    txs, post = _make_sstore_txs(
-        pre, fork, num_txs, num_sstores=num_sstores,
+    txs, post = sstore_txs(
+        pre,
+        fork,
+        num_txs,
+        num_sstores=num_sstores,
     )
     blockchain_test(
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            header_verify=Header(gas_used=expected),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=block_state),
+            )
+        ],
         post=post,
     )
 
@@ -160,18 +144,23 @@ def test_block_gas_used_regular_dominates(
     """
     Verify block.gas_used = block_regular_gas when state gas is zero.
 
-    STOP transactions to existing contracts produce no state gas.
+    A block containing only STOP transactions to existing contracts
+    produces no state gas. The block header gas_used must equal the
+    sum of regular gas across all transactions, since
+    max(regular, 0) = regular.
     """
     num_txs = 3
-    stop_gas = _stop_tx_gas(fork)
-    txs = _make_stop_txs(pre, fork, num_txs)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    txs = stop_txs(pre, fork, num_txs)
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            header_verify=Header(gas_used=num_txs * stop_gas),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=num_txs * intrinsic_gas),
+            )
+        ],
         post={},
     )
 
@@ -199,34 +188,34 @@ def test_block_gas_used_mixed_txs(
     The interleaved variant alternates SSTORE/STOP to test that
     non-contiguous state gas contributions accumulate correctly.
     """
-    tx_r_sstore, tx_s_sstore = _sstore_tx_gas(fork)
-    stop_gas = _stop_tx_gas(fork)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    tx_regular_sstore, tx_state_sstore = sstore_tx_gas(fork)
 
-    block_regular = (
-        num_stop * stop_gas + num_sstore * tx_r_sstore
-    )
-    block_state = num_sstore * tx_s_sstore
+    block_regular = num_stop * intrinsic_gas + num_sstore * tx_regular_sstore
+    block_state = num_sstore * tx_state_sstore
     expected = max(block_regular, block_state)
 
-    sstore_txs, post = _make_sstore_txs(pre, fork, num_sstore)
-    stop_txs = _make_stop_txs(pre, fork, num_stop)
+    txs_sstore, post = sstore_txs(pre, fork, num_sstore)
+    txs_stop = stop_txs(pre, fork, num_stop)
 
     if interleaved:
         txs = []
         for i in range(max(num_sstore, num_stop)):
             if i < num_sstore:
-                txs.append(sstore_txs[i])
+                txs.append(txs_sstore[i])
             if i < num_stop:
-                txs.append(stop_txs[i])
+                txs.append(txs_stop[i])
     else:
-        txs = stop_txs + sstore_txs
+        txs = txs_stop + txs_sstore
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            header_verify=Header(gas_used=expected),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=expected),
+            )
+        ],
         post=post,
     )
 
@@ -240,44 +229,44 @@ def test_block_gas_refund_eip7778_no_block_reduction(
     """
     Verify block gas accounting excludes refunds per EIP-7778.
 
-    Each tx does SSTORE(0,1) then SSTORE(0,0) — set then restore.
+    Each tx does SSTORE(0,1) then SSTORE(0,0), set then restore.
     The user gets a refund (reduced receipt gas_used), but EIP-7778
     says block gas is NOT reduced by refunds.
     """
-    gc = fork.gas_costs()
-    cap = fork.transaction_gas_limit_cap()
-    assert cap is not None
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
     sstore_state_gas = fork.sstore_state_gas()
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
 
     num_txs = 3
-    tx_regular = (
-        gc.GAS_TX_BASE
-        + 4 * gc.GAS_VERY_LOW
-        + gc.GAS_COLD_STORAGE_WRITE
-        + gc.GAS_WARM_SLOAD
-    )
-    tx_state = sstore_state_gas
-    expected = max(num_txs * tx_regular, num_txs * tx_state)
-
+    # Set then restore: second SSTORE is warm with current_value=1
+    code = Op.SSTORE(0, 1) + Op.SSTORE.with_metadata(
+        key_warm=True,
+        original_value=0,
+        current_value=1,
+        new_value=0,
+    )(0, 0)
+    tx_regular = intrinsic_gas + code.gas_cost(fork) - sstore_state_gas
+    expected = max(num_txs * tx_regular, num_txs * sstore_state_gas)
     txs = []
     for _ in range(num_txs):
-        contract = pre.deploy_contract(
-            code=Op.SSTORE(0, 1) + Op.SSTORE(0, 0),
+        contract = pre.deploy_contract(code=code)
+        txs.append(
+            Transaction(
+                to=contract,
+                gas_limit=gas_limit_cap + sstore_state_gas,
+                sender=pre.fund_eoa(),
+            )
         )
-        txs.append(Transaction(
-            to=contract,
-            gas_limit=cap + sstore_state_gas,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
-            sender=pre.fund_eoa(),
-        ))
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            header_verify=Header(gas_used=expected),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=expected),
+            )
+        ],
         post={},
     )
 
@@ -285,9 +274,9 @@ def test_block_gas_refund_eip7778_no_block_reduction(
 @pytest.mark.parametrize(
     "num_txs,num_sstores",
     [
-        pytest.param(5, 1, id="5tx_1sstore"),
-        pytest.param(20, 1, id="20tx_1sstore"),
-        pytest.param(10, 5, id="10tx_5sstore"),
+        pytest.param(5, 1, id="single_sstore"),
+        pytest.param(20, 1, id="single_sstore_many_txs"),
+        pytest.param(10, 5, id="multi_sstore_many_txs"),
     ],
 )
 @pytest.mark.valid_from("Amsterdam")
@@ -304,16 +293,21 @@ def test_block_2d_gas_boundary_exact_fit(
     Set block_gas_limit = block_state_gas (the dominant dimension).
     Clients that sum regular + state will reject this valid block.
     """
-    tx_regular, tx_state = _sstore_tx_gas(fork, num_sstores)
+    tx_regular, tx_state = sstore_tx_gas(fork, num_sstores)
     block_state = num_txs * tx_state
     block_gas_limit = block_state
 
-    tx_limit = tx_regular + tx_state + 1000
+    # tx_limit must exceed tx_regular + tx_state so the tx is valid,
+    # but the per-tx regular reservation against block gas must still
+    # leave room for all txs.
+    tx_limit = tx_regular + tx_state + tx_regular // 10
     worst = block_gas_limit - (num_txs - 1) * tx_regular
     assert worst >= tx_limit, "per-tx regular gas check fails"
 
-    txs, post = _make_sstore_txs(
-        pre, fork, num_txs,
+    txs, post = sstore_txs(
+        pre,
+        fork,
+        num_txs,
         num_sstores=num_sstores,
         tx_gas_limit=tx_limit,
     )
@@ -322,11 +316,13 @@ def test_block_2d_gas_boundary_exact_fit(
             gas_limit=block_gas_limit,
         ),
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            gas_limit=block_gas_limit,
-            header_verify=Header(gas_used=block_gas_limit),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                gas_limit=block_gas_limit,
+                header_verify=Header(gas_used=block_gas_limit),
+            )
+        ],
         post=post,
     )
 
@@ -340,47 +336,35 @@ def test_block_gas_used_call_new_account(
     """
     Verify block.gas_used includes state gas from CALL creating accounts.
 
-    A contract does CALL(value=1) to a dead address (charges
-    GAS_NEW_ACCOUNT state gas) then SSTORE.  Combined with a STOP tx,
+    A contract does CALL(value=1) to a non-existent address (charges
+    GAS_NEW_ACCOUNT state gas) then SSTORE. Combined with a STOP tx,
     the 2D max must reflect state gas from account creation.
     """
-    gc = fork.gas_costs()
-    cap = fork.transaction_gas_limit_cap()
-    assert cap is not None
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
     sstore_state_gas = fork.sstore_state_gas()
+
+    target = pre.fund_eoa(amount=0)
 
     parent_storage = Storage()
     parent = pre.deploy_contract(
         code=(
-            Op.CALL(
-                gas=500_000, address=0xDEAD0001, value=1,
-            )
+            Op.CALL(gas=100_000, address=target, value=1)
             + Op.SSTORE(parent_storage.store_next(1), 1)
         ),
         balance=10**18,
     )
 
-    stop_contract = pre.deploy_contract(code=Op.STOP)
-    stop_gas = _stop_tx_gas(fork)
-
     txs = [
         Transaction(
             to=parent,
             gas_limit=(
-                cap + gc.GAS_NEW_ACCOUNT + sstore_state_gas
+                gas_limit_cap + new_account_state_gas + sstore_state_gas
             ),
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
             sender=pre.fund_eoa(),
         ),
-        Transaction(
-            to=stop_contract,
-            gas_limit=stop_gas,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
-            sender=pre.fund_eoa(),
-        ),
-    ]
+    ] + stop_txs(pre, fork, 1)
 
     blockchain_test(
         pre=pre,
@@ -401,48 +385,40 @@ def test_block_gas_used_create_tx(
     Contract creation charges GAS_NEW_ACCOUNT as intrinsic state gas.
     Combined with a STOP tx, verify the 2D max is correct.
     """
-    gc = fork.gas_costs()
-    cap = fork.transaction_gas_limit_cap()
-    assert cap is not None
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    intrinsic_calc = fork.transaction_intrinsic_cost_calculator()
+    create_state_gas = fork.create_state_gas(code_size=0)
 
     init_code = bytes(Op.STOP)
-    intrinsic = fork.transaction_intrinsic_cost_calculator()
-
-    create_total = intrinsic(
-        calldata=init_code, contract_creation=True,
+    create_regular = (
+        intrinsic_calc(
+            calldata=init_code,
+            contract_creation=True,
+        )
+        - create_state_gas
     )
-    create_state = gc.GAS_NEW_ACCOUNT
-    create_regular = create_total - create_state
+    stop_regular = intrinsic_calc()
 
-    stop_contract = pre.deploy_contract(code=Op.STOP)
-    stop_gas = _stop_tx_gas(fork)
-
-    expected = max(create_regular + stop_gas, create_state)
+    expected = max(create_regular + stop_regular, create_state_gas)
 
     txs = [
         Transaction(
             to=None,
             data=init_code,
-            gas_limit=cap + create_state,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
+            gas_limit=gas_limit_cap + create_state_gas,
             sender=pre.fund_eoa(),
         ),
-        Transaction(
-            to=stop_contract,
-            gas_limit=stop_gas,
-            max_priority_fee_per_gas=1,
-            max_fee_per_gas=8,
-            sender=pre.fund_eoa(),
-        ),
-    ]
+    ] + stop_txs(pre, fork, 1)
 
     blockchain_test(
         pre=pre,
-        blocks=[Block(
-            txs=txs,
-            header_verify=Header(gas_used=expected),
-        )],
+        blocks=[
+            Block(
+                txs=txs,
+                header_verify=Header(gas_used=expected),
+            )
+        ],
         post={},
     )
 
@@ -461,28 +437,25 @@ def test_multi_block_dimension_flip(
     Each block independently computes its own 2D max.
     """
     n = 3
-    stop_gas = _stop_tx_gas(fork)
-    tx_regular, tx_state = _sstore_tx_gas(fork)
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    tx_regular, tx_state = sstore_tx_gas(fork)
 
-    block1_txs = _make_stop_txs(pre, fork, n)
-    block2_txs, post = _make_sstore_txs(pre, fork, n)
+    block_1 = stop_txs(pre, fork, n)
+    block_2, post_2 = sstore_txs(pre, fork, n)
 
     blockchain_test(
         pre=pre,
         blocks=[
             Block(
-                txs=block1_txs,
-                header_verify=Header(gas_used=n * stop_gas),
+                txs=block_1,
+                header_verify=Header(gas_used=n * intrinsic_gas),
             ),
             Block(
-                txs=block2_txs,
+                txs=block_2,
                 header_verify=Header(
-                    gas_used=max(
-                        n * tx_regular, n * tx_state,
-                    ),
+                    gas_used=max(n * tx_regular, n * tx_state),
                 ),
             ),
         ],
-        post=post,
+        post=post_2,
     )
-

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_block_2d_gas_accounting.py
@@ -1,0 +1,488 @@
+"""
+Block-level 2D gas accounting tests for EIP-8037.
+
+EIP-8037 introduces two-dimensional gas metering: each transaction
+contributes to both ``block_gas_used`` (regular gas) and
+``block_state_gas_used`` (state gas).  The block header's ``gas_used``
+field is ``max(block_gas_used, block_state_gas_used)``.
+
+These tests target inter-client disagreements observed on BAL devnet-3.
+
+Tests for [EIP-8037: State Creation Gas Cost Increase]
+(https://eips.ethereum.org/EIPS/eip-8037).
+"""
+
+import pytest
+from execution_testing import (
+    Account,
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Bytecode,
+    Environment,
+    Fork,
+    Header,
+    Op,
+    Storage,
+    Transaction,
+)
+
+from .spec import ref_spec_8037
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
+REFERENCE_SPEC_VERSION = ref_spec_8037.version
+
+
+# -- Helpers --
+
+
+def _sstore_tx_gas(fork, num_sstores=1):
+    """Return (regular, state) gas for a tx with N SSTOREs."""
+    gc = fork.gas_costs()
+    evm = num_sstores * (
+        2 * gc.GAS_VERY_LOW + gc.GAS_COLD_STORAGE_WRITE
+    )
+    state = num_sstores * fork.sstore_state_gas()
+    return gc.GAS_TX_BASE + evm, state
+
+
+def _stop_tx_gas(fork):
+    """Return per-tx regular gas for a STOP transaction."""
+    return fork.transaction_intrinsic_cost_calculator()()
+
+
+def _make_sstore_txs(pre, fork, n, num_sstores=1,
+                     tx_gas_limit=None):
+    """
+    Build n txs each doing num_sstores zero-to-nonzero SSTOREs.
+
+    Return (txs, post).
+    """
+    if tx_gas_limit is None:
+        cap = fork.transaction_gas_limit_cap()
+        assert cap is not None
+        tx_gas_limit = (
+            cap + num_sstores * fork.sstore_state_gas()
+        )
+    txs, post = [], {}
+    for _ in range(n):
+        storage = Storage()
+        code = Bytecode()
+        for _ in range(num_sstores):
+            code += Op.SSTORE(storage.store_next(1), 1)
+        contract = pre.deploy_contract(code=code)
+        txs.append(Transaction(
+            to=contract,
+            gas_limit=tx_gas_limit,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ))
+        post[contract] = Account(storage=storage)
+    return txs, post
+
+
+def _make_stop_txs(pre, fork, n):
+    """Build n STOP transactions. Return list of txs."""
+    gas = _stop_tx_gas(fork)
+    txs = []
+    for _ in range(n):
+        contract = pre.deploy_contract(code=Op.STOP)
+        txs.append(Transaction(
+            to=contract,
+            gas_limit=gas,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ))
+    return txs
+
+
+# -- Tests --
+
+
+@pytest.mark.parametrize(
+    "num_txs,num_sstores",
+    [
+        pytest.param(5, 1, id="5tx_1sstore"),
+        pytest.param(20, 1, id="20tx_1sstore"),
+        pytest.param(2, 3, id="2tx_3sstore_spillover"),
+        pytest.param(10, 5, id="10tx_5sstore"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_used_state_dominates(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_txs: int,
+    num_sstores: int,
+) -> None:
+    """
+    Verify block.gas_used = block_state_gas when state > regular.
+
+    Each tx does ``num_sstores`` zero-to-nonzero SSTOREs.  Since
+    state gas per SSTORE exceeds regular gas, block_state_gas exceeds
+    block_regular_gas and becomes the header gas_used.
+
+    The spillover variant (2tx_3sstore) provides reservoir for only
+    one SSTORE per tx; the remaining state gas spills into gas_left.
+    Block-level accounting must still separate the two dimensions.
+
+    Catches: clients ignoring state gas, summing instead of max,
+    or conflating spillover gas with the regular dimension.
+    """
+    tx_regular, tx_state = _sstore_tx_gas(fork, num_sstores)
+    block_regular = num_txs * tx_regular
+    block_state = num_txs * tx_state
+    assert block_state > block_regular
+    expected = block_state
+
+    txs, post = _make_sstore_txs(
+        pre, fork, num_txs, num_sstores=num_sstores,
+    )
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            header_verify=Header(gas_used=expected),
+        )],
+        post=post,
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_used_regular_dominates(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block.gas_used = block_regular_gas when state gas is zero.
+
+    STOP transactions to existing contracts produce no state gas.
+    """
+    num_txs = 3
+    stop_gas = _stop_tx_gas(fork)
+    txs = _make_stop_txs(pre, fork, num_txs)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            header_verify=Header(gas_used=num_txs * stop_gas),
+        )],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "num_stop,num_sstore,interleaved",
+    [
+        pytest.param(2, 3, False, id="grouped"),
+        pytest.param(10, 10, True, id="interleaved"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_used_mixed_txs(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_stop: int,
+    num_sstore: int,
+    interleaved: bool,
+) -> None:
+    """
+    Verify block.gas_used with mixed STOP and SSTORE transactions.
+
+    STOP txs contribute only regular gas; SSTORE txs contribute both.
+    The interleaved variant alternates SSTORE/STOP to test that
+    non-contiguous state gas contributions accumulate correctly.
+    """
+    tx_r_sstore, tx_s_sstore = _sstore_tx_gas(fork)
+    stop_gas = _stop_tx_gas(fork)
+
+    block_regular = (
+        num_stop * stop_gas + num_sstore * tx_r_sstore
+    )
+    block_state = num_sstore * tx_s_sstore
+    expected = max(block_regular, block_state)
+
+    sstore_txs, post = _make_sstore_txs(pre, fork, num_sstore)
+    stop_txs = _make_stop_txs(pre, fork, num_stop)
+
+    if interleaved:
+        txs = []
+        for i in range(max(num_sstore, num_stop)):
+            if i < num_sstore:
+                txs.append(sstore_txs[i])
+            if i < num_stop:
+                txs.append(stop_txs[i])
+    else:
+        txs = stop_txs + sstore_txs
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            header_verify=Header(gas_used=expected),
+        )],
+        post=post,
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_refund_eip7778_no_block_reduction(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block gas accounting excludes refunds per EIP-7778.
+
+    Each tx does SSTORE(0,1) then SSTORE(0,0) — set then restore.
+    The user gets a refund (reduced receipt gas_used), but EIP-7778
+    says block gas is NOT reduced by refunds.
+    """
+    gc = fork.gas_costs()
+    cap = fork.transaction_gas_limit_cap()
+    assert cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    num_txs = 3
+    tx_regular = (
+        gc.GAS_TX_BASE
+        + 4 * gc.GAS_VERY_LOW
+        + gc.GAS_COLD_STORAGE_WRITE
+        + gc.GAS_WARM_SLOAD
+    )
+    tx_state = sstore_state_gas
+    expected = max(num_txs * tx_regular, num_txs * tx_state)
+
+    txs = []
+    for _ in range(num_txs):
+        contract = pre.deploy_contract(
+            code=Op.SSTORE(0, 1) + Op.SSTORE(0, 0),
+        )
+        txs.append(Transaction(
+            to=contract,
+            gas_limit=cap + sstore_state_gas,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ))
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            header_verify=Header(gas_used=expected),
+        )],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "num_txs,num_sstores",
+    [
+        pytest.param(5, 1, id="5tx_1sstore"),
+        pytest.param(20, 1, id="20tx_1sstore"),
+        pytest.param(10, 5, id="10tx_5sstore"),
+    ],
+)
+@pytest.mark.valid_from("Amsterdam")
+def test_block_2d_gas_boundary_exact_fit(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    num_txs: int,
+    num_sstores: int,
+) -> None:
+    """
+    Verify a block is valid when max(regular, state) == gas_limit.
+
+    Set block_gas_limit = block_state_gas (the dominant dimension).
+    Clients that sum regular + state will reject this valid block.
+    """
+    tx_regular, tx_state = _sstore_tx_gas(fork, num_sstores)
+    block_state = num_txs * tx_state
+    block_gas_limit = block_state
+
+    tx_limit = tx_regular + tx_state + 1000
+    worst = block_gas_limit - (num_txs - 1) * tx_regular
+    assert worst >= tx_limit, "per-tx regular gas check fails"
+
+    txs, post = _make_sstore_txs(
+        pre, fork, num_txs,
+        num_sstores=num_sstores,
+        tx_gas_limit=tx_limit,
+    )
+    blockchain_test(
+        genesis_environment=Environment(
+            gas_limit=block_gas_limit,
+        ),
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            gas_limit=block_gas_limit,
+            header_verify=Header(gas_used=block_gas_limit),
+        )],
+        post=post,
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_used_call_new_account(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block.gas_used includes state gas from CALL creating accounts.
+
+    A contract does CALL(value=1) to a dead address (charges
+    GAS_NEW_ACCOUNT state gas) then SSTORE.  Combined with a STOP tx,
+    the 2D max must reflect state gas from account creation.
+    """
+    gc = fork.gas_costs()
+    cap = fork.transaction_gas_limit_cap()
+    assert cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    parent_storage = Storage()
+    parent = pre.deploy_contract(
+        code=(
+            Op.CALL(
+                gas=500_000, address=0xDEAD0001, value=1,
+            )
+            + Op.SSTORE(parent_storage.store_next(1), 1)
+        ),
+        balance=10**18,
+    )
+
+    stop_contract = pre.deploy_contract(code=Op.STOP)
+    stop_gas = _stop_tx_gas(fork)
+
+    txs = [
+        Transaction(
+            to=parent,
+            gas_limit=(
+                cap + gc.GAS_NEW_ACCOUNT + sstore_state_gas
+            ),
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ),
+        Transaction(
+            to=stop_contract,
+            gas_limit=stop_gas,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=txs)],
+        post={parent: Account(storage=parent_storage)},
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_block_gas_used_create_tx(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block.gas_used includes intrinsic state gas from CREATE txs.
+
+    Contract creation charges GAS_NEW_ACCOUNT as intrinsic state gas.
+    Combined with a STOP tx, verify the 2D max is correct.
+    """
+    gc = fork.gas_costs()
+    cap = fork.transaction_gas_limit_cap()
+    assert cap is not None
+
+    init_code = bytes(Op.STOP)
+    intrinsic = fork.transaction_intrinsic_cost_calculator()
+
+    create_total = intrinsic(
+        calldata=init_code, contract_creation=True,
+    )
+    create_state = gc.GAS_NEW_ACCOUNT
+    create_regular = create_total - create_state
+
+    stop_contract = pre.deploy_contract(code=Op.STOP)
+    stop_gas = _stop_tx_gas(fork)
+
+    expected = max(create_regular + stop_gas, create_state)
+
+    txs = [
+        Transaction(
+            to=None,
+            data=init_code,
+            gas_limit=cap + create_state,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ),
+        Transaction(
+            to=stop_contract,
+            gas_limit=stop_gas,
+            max_priority_fee_per_gas=1,
+            max_fee_per_gas=8,
+            sender=pre.fund_eoa(),
+        ),
+    ]
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(
+            txs=txs,
+            header_verify=Header(gas_used=expected),
+        )],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_multi_block_dimension_flip(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify gas_used across blocks where dominant dimension flips.
+
+    Block 1: STOP txs only (regular dominates).
+    Block 2: SSTORE txs only (state dominates).
+    Each block independently computes its own 2D max.
+    """
+    n = 3
+    stop_gas = _stop_tx_gas(fork)
+    tx_regular, tx_state = _sstore_tx_gas(fork)
+
+    block1_txs = _make_stop_txs(pre, fork, n)
+    block2_txs, post = _make_sstore_txs(pre, fork, n)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=block1_txs,
+                header_verify=Header(gas_used=n * stop_gas),
+            ),
+            Block(
+                txs=block2_txs,
+                header_verify=Header(
+                    gas_used=max(
+                        n * tx_regular, n * tx_state,
+                    ),
+                ),
+            ),
+        ],
+        post=post,
+    )
+


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

- Add 9 blockchain tests (28 parametrized items) for block-level two-dimensional gas accounting under EIP-8037
- Tests target inter-client disagreements observed on BAL devnet-3 where EL clients diverged on `block.gas_used` due to incorrect 2D gas metering.

### Test Coverage

| Test | What it catches |
|------|----------------|
| `test_block_gas_used_state_dominates` (4 variants) | Clients ignoring state gas dimension, summing instead of max, or conflating spillover with regular gas |
| `test_block_gas_used_regular_dominates` | Multi-tx block accumulation when state gas is zero |
| `test_block_gas_used_mixed_txs` (2 variants) | Non-contiguous state gas contributions across interleaved STOP/SSTORE txs |
| `test_block_gas_refund_eip7778_no_block_reduction` | EIP-7778 interaction: refunds must not reduce block-level gas accounting |
| `test_block_2d_gas_boundary_exact_fit` (3 variants) | Block validity when `max(regular, state) == gas_limit` exactly — catches clients that sum dimensions |
| `test_block_gas_used_call_new_account` | `GAS_NEW_ACCOUNT` state gas from CALL creating accounts reflected in block gas |
| `test_block_gas_used_create_tx` | CREATE tx intrinsic state gas in block-level 2D accounting |
| `test_multi_block_dimension_flip` | Independent per-block 2D max when dominant dimension flips between blocks |

### Motivation

On BAL devnet-3, multiple EL clients (erigon, reth, ethrex, nimbus) produced incorrect `block.gas_used` values because they either:
1. Had no 2D gas metering at all (reth, nimbus)
2. Only tracked regular gas at the block level, allowing state gas to grow unbounded (erigon)
3. Disagreed on reservoir spillover accounting

These tests reproduce the exact failure modes observed in production devnet testing.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
