### PR TITLE
chore(tooling): state db support for t8n

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1332,7 +1332,7 @@ def t8n(
         session_t8n.remove_cache()
     # Reset the traces and per-block state-diffs
     session_t8n.reset_traces()
-    session_t8n._state_diffs = [] if session_t8n.state_db_path else None
+    session_t8n.reset_state_diffs()
     session_t8n.call_counter = 0
     session_t8n.debug_dump_dir = dump_dir_parameter_level
     # TODO: Configure the transition tool to count opcodes only when required.
@@ -1719,7 +1719,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
             __is_base_test_wrapper__ = True
 
             def __init__(self, *args: Any, **kwargs: Any) -> None:
-                if t8n.state_db_path is not None:
+                if t8n.use_state_db:
                     # With state-db, the pre-state is in the DB,
                     # not in the test's pre allocation.
                     kwargs["pre"] = pre.__class__(
@@ -1853,7 +1853,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     # of the spec.
                     assert isinstance(fixture, BlockchainEngineXFixture)
 
-                    if t8n.state_db_path is not None:
+                    if t8n.use_state_db:
                         assert t8n.state_db_root is not None
                         fixture.pre_hash = t8n.state_db_root
                     else:
@@ -1863,7 +1863,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                         hasattr(fixture, "post_state")
                         and fixture.post_state is not None
                     ):
-                        if t8n.state_db_path is not None:
+                        if t8n.use_state_db:
                             # In state-db mode, post_state contains only
                             # accounts modified during execution.
                             fixture.post_state_diff = fixture.post_state

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1864,9 +1864,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                             # accounts modified during execution.
                             fixture.post_state_diff = fixture.post_state
                         else:
-                            group = session.get_pre_alloc_group(
-                                pre_alloc_hash
-                            )
+                            group = session.get_pre_alloc_group(pre_alloc_hash)
                             fixture.post_state_diff = (
                                 calculate_post_state_diff(
                                     fixture.post_state, group.pre

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -627,6 +627,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "Default: The first (geth) 'evm' entry in PATH."
         ),
     )
+    evm_group.addoption(
+        "--state-db",
+        action="store",
+        dest="state_db",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a client state database directory. When provided, "
+            "t8n reads initial state from this DB (read-only) instead of "
+            "--input.alloc. Requires a snapshot env metadata file at "
+            "<state-db>/env.json containing the head block's env and "
+            "a stateRoot field for verification."
+        ),
+    )
 
     test_group = parser.getgroup(
         "tests", "Arguments defining filler location and output"
@@ -930,6 +944,36 @@ def pytest_configure(config: pytest.Config) -> None:
             "with the xdist plugin; use -n=0.",
             returncode=pytest.ExitCode.USAGE_ERROR,
         )
+    state_db_path = config.getoption("state_db")
+    if state_db_path is not None:
+        if not state_db_path.exists():
+            pytest.exit(
+                f"State database path does not exist: {state_db_path}",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+        env_meta_path = state_db_path / "env.json"
+        if not env_meta_path.exists():
+            pytest.exit(
+                f"Snapshot env metadata not found: {env_meta_path}. "
+                "Expected a valid env JSON file with a stateRoot field.",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+        env_meta = json.loads(env_meta_path.read_text())
+        state_db_root = env_meta.get("stateRoot")
+        if state_db_root is None:
+            pytest.exit(
+                f"Snapshot env metadata missing stateRoot: {env_meta_path}",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+        if t8n.t8n_use_server or t8n.t8n_use_stream:
+            pytest.exit(
+                "--state-db is only supported in filesystem mode, "
+                "not server or stream mode.",
+                returncode=pytest.ExitCode.USAGE_ERROR,
+            )
+        t8n.state_db_path = state_db_path
+        t8n.state_db_root = state_db_root
+
     config.t8n = t8n  # type: ignore[attr-defined]
 
     if "Tools" not in config.stash[metadata_key]:
@@ -1286,8 +1330,9 @@ def t8n(
     else:
         # Test cannot use output cache, remove it
         session_t8n.remove_cache()
-    # Reset the traces
+    # Reset the traces and per-block state-diffs
     session_t8n.reset_traces()
+    session_t8n._state_diffs = [] if session_t8n.state_db_path else None
     session_t8n.call_counter = 0
     session_t8n.debug_dump_dir = dump_dir_parameter_level
     # TODO: Configure the transition tool to count opcodes only when required.
@@ -1674,7 +1719,11 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
             __is_base_test_wrapper__ = True
 
             def __init__(self, *args: Any, **kwargs: Any) -> None:
-                if "pre" not in kwargs:
+                if t8n.state_db_path is not None:
+                    # With state-db, the pre-state is in the DB,
+                    # not in the test's pre allocation.
+                    kwargs["pre"] = pre.__class__()
+                elif "pre" not in kwargs:
                     kwargs["pre"] = pre
                 if "expected_benchmark_gas_used" not in kwargs:
                     kwargs["expected_benchmark_gas_used"] = gas_benchmark_value
@@ -1800,17 +1849,29 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     # TODO: This should be handled by the `generate` method
                     # of the spec.
                     assert isinstance(fixture, BlockchainEngineXFixture)
-                    fixture.pre_hash = pre_alloc_hash
 
-                    # Calculate state diff for efficiency
+                    if t8n.state_db_path is not None:
+                        fixture.pre_hash = t8n.state_db_root
+                    else:
+                        fixture.pre_hash = pre_alloc_hash
+
                     if (
                         hasattr(fixture, "post_state")
                         and fixture.post_state is not None
                     ):
-                        group = session.get_pre_alloc_group(pre_alloc_hash)
-                        fixture.post_state_diff = calculate_post_state_diff(
-                            fixture.post_state, group.pre
-                        )
+                        if t8n.state_db_path is not None:
+                            # In state-db mode, post_state contains only
+                            # accounts modified during execution.
+                            fixture.post_state_diff = fixture.post_state
+                        else:
+                            group = session.get_pre_alloc_group(
+                                pre_alloc_hash
+                            )
+                            fixture.post_state_diff = (
+                                calculate_post_state_diff(
+                                    fixture.post_state, group.pre
+                                )
+                            )
 
                 fill_metadata: Dict[str, Any] = {}
                 if t8n.opcode_count is not None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -1722,7 +1722,10 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                 if t8n.state_db_path is not None:
                     # With state-db, the pre-state is in the DB,
                     # not in the test's pre allocation.
-                    kwargs["pre"] = pre.__class__()
+                    kwargs["pre"] = pre.__class__(
+                        fork=pre._fork,  # type: ignore[arg-type]
+                        flags=pre._flags,
+                    )
                 elif "pre" not in kwargs:
                     kwargs["pre"] = pre
                 if "expected_benchmark_gas_used" not in kwargs:
@@ -1851,6 +1854,7 @@ def base_test_parametrizer(cls: Type[BaseTest]) -> Any:
                     assert isinstance(fixture, BlockchainEngineXFixture)
 
                     if t8n.state_db_path is not None:
+                        assert t8n.state_db_root is not None
                         fixture.pre_hash = t8n.state_db_root
                     else:
                         fixture.pre_hash = pre_alloc_hash

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -470,13 +470,17 @@ class TransitionToolOutput:
 
     @classmethod
     def model_validate_files(
-        cls, directory_path: Path, *, context: Any | None = None
+        cls,
+        directory_path: Path,
+        *,
+        alloc_filename: str = "alloc.json",
+        context: Any | None = None,
     ) -> "Self":
         """
         Validate the model from the file system where each key is a
         different JSON file.
         """
-        alloc_data = (directory_path / "alloc.json").read_text()
+        alloc_data = (directory_path / alloc_filename).read_text()
         result_data = (directory_path / "result.json").read_text()
         result = Result.model_validate_json(
             json_data=result_data, context=context

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -45,7 +45,6 @@ from execution_testing.test_types import Alloc, Environment, Transaction
 
 from .cli_types import (
     LazyAlloc,
-    LazyAllocStr,
     OpcodeCount,
     Traces,
     TransactionReceipt,
@@ -195,7 +194,7 @@ class TransitionTool(EthereumCLI):
     opcode_count: OpcodeCount | None = None
     state_db_path: Path | None = None
     state_db_root: str | None = None
-    _state_diffs: list[LazyAlloc] | None = None
+    _state_diff_jsons: list[str] | None = None
 
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
@@ -242,6 +241,15 @@ class TransitionTool(EthereumCLI):
     def reset_traces(self) -> None:
         """Reset the internal trace storage for a new test to begin."""
         self.traces = []
+
+    @property
+    def use_state_db(self) -> bool:
+        """Return whether state-db mode is active."""
+        return self.state_db_path is not None
+
+    def reset_state_diffs(self) -> None:
+        """Reset per-block state-diffs for a new test."""
+        self._state_diff_jsons = [] if self.use_state_db else None
 
     def append_traces(self, new_traces: Traces) -> None:
         """
@@ -387,12 +395,11 @@ class TransitionTool(EthereumCLI):
             temp_dir_path / "input", **model_dump_config
         )
 
-        use_state_db = self.state_db_path is not None
 
         output_paths = {
             "result": os.path.join("output", "result.json"),
         }
-        if use_state_db:
+        if self.use_state_db:
             output_paths["state_diff"] = os.path.join(
                 "output", "state-diff.json"
             )
@@ -429,19 +436,15 @@ class TransitionTool(EthereumCLI):
             str(t8n_data.chain_id),
         ]
 
-        if use_state_db:
+        if self.use_state_db:
             args.extend(["--input.state-db", str(self.state_db_path)])
-            for i, diff in enumerate(self._state_diffs or []):
+            assert self._state_diff_jsons is not None
+            for i, diff_json in enumerate(self._state_diff_jsons):
                 diff_path = temp_dir_path / "input" / f"state-diff-{i}.json"
-                if isinstance(diff, LazyAllocStr):
-                    diff_path.write_text(diff.raw)
-                else:
-                    diff_path.write_text(
-                        diff.get().model_dump_json(**model_dump_config)
-                    )
+                diff_path.write_text(diff_json)
                 args.extend(["--input.state-diff", str(diff_path)])
             args.extend(["--output.state-diff", output_paths["state_diff"]])
-            if self.state_db_root is not None and not self._state_diffs:
+            if self.state_db_root and not self._state_diff_jsons:
                 args.extend(["--input.state-db-root", self.state_db_root])
         else:
             args.extend(
@@ -518,16 +521,16 @@ class TransitionTool(EthereumCLI):
         if result.returncode != 0:
             raise Exception("failed to evaluate: " + result.stderr.decode())
 
-        alloc_filename = "state-diff.json" if use_state_db else "alloc.json"
+        alloc_filename = "state-diff.json" if self.use_state_db else "alloc.json"
         output = TransitionToolOutput.model_validate_files(
             temp_dir_path / "output",
             alloc_filename=alloc_filename,
             context={"exception_mapper": self.exception_mapper},
         )
-        if use_state_db:
-            if self._state_diffs is None:
-                self._state_diffs = []
-            self._state_diffs.append(output.alloc)
+        if self.use_state_db:
+            assert self._state_diff_jsons is not None
+            diff_raw = (temp_dir_path / "output" / alloc_filename).read_text()
+            self._state_diff_jsons.append(diff_raw)
         if self.supports_opcode_count and self.opcode_count is not None:
             opcode_count_file_path = Path(temp_dir.name) / "opcodes.json"
             if opcode_count_file_path.exists():

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -439,16 +439,10 @@ class TransitionTool(EthereumCLI):
                     diff_path.write_text(
                         diff.model_dump_json(**model_dump_config)
                     )
-                args.extend(
-                    ["--input.state-diff", str(diff_path)]
-                )
-            args.extend(
-                ["--output.state-diff", output_paths["state_diff"]]
-            )
+                args.extend(["--input.state-diff", str(diff_path)])
+            args.extend(["--output.state-diff", output_paths["state_diff"]])
             if self.state_db_root is not None and len(self._state_diffs) == 0:
-                args.extend(
-                    ["--input.state-db-root", self.state_db_root]
-                )
+                args.extend(["--input.state-db-root", self.state_db_root])
         else:
             args.extend(
                 [
@@ -524,9 +518,7 @@ class TransitionTool(EthereumCLI):
         if result.returncode != 0:
             raise Exception("failed to evaluate: " + result.stderr.decode())
 
-        alloc_filename = (
-            "state-diff.json" if use_state_db else "alloc.json"
-        )
+        alloc_filename = "state-diff.json" if use_state_db else "alloc.json"
         output = TransitionToolOutput.model_validate_files(
             temp_dir_path / "output",
             alloc_filename=alloc_filename,

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -45,6 +45,7 @@ from execution_testing.test_types import Alloc, Environment, Transaction
 
 from .cli_types import (
     LazyAlloc,
+    LazyAllocStr,
     OpcodeCount,
     Traces,
     TransactionReceipt,
@@ -192,6 +193,9 @@ class TransitionTool(EthereumCLI):
     debug_dump_dir: Path | None = None
     call_counter: int = 0
     opcode_count: OpcodeCount | None = None
+    state_db_path: Path | None = None
+    state_db_root: str | None = None
+    _state_diffs: list[LazyAlloc] | None = None
 
     supports_opcode_count: ClassVar[bool] = False
     supports_xdist: ClassVar[bool] = True
@@ -383,10 +387,17 @@ class TransitionTool(EthereumCLI):
             temp_dir_path / "input", **model_dump_config
         )
 
+        use_state_db = self.state_db_path is not None
+
         output_paths = {
-            output: os.path.join("output", f"{output}.json")
-            for output in ["alloc", "result"]
+            "result": os.path.join("output", "result.json"),
         }
+        if use_state_db:
+            output_paths["state_diff"] = os.path.join(
+                "output", "state-diff.json"
+            )
+        else:
+            output_paths["alloc"] = os.path.join("output", "alloc.json")
         output_paths["body"] = os.path.join("output", "txs.rlp")
 
         # Get fork name and apply any tool-specific mapping
@@ -402,8 +413,6 @@ class TransitionTool(EthereumCLI):
             str(self.binary),
             "--state.fork",
             fork_name,
-            "--input.alloc",
-            input_paths["alloc"],
             "--input.env",
             input_paths["env"],
             "--input.txs",
@@ -412,8 +421,6 @@ class TransitionTool(EthereumCLI):
             temp_dir.name,
             "--output.result",
             output_paths["result"],
-            "--output.alloc",
-            output_paths["alloc"],
             "--output.body",
             output_paths["body"],
             "--state.reward",
@@ -421,6 +428,36 @@ class TransitionTool(EthereumCLI):
             "--state.chainid",
             str(t8n_data.chain_id),
         ]
+
+        if use_state_db:
+            args.extend(["--input.state-db", str(self.state_db_path)])
+            for i, diff in enumerate(self._state_diffs):
+                diff_path = temp_dir_path / "input" / f"state-diff-{i}.json"
+                if isinstance(diff, LazyAllocStr):
+                    diff_path.write_text(diff.raw)
+                else:
+                    diff_path.write_text(
+                        diff.model_dump_json(**model_dump_config)
+                    )
+                args.extend(
+                    ["--input.state-diff", str(diff_path)]
+                )
+            args.extend(
+                ["--output.state-diff", output_paths["state_diff"]]
+            )
+            if self.state_db_root is not None and len(self._state_diffs) == 0:
+                args.extend(
+                    ["--input.state-db-root", self.state_db_root]
+                )
+        else:
+            args.extend(
+                [
+                    "--input.alloc",
+                    input_paths["alloc"],
+                    "--output.alloc",
+                    output_paths["alloc"],
+                ]
+            )
         if self.supports_opcode_count and self.opcode_count is not None:
             args.extend(
                 [
@@ -487,10 +524,16 @@ class TransitionTool(EthereumCLI):
         if result.returncode != 0:
             raise Exception("failed to evaluate: " + result.stderr.decode())
 
+        alloc_filename = (
+            "state-diff.json" if use_state_db else "alloc.json"
+        )
         output = TransitionToolOutput.model_validate_files(
             temp_dir_path / "output",
+            alloc_filename=alloc_filename,
             context={"exception_mapper": self.exception_mapper},
         )
+        if use_state_db:
+            self._state_diffs.append(output.alloc)
         if self.supports_opcode_count and self.opcode_count is not None:
             opcode_count_file_path = Path(temp_dir.name) / "opcodes.json"
             if opcode_count_file_path.exists():

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -395,7 +395,6 @@ class TransitionTool(EthereumCLI):
             temp_dir_path / "input", **model_dump_config
         )
 
-
         output_paths = {
             "result": os.path.join("output", "result.json"),
         }
@@ -521,7 +520,9 @@ class TransitionTool(EthereumCLI):
         if result.returncode != 0:
             raise Exception("failed to evaluate: " + result.stderr.decode())
 
-        alloc_filename = "state-diff.json" if self.use_state_db else "alloc.json"
+        alloc_filename = (
+            "state-diff.json" if self.use_state_db else "alloc.json"
+        )
         output = TransitionToolOutput.model_validate_files(
             temp_dir_path / "output",
             alloc_filename=alloc_filename,

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -431,17 +431,17 @@ class TransitionTool(EthereumCLI):
 
         if use_state_db:
             args.extend(["--input.state-db", str(self.state_db_path)])
-            for i, diff in enumerate(self._state_diffs):
+            for i, diff in enumerate(self._state_diffs or []):
                 diff_path = temp_dir_path / "input" / f"state-diff-{i}.json"
                 if isinstance(diff, LazyAllocStr):
                     diff_path.write_text(diff.raw)
                 else:
                     diff_path.write_text(
-                        diff.model_dump_json(**model_dump_config)
+                        diff.get().model_dump_json(**model_dump_config)
                     )
                 args.extend(["--input.state-diff", str(diff_path)])
             args.extend(["--output.state-diff", output_paths["state_diff"]])
-            if self.state_db_root is not None and len(self._state_diffs) == 0:
+            if self.state_db_root is not None and not self._state_diffs:
                 args.extend(["--input.state-db-root", self.state_db_root])
         else:
             args.extend(
@@ -525,6 +525,8 @@ class TransitionTool(EthereumCLI):
             context={"exception_mapper": self.exception_mapper},
         )
         if use_state_db:
+            if self._state_diffs is None:
+                self._state_diffs = []
             self._state_diffs.append(output.alloc)
         if self.supports_opcode_count and self.opcode_count is not None:
             opcode_count_file_path = Path(temp_dir.name) / "opcodes.json"

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -296,9 +296,7 @@ class T8N(Load):
             self.options.input_state_diff is not None
             and self.options.input_state_db is None
         ):
-            raise ValueError(
-                "--input.state-diff requires --input.state-db."
-            )
+            raise ValueError("--input.state-diff requires --input.state-db.")
 
         if self.options.input_state_db is not None:
             raise NotImplementedError(

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -64,7 +64,32 @@ def t8n_arguments(subparsers: argparse._SubParsersAction) -> None:
         default=None,
     )
     t8n_parser.add_argument(
+        "--input.state-db",
+        dest="input_state_db",
+        type=str,
+        default=None,
+    )
+    t8n_parser.add_argument(
+        "--input.state-diff",
+        dest="input_state_diff",
+        type=str,
+        action="append",
+        default=None,
+    )
+    t8n_parser.add_argument(
+        "--input.state-db-root",
+        dest="input_state_db_root",
+        type=str,
+        default=None,
+    )
+    t8n_parser.add_argument(
         "--output.alloc", dest="output_alloc", type=str, default="alloc.json"
+    )
+    t8n_parser.add_argument(
+        "--output.state-diff",
+        dest="output_state_diff",
+        type=str,
+        default=None,
     )
     t8n_parser.add_argument(
         "--output.basedir", dest="output_basedir", type=str, default="."
@@ -266,6 +291,21 @@ class T8N(Load):
         super().__init__(fork)
 
         self.chain_id = parse_hex_or_int(self.options.state_chainid, U64)
+
+        if (
+            self.options.input_state_diff is not None
+            and self.options.input_state_db is None
+        ):
+            raise ValueError(
+                "--input.state-diff requires --input.state-db."
+            )
+
+        if self.options.input_state_db is not None:
+            raise NotImplementedError(
+                "--input.state-db is not supported by the Python t8n. "
+                "Use a client t8n implementation (geth, nethermind, etc.)."
+            )
+
         self.alloc = Alloc(self, stdin)
         self.env = Env(self, stdin)
         self.txs = Txs(self, stdin)


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

This allows t8n to access a database for state, storing the state diffs in memory.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
