### PR TITLE
chore(tests): fix import sorting and stale type annotation for static checks

### DIFF
--- a/tests/ported_static/stCallCodes/test_callcallcall_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcallcall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcodecallcall_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCodes/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallCodes/test_callcodecallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCreateCallCodeTest/test_call_lose_gas_oog.py
+++ b/tests/ported_static/stCallCreateCallCodeTest/test_call_lose_gas_oog.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallCreateCallCodeTest/test_create_js_no_collision.py
+++ b/tests/ported_static/stCallCreateCallCodeTest/test_create_js_no_collision.py
@@ -13,12 +13,11 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-
 from execution_testing.forks import Amsterdam
 
 REFERENCE_SPEC_GIT_PATH = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesCallCodeHomestead/test_callcodecallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecall_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecall_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecallcode_abcb_recursive.py
+++ b/tests/ported_static/stCallDelegateCodesHomestead/test_callcodecallcodecallcode_abcb_recursive.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_call_outsize_then_create2_successful_then_returndatasize.py
+++ b/tests/ported_static/stCreate2/test_call_outsize_then_create2_successful_then_returndatasize.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_call_then_create2_successful_then_returndatasize.py
+++ b/tests/ported_static/stCreate2/test_call_then_create2_successful_then_returndatasize.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code_returndata_size.py
+++ b/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code_returndata_size.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code_revert.py
+++ b/tests/ported_static/stCreate2/test_create2_oo_gafter_init_code_revert.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_returndatacopy_0_0_following_successful_create.py
+++ b/tests/ported_static/stCreate2/test_returndatacopy_0_0_following_successful_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_returndatacopy_after_failing_create.py
+++ b/tests/ported_static/stCreate2/test_returndatacopy_after_failing_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_returndatacopy_following_revert_in_create.py
+++ b/tests/ported_static/stCreate2/test_returndatacopy_following_revert_in_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_returndatasize_following_successful_create.py
+++ b/tests/ported_static/stCreate2/test_returndatasize_following_successful_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreate2/test_revert_opcode_in_create_returns_create2.py
+++ b/tests/ported_static/stCreate2/test_revert_opcode_in_create_returns_create2.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreateTest/test_create2_call_data.py
+++ b/tests/ported_static/stCreateTest/test_create2_call_data.py
@@ -14,13 +14,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreateTest/test_create_contract_sstore_during_init.py
+++ b/tests/ported_static/stCreateTest/test_create_contract_sstore_during_init.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stCreateTest/test_create_transaction_refund_ef.py
+++ b/tests/ported_static/stCreateTest/test_create_transaction_refund_ef.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stDelegatecallTestHomestead/test_call_lose_gas_oog.py
+++ b/tests/ported_static/stDelegatecallTestHomestead/test_call_lose_gas_oog.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stDelegatecallTestHomestead/test_delegatecall_in_initcode_to_existing_contract_oog.py
+++ b/tests/ported_static/stDelegatecallTestHomestead/test_delegatecall_in_initcode_to_existing_contract_oog.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stEIP150Specific/test_execute_call_that_ask_fore_gas_then_trabsaction_has.py
+++ b/tests/ported_static/stEIP150Specific/test_execute_call_that_ask_fore_gas_then_trabsaction_has.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_and_call_it_oog.py
+++ b/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_and_call_it_oog.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_oog_bonus_gas.py
+++ b/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_oog_bonus_gas.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_which_would_create_contract_in_init_code.py
+++ b/tests/ported_static/stInitCodeTest/test_call_contract_to_create_contract_which_would_create_contract_in_init_code.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_stack_under_flow_contract_creation.py
+++ b/tests/ported_static/stInitCodeTest/test_stack_under_flow_contract_creation.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_transaction_create_random_init_code.py
+++ b/tests/ported_static/stInitCodeTest/test_transaction_create_random_init_code.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stInitCodeTest/test_transaction_create_suicide_in_initcode.py
+++ b/tests/ported_static/stInitCodeTest/test_transaction_create_suicide_in_initcode.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemExpandingEIP150Calls/test_execute_call_that_ask_more_gas_then_transaction_has_with_mem_expanding_calls.py
+++ b/tests/ported_static/stMemExpandingEIP150Calls/test_execute_call_that_ask_more_gas_then_transaction_has_with_mem_expanding_calls.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_minus_1.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_minus_1.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_minus_31.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_minus_31.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_minus_32.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_minus_32.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_minus_33.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_minus_33.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_plus_1.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_plus_1.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_plus_31.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_plus_31.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_plus_32.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_plus_32.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem32kb_plus_33.py
+++ b/tests/ported_static/stMemoryTest/test_mem32kb_plus_33.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_minus_1.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_minus_1.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_minus_31.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_minus_31.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_minus_32.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_minus_32.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_minus_33.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_minus_33.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_plus_1.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_plus_1.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_plus_31.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_plus_31.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_plus_32.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_plus_32.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stMemoryTest/test_mem64kb_plus_33.py
+++ b/tests/ported_static/stMemoryTest/test_mem64kb_plus_33.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest138.py
+++ b/tests/ported_static/stRandom/test_random_statetest138.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest14.py
+++ b/tests/ported_static/stRandom/test_random_statetest14.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest147.py
+++ b/tests/ported_static/stRandom/test_random_statetest147.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest164.py
+++ b/tests/ported_static/stRandom/test_random_statetest164.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest17.py
+++ b/tests/ported_static/stRandom/test_random_statetest17.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest173.py
+++ b/tests/ported_static/stRandom/test_random_statetest173.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest198.py
+++ b/tests/ported_static/stRandom/test_random_statetest198.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest201.py
+++ b/tests/ported_static/stRandom/test_random_statetest201.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest212.py
+++ b/tests/ported_static/stRandom/test_random_statetest212.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest22.py
+++ b/tests/ported_static/stRandom/test_random_statetest22.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest232.py
+++ b/tests/ported_static/stRandom/test_random_statetest232.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest236.py
+++ b/tests/ported_static/stRandom/test_random_statetest236.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest237.py
+++ b/tests/ported_static/stRandom/test_random_statetest237.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest245.py
+++ b/tests/ported_static/stRandom/test_random_statetest245.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest270.py
+++ b/tests/ported_static/stRandom/test_random_statetest270.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest291.py
+++ b/tests/ported_static/stRandom/test_random_statetest291.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest293.py
+++ b/tests/ported_static/stRandom/test_random_statetest293.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest31.py
+++ b/tests/ported_static/stRandom/test_random_statetest31.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest337.py
+++ b/tests/ported_static/stRandom/test_random_statetest337.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest338.py
+++ b/tests/ported_static/stRandom/test_random_statetest338.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest343.py
+++ b/tests/ported_static/stRandom/test_random_statetest343.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest349.py
+++ b/tests/ported_static/stRandom/test_random_statetest349.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest368.py
+++ b/tests/ported_static/stRandom/test_random_statetest368.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest371.py
+++ b/tests/ported_static/stRandom/test_random_statetest371.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest376.py
+++ b/tests/ported_static/stRandom/test_random_statetest376.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest39.py
+++ b/tests/ported_static/stRandom/test_random_statetest39.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest43.py
+++ b/tests/ported_static/stRandom/test_random_statetest43.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest64.py
+++ b/tests/ported_static/stRandom/test_random_statetest64.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom/test_random_statetest98.py
+++ b/tests/ported_static/stRandom/test_random_statetest98.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest406.py
+++ b/tests/ported_static/stRandom2/test_random_statetest406.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest409.py
+++ b/tests/ported_static/stRandom2/test_random_statetest409.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest435.py
+++ b/tests/ported_static/stRandom2/test_random_statetest435.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest437.py
+++ b/tests/ported_static/stRandom2/test_random_statetest437.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest442.py
+++ b/tests/ported_static/stRandom2/test_random_statetest442.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest487.py
+++ b/tests/ported_static/stRandom2/test_random_statetest487.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest493.py
+++ b/tests/ported_static/stRandom2/test_random_statetest493.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest495.py
+++ b/tests/ported_static/stRandom2/test_random_statetest495.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest501.py
+++ b/tests/ported_static/stRandom2/test_random_statetest501.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest517.py
+++ b/tests/ported_static/stRandom2/test_random_statetest517.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest521.py
+++ b/tests/ported_static/stRandom2/test_random_statetest521.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest542.py
+++ b/tests/ported_static/stRandom2/test_random_statetest542.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest559.py
+++ b/tests/ported_static/stRandom2/test_random_statetest559.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest581.py
+++ b/tests/ported_static/stRandom2/test_random_statetest581.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest584.py
+++ b/tests/ported_static/stRandom2/test_random_statetest584.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest612.py
+++ b/tests/ported_static/stRandom2/test_random_statetest612.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRandom2/test_random_statetest635.py
+++ b/tests/ported_static/stRandom2/test_random_statetest635.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_call_outsize_then_create_successful_then_returndatasize.py
+++ b/tests/ported_static/stReturnDataTest/test_call_outsize_then_create_successful_then_returndatasize.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_call_then_create_successful_then_returndatasize.py
+++ b/tests/ported_static/stReturnDataTest/test_call_then_create_successful_then_returndatasize.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_create_callprecompile_returndatasize.py
+++ b/tests/ported_static/stReturnDataTest/test_create_callprecompile_returndatasize.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_returndatacopy_0_0_following_successful_create.py
+++ b/tests/ported_static/stReturnDataTest/test_returndatacopy_0_0_following_successful_create.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_returndatacopy_after_failing_create.py
+++ b/tests/ported_static/stReturnDataTest/test_returndatacopy_after_failing_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_returndatacopy_following_revert_in_create.py
+++ b/tests/ported_static/stReturnDataTest/test_returndatacopy_following_revert_in_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stReturnDataTest/test_returndatasize_following_successful_create.py
+++ b/tests/ported_static/stReturnDataTest/test_returndatasize_following_successful_create.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRevertTest/test_revert_in_call_code.py
+++ b/tests/ported_static/stRevertTest/test_revert_in_call_code.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRevertTest/test_revert_in_delegate_call.py
+++ b/tests/ported_static/stRevertTest/test_revert_in_delegate_call.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stRevertTest/test_revert_opcode_in_create_returns.py
+++ b/tests/ported_static/stRevertTest/test_revert_opcode_in_create_returns.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSelfBalance/test_self_balance_update.py
+++ b/tests/ported_static/stSelfBalance/test_self_balance_update.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSolidityTest/test_call_low_level_creates_solidity.py
+++ b/tests/ported_static/stSolidityTest/test_call_low_level_creates_solidity.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSolidityTest/test_recursive_create_contracts_create4_contracts.py
+++ b/tests/ported_static/stSolidityTest/test_recursive_create_contracts_create4_contracts.py
@@ -13,15 +13,14 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     Hash,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSpecialTest/test_deployment_error.py
+++ b/tests/ported_static/stSpecialTest/test_deployment_error.py
@@ -13,12 +13,11 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-
 from execution_testing.forks import Amsterdam
 
 REFERENCE_SPEC_GIT_PATH = "N/A"

--- a/tests/ported_static/stSpecialTest/test_failed_create_reverts_deletion_paris.py
+++ b/tests/ported_static/stSpecialTest/test_failed_create_reverts_deletion_paris.py
@@ -12,13 +12,12 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_called_contract.py
+++ b/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_called_contract.py
@@ -18,13 +18,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_contract_initialization.py
+++ b/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_contract_initialization.py
@@ -18,13 +18,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_transaction.py
+++ b/tests/ported_static/stStaticFlagEnabled/test_callcode_to_precompile_from_transaction.py
@@ -17,13 +17,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSystemOperationsTest/test_extcodecopy.py
+++ b/tests/ported_static/stSystemOperationsTest/test_extcodecopy.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stSystemOperationsTest/test_test_random_test.py
+++ b/tests/ported_static/stSystemOperationsTest/test_test_random_test.py
@@ -13,13 +13,12 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stTransactionTest/test_create_message_success.py
+++ b/tests/ported_static/stTransactionTest/test_create_message_success.py
@@ -13,14 +13,13 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stTransactionTest/test_create_transaction_success.py
+++ b/tests/ported_static/stTransactionTest/test_create_transaction_success.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stTransactionTest/test_empty_transaction3.py
+++ b/tests/ported_static/stTransactionTest/test_empty_transaction3.py
@@ -13,12 +13,11 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-
 from execution_testing.forks import Amsterdam
 
 REFERENCE_SPEC_GIT_PATH = "N/A"

--- a/tests/ported_static/stTransactionTest/test_transaction_sending_to_empty.py
+++ b/tests/ported_static/stTransactionTest/test_transaction_sending_to_empty.py
@@ -13,12 +13,11 @@ from execution_testing import (
     Alloc,
     Bytes,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-
 from execution_testing.forks import Amsterdam
 
 REFERENCE_SPEC_GIT_PATH = "N/A"

--- a/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_after.py
+++ b/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_after.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_at.py
+++ b/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_at.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_before.py
+++ b/tests/ported_static/stTransitionTest/test_create_name_registrator_per_txs_before.py
@@ -12,14 +12,13 @@ from execution_testing import (
     Address,
     Alloc,
     Environment,
+    Fork,
     StateTestFiller,
     Transaction,
     compute_create_address,
-    Fork,
 )
-from execution_testing.vm import Op
-
 from execution_testing.forks import Amsterdam
+from execution_testing.vm import Op
 
 REFERENCE_SPEC_GIT_PATH = "N/A"
 REFERENCE_SPEC_VERSION = "N/A"

--- a/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
+++ b/tests/prague/eip7002_el_triggerable_withdrawals/conftest.py
@@ -10,7 +10,6 @@ from execution_testing import (
     Fork,
     Header,
     Requests,
-    TransitionFork,
 )
 
 from .helpers import (
@@ -89,7 +88,7 @@ def timestamp() -> int:
 
 @pytest.fixture
 def blocks(
-    fork: Fork | TransitionFork,
+    fork: Fork,
     update_pre: None,  # Fixture is used for its side effects
     blocks_withdrawal_requests: List[List[WithdrawalRequestInteractionBase]],
     included_requests: List[List[WithdrawalRequest]],


### PR DESCRIPTION
## 🗒️ Description

Fix `tox -e static` failures on the `eips/amsterdam/eip-8037` branch:

- Auto-fix 137 ruff import sorting errors (I001) across ported static test files
- Remove stale `TransitionFork` type annotation in `tests/prague/eip7002_el_triggerable_withdrawals/conftest.py` that caused a mypy error

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast `tox` checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    uvx tox -e static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).