### PR TITLE
feat(tests): EIP-8037 - blockchain header gas used cases

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -19,6 +19,8 @@ from execution_testing import (
     Account,
     Address,
     Alloc,
+    Block,
+    BlockchainTestFiller,
     Environment,
     Fork,
     Op,
@@ -866,3 +868,49 @@ def test_call_pre_charged_costs_excluded_from_forwarding(
     }
 
     state_test(pre=pre, tx=tx, post=post)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_call_new_account_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block gas accounting for CALL creating a new account.
+
+    A contract CALLs a non-existent address with value, charging
+    GAS_NEW_ACCOUNT state gas. The block must be accepted with
+    correct 2D max(regular, state) accounting in the header.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    target = pre.fund_eoa(amount=0)
+
+    storage = Storage()
+    contract = pre.deploy_contract(
+        code=(
+            Op.SSTORE(
+                storage.store_next(1, "call_succeeds"),
+                Op.CALL(gas=100_000, address=target, value=1),
+            )
+        ),
+        balance=1,
+    )
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit_cap + new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[tx]),
+        ],
+        post={contract: Account(storage=storage)},
+    )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_create.py
@@ -19,6 +19,7 @@ from execution_testing import (
     BlockchainTestFiller,
     Environment,
     Fork,
+    Header,
     Initcode,
     Op,
     StateTestFiller,
@@ -883,4 +884,221 @@ def test_code_deposit_halt_discards_initcode_state_gas(
             ),
         ],
         post={},
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_create_tx_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block header gas_used for a successful CREATE transaction.
+
+    A contract creation tx (to=None) with known gas costs. Compute
+    exact gas_used from first principles and verify against the block
+    header. Catches bugs where clients report gas_limit instead of
+    actual consumed gas.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    gas_costs = fork.gas_costs()
+    initcode = Op.STOP
+    create_state_gas = fork.create_state_gas(code_size=1)
+
+    tx = Transaction(
+        to=None,
+        data=initcode,
+        gas_limit=gas_limit_cap + create_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    # block_gas_used = max(block_regular, block_state)
+    # For a minimal CREATE tx deploying Op.STOP (1 byte),
+    # state gas (new account) dominates regular gas.
+    expected_gas_used = gas_costs.GAS_NEW_ACCOUNT
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_create_initcode_halt_no_code_deposit_state_gas(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify initcode exceptional halt excludes code deposit state gas.
+
+    A CREATE tx runs initcode that hits INVALID (exceptional halt)
+    before returning any code. Code deposit never happens, so code
+    deposit state gas must NOT be charged. Only the intrinsic state
+    gas (new account creation) should count.
+
+    Complements test_create_revert_no_code_deposit_state_gas which
+    covers the REVERT path.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    # Initcode that immediately halts, no code returned
+    initcode = Op.INVALID
+
+    # State gas = new account only (no code deposit on halt)
+    intrinsic_state_gas = fork.create_state_gas(code_size=0)
+
+    gas_limit = gas_limit_cap + intrinsic_state_gas
+
+    tx = Transaction(
+        to=None,
+        data=initcode,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    # On exceptional halt all gas_left is consumed.
+    # block_gas_used = max(block_regular, block_state)
+    # block_state = intrinsic_state_gas (new account only, no deposit)
+    # block_regular = gas_limit - intrinsic_state_gas (all remaining)
+    tx_regular = gas_limit - intrinsic_state_gas
+    tx_state = intrinsic_state_gas
+    expected_gas_used = max(tx_regular, tx_state)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={},
+    )
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_state_gas_spill_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify header gas_used when state gas spills into gas_left.
+
+    A transaction performs an SSTORE with state gas partially from
+    the reservoir and partially spilling into gas_left. Verify the
+    block header gas_used reflects the correct 2D max accounting.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # SSTORE zero-to-nonzero with small reservoir
+    sstore_code = Op.SSTORE(0, 1) + Op.STOP
+    contract = pre.deploy_contract(code=sstore_code)
+
+    intrinsic_cost = fork.transaction_intrinsic_cost_calculator()
+    intrinsic_gas = intrinsic_cost()
+
+    evm_regular = 2 * gas_costs.GAS_VERY_LOW + gas_costs.GAS_COLD_STORAGE_WRITE
+
+    # Reservoir = half the SSTORE state gas, rest spills to gas_left
+    reservoir = sstore_state_gas // 2
+    gas_limit = gas_limit_cap + reservoir
+
+    tx = Transaction(
+        to=contract,
+        gas_limit=gas_limit,
+        sender=pre.fund_eoa(),
+    )
+
+    tx_regular = intrinsic_gas + evm_regular
+    tx_state = sstore_state_gas
+    expected_gas_used = max(tx_regular, tx_state)
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=expected_gas_used),
+            ),
+        ],
+        post={contract: Account(storage={0: 1})},
+    )
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    [
+        pytest.param("revert", id="revert"),
+        pytest.param("halt", id="halt"),
+    ],
+)
+@pytest.mark.with_all_create_opcodes()
+@pytest.mark.valid_from("Amsterdam")
+def test_failed_create_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    failure_mode: str,
+) -> None:
+    """
+    Verify block header gas_used for failed CREATE/CREATE2 via opcode.
+
+    A factory contract calls CREATE/CREATE2 which fails (revert or
+    halt). Verify the block is accepted with correct gas accounting.
+    Parametrized across failure modes and create opcodes.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    create_state_gas = fork.create_state_gas(code_size=0)
+
+    if failure_mode == "revert":
+        init_code = Op.REVERT(0, 0)
+    else:
+        init_code = Op.INVALID
+
+    create_call = (
+        create_opcode(value=0, offset=0, size=len(init_code), salt=0)
+        if create_opcode == Op.CREATE2
+        else create_opcode(value=0, offset=0, size=len(init_code))
+    )
+
+    storage = Storage()
+    factory_code = Op.MSTORE(
+        0,
+        int.from_bytes(bytes(init_code), "big") << (256 - 8 * len(init_code)),
+    ) + Op.SSTORE(
+        storage.store_next(0, "create_fails"),
+        create_call,
+    )
+
+    factory = pre.deploy_contract(factory_code)
+
+    tx = Transaction(
+        to=factory,
+        gas_limit=gas_limit_cap + create_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[tx]),
+        ],
+        post={factory: Account(storage=storage)},
     )

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_selfdestruct.py
@@ -12,11 +12,15 @@ Tests for [EIP-8037: State Creation Gas Cost Increase]
 
 import pytest
 from execution_testing import (
+    Account,
     Alloc,
+    Block,
+    BlockchainTestFiller,
     Environment,
     Fork,
     Op,
     StateTestFiller,
+    Storage,
     Transaction,
 )
 
@@ -197,3 +201,50 @@ def test_selfdestruct_to_self_in_create_tx(
     )
 
     state_test(env=env, pre=pre, post={}, tx=tx)
+
+
+@pytest.mark.valid_from("Amsterdam")
+def test_selfdestruct_new_beneficiary_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Verify block gas accounting for SELFDESTRUCT to new beneficiary.
+
+    A contract with nonzero balance SELFDESTRUCTs to a non-existent
+    beneficiary, charging GAS_NEW_ACCOUNT state gas. The block must
+    be accepted with correct 2D gas accounting in the header.
+    """
+    gas_costs = fork.gas_costs()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = gas_costs.GAS_NEW_ACCOUNT
+
+    beneficiary = pre.fund_eoa(amount=0)
+
+    storage = Storage()
+    inner = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(beneficiary),
+        balance=1,
+    )
+    caller = pre.deploy_contract(
+        code=(
+            Op.CALL(gas=100_000, address=inner)
+            + Op.SSTORE(storage.store_next(1, "completed"), 1)
+        ),
+    )
+
+    tx = Transaction(
+        to=caller,
+        gas_limit=gas_limit_cap + new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(txs=[tx]),
+        ],
+        post={caller: Account(storage=storage)},
+    )


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

Adds blockchain tests verifying block header `gas_used` for state-creating operations under EIP-8037. The existing test suite (121 `state_tests`) validates post-state correctness but does not verify block header `gas_used` values.

### CREATE/CREATE2
- `test_create_tx_header_gas_used`: successful CREATE tx, verify header `gas_used` = `max(regular, state)`
- `test_create_initcode_halt_no_code_deposit_state_gas`: initcode INVALID halt excludes code deposit state gas 
- `test_state_gas_spill_header_gas_used`: state gas spills from reservoir to `gas_left`, verify correct 2D header accounting
- `test_failed_create_header_gas_used`: parametrized across revert/halt failure modes and CREATE/CREATE2 opcodes

### CALL
- `test_call_new_account_header_gas_used`: CALL with value to non-existent account, verify block acceptance with GAS_NEW_ACCOUNT state gas

### SELFDESTRUCT
- `test_selfdestruct_new_beneficiary_header_gas_used`: SELFDESTRUCT to new beneficiary, verify block acceptance with GAS_NEW_ACCOUNT state gas

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
