### PR TITLE
fix: Remove inaccurate 'unimplemented stub' comments from all fork encode_node functions

### DIFF
--- a/src/ethereum/forks/amsterdam/trie.py
+++ b/src/ethereum/forks/amsterdam/trie.py
@@ -133,8 +133,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/arrow_glacier/trie.py
+++ b/src/ethereum/forks/arrow_glacier/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/berlin/trie.py
+++ b/src/ethereum/forks/berlin/trie.py
@@ -174,7 +174,6 @@ def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
 
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/berlin/trie.py
+++ b/src/ethereum/forks/berlin/trie.py
@@ -173,7 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/bpo1/trie.py
+++ b/src/ethereum/forks/bpo1/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/bpo2/trie.py
+++ b/src/ethereum/forks/bpo2/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/bpo3/trie.py
+++ b/src/ethereum/forks/bpo3/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/bpo4/trie.py
+++ b/src/ethereum/forks/bpo4/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/bpo5/trie.py
+++ b/src/ethereum/forks/bpo5/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/byzantium/trie.py
+++ b/src/ethereum/forks/byzantium/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/cancun/trie.py
+++ b/src/ethereum/forks/cancun/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/constantinople/trie.py
+++ b/src/ethereum/forks/constantinople/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/dao_fork/trie.py
+++ b/src/ethereum/forks/dao_fork/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/frontier/trie.py
+++ b/src/ethereum/forks/frontier/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/gray_glacier/trie.py
+++ b/src/ethereum/forks/gray_glacier/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/homestead/trie.py
+++ b/src/ethereum/forks/homestead/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/istanbul/trie.py
+++ b/src/ethereum/forks/istanbul/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/london/trie.py
+++ b/src/ethereum/forks/london/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/muir_glacier/trie.py
+++ b/src/ethereum/forks/muir_glacier/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/osaka/trie.py
+++ b/src/ethereum/forks/osaka/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/paris/trie.py
+++ b/src/ethereum/forks/paris/trie.py
@@ -174,8 +174,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/prague/trie.py
+++ b/src/ethereum/forks/prague/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/shanghai/trie.py
+++ b/src/ethereum/forks/shanghai/trie.py
@@ -175,8 +175,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/spurious_dragon/trie.py
+++ b/src/ethereum/forks/spurious_dragon/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None

--- a/src/ethereum/forks/tangerine_whistle/trie.py
+++ b/src/ethereum/forks/tangerine_whistle/trie.py
@@ -173,8 +173,6 @@ def encode_internal_node(node: Optional[InternalNode]) -> Extended:
 def encode_node(node: Node, storage_root: Optional[Bytes] = None) -> Bytes:
     """
     Encode a Node for storage in the Merkle Trie.
-
-    Currently mostly an unimplemented stub.
     """
     if isinstance(node, Account):
         assert storage_root is not None


### PR DESCRIPTION
## Description

This PR fixes a systematic documentation bug across 23 Ethereum fork implementations. The `encode_node` function is fully implemented in all forks, but the docstring incorrectly claimed it was "Currently mostly an unimplemented stub."

## Problem

The misleading docstring existed in 23 fork versions:
- amsterdam, arrow_glacier, bpo1-5, byzantium, cancun, constantinople
- dao_fork, frontier, gray_glacier, homestead, istanbul, london
- muir_glacier, osaka, paris, prague, shanghai, spurious_dragon, tangerine_whistle

## Current Implementation (All Forks)

The `encode_node` function properly handles:
- `Account` objects (via `encode_account`)
- `LegacyTransaction` and `Receipt` objects (via `rlp.encode`)
- `U256` and `Uint` numeric types (via `rlp.encode`)
- `Bytes` (returned as-is)
- Other node types (fallback to `previous_trie.encode_node`)

## Impact

The inaccurate docstring could confuse developers reading the code, suggesting the function is incomplete when it actually handles all node types properly.

## Changes

Removes the line "Currently mostly an unimplemented stub." from all 23 affected fork implementations.

## Related

This is a follow-up to PR #2626 which fixed the same issue in the berlin fork.

Fixes #1186