### PR TITLE
feat(test-benchmark): add cache strategy to storage benchmark

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/execute/pre_alloc.py
@@ -44,6 +44,7 @@ from execution_testing.tools import Initcode
 from execution_testing.vm import Bytecode, Op
 
 from ..shared.address_stubs import AddressStubs
+from ..shared.execute_fill import stub_eoas_key
 from ..shared.pre_alloc import Alloc as SharedAlloc
 from ..shared.pre_alloc import AllocFlags
 from .contracts import (
@@ -106,6 +107,14 @@ def address_stubs(
     else:
         logger.debug("No address stubs configured")
     return address_stubs
+
+
+@pytest.fixture(scope="session")
+def stub_eoas(
+    request: pytest.FixtureRequest,
+) -> Dict[str, EOA]:
+    """Return stub EOAs pre-populated during configuration."""
+    return request.config.stash.get(stub_eoas_key, {})
 
 
 @pytest.fixture(scope="session")
@@ -973,6 +982,7 @@ def pre(
     eth_rpc: EthRPC,
     chain_config: ChainConfig,
     address_stubs: AddressStubs | None,
+    stub_eoas: Dict[str, EOA],
     skip_cleanup: bool,
     max_fee_per_gas: int,
     max_priority_fee_per_gas: int,
@@ -994,6 +1004,7 @@ def pre(
     pre = Alloc(
         fork=actual_fork,
         flags=alloc_flags,
+        stub_eoas=stub_eoas,
         sender=worker_key,
         eth_rpc=eth_rpc,
         eoa_iterator=eoa_iterator,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/pre_alloc.py
@@ -69,7 +69,6 @@ class Alloc(SharedAlloc):
     _eoa_fund_amount_default: int = PrivateAttr(10**21)
     _account_salt: Dict[Hash, int] = PrivateAttr(default_factory=dict)
     _stub_accounts: Dict[str, Account] = PrivateAttr(default_factory=dict)
-    _stub_eoas: Dict[str, EOA] = PrivateAttr(default_factory=dict)
 
     def __init__(
         self,
@@ -81,20 +80,15 @@ class Alloc(SharedAlloc):
         **kwargs: Any,
     ) -> None:
         """Initialize the pre-alloc."""
-        super().__init__(*args, fork=fork, flags=flags, **kwargs)
+        super().__init__(
+            *args,
+            fork=fork,
+            flags=flags,
+            stub_eoas=stub_eoas,
+            **kwargs,
+        )
         if stub_accounts is not None:
             self._stub_accounts = stub_accounts
-        if stub_eoas is not None:
-            self._stub_eoas = stub_eoas
-
-    def stub_eoa(self, label: str) -> EOA:
-        """Return the EOA for a key-bearing stub."""
-        if label not in self._stub_eoas:
-            raise ValueError(
-                f"Stub EOA '{label}' not found. "
-                "Provide --address-stubs with a pkey entry."
-            )
-        return self._stub_eoas[label]
 
     def get_next_account_salt(self, account_hash: Hash) -> int:
         """Retrieve the next salt for this account."""

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -1,7 +1,7 @@
 """Shared pre-alloc functionality."""
 
 from enum import IntFlag, auto
-from typing import Any, Literal, Set
+from typing import Any, Dict, Literal, Set
 
 from pydantic import PrivateAttr
 
@@ -43,6 +43,7 @@ class Alloc(BaseAlloc):
     _hardcoded_addresses_deployed_to: Set[Address] = PrivateAttr(
         default_factory=set
     )
+    _stub_eoas: Dict[str, EOA] = PrivateAttr(default_factory=dict)
 
     def is_mutable(self) -> bool:
         """Return whether the pre-alloc is mutable."""
@@ -62,12 +63,24 @@ class Alloc(BaseAlloc):
         *args: Any,
         fork: Fork,
         flags: AllocFlags,
+        stub_eoas: Dict[str, EOA] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize allocation with the given properties."""
         super().__init__(*args, **kwargs)
         self._fork = fork
         self._flags = flags
+        if stub_eoas is not None:
+            self._stub_eoas = stub_eoas
+
+    def stub_eoa(self, label: str) -> EOA:
+        """Return the EOA for a key-bearing stub."""
+        if label not in self._stub_eoas:
+            raise ValueError(
+                f"Stub EOA '{label}' not found. "
+                "Provide --address-stubs with a pkey entry."
+            )
+        return self._stub_eoas[label]
 
     def __setitem__(
         self,

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/shared/pre_alloc.py
@@ -80,7 +80,7 @@ class Alloc(BaseAlloc):
                 f"Stub EOA '{label}' not found. "
                 "Provide --address-stubs with a pkey entry."
             )
-        return self._stub_eoas[label]
+        return self._stub_eoas[label].copy()
 
     def __setitem__(
         self,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -188,7 +188,7 @@ def test_sload_bloated(
         + Op.SLOAD  # [s[index], index]
         + Op.POP  # [index]
     )
-    # CACHE_TX: access each slot twice so the second hit is unchached
+    # CACHE_TX: access each slot twice so the second hit is uncached
     if cache_strategy == CacheStrategy.CACHE_TX:
         slot_access *= 2
 
@@ -275,7 +275,8 @@ def test_sstore_bloated(
     # The cache mechanism touches the slot before SSTORE
 
     runtime_code = (
-        +While(
+        setup
+        + While(
             body=(
                 cache_op  # [slot, value]
                 + Op.DUP2  # [value, slot, value]

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -99,6 +99,7 @@ def run_bloated_eoa_benchmark(
     authority: EOA,
     existing_slots: bool,
     runtime_code: Bytecode,
+    cache_strategy: CacheStrategy,
 ) -> None:
     """
     Run a bloated-EOA benchmark with the given runtime delegation code.
@@ -125,17 +126,32 @@ def run_bloated_eoa_benchmark(
     sender = pre.fund_eoa()
 
     txs: list[Transaction] = []
-    while gas_available >= intrinsic_gas:
-        tx_gas = min(gas_available, tx_gas_limit)
-        txs.append(
-            Transaction(
-                gas_limit=tx_gas,
-                to=authority,
-                sender=sender,
+    with TestPhaseManager.execution():
+        while gas_available >= intrinsic_gas:
+            tx_gas = min(gas_available, tx_gas_limit)
+            txs.append(
+                Transaction(
+                    gas_limit=tx_gas,
+                    to=authority,
+                    sender=sender,
+                )
             )
-        )
-        gas_available -= tx_gas
-    blocks.append(Block(txs=txs))
+            gas_available -= tx_gas
+
+    cache_txs: list[Transaction] = []
+    if cache_strategy == CacheStrategy.CACHE_PREVIOUS_BLOCK:
+        with TestPhaseManager.setup():
+            cache_sender = pre.fund_eoa()
+            for tx in txs:
+                cache_txs.append(
+                    Transaction(
+                        gas_limit=tx.gas_limit,
+                        to=authority,
+                        sender=cache_sender,
+                    )
+                )
+
+    blocks += build_cache_strategy_blocks(cache_strategy, txs, cache_txs)
 
     benchmark_test(
         pre=pre,
@@ -148,6 +164,7 @@ def run_bloated_eoa_benchmark(
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("existing_slots", [False, True])
+@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 def test_sload_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -156,6 +173,7 @@ def test_sload_bloated(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
+    cache_strategy: CacheStrategy,
 ) -> None:
     """
     Benchmark SLOAD opcodes targeting an EOA with storage bloated.
@@ -165,14 +183,28 @@ def test_sload_bloated(
     storage layout of the target account, then the existing_slots
     parameter will not be correct.
     """
+    slot_access = (
+        Op.DUP1  # [index, index]
+        + Op.SLOAD  # [s[index], index]
+        + Op.POP  # [index]
+    )
+    # CACHE_TX: access each slot twice so the second hit is unchached
+    if cache_strategy == CacheStrategy.CACHE_TX:
+        slot_access *= 2
+
     runtime_code = (
-        Op.SLOAD(Op.PUSH0)
+        Op.PUSH0  # [0]
+        + Op.SLOAD  # [index], s[0] = index
         + While(
-            body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
+            body=(
+                slot_access
+                + Op.PUSH1(1)  # [1, index]
+                + Op.ADD  # [index+1]
+            ),
             condition=Op.GT(Op.GAS, 0xFFFF),
         )
-        + Op.PUSH0
-        + Op.SSTORE
+        + Op.PUSH0  # [0, index+1]
+        + Op.SSTORE  # s[0] = index+1
     )
 
     run_bloated_eoa_benchmark(
@@ -184,6 +216,7 @@ def test_sload_bloated(
         authority=pre.stub_eoa(token_name),
         existing_slots=existing_slots,
         runtime_code=runtime_code,
+        cache_strategy=cache_strategy,
     )
 
 
@@ -191,6 +224,7 @@ def test_sload_bloated(
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("write_new_value", [False, True])
 @pytest.mark.parametrize("existing_slots", [True, False])
+@pytest.mark.parametrize("cache_strategy", list(CacheStrategy))
 def test_sstore_bloated(
     benchmark_test: BenchmarkTestFiller,
     pre: Alloc,
@@ -200,6 +234,7 @@ def test_sstore_bloated(
     token_name: str,
     write_new_value: bool,
     existing_slots: bool,
+    cache_strategy: CacheStrategy,
 ) -> None:
     """
     Benchmark SSTORE opcodes targeting an EOA with storage bloated.
@@ -213,29 +248,50 @@ def test_sstore_bloated(
     test what they claim to do. For instance, for `write_new_value`
     set to False we need to know the current value of the slots.
     """
-    stack_init = Op.DUP1 + (
-        Op.PUSH1(1) + Op.ADD + Op.SWAP1 if write_new_value else Bytecode()
+    setup = (
+        Op.PUSH0  # [0]
+        + Op.SLOAD  # [key], s[0] = key
+        + Op.DUP1  # [key, key]
     )
 
+    if write_new_value:
+        setup += (
+            Op.PUSH1(1)  # [1, key, key]
+            + Op.ADD  # [key+1, key]
+            + Op.SWAP1  # [key, key+1]
+        )
+
+    # After setup phase, the stack element represents
+    # [slot, value], slot to write and value to write
+
+    cache_op = Bytecode()
+    if cache_strategy == CacheStrategy.CACHE_TX:
+        cache_op = (
+            Op.DUP1  # [slot, slot, value]
+            + Op.SLOAD  # [s[slot], slot, value]
+            + Op.POP  # [slot, value]
+        )
+
+    # The cache mechanism touches the slot before SSTORE
+
     runtime_code = (
-        Op.SLOAD(Op.PUSH0)
-        + stack_init
-        + While(
+        +While(
             body=(
-                Op.DUP2
-                + Op.DUP2
-                + Op.SSTORE
-                + Op.PUSH1(1)
-                + Op.ADD
-                + Op.SWAP1
-                + Op.PUSH1(1)
-                + Op.ADD
-                + Op.SWAP1
+                cache_op  # [slot, value]
+                + Op.DUP2  # [value, slot, value]
+                + Op.DUP2  # [slot, value, slot, value]
+                + Op.SSTORE  # [slot, value], s[slot] = value
+                + Op.PUSH1(1)  # [1, slot, value]
+                + Op.ADD  # [slot+1, value]
+                + Op.SWAP1  # [value, slot+1]
+                + Op.PUSH1(1)  # [1, value, slot+1]
+                + Op.ADD  # [value+1, slot+1]
+                + Op.SWAP1  # [slot+1, value+1]
             ),
             condition=Op.GT(Op.GAS, 0xFFFF),
         )
-        + Op.PUSH0
-        + Op.SSTORE
+        + Op.PUSH0  # [0, slot+1, value+1]
+        + Op.SSTORE  # s[0] = slot+1
     )
 
     run_bloated_eoa_benchmark(
@@ -247,6 +303,7 @@ def test_sstore_bloated(
         authority=pre.stub_eoa(token_name),
         existing_slots=existing_slots,
         runtime_code=runtime_code,
+        cache_strategy=cache_strategy,
     )
 
 


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

We have test_sload_bloated and test_sstore_bloated benchmark, which uses the 7702 approach. However, these benchmarks do not support different cache mechanism, this PR adds the lacking cache dimension.

cc @CPerezz 

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
None

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
