### PR TITLE
chore(test-client-clis): update `GAS_USED_OVERFLOW` exception mapper

### DIFF
--- a/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
+++ b/packages/testing/src/execution_testing/client_clis/clis/ethrex.py
@@ -32,7 +32,7 @@ class EthrexExceptionMapper(ExceptionMapper):
             "World State Root does not match the one in "
             "the header after executing"
         ),
-        BlockException.GAS_USED_OVERFLOW: "Block gas used overflow",
+        BlockException.GAS_USED_OVERFLOW: "Gas allowance exceeded",
         BlockException.INVALID_BLOCK_ACCESS_LIST: (
             "Block access list hash does not match the one in "
             "the header after executing"
@@ -142,7 +142,7 @@ class EthrexExceptionMapper(ExceptionMapper):
         TransactionException.GAS_ALLOWANCE_EXCEEDED: (
             r"Gas allowance exceeded.*"
         ),
-        BlockException.GAS_USED_OVERFLOW: (r"Block gas used overflow.*"),
+        BlockException.GAS_USED_OVERFLOW: (r"Gas allowance exceeded.*"),
         TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED: (
             r"Blob count exceeded.*"
         ),


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->
<!-- Don't submit this PR if it could expose a mainnet bug, see SECURITY.md in the repo root for details -->

ethrex no longer includes "Block gas used overflow" in its per-tx gas check error messages. Map `GAS_USED_OVERFLOW` to the same "Gas allowance exceeded" pattern used for `GAS_ALLOWANCE_EXCEEDED`, since ethrex uses a single per-tx check for both cases.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
