### PR TITLE
experiments(test-fill): add local t8n cache with SQLite + pickle + zlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ cached_downloads/
 __pycache__/
 .pytest_cache/
 pytest-cache-files-*/
+.t8n-cache*
 
 # Distribution / packaging
 .Python

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/disk_cache.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/disk_cache.py
@@ -1,0 +1,395 @@
+"""Disk-based cache for t8n outputs that persists across fill runs."""
+
+import hashlib
+import json
+import logging
+import pickle
+import re
+import sqlite3
+import zlib
+from pathlib import Path
+from typing import Any, Dict
+
+from execution_testing.base_types import Bytes
+from execution_testing.client_clis.cli_types import (
+    LazyAllocJson,
+    LazyAllocStr,
+    Result,
+    TransitionToolOutput,
+    TransitionToolRequest,
+)
+from execution_testing.client_clis.transition_tool import model_dump_config
+
+logger = logging.getLogger(__name__)
+
+
+def fork_name_to_module(fork_name: str) -> str:
+    """
+    Convert a PascalCase fork name to its snake_case module/directory name.
+
+    E.g. "ArrowGlacier" -> "arrow_glacier", "BPO1" -> "bpo1".
+    """
+    # Handle BPO forks: "BPO1" -> "bpo1"
+    if fork_name.upper().startswith("BPO"):
+        return fork_name.lower()
+    # Standard PascalCase to snake_case
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", fork_name)
+    return s.lower()
+
+
+def hash_files(directory: Path) -> bytes:
+    """
+    Hash all .py files in a directory tree.
+
+    Return raw SHA-256 digest bytes. Files are sorted by relative path
+    for determinism.
+    """
+    h = hashlib.sha256()
+    for py_file in sorted(directory.rglob("*.py")):
+        h.update(str(py_file.relative_to(directory)).encode())
+        h.update(py_file.read_bytes())
+    return h.digest()
+
+
+def compute_shared_spec_hash(ethereum_root: Path) -> bytes:
+    """
+    Hash all shared spec modules (everything in src/ethereum/ except forks/).
+
+    Return raw SHA-256 digest bytes.
+    """
+    h = hashlib.sha256()
+    for py_file in sorted(ethereum_root.rglob("*.py")):
+        rel = py_file.relative_to(ethereum_root)
+        if rel.parts and rel.parts[0] == "forks":
+            continue
+        h.update(str(rel).encode())
+        h.update(py_file.read_bytes())
+    return h.digest()
+
+
+def compute_fork_spec_hash(
+    fork_name: str,
+    ethereum_root: Path,
+    shared_hash: bytes,
+) -> str:
+    """
+    Compute a spec hash for a given fork.
+
+    Combine the shared modules hash with the fork-specific directory hash.
+    Return a hex string (truncated to 16 chars for directory names).
+    """
+    module_name = fork_name_to_module(fork_name)
+    fork_dir = ethereum_root / "forks" / module_name
+    h = hashlib.sha256()
+    h.update(shared_hash)
+    if fork_dir.is_dir():
+        h.update(hash_files(fork_dir))
+    return h.hexdigest()[:16]
+
+
+def compute_content_hash(
+    request_data: TransitionToolRequest,
+    state_test: bool,
+) -> str:
+    """
+    Compute a content hash for a t8n call.
+
+    Hash the context (fork, chain_id, reward), alloc, env, txs,
+    and blob_params. Uses raw alloc representations when available
+    to avoid expensive model_dump() calls.
+    """
+    h = hashlib.sha256()
+
+    def feed(data: bytes) -> None:
+        """Update hash with length-prefixed data to prevent collisions."""
+        h.update(len(data).to_bytes(4, "big"))
+        h.update(data)
+
+    def feed_json_sorted(obj: Any) -> None:
+        """Serialize to sorted JSON then feed to hash."""
+        feed(json.dumps(obj, sort_keys=True, separators=(",", ":")).encode())
+
+    # State context (fork, chain_id, reward) — fixed fields, no dicts
+    feed(request_data.state.model_dump_json(**model_dump_config).encode())
+    # Alloc: use pre-computed state_root for LazyAlloc (free),
+    # fall back to sorted serialization for genesis Alloc (block 0).
+    alloc = request_data.input.alloc
+    if isinstance(alloc, (LazyAllocStr, LazyAllocJson)):
+        feed(bytes(alloc.state_root()))
+    else:
+        assert hasattr(alloc, "model_dump")
+        feed_json_sorted(alloc.model_dump(mode="json", **model_dump_config))
+    # Env — contains dict fields (blockHashes), must sort keys
+    feed_json_sorted(
+        request_data.input.env.model_dump(mode="json", **model_dump_config)
+    )
+    # Txs — fixed fields per tx, but sort for safety
+    for tx in request_data.input.txs:
+        feed_json_sorted(tx.model_dump(mode="json", **model_dump_config))
+    # Blob params
+    if request_data.input.blob_params is not None:
+        feed_json_sorted(
+            request_data.input.blob_params.model_dump(
+                mode="json", **model_dump_config
+            )
+        )
+    feed(b"\x01" if state_test else b"\x00")
+    return h.hexdigest()
+
+
+def serialize_output(output: TransitionToolOutput) -> bytes:
+    """
+    Serialize a TransitionToolOutput to pickle bytes.
+
+    Build a plain dict of strings/dicts (no Pydantic models) then pickle
+    it. This is portable across Python versions since we only pickle
+    primitive types.
+    """
+    if isinstance(output.alloc, LazyAllocStr):
+        alloc_str = output.alloc.raw
+    elif isinstance(output.alloc, LazyAllocJson):
+        alloc_str = json.dumps(
+            output.alloc.raw, sort_keys=True, separators=(",", ":")
+        )
+    else:
+        alloc_str = output.alloc.get().model_dump_json(**model_dump_config)
+
+    data = {
+        "alloc": alloc_str,
+        "result": output.result.model_dump(mode="json", **model_dump_config),
+        "body": output.body.hex() if output.body else None,
+    }
+    return pickle.dumps(data, protocol=5)
+
+
+def deserialize_output(
+    data: Dict[str, Any],
+    context: Any | None = None,
+) -> TransitionToolOutput:
+    """Deserialize a dict back to a TransitionToolOutput."""
+    result = Result.model_validate(obj=data["result"], context=context)
+    # alloc is always stored as a JSON string in serialize_output
+    alloc = LazyAllocStr(raw=data["alloc"], _state_root=result.state_root)
+    body = Bytes(bytes.fromhex(data["body"])) if data.get("body") else None
+    return TransitionToolOutput(alloc=alloc, result=result, body=body)
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS cache (
+    spec_hash    TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    data         BLOB NOT NULL,
+    PRIMARY KEY (spec_hash, content_hash)
+) WITHOUT ROWID
+"""
+
+
+class DiskCache:
+    """
+    Content-addressed SQLite cache for t8n outputs.
+
+    Cache entries are keyed by (spec_hash, content_hash) where:
+    - spec_hash identifies the EELS source code version for a fork
+    - content_hash identifies the specific t8n call inputs
+
+    Uses WAL mode for safe concurrent access under xdist.
+    Entries are pickle-serialized plain dicts (portable across
+    Python versions).
+    """
+
+    def __init__(
+        self,
+        db_path: Path,
+        exception_mapper_context: Any | None = None,
+    ) -> None:
+        """Initialize the disk cache."""
+        self.db_path = db_path
+        self.exception_mapper_context = exception_mapper_context
+        self.spec_hashes: Dict[str, str] = {}
+        self.shared_hash: bytes | None = None
+        self.ethereum_root: Path | None = None
+        self.hits = 0
+        self.misses = 0
+        self.connection: sqlite3.Connection | None = None
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        """Lazy connection initialization with WAL mode."""
+        if self.connection is None:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self.connection = sqlite3.connect(
+                str(self.db_path),
+                timeout=10.0,
+                isolation_level=None,  # autocommit
+            )
+            self.connection.execute("PRAGMA journal_mode=WAL")
+            self.connection.execute("PRAGMA synchronous=NORMAL")
+            self.connection.execute("PRAGMA cache_size=-2000")
+            self.connection.execute("PRAGMA mmap_size=0")
+            self.connection.execute(SCHEMA)
+        return self.connection
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    def set_ethereum_root(self, ethereum_root: Path) -> None:
+        """
+        Set the ethereum package root for spec hash computation.
+
+        Compute the shared modules hash once upfront.
+        """
+        self.ethereum_root = ethereum_root
+        self.shared_hash = compute_shared_spec_hash(ethereum_root)
+        logger.debug(
+            "Disk cache: computed shared spec hash from %s",
+            ethereum_root,
+        )
+
+    def get_spec_hash(self, fork: Any) -> str:
+        """
+        Get the spec hash for a fork, computing it on first access.
+
+        For transition forks (e.g. ShanghaiToCancunAtTime15k), hash
+        both the source and target fork directories.
+        """
+        fork_name = fork.name()
+        if fork_name not in self.spec_hashes:
+            assert self.ethereum_root is not None
+            assert self.shared_hash is not None
+            h = hashlib.sha256()
+            h.update(self.shared_hash)
+            if hasattr(fork, "transitions_from"):
+                from_name = fork.transitions_from().name()
+                to_name = fork.transitions_to().name()
+                from_dir = (
+                    self.ethereum_root
+                    / "forks"
+                    / fork_name_to_module(from_name)
+                )
+                to_dir = (
+                    self.ethereum_root / "forks" / fork_name_to_module(to_name)
+                )
+                if from_dir.is_dir():
+                    h.update(hash_files(from_dir))
+                if to_dir.is_dir():
+                    h.update(hash_files(to_dir))
+            else:
+                fork_dir = (
+                    self.ethereum_root
+                    / "forks"
+                    / fork_name_to_module(fork_name)
+                )
+                if fork_dir.is_dir():
+                    h.update(hash_files(fork_dir))
+            self.spec_hashes[fork_name] = h.hexdigest()[:16]
+        return self.spec_hashes[fork_name]
+
+    def lookup(
+        self,
+        fork: Any,
+        request_data: TransitionToolRequest,
+        state_test: bool,
+    ) -> tuple[TransitionToolOutput | None, str, str]:
+        """
+        Look up a cached result by fork and t8n inputs.
+
+        Return (result_or_none, spec_hash, content_hash). The caller
+        passes spec_hash and content_hash back to store() on a miss.
+        """
+        spec_hash = self.get_spec_hash(fork)
+        content_hash = compute_content_hash(request_data, state_test)
+        return (
+            self.get(spec_hash, content_hash),
+            spec_hash,
+            content_hash,
+        )
+
+    def store(
+        self,
+        spec_hash: str,
+        content_hash: str,
+        output: TransitionToolOutput,
+    ) -> None:
+        """Store a computed result in the disk cache."""
+        self.set(spec_hash, content_hash, output)
+
+    def get(
+        self,
+        spec_hash: str,
+        content_hash: str,
+    ) -> TransitionToolOutput | None:
+        """
+        Look up a cached t8n output.
+
+        Return None on miss or if the cached data is corrupt.
+        """
+        try:
+            row = self.conn.execute(
+                "SELECT data FROM cache"
+                " WHERE spec_hash = ? AND content_hash = ?",
+                (spec_hash, content_hash),
+            ).fetchone()
+        except sqlite3.Error:
+            logger.debug("Disk cache: DB read error", exc_info=True)
+            self.misses += 1
+            return None
+
+        if row is None:
+            self.misses += 1
+            return None
+
+        try:
+            # Safe: local cache, not untrusted data
+            data = pickle.loads(  # noqa: S301
+                zlib.decompress(row[0])
+            )
+            result = deserialize_output(
+                data, context=self.exception_mapper_context
+            )
+            self.hits += 1
+            return result
+        except (
+            pickle.UnpicklingError,
+            zlib.error,
+            KeyError,
+            ValueError,
+            TypeError,
+        ):
+            logger.warning(
+                "Disk cache: corrupt entry %s/%s, ignoring",
+                spec_hash,
+                content_hash,
+            )
+            self.misses += 1
+            return None
+
+    def set(
+        self,
+        spec_hash: str,
+        content_hash: str,
+        output: TransitionToolOutput,
+    ) -> None:
+        """
+        Write a t8n output to the disk cache.
+
+        Uses INSERT OR IGNORE for idempotent writes under xdist.
+        """
+        try:
+            encoded = serialize_output(output)
+            compressed = zlib.compress(encoded, level=1)
+            self.conn.execute(
+                "INSERT OR IGNORE INTO cache"
+                " (spec_hash, content_hash, data)"
+                " VALUES (?, ?, ?)",
+                (spec_hash, content_hash, compressed),
+            )
+        except sqlite3.Error:
+            logger.debug(
+                "Disk cache: failed to write %s/%s",
+                spec_hash,
+                content_hash,
+                exc_info=True,
+            )

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/filler.py
@@ -94,6 +94,7 @@ from ..shared.helpers import (
 from ..spec_version_checker.spec_version_checker import (
     get_ref_spec_from_module,
 )
+from .disk_cache import DiskCache
 
 if TYPE_CHECKING:
     from .pre_alloc import Alloc
@@ -446,6 +447,8 @@ class TransitionToolCacheStats:
     key_test_miss: int = 0
     subkey_test_hits: int = 0
     subkey_test_miss: int = 0
+    disk_hits: int = 0
+    disk_misses: int = 0
     unique_keys: int = 0
     _seen_keys: Set[str] = field(default_factory=set, repr=False)
 
@@ -467,6 +470,8 @@ class TransitionToolCacheStats:
             "key_test_miss": self.key_test_miss,
             "subkey_test_hits": self.subkey_test_hits,
             "subkey_test_miss": self.subkey_test_miss,
+            "disk_hits": self.disk_hits,
+            "disk_misses": self.disk_misses,
             "unique_keys": self.unique_keys,
         }
 
@@ -476,6 +481,8 @@ class TransitionToolCacheStats:
         self.key_test_miss += other.key_test_miss
         self.subkey_test_hits += other.subkey_test_hits
         self.subkey_test_miss += other.subkey_test_miss
+        self.disk_hits += other.disk_hits
+        self.disk_misses += other.disk_misses
         self.unique_keys += other.unique_keys
 
     @classmethod
@@ -486,6 +493,8 @@ class TransitionToolCacheStats:
             key_test_miss=data.get("key_test_miss", 0),
             subkey_test_hits=data.get("subkey_test_hits", 0),
             subkey_test_miss=data.get("subkey_test_miss", 0),
+            disk_hits=data.get("disk_hits", 0),
+            disk_misses=data.get("disk_misses", 0),
             unique_keys=data.get("unique_keys", 0),
         )
 
@@ -625,6 +634,23 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help=(
             "Path to an evm executable that provides the `blocktest` command. "
             "Default: The first (geth) 'evm' entry in PATH."
+        ),
+    )
+    evm_group.addoption(
+        "--cache",
+        action="store_true",
+        dest="cache",
+        default=False,
+        help="Enable the disk cache for t8n results.",
+    )
+    evm_group.addoption(
+        "--cache-dir",
+        action="store",
+        dest="cache_dir",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the t8n disk cache database file. Default: .t8n-cache.db"
         ),
     )
 
@@ -932,6 +958,21 @@ def pytest_configure(config: pytest.Config) -> None:
         )
     config.t8n = t8n  # type: ignore[attr-defined]
 
+    # Initialize disk cache (opt-in via --cache, disabled with --traces)
+    if config.getoption("cache") and not config.getoption(
+        "evm_collect_traces"
+    ):
+        db_path = config.getoption("cache_dir") or Path(".t8n-cache.db")
+        t8n.disk_cache = DiskCache(
+            db_path=db_path,
+            exception_mapper_context={
+                "exception_mapper": t8n.exception_mapper
+            },
+        )
+        import ethereum
+
+        t8n.disk_cache.set_ethereum_root(Path(ethereum.__file__).parent)
+
     if "Tools" not in config.stash[metadata_key]:
         config.stash[metadata_key]["Tools"] = {
             "t8n": t8n.version(),
@@ -1046,6 +1087,19 @@ def pytest_terminal_summary(
                     " test groups, no cache sharing possible"
                 ),
                 bold=True,
+            )
+        disk_total = t8n_cache_stats.disk_hits + t8n_cache_stats.disk_misses
+        if disk_total > 0:
+            disk_pct = t8n_cache_stats.disk_hits / disk_total * 100
+            terminalreporter.write_sep(
+                "=",
+                (
+                    f" T8n disk cache: {disk_pct:.0f}% hit rate"
+                    f" ({t8n_cache_stats.disk_hits} hits,"
+                    f" {t8n_cache_stats.disk_misses} misses)"
+                ),
+                bold=True,
+                green=disk_pct > 90,
             )
     stats = terminalreporter.stats
     if "passed" in stats and stats["passed"]:
@@ -1241,6 +1295,8 @@ def session_t8n(
             stacklevel=2,
         )
     yield t8n
+    if t8n.disk_cache is not None:
+        t8n.disk_cache.close()
     t8n.shutdown()
 
 
@@ -1306,6 +1362,14 @@ def t8n(
         # Reset counters to avoid double-counting (cache persists across tests)
         session_t8n.output_cache.hits = 0
         session_t8n.output_cache.misses = 0
+    # Collect disk cache stats
+    if session_t8n.disk_cache is not None:
+        transition_tool_cache_stats.disk_hits += session_t8n.disk_cache.hits
+        transition_tool_cache_stats.disk_misses += (
+            session_t8n.disk_cache.misses
+        )
+        session_t8n.disk_cache.hits = 0
+        session_t8n.disk_cache.misses = 0
 
 
 @pytest.fixture(scope="session")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_t8n_cache.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/filler/tests/test_t8n_cache.py
@@ -1,11 +1,17 @@
 """Unit tests for the t8n output cache functionality."""
 
 import hashlib
+from pathlib import Path
 from typing import Any
 from unittest.mock import sentinel
 
 import pytest
 
+from execution_testing.client_clis.cli_types import (
+    LazyAllocStr,
+    Result,
+    TransitionToolOutput,
+)
 from execution_testing.client_clis.transition_tool import OutputCache
 from execution_testing.fixtures import (
     BlockchainEngineFixture,
@@ -608,3 +614,210 @@ class TestOutputCache:
 
         assert cache.hits == 2
         assert cache.misses == 1
+
+
+def make_test_output(alloc_data: str = '{"0x00": {}}') -> TransitionToolOutput:
+    """Create a minimal TransitionToolOutput for testing."""
+    result = Result.model_validate(
+        {
+            "stateRoot": "0x" + "00" * 32,
+            "txRoot": "0x" + "00" * 32,
+            "receiptsRoot": "0x" + "00" * 32,
+            "logsHash": "0x" + "00" * 32,
+            "logsBloom": "0x" + "00" * 256,
+            "receipts": [],
+            "gasUsed": "0x0",
+        }
+    )
+    alloc = LazyAllocStr(raw=alloc_data, _state_root=result.state_root)
+    return TransitionToolOutput(alloc=alloc, result=result)
+
+
+class TestDiskCache:
+    """Unit tests for the DiskCache SQLite + pickle cache."""
+
+    def test_set_and_get(self, tmp_path: Path) -> None:
+        """Test round-trip: set then get returns equivalent output."""
+        from ..disk_cache import DiskCache
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        output = make_test_output()
+
+        cache.set("spec123", "content456", output)
+        result = cache.get("spec123", "content456")
+
+        assert result is not None
+        assert result.alloc.raw == output.alloc.raw
+        assert result.result.state_root == output.result.state_root
+
+    def test_get_miss_returns_none(self, tmp_path: Path) -> None:
+        """Test get returns None for a nonexistent key."""
+        from ..disk_cache import DiskCache
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        assert cache.get("spec123", "content456") is None
+        assert cache.misses == 1
+
+    def test_hit_miss_counters(self, tmp_path: Path) -> None:
+        """Test hit and miss counters track correctly."""
+        from ..disk_cache import DiskCache
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        output = make_test_output()
+
+        cache.set("spec", "content_a", output)
+        cache.get("spec", "content_a")  # hit
+        cache.get("spec", "content_b")  # miss
+        cache.get("spec", "content_a")  # hit
+
+        assert cache.hits == 2
+        assert cache.misses == 1
+
+    def test_content_hash_deterministic(self) -> None:
+        """Test same inputs produce the same content hash."""
+        from execution_testing.client_clis.cli_types import (
+            TransitionToolContext,
+            TransitionToolInput,
+            TransitionToolRequest,
+        )
+        from execution_testing.test_types import Alloc, Environment
+
+        from ..disk_cache import compute_content_hash
+
+        alloc = Alloc()
+        env = Environment()
+        request = TransitionToolRequest(
+            state=TransitionToolContext(
+                fork="Amsterdam", chain_id=1, reward=0
+            ),
+            input=TransitionToolInput(alloc=alloc, txs=[], env=env),
+        )
+
+        hash_1 = compute_content_hash(request, state_test=False)
+        hash_2 = compute_content_hash(request, state_test=False)
+        assert hash_1 == hash_2
+
+    def test_content_hash_varies_with_state_test(self) -> None:
+        """Test state_test flag changes the content hash."""
+        from execution_testing.client_clis.cli_types import (
+            TransitionToolContext,
+            TransitionToolInput,
+            TransitionToolRequest,
+        )
+        from execution_testing.test_types import Alloc, Environment
+
+        from ..disk_cache import compute_content_hash
+
+        alloc = Alloc()
+        env = Environment()
+        request = TransitionToolRequest(
+            state=TransitionToolContext(
+                fork="Amsterdam", chain_id=1, reward=0
+            ),
+            input=TransitionToolInput(alloc=alloc, txs=[], env=env),
+        )
+
+        hash_false = compute_content_hash(request, state_test=False)
+        hash_true = compute_content_hash(request, state_test=True)
+        assert hash_false != hash_true
+
+    def test_fork_name_to_module(self) -> None:
+        """Test PascalCase to snake_case conversion for fork names."""
+        from ..disk_cache import fork_name_to_module
+
+        assert fork_name_to_module("Amsterdam") == "amsterdam"
+        assert fork_name_to_module("ArrowGlacier") == "arrow_glacier"
+        assert fork_name_to_module("TangerineWhistle") == "tangerine_whistle"
+        assert fork_name_to_module("BPO1") == "bpo1"
+        assert fork_name_to_module("BPO5") == "bpo5"
+
+    def test_spec_hash_changes_for_different_forks(
+        self, tmp_path: Path
+    ) -> None:
+        """Test that different forks produce different spec hashes."""
+        from ..disk_cache import DiskCache
+
+        # Create fake ethereum source tree
+        eth_root = tmp_path / "ethereum"
+        eth_root.mkdir()
+        (eth_root / "__init__.py").write_text("# shared")
+        forks_dir = eth_root / "forks"
+        forks_dir.mkdir()
+
+        fork_a = forks_dir / "fork_a"
+        fork_a.mkdir()
+        (fork_a / "__init__.py").write_text("# fork a code")
+
+        fork_b = forks_dir / "fork_b"
+        fork_b.mkdir()
+        (fork_b / "__init__.py").write_text("# fork b code")
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        cache.set_ethereum_root(eth_root)
+
+        # Use raw module names since fake dirs are already snake_case
+        from ..disk_cache import compute_fork_spec_hash
+
+        assert cache.shared_hash is not None
+        hash_a = compute_fork_spec_hash("ForkA", eth_root, cache.shared_hash)
+        hash_b = compute_fork_spec_hash("ForkB", eth_root, cache.shared_hash)
+        assert hash_a != hash_b
+
+    def test_corrupt_cache_entry_returns_none(self, tmp_path: Path) -> None:
+        """Test that a corrupt cache entry is handled gracefully."""
+        from ..disk_cache import DiskCache
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        # Insert garbage data directly into the DB
+        cache.conn.execute(
+            "INSERT INTO cache (spec_hash, content_hash, data)"
+            " VALUES (?, ?, ?)",
+            ("spec123", "content456", b"not valid pickle"),
+        )
+        cache.conn.commit()
+
+        result = cache.get("spec123", "content456")
+        assert result is None
+        assert cache.misses == 1
+
+    def test_set_skips_existing(self, tmp_path: Path) -> None:
+        """Test set does not overwrite an existing cache entry."""
+        from ..disk_cache import DiskCache
+
+        cache = DiskCache(db_path=tmp_path / "cache.db")
+        output_1 = make_test_output('{"0x01": {}}')
+        output_2 = make_test_output('{"0x02": {}}')
+
+        cache.set("spec", "content", output_1)
+        cache.set("spec", "content", output_2)
+
+        result = cache.get("spec", "content")
+        assert result is not None
+        assert result.alloc.raw == output_1.alloc.raw
+
+    def test_db_file_created(self, tmp_path: Path) -> None:
+        """Test cache creates the SQLite database file."""
+        from ..disk_cache import DiskCache
+
+        db_path = tmp_path / "cache.db"
+        cache = DiskCache(db_path=db_path)
+        output = make_test_output()
+
+        cache.set("myspechash", "abcdef1234567890", output)
+        assert db_path.exists()
+
+    def test_concurrent_writers(self, tmp_path: Path) -> None:
+        """Test two cache instances can write to the same DB."""
+        from ..disk_cache import DiskCache
+
+        db_path = tmp_path / "cache.db"
+        cache_a = DiskCache(db_path=db_path)
+        cache_b = DiskCache(db_path=db_path)
+        output = make_test_output()
+
+        cache_a.set("spec", "content_a", output)
+        cache_b.set("spec", "content_b", output)
+
+        assert cache_a.get("spec", "content_a") is not None
+        assert cache_a.get("spec", "content_b") is not None
+        assert cache_b.get("spec", "content_a") is not None

--- a/packages/testing/src/execution_testing/client_clis/cli_types.py
+++ b/packages/testing/src/execution_testing/client_clis/cli_types.py
@@ -538,6 +538,8 @@ class TransitionToolInput:
             )
         elif isinstance(self.alloc, LazyAllocJson):
             alloc_contents = self.alloc.raw
+        elif isinstance(self.alloc, LazyAllocStr):
+            alloc_contents = json.loads(self.alloc.raw)
         else:
             raise Exception(f"Invalid alloc type: {type(self.alloc)}")
 

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -189,6 +189,7 @@ class TransitionTool(EthereumCLI):
     server_url: str | None = None
     process: Optional[subprocess.Popen] = None
     output_cache: OutputCache | None = None
+    disk_cache: Any = None
     debug_dump_dir: Path | None = None
     call_counter: int = 0
     opcode_count: OpcodeCount | None = None
@@ -927,9 +928,24 @@ class TransitionTool(EthereumCLI):
         if self.output_cache is not None:
             cached_result = self.output_cache.get(current_call_id)
             if cached_result is not None:
-                if self.trace and cached_result.result.traces is not None:
-                    self.append_traces(cached_result.result.traces)
                 return self.process_result(cached_result)
+
+        # Check disk cache (content-addressed, persists across runs)
+        disk_spec_hash = None
+        disk_content_hash = None
+        if self.disk_cache is not None:
+            disk_result, disk_spec_hash, disk_content_hash = (
+                self.disk_cache.lookup(
+                    transition_tool_data.fork,
+                    transition_tool_data.get_request_data(),
+                    transition_tool_data.state_test,
+                )
+            )
+            if disk_result is not None:
+                if self.output_cache is not None:
+                    self.output_cache.set(current_call_id, disk_result)
+                return self.process_result(disk_result)
+
         debug_output_path = self.get_next_transition_tool_output_path(
             current_call_id
         )
@@ -947,4 +963,6 @@ class TransitionTool(EthereumCLI):
             )
         if self.output_cache is not None:
             self.output_cache.set(current_call_id, result)
+        if self.disk_cache is not None and disk_content_hash is not None:
+            self.disk_cache.store(disk_spec_hash, disk_content_hash, result)
         return self.process_result(result)


### PR DESCRIPTION
## 🗒️ Description

**Experimental**: Adds an optional disk cache for t8n results that persists across fill runs.

This PR adds a content addressed SQLite cache that stores t8n outputs keyed by:
- **Spec hash**: SHA-256 of the EELS source code (per fork, including shared modules). Automatically invalidates when spec code changes.
- **Content hash**: SHA-256 of the t8n call inputs (fork, chain_id, reward, alloc, env, txs, blob_params, state_test). 
  - Uses the pre-computed `state_root` from `LazyAlloc` for zero cost alloc hashing on subsequent blocks.

Entries are pickle serialized and zlib-compressed (level 1). SQLite WAL mode handles concurrent xdist workers. Transition forks hash both source and target fork directories.

### Benchmarks

`--fork Amsterdam -n 8` (35,716 tests), cache size 402MB:

| Run | Time | vs No Cache |
|---|---|---|
| No cache | 2:30 | baseline |
| Cold | 2:30 | ~1x |
| Warm | **1:15** | **~2x faster** |

`--until Amsterdam -n 8` (132,090 tests), cache size 2.5GB:

| Run | Time | vs No Cache |
|---|---|---|
| No cache | 10:53 | baseline |
| Cold | 12:37 | ~0.9x (slightly slower) |
| Warm | **5:59** | **~1.8x faster** |

`--generate-all-formats --fork Amsterdam -n 8` (50,035 tests), cache size 12GB:

| Run | Time | vs No Cache |
|---|---|---|
| No cache | 33:53 | baseline |
| Cold | 24:01 | ~1.4x faster |
| Warm | **5:40** | **~6x faster** |

`--generate-all-formats --until Amsterdam -n 8` (175,569 tests), cache size 38GB:

| Run | Time | vs No Cache (~1:54) |
|---|---|---|
| No cache | <1:54:15 | baseline |
| Cold | 1:54:15 | ~1x |
| Warm | 45:02 | ~2.5x faster |
| Warm (-n 12) | **34:02** | **~3.4x faster** |

### Usage

```bash
# Enable cache with the flag
uv run fill --fork Amsterdam --cache

# Custom DB path
uv run fill --fork Amsterdam --cache --cache-dir /path/to/cache.db

# Clear cache
rm .t8n-cache.db*
```

### Open Questions

- Disk usage: 38GB for all forks + all formats (zlib compressed), quite large!
- Needs strategy for CI: per fork caching?
  - S3 FUSE mount? Download into runners? Only for forks <Osaka?
- Spilt cache by fork, given the cache is faster?
- Useful for local or CI only?

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fgetwallpapers.com%2Fwallpaper%2Ffull%2Fc%2F6%2F1%2F947646-cute-baby-animals-wallpapers-1920x1080-for-4k-monitor.jpg&f=1&nofb=1&ipt=123bbcf61c10cf16f978f683a780015500ac5c5593c055e3997523592e6223fb)