### PR TITLE
fix: Remove inaccurate 'unimplemented stub' comment from encode_node

### DIFF
--- a/src/ethereum/forks/berlin/trie.py
+++ b/src/ethereum/forks/berlin/trie.py
@@ -174,7 +174,6 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
 
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None


### PR DESCRIPTION
## Description

The `encode_node` function in `src/ethereum/forks/berlin/trie.py` was documented as "Currently mostly an unimplemented stub" but it is actually fully implemented.

## Current Implementation

The function handles:
- `Account` objects (via `encode_account`)
- `LegacyTransaction` and `Receipt` objects (via `rlp.encode`)
- `U256` and `Uint` numeric types (via `rlp.encode`)
- `Bytes` (returned as-is)
- Other node types (fallback to `previous_trie.encode_node`)

## Issue

The misleading docstring could confuse developers reading the code, suggesting the function is incomplete when it actually handles all node types properly.

## Fix

Remove the inaccurate "Currently mostly an unimplemented stub" comment from the docstring.

Fixes #1186