### PR TITLE
feat(scripts): skip @manually-enhanced files in filler_to_python

### DIFF
--- a/scripts/filler_to_python/__main__.py
+++ b/scripts/filler_to_python/__main__.py
@@ -16,6 +16,21 @@ from .render import render_test
 
 logger = logging.getLogger(__name__)
 
+MANUALLY_ENHANCED_TAG = "@manually-enhanced"
+
+
+def _has_manually_enhanced_tag(file_path: Path) -> bool:
+    """Check if a file has @manually-enhanced in its module docstring."""
+    try:
+        source = file_path.read_text()
+        tree = ast.parse(source)
+    except (OSError, SyntaxError):
+        return False
+    docstring = ast.get_docstring(tree)
+    if docstring is None:
+        return False
+    return MANUALLY_ENHANCED_TAG in docstring
+
 
 def post_format(source: str) -> str:
     """Format generated Python source with ruff."""
@@ -118,7 +133,7 @@ def process_single_filler(
     """
     Process one filler file.
 
-    Return "ok", "fail", or "warn".
+    Return "ok", "fail", "warn", or "skip".
     """
     try:
         # Relative path for the generated test's ported_from marker
@@ -126,6 +141,19 @@ def process_single_filler(
             rel_path = filler_path.relative_to(fillers_base.parent)
         except ValueError:
             rel_path = filler_path
+
+        # Skip files that have been manually enhanced
+        category = rel_path.parts[-2] if len(rel_path.parts) >= 2 else ""
+        out_file = (
+            output_dir / category / _filler_name_to_filename(filler_path.stem)
+        )
+        if out_file.exists() and _has_manually_enhanced_tag(out_file):
+            logger.info(
+                "SKIP: %s (existing file has %s tag)",
+                out_file,
+                MANUALLY_ENHANCED_TAG,
+            )
+            return "skip"
 
         # Load
         test_name, model = load_filler(filler_path)
@@ -155,18 +183,15 @@ def process_single_filler(
             return "ok"
 
         # Write
-        category = rel_path.parts[-2] if len(rel_path.parts) >= 2 else ""
-        out_subdir = output_dir / category
-        out_subdir.mkdir(parents=True, exist_ok=True)
+        out_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Write __init__.py if needed
-        init_file = out_subdir / "__init__.py"
+        init_file = out_file.parent / "__init__.py"
         if not init_file.exists():
             init_file.write_text(
                 f'"""Ported static tests: {category}."""  # noqa: N999\n'
             )
 
-        out_file = out_subdir / _filler_name_to_filename(filler_path.stem)
         out_file.write_text(source)
         logger.info("OK: %s -> %s", filler_path.name, out_file)
         return "ok"
@@ -251,7 +276,7 @@ def main() -> None:
 
     logger.info("Processing %d filler(s)...", len(filler_paths))
 
-    counts = {"ok": 0, "fail": 0, "warn": 0}
+    counts = {"ok": 0, "fail": 0, "warn": 0, "skip": 0}
     for filler_path in filler_paths:
         status = process_single_filler(
             filler_path,
@@ -263,9 +288,11 @@ def main() -> None:
 
     # Summary
     total = sum(counts.values())
+    skip_msg = f", {counts['skip']} skipped" if counts["skip"] else ""
     print(
         f"\nDone: {counts['ok']}/{total} OK, "
         f"{counts['fail']} failed, {counts['warn']} warnings"
+        f"{skip_msg}"
     )
     if counts["fail"] > 0:
         sys.exit(1)


### PR DESCRIPTION
## 🗒️ Description

`filler_to_python` now skips overwriting test files in the output directory that contain `@manually-enhanced` in their module docstring. The check happens early — before loading, analyzing, or rendering — so skipped files incur no processing cost. Skipped files are reported in the summary line.

This allows manually reviewed and improved ported tests to coexist with regenerated ones. To protect a file, add the tag to its module docstring:

```python
"""
Test_something.

Ported from:
state_tests/stCategory/somethingFiller.yml

@manually-enhanced: Do not overwrite. This test has been manually reviewed and
enhanced.
"""
```

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![Sea otter](https://upload.wikimedia.org/wikipedia/commons/0/02/Sea_Otter_%28Enhydra_lutris%29_%2825169790524%29_crop.jpg)