### PR TITLE
src(focil): add FOCIL src features + first set of FOCIL tests

### DIFF
--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py
@@ -15,6 +15,8 @@ responses.
 
 from typing import Union
 
+import pytest
+
 from execution_testing.exceptions import UndefinedException
 from execution_testing.fixtures import (
     BlockchainEngineFixture,
@@ -42,14 +44,7 @@ from ..helpers.timing import TimingData
 logger = get_logger(__name__)
 
 
-def test_blockchain_via_engine(
-    timing_data: TimingData,
-    eth_rpc: EthRPC,
-    engine_rpc: EngineRPC,
-    fixture: Union[BlockchainEngineFixture, BlockchainEngineXFixture],
-    strict_exception_matching: bool,
-    genesis_header: FixtureHeader,
-) -> None:
+def test_blockchain_via_engine(request: pytest.FixtureRequest) -> None:
     """
     Execute blockchain test fixtures against a client using the Engine API.
 
@@ -75,6 +70,20 @@ def test_blockchain_via_engine(
     3. For valid payloads, perform forkchoice update to finalize chain
        (unless client is being reused, in which case skip FCU)
     """
+    if not hasattr(request.config, "fixtures_source"):
+        pytest.skip("requires consume simulator context")
+
+    timing_data: TimingData = request.getfixturevalue("timing_data")
+    eth_rpc: EthRPC = request.getfixturevalue("eth_rpc")
+    engine_rpc: EngineRPC = request.getfixturevalue("engine_rpc")
+    fixture: Union[BlockchainEngineFixture, BlockchainEngineXFixture] = (
+        request.getfixturevalue("fixture")
+    )
+    strict_exception_matching: bool = request.getfixturevalue(
+        "strict_exception_matching"
+    )
+    genesis_header: FixtureHeader = request.getfixturevalue("genesis_header")
+
     if isinstance(fixture, BlockchainEngineFixture):
         with timing_data.time("Initial forkchoice update"):
             logger.info(
@@ -134,20 +143,21 @@ def test_blockchain_via_engine(
                     version = payload.new_payload_version
                     logger.info(f"Sending engine_newPayloadV{version}...")
                     try:
+                        params = list(payload.params)
+                        if payload.inclusion_list_transactions is not None:
+                            params.append(payload.inclusion_list_transactions)
                         payload_response = engine_rpc.new_payload(
-                            *payload.params,
+                            *params,
                             version=payload.new_payload_version,
                         )
                         status = payload_response.status
                         logger.info(f"Payload response status: {status}")
-                        expected_validity = (
-                            PayloadStatusEnum.VALID
-                            if payload.valid()
-                            else PayloadStatusEnum.INVALID
+                        expected_status = PayloadStatusEnum(
+                            payload.expected_status()
                         )
-                        if payload_response.status != expected_validity:
+                        if payload_response.status != expected_status:
                             raise LoggedError(
-                                f"unexpected status: want {expected_validity},"
+                                f"unexpected status: want {expected_status},"
                                 f" got {payload_response.status}"
                             )
                         if payload.error_code is not None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py
@@ -41,19 +41,7 @@ from ..helpers.timing import TimingData
 logger = get_logger(__name__)
 
 
-def test_blockchain_via_sync(
-    timing_data: TimingData,
-    eth_rpc: EthRPC,
-    engine_rpc: EngineRPC,
-    net_rpc: NetRPC,
-    sync_eth_rpc: EthRPC,
-    sync_engine_rpc: EngineRPC,
-    sync_net_rpc: NetRPC,
-    sync_admin_rpc: AdminRPC,
-    client_enode_url: str,
-    fixture: BlockchainEngineSyncFixture,
-    strict_exception_matching: bool,
-) -> None:
+def test_blockchain_via_sync(request: pytest.FixtureRequest) -> None:
     """
     Test blockchain synchronization between two clients.
 
@@ -64,6 +52,23 @@ def test_blockchain_via_sync(
        synchronization
     5. Verify that the sync client successfully syncs to the same state
     """
+    if not hasattr(request.config, "fixtures_source"):
+        pytest.skip("requires consume simulator context")
+
+    timing_data: TimingData = request.getfixturevalue("timing_data")
+    eth_rpc: EthRPC = request.getfixturevalue("eth_rpc")
+    engine_rpc: EngineRPC = request.getfixturevalue("engine_rpc")
+    net_rpc: NetRPC = request.getfixturevalue("net_rpc")
+    sync_eth_rpc: EthRPC = request.getfixturevalue("sync_eth_rpc")
+    sync_engine_rpc: EngineRPC = request.getfixturevalue("sync_engine_rpc")
+    sync_net_rpc: NetRPC = request.getfixturevalue("sync_net_rpc")
+    sync_admin_rpc: AdminRPC = request.getfixturevalue("sync_admin_rpc")
+    client_enode_url: str = request.getfixturevalue("client_enode_url")
+    fixture: BlockchainEngineSyncFixture = request.getfixturevalue("fixture")
+    strict_exception_matching: bool = request.getfixturevalue(
+        "strict_exception_matching"
+    )
+
     # Initialize client under test
     with timing_data.time("Initialize client under test"):
         logger.info("Initializing client under test with genesis block...")
@@ -127,20 +132,21 @@ def test_blockchain_via_sync(
                     logger.info(f"Sending engine_newPayloadV{version}...")
                     # Note: This is similar to the logic in test_via_engine.py
                     try:
+                        params = list(payload.params)
+                        if payload.inclusion_list_transactions is not None:
+                            params.append(payload.inclusion_list_transactions)
                         payload_response = engine_rpc.new_payload(
-                            *payload.params,
+                            *params,
                             version=payload.new_payload_version,
                         )
                         status = payload_response.status
                         logger.info(f"Payload response status: {status}")
-                        expected_validity = (
-                            PayloadStatusEnum.VALID
-                            if payload.valid()
-                            else PayloadStatusEnum.INVALID
+                        expected_status = PayloadStatusEnum(
+                            payload.expected_status()
                         )
-                        if payload_response.status != expected_validity:
+                        if payload_response.status != expected_status:
                             raise LoggedError(
-                                f"unexpected status: want {expected_validity},"
+                                f"unexpected status: want {expected_status},"
                                 f" got {payload_response.status}"
                             )
                         if payload.error_code is not None:

--- a/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py
@@ -7,6 +7,7 @@ from typing import Any, Type
 
 import pytest
 
+from execution_testing.base_types import Bloom, Hash
 from execution_testing.client_clis import (
     CLINotFoundInPathError,
     EvmOneTransitionTool,
@@ -19,8 +20,10 @@ from execution_testing.client_clis.cli_types import (
     LazyAlloc,
     LazyAllocJson,
     LazyAllocStr,
+    TransitionToolOutput,
 )
-from execution_testing.test_types import Alloc
+from execution_testing.forks import Berlin
+from execution_testing.test_types import Alloc, Environment, Transaction
 
 
 def test_default_tool() -> None:
@@ -128,3 +131,45 @@ def test_lazy_alloc(ty: Type[LazyAlloc], raw: Any) -> None:
     lazy_instance = ty(raw=raw, _state_root=TEST_ALLOC_STATE_ROOT)
     assert lazy_instance.get() == TEST_ALLOC
     assert lazy_instance.state_root() == TEST_ALLOC_STATE_ROOT
+
+
+def test_transition_tool_data_inclusion_list_transactions() -> None:
+    """Test that inclusion list txs are serialized into the transition env."""
+    il_tx = Transaction(gas_limit=21_000).with_signature_and_sender()
+
+    transition_tool_data = TransitionTool.TransitionToolData(
+        alloc=TEST_ALLOC,
+        txs=[],
+        env=Environment(),
+        fork=Berlin,
+        chain_id=1,
+        reward=0,
+        blob_schedule=Berlin.blob_schedule(),
+        inclusion_list_txs=[il_tx],
+    )
+
+    transition_tool_input = transition_tool_data.to_input()
+    assert transition_tool_input.env.inclusion_list_transactions == [
+        il_tx.rlp()
+    ]
+
+
+def test_transition_tool_output_parses_inclusion_list_satisfaction() -> None:
+    """Test that the transition tool output parses IL satisfaction results."""
+    output = TransitionToolOutput.model_validate(
+        {
+            "alloc": TEST_ALLOC.model_dump(),
+            "result": {
+                "stateRoot": TEST_ALLOC_STATE_ROOT.hex(),
+                "txRoot": Hash(1).hex(),
+                "receiptsRoot": Hash(2).hex(),
+                "logsHash": Hash(3).hex(),
+                "logsBloom": Bloom(0).hex(),
+                "receipts": [],
+                "gasUsed": hex(0),
+                "isInclusionListSatisfied": False,
+            },
+        }
+    )
+
+    assert output.result.is_inclusion_list_satisfied is False

--- a/packages/testing/src/execution_testing/client_clis/transition_tool.py
+++ b/packages/testing/src/execution_testing/client_clis/transition_tool.py
@@ -309,6 +309,7 @@ class TransitionTool(EthereumCLI):
         chain_id: int
         reward: int
         blob_schedule: BlobSchedule | None
+        inclusion_list_txs: List[Transaction] | None = None
         state_test: bool = False
 
         @property
@@ -345,10 +346,17 @@ class TransitionTool(EthereumCLI):
 
         def to_input(self) -> TransitionToolInput:
             """Convert the data to a TransactionToolInput object."""
+            env = self.env
+            if self.inclusion_list_txs is not None:
+                env = env.copy(
+                    inclusion_list_transactions=[
+                        tx.rlp() for tx in self.inclusion_list_txs
+                    ]
+                )
             return TransitionToolInput(
                 alloc=self.alloc,
                 txs=self.txs,
-                env=self.env,
+                env=env,
                 blob_params=self.blob_params,
             )
 

--- a/packages/testing/src/execution_testing/fixtures/blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/blockchain.py
@@ -454,9 +454,23 @@ class FixtureEngineNewPayload(CamelModel):
     """
 
     params: EngineNewPayloadParameters
+    inclusion_list_transactions: List[Bytes] | None = Field(
+        None, alias="inclusionListTransactions"
+    )
     new_payload_version: Number
     forkchoice_updated_version: Number
     validation_error: ExceptionInstanceOrList | None = None
+    status: (
+        Literal[
+            "VALID",
+            "INVALID",
+            "SYNCING",
+            "ACCEPTED",
+            "INVALID_BLOCK_HASH",
+            "INCLUSION_LIST_UNSATISFIED",
+        ]
+        | None
+    ) = None
     error_code: (
         Annotated[
             EngineAPIError,
@@ -470,7 +484,13 @@ class FixtureEngineNewPayload(CamelModel):
 
     def valid(self) -> bool:
         """Return whether the payload is valid."""
-        return self.validation_error is None
+        return self.expected_status() == "VALID"
+
+    def expected_status(self) -> str:
+        """Return the expected Engine API payload status."""
+        if self.status is not None:
+            return self.status
+        return "INVALID" if self.validation_error is not None else "VALID"
 
     @classmethod
     def from_fixture_header(
@@ -480,6 +500,7 @@ class FixtureEngineNewPayload(CamelModel):
         transactions: List[Transaction],
         withdrawals: List[Withdrawal] | None,
         requests: List[Bytes] | None,
+        inclusion_list_transactions: List[Transaction] | None = None,
         block_access_list: Bytes | None = None,
         **kwargs: Any,
     ) -> Self:
@@ -531,6 +552,11 @@ class FixtureEngineNewPayload(CamelModel):
         )
         new_payload = cls(
             params=payload_params,
+            inclusion_list_transactions=(
+                [tx.rlp() for tx in inclusion_list_transactions]
+                if inclusion_list_transactions is not None
+                else None
+            ),
             new_payload_version=new_payload_version,
             forkchoice_updated_version=forkchoice_updated_version,
             **kwargs,
@@ -594,6 +620,9 @@ class FixtureBlockBase(CamelModel):
     )
     ommers: List[FixtureHeader] = Field(
         default_factory=list, alias="uncleHeaders"
+    )
+    inclusion_list_transactions: List[Bytes] | None = Field(
+        None, alias="inclusionListTransactions"
     )
     withdrawals: List[FixtureWithdrawal] | None = None
     receipts: List[FixtureTransactionReceipt] | None = None

--- a/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
+++ b/packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py
@@ -24,6 +24,7 @@ from execution_testing.exceptions import (
     TransactionException,
 )
 from execution_testing.forks import Prague
+from execution_testing.rpc.rpc_types import PayloadStatusEnum
 from execution_testing.test_types import (
     EOA,
     AuthorizationTuple,
@@ -472,6 +473,62 @@ fixture_header_ones = FixtureHeader(
                     blob_gas_used=17,
                     excess_blob_gas=18,
                 ),
+                inclusion_list_transactions=[Bytes([0xAA, 0xBB])],
+            ),
+            {
+                "blockHeader": {
+                    "parentHash": Hash(0).hex(),
+                    "uncleHash": Hash(1).hex(),
+                    "coinbase": Address(2).hex(),
+                    "stateRoot": Hash(3).hex(),
+                    "transactionsTrie": Hash(4).hex(),
+                    "receiptTrie": Hash(5).hex(),
+                    "bloom": Bloom(6).hex(),
+                    "difficulty": ZeroPaddedHexNumber(7).hex(),
+                    "number": ZeroPaddedHexNumber(8).hex(),
+                    "gasLimit": ZeroPaddedHexNumber(9).hex(),
+                    "gasUsed": ZeroPaddedHexNumber(10).hex(),
+                    "timestamp": ZeroPaddedHexNumber(11).hex(),
+                    "extraData": Bytes([12]).hex(),
+                    "mixHash": Hash(13).hex(),
+                    "nonce": HeaderNonce(14).hex(),
+                    "baseFeePerGas": ZeroPaddedHexNumber(15).hex(),
+                    "withdrawalsRoot": Hash(16).hex(),
+                    "blobGasUsed": ZeroPaddedHexNumber(17).hex(),
+                    "excessBlobGas": ZeroPaddedHexNumber(18).hex(),
+                    "hash": "0xd90115b7fde329f64335763a446af150ab67e639281dccdb07a007d18bb80211",  # noqa: E501
+                },
+                "blocknumber": "8",
+                "uncleHeaders": [],
+                "transactions": [],
+                "inclusionListTransactions": [Bytes([0xAA, 0xBB]).hex()],
+            },
+            id="fixture_block_inclusion_list_transactions",
+        ),
+        pytest.param(
+            True,
+            FixtureBlockBase(
+                header=FixtureHeader(
+                    parent_hash=Hash(0),
+                    ommers_hash=Hash(1),
+                    fee_recipient=Address(2),
+                    state_root=Hash(3),
+                    transactions_trie=Hash(4),
+                    receipts_root=Hash(5),
+                    logs_bloom=Bloom(6),
+                    difficulty=7,
+                    number=8,
+                    gas_limit=9,
+                    gas_used=10,
+                    timestamp=11,
+                    extra_data=Bytes([12]),
+                    prev_randao=Hash(13),
+                    nonce=HeaderNonce(14),
+                    base_fee_per_gas=15,
+                    withdrawals_root=Hash(16),
+                    blob_gas_used=17,
+                    excess_blob_gas=18,
+                ),
                 txs=[
                     FixtureTransaction.from_transaction(
                         Transaction(to=None).with_signature_and_sender()
@@ -828,6 +885,81 @@ fixture_header_ones = FixtureHeader(
                 "errorCode": "-32600",
             },
             id="fixture_engine_new_payload_1",
+        ),
+        pytest.param(
+            True,
+            FixtureEngineNewPayload.from_fixture_header(
+                fork=Prague,
+                header=FixtureHeader(
+                    fork=Prague,
+                    parent_hash=Hash(0),
+                    ommers_hash=Hash(1),
+                    fee_recipient=Address(2),
+                    state_root=Hash(3),
+                    transactions_trie=Hash(4),
+                    receipts_root=Hash(5),
+                    logs_bloom=Bloom(6),
+                    difficulty=7,
+                    number=8,
+                    gas_limit=9,
+                    gas_used=10,
+                    timestamp=11,
+                    extra_data=Bytes([12]),
+                    prev_randao=Hash(13),
+                    nonce=HeaderNonce(14),
+                    base_fee_per_gas=15,
+                    withdrawals_root=Hash(16),
+                    blob_gas_used=17,
+                    excess_blob_gas=18,
+                    parent_beacon_block_root=19,
+                    requests_hash=20,
+                ),
+                transactions=[],
+                withdrawals=[],
+                requests=[],
+                inclusion_list_transactions=[
+                    Transaction(gas_limit=21_000).with_signature_and_sender()
+                ],
+                status=PayloadStatusEnum.INCLUSION_LIST_UNSATISFIED.value,
+            ),
+            {
+                "params": [
+                    {
+                        "parentHash": Hash(0).hex(),
+                        "feeRecipient": Address(2).hex(),
+                        "stateRoot": Hash(3).hex(),
+                        "receiptsRoot": Hash(5).hex(),
+                        "logsBloom": Bloom(6).hex(),
+                        "blockNumber": hex(8),
+                        "gasLimit": hex(9),
+                        "gasUsed": hex(10),
+                        "timestamp": hex(11),
+                        "extraData": Bytes([12]).hex(),
+                        "prevRandao": Hash(13).hex(),
+                        "baseFeePerGas": hex(15),
+                        "blobGasUsed": hex(17),
+                        "excessBlobGas": hex(18),
+                        "blockHash": (
+                            "0x93bd662d8a80a1f54bffc6d140b83d6cda233209998809f9540be51178b4d0b6"
+                        ),
+                        "transactions": [],
+                        "withdrawals": [],
+                    },
+                    [],
+                    str(Hash(19)),
+                    [],
+                ],
+                "inclusionListTransactions": [
+                    Transaction(gas_limit=21_000)
+                    .with_signature_and_sender()
+                    .rlp()
+                    .hex()
+                ],
+                "forkchoiceUpdatedVersion": "3",
+                "newPayloadVersion": "4",
+                "status": PayloadStatusEnum.INCLUSION_LIST_UNSATISFIED.value,
+            },
+            id="fixture_engine_new_payload_inclusion_list_unsatisfied",
         ),
         pytest.param(
             True,

--- a/packages/testing/src/execution_testing/rpc/rpc_types.py
+++ b/packages/testing/src/execution_testing/rpc/rpc_types.py
@@ -171,6 +171,7 @@ class PayloadStatusEnum(str, Enum):
     SYNCING = "SYNCING"
     ACCEPTED = "ACCEPTED"
     INVALID_BLOCK_HASH = "INVALID_BLOCK_HASH"
+    INCLUSION_LIST_UNSATISFIED = "INCLUSION_LIST_UNSATISFIED"
 
 
 class BlockTransactionExceptionWithMessage(

--- a/packages/testing/src/execution_testing/specs/blockchain.py
+++ b/packages/testing/src/execution_testing/specs/blockchain.py
@@ -76,6 +76,7 @@ from execution_testing.fixtures.common import (
 )
 from execution_testing.fixtures.post_verifications import PostVerifications
 from execution_testing.forks import Fork, TransitionFork
+from execution_testing.rpc.rpc_types import PayloadStatusEnum
 from execution_testing.test_types import (
     Alloc,
     Environment,
@@ -287,6 +288,8 @@ class Block(Header):
     """
     txs: List[Transaction] = Field(default_factory=list)
     """List of transactions included in the block."""
+    inclusion_list_txs: List[Transaction] | None = None
+    """Transactions supplied as the block's inclusion list."""
     ommers: List[Header] | None = None
     """List of ommer headers included in the block."""
     withdrawals: List[Withdrawal] | None = None
@@ -375,6 +378,7 @@ class BuiltBlock(CamelModel):
     alloc: LazyAlloc
     state_root: Hash
     txs: List[Transaction]
+    inclusion_list_txs: List[Transaction] | None
     ommers: List[FixtureHeader]
     withdrawals: List[Withdrawal] | None
     requests: List[Bytes] | None
@@ -391,6 +395,11 @@ class BuiltBlock(CamelModel):
         fixture_block = FixtureBlockBase(
             header=self.header,
             txs=[FixtureTransaction.from_transaction(tx) for tx in self.txs],
+            inclusion_list_transactions=(
+                [tx.rlp() for tx in self.inclusion_list_txs]
+                if self.inclusion_list_txs is not None
+                else None
+            ),
             withdrawals=(
                 [
                     FixtureWithdrawal.from_withdrawal(w)
@@ -441,10 +450,16 @@ class BuiltBlock(CamelModel):
             transactions=self.txs,
             withdrawals=self.withdrawals,
             requests=self.requests,
+            inclusion_list_transactions=self.inclusion_list_txs,
             block_access_list=self.block_access_list.rlp
             if self.block_access_list
             else None,
             validation_error=self.expected_exception,
+            status=(
+                PayloadStatusEnum.INCLUSION_LIST_UNSATISFIED.value
+                if self.result.is_inclusion_list_satisfied is False
+                else None
+            ),
             error_code=self.engine_api_error_code,
         )
 
@@ -626,6 +641,11 @@ class BlockchainTest(BaseTest):
         )
         env = env.set_fork_requirements(fork)
         txs = [tx.with_signature_and_sender() for tx in block.txs]
+        inclusion_list_txs = (
+            [tx.with_signature_and_sender() for tx in block.inclusion_list_txs]
+            if block.inclusion_list_txs is not None
+            else None
+        )
 
         if failing_tx_count := len([tx for tx in txs if tx.error]) > 0:
             if failing_tx_count > 1:
@@ -648,6 +668,7 @@ class BlockchainTest(BaseTest):
                 chain_id=self.chain_id,
                 reward=fork.get_reward(),
                 blob_schedule=fork.blob_schedule(),
+                inclusion_list_txs=inclusion_list_txs,
             ),
             slow_request=self.is_tx_gas_heavy_test,
         )
@@ -765,6 +786,7 @@ class BlockchainTest(BaseTest):
             state_root=transition_tool_output.result.state_root,
             env=env,
             txs=txs,
+            inclusion_list_txs=inclusion_list_txs,
             ommers=[],
             withdrawals=env.withdrawals,
             requests=requests_list,

--- a/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
+++ b/packages/testing/src/execution_testing/specs/tests/test_fixtures.py
@@ -3,7 +3,7 @@
 import json
 from os.path import realpath
 from pathlib import Path
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, cast
 
 import pytest
 from click.testing import CliRunner
@@ -25,7 +25,9 @@ from execution_testing.fixtures import (
     FixtureFormat,
     StateFixture,
 )
+from execution_testing.fixtures.blockchain import FixtureBlockBase
 from execution_testing.forks import (
+    Amsterdam,
     Berlin,
     Cancun,
     Fork,
@@ -34,6 +36,7 @@ from execution_testing.forks import (
     Paris,
     Shanghai,
 )
+from execution_testing.rpc.rpc_types import PayloadStatusEnum
 from execution_testing.test_types import (
     Alloc,
     Environment,
@@ -124,6 +127,60 @@ def test_make_genesis(  # noqa: D103
 
     assert fixture.genesis.block_hash is not None
     assert fixture.genesis.block_hash.startswith(fixture_hash)
+
+
+def test_blockchain_fixtures_include_inclusion_lists(
+    default_t8n: TransitionTool,
+) -> None:
+    """Test inclusion list plumbing across classic and engine fixtures."""
+    tx = Transaction(
+        nonce=0,
+        to=Address(0x1234),
+        gas_limit=21_000,
+        gas_price=10,
+    )
+    block = Block()
+    sender = Address("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    signed_il_tx = tx.with_signature_and_sender()
+
+    pre = Alloc({sender: Account(balance=10**18)})
+
+    block.inclusion_list_txs = [tx]
+
+    classic_fixture = (
+        BlockchainTest(
+            fork=Amsterdam,
+            pre=pre,
+            post={},
+            blocks=[block],
+            genesis_environment=Environment(),
+        )
+        .generate(t8n=default_t8n, fixture_format=BlockchainFixture)
+        .fixture
+    )
+    assert isinstance(classic_fixture, BlockchainFixture)
+    classic_block = cast(FixtureBlockBase, classic_fixture.blocks[0])
+    assert classic_block.inclusion_list_transactions == [signed_il_tx.rlp()]
+
+    engine_fixture = (
+        BlockchainTest(
+            fork=Amsterdam,
+            pre=pre,
+            post={},
+            blocks=[block],
+            genesis_environment=Environment(),
+        )
+        .generate(t8n=default_t8n, fixture_format=BlockchainEngineFixture)
+        .fixture
+    )
+    assert isinstance(engine_fixture, BlockchainEngineFixture)
+    assert engine_fixture.payloads[0].inclusion_list_transactions == [
+        signed_il_tx.rlp()
+    ]
+    assert (
+        engine_fixture.payloads[0].expected_status()
+        == PayloadStatusEnum.INCLUSION_LIST_UNSATISFIED.value
+    )
 
 
 @pytest.mark.parametrize(

--- a/packages/testing/src/execution_testing/test_types/block_types.py
+++ b/packages/testing/src/execution_testing/test_types/block_types.py
@@ -144,6 +144,9 @@ class Environment(EnvironmentGeneric[ZeroPaddedHexNumber]):
     # EIP-7928: Block-level access lists
     bal_hash: Hash | None = Field(None)
     block_access_lists: Bytes | None = Field(None)
+    inclusion_list_transactions: List[Bytes] | None = Field(
+        None, alias="inclusionListTransactions"
+    )
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property

--- a/src/ethereum_spec_tools/evm_tools/t8n/env.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/env.py
@@ -326,10 +326,13 @@ class Env:
         self.inclusion_list_transactions = None
 
         if not t8n.fork.has_is_inclusion_list_satisfied:
+            print("Block does not have an 'is_inclusion_list_satisfied' field")
             return
 
         inclusion_list_transactions = []
         if "inclusionListTransactions" in data:
+            il_tx_amount = len(data["inclusionListTransactions"])
+            print(f"Detected {il_tx_amount} IL txs")
             for tx in data["inclusionListTransactions"]:
                 inclusion_list_transactions.append(hex_to_bytes(tx))
 

--- a/tests/amsterdam/eip7805_focil/__init__.py
+++ b/tests/amsterdam/eip7805_focil/__init__.py
@@ -1,0 +1,1 @@
+"""FOCIL tests for Amsterdam."""

--- a/tests/amsterdam/eip7805_focil/helpers.py
+++ b/tests/amsterdam/eip7805_focil/helpers.py
@@ -56,6 +56,11 @@ class BuiltBlock(NamedTuple):
     1. Sender `nonce` is correct
     2. Sender `balance` could have afforded the tx
 
+    These helpers only describe the block body, the flattened IL view, and
+    the gas headroom for a scenario. The actual satisfaction check is done by
+    the Amsterdam fork logic after block execution, when it re-validates any
+    missing IL transactions against the block's post-state.
+
     """
 
     block_txs: list[Transaction]

--- a/tests/amsterdam/eip7805_focil/helpers.py
+++ b/tests/amsterdam/eip7805_focil/helpers.py
@@ -1,0 +1,224 @@
+"""Shared helpers for Amsterdam EIP-7805 FOCIL tests."""
+
+from typing import NamedTuple
+
+from execution_testing import (
+    EOA,
+    Alloc,
+    Fork,
+    Transaction,
+)
+
+
+class TransactionWithOrigin(NamedTuple):
+    """Transaction plus whether it appeared in any inclusion list."""
+
+    tx: Transaction
+    is_inclusion_list_tx: bool
+
+
+class IncludedBlockTx(NamedTuple):
+    """Description of a transaction already included in the block body."""
+
+    actual_gas_used: int
+    nonce: int = 0
+    is_inclusion_list_tx: bool = False
+    sender_label: str | None = None
+    sender_balance: int = 10**18
+
+
+class PendingInclusionListTx(NamedTuple):
+    """Description of an IL transaction omitted from the block body."""
+
+    actual_gas_used: int
+    nonce: int = 0
+    sender_label: str | None = None
+    sender_balance: int = 10**18
+
+
+class BuiltBlock(NamedTuple):
+    """
+    Concrete block data plus the derived gas headroom.
+
+    We simulate having received a block that contains a bunch of `block_txs`.
+    We also simulate that we have access to every committee member's
+    inclusion lists and we already flattened all of these IL txs into one list
+    we call `inclusion_list_txs`. If a member of this list was included in a
+    block it will exists both in `block_txs` and in `inclusion_list_txs`.
+    If a member of `inclusion_list_txs` is not in `block_txs` then for an
+    accepted block this means that one of the IL tx validity checks failed.
+
+    A block is invalid when it has enough `remaining_gas` so that it could
+    have included a valid member of `inclusion_list_txs` in `block_txs` but did
+    not.
+
+    The validity checks for any member of `inclusion_list_txs` are:
+    1. Sender `nonce` is correct
+    2. Sender `balance` could have afforded the tx
+
+    """
+
+    block_txs: list[Transaction]
+    inclusion_list_txs: list[Transaction]
+    remaining_gas: int
+
+
+def _resolve_sender(
+    pre: Alloc,
+    *,
+    senders_by_label: dict[str, EOA],
+    sender_label: str | None,
+    sender_balance: int,
+) -> EOA:
+    """
+    Return a fresh sender or reuse one selected by label.
+
+    This is a helper function for `build_block()`.
+
+    """
+    if sender_label is None:
+        return pre.fund_eoa(amount=sender_balance)
+    if sender_label not in senders_by_label:
+        senders_by_label[sender_label] = pre.fund_eoa(amount=sender_balance)
+    return senders_by_label[sender_label]
+
+
+def generate_custom_tx(
+    pre: Alloc,
+    *,
+    fork: Fork,
+    actual_gas_used: int,
+    is_inclusion_list_tx: bool,
+    nonce: int = 0,
+    sender: EOA | None = None,
+) -> TransactionWithOrigin:
+    """Create a plain transfer tx with a specific intrinsic gas usage."""
+    if sender is None:
+        sender = pre.fund_eoa(amount=10**18)
+    recipient = pre.fund_eoa()
+    calldata = _build_calldata_for_intrinsic_gas_used(
+        fork=fork,
+        actual_gas_used=actual_gas_used,
+    )
+    tx = Transaction(
+        sender=sender,
+        nonce=nonce,
+        to=recipient,
+        gas_limit=actual_gas_used,
+        data=calldata,
+    )
+    return TransactionWithOrigin(
+        tx=tx, is_inclusion_list_tx=is_inclusion_list_tx
+    )
+
+
+def _build_calldata_for_intrinsic_gas_used(
+    *, fork: Fork, actual_gas_used: int
+) -> bytes:
+    """
+    Build calldata for a plain transfer with exactly this intrinsic gas.
+
+    This is a helper function for `generate_custom_tx()`.
+    """
+    intrinsic_cost_calculator = fork.transaction_intrinsic_cost_calculator()
+    empty_transfer_gas = intrinsic_cost_calculator()
+    if actual_gas_used < empty_transfer_gas:
+        raise ValueError(
+            f"actual gas used must be >= empty transfer intrinsic gas: "
+            f"{actual_gas_used} < {empty_transfer_gas}"
+        )
+
+    additional_gas = actual_gas_used - empty_transfer_gas
+    if additional_gas == 0:
+        return b""
+
+    zero_byte_cost = (
+        intrinsic_cost_calculator(calldata=b"\x00") - empty_transfer_gas
+    )
+    nonzero_byte_cost = (
+        intrinsic_cost_calculator(calldata=b"\x01") - empty_transfer_gas
+    )
+    for nonzero_byte_count in range(additional_gas // nonzero_byte_cost + 1):
+        remaining_gas = additional_gas - (
+            nonzero_byte_count * nonzero_byte_cost
+        )
+        if remaining_gas % zero_byte_cost == 0:
+            zero_byte_count = remaining_gas // zero_byte_cost
+            return (b"\x01" * nonzero_byte_count) + (b"\x00" * zero_byte_count)
+
+    raise ValueError(
+        "requested actual gas used is not representable with calldata "
+        f"costs for this fork: {actual_gas_used}"
+    )
+
+
+def flatten_inclusion_list_txs(
+    txs_with_origins: list[TransactionWithOrigin],
+) -> list[Transaction]:
+    """
+    Return the flattened EL view of transactions that appeared in any IL.
+
+    These tests do not model distinct committee-member inclusion lists.
+    Instead, they pass the execution layer the single flattened list of
+    transactions that appeared in any inclusion list, because that is the
+    only membership information the EL consumes here.
+    """
+    return [
+        tx_with_origin.tx
+        for tx_with_origin in txs_with_origins
+        if tx_with_origin.is_inclusion_list_tx
+    ]
+
+
+def build_block(
+    pre: Alloc,
+    *,
+    fork: Fork,
+    block_gas_limit: int,
+    included_block_tx_specs: tuple[IncludedBlockTx, ...],
+    pending_inclusion_list_tx_specs: tuple[PendingInclusionListTx, ...],
+) -> BuiltBlock:
+    """Build block-body txs, flattened IL txs, and remaining gas."""
+    senders_by_label: dict[str, EOA] = {}
+    included_block_txs = [
+        generate_custom_tx(
+            pre,
+            fork=fork,
+            actual_gas_used=tx_spec.actual_gas_used,
+            nonce=tx_spec.nonce,
+            is_inclusion_list_tx=tx_spec.is_inclusion_list_tx,
+            sender=_resolve_sender(
+                pre,
+                senders_by_label=senders_by_label,
+                sender_label=tx_spec.sender_label,
+                sender_balance=tx_spec.sender_balance,
+            ),
+        )
+        for tx_spec in included_block_tx_specs
+    ]
+    pending_inclusion_list_txs = [
+        generate_custom_tx(
+            pre,
+            fork=fork,
+            actual_gas_used=tx_spec.actual_gas_used,
+            nonce=tx_spec.nonce,
+            is_inclusion_list_tx=True,
+            sender=_resolve_sender(
+                pre,
+                senders_by_label=senders_by_label,
+                sender_label=tx_spec.sender_label,
+                sender_balance=tx_spec.sender_balance,
+            ),
+        )
+        for tx_spec in pending_inclusion_list_tx_specs
+    ]
+    gas_used_by_included_txs = sum(
+        tx_spec.actual_gas_used for tx_spec in included_block_tx_specs
+    )
+    return BuiltBlock(
+        block_txs=[tx_with_origin.tx for tx_with_origin in included_block_txs],
+        inclusion_list_txs=flatten_inclusion_list_txs(
+            included_block_txs + pending_inclusion_list_txs
+        ),
+        remaining_gas=block_gas_limit - gas_used_by_included_txs,
+    )

--- a/tests/amsterdam/eip7805_focil/spec.py
+++ b/tests/amsterdam/eip7805_focil/spec.py
@@ -1,0 +1,24 @@
+"""Reference spec for [EIP-7805: FOCIL](https://eips.ethereum.org/EIPS/eip-7805)."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReferenceSpec:
+    """Reference specification."""
+
+    git_path: str
+    version: str
+
+
+ref_spec_7805 = ReferenceSpec(
+    git_path="EIPS/eip-7805.md",
+    version="0a3955d9e8772b7666f560402b2d81ae032a3d06",
+)
+
+
+@dataclass(frozen=True)
+class Spec:
+    """Constants and parameters from EIP-7805."""
+
+    INCLUSION_LIST_UNSATISFIED_STATUS = "INCLUSION_LIST_UNSATISFIED"

--- a/tests/amsterdam/eip7805_focil/test_focil.py
+++ b/tests/amsterdam/eip7805_focil/test_focil.py
@@ -1,0 +1,342 @@
+"""Tests EIP-7805 FOCIL execution-layer inclusion-list handling."""
+
+from typing import Literal, TypedDict
+
+import pytest
+from execution_testing import (
+    Alloc,
+    Block,
+    BlockchainTestFiller,
+    Environment,
+    Fork,
+    Op,
+    Transaction,
+)
+from execution_testing.test_types.transaction_types import (
+    TransactionDefaults,
+)
+
+from .helpers import (
+    IncludedBlockTx,
+    PendingInclusionListTx,
+    build_block,
+)
+from .spec import Spec, ref_spec_7805
+
+REFERENCE_SPEC_GIT_PATH = ref_spec_7805.git_path
+REFERENCE_SPEC_VERSION = ref_spec_7805.version
+
+pytestmark = [
+    pytest.mark.valid_from("Amsterdam"),
+    pytest.mark.blockchain_test_engine_only,
+]
+
+# Number of zero-byte calldata bytes used to differentiate the
+# second tx's gas cost from a simple transfer.
+SECOND_TX_ZERO_BYTES = 50
+# Remaining block gas headroom in the same-sender test.
+SAME_SENDER_BLOCK_HEADROOM = 7_500
+
+PendingSpecValueKey = Literal[
+    "simple_transfer_gas",
+    "one_nonzero_byte_gas",
+    "remaining_gas_plus_zero_byte_gas",
+    "simple_transfer_gas_times_gas_price",
+]
+
+
+class PendingSpecDataRequired(TypedDict):
+    """Required fields for a pending IL tx parametrization entry."""
+
+    actual_gas_used: int | PendingSpecValueKey
+
+
+class PendingSpecData(PendingSpecDataRequired, total=False):
+    """Optional fields for a pending IL tx parametrization entry."""
+
+    nonce: int
+    sender_label: str
+    sender_balance: int | PendingSpecValueKey
+
+
+def test_block_with_same_sender_included_il_txs_is_valid(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """Including two IL txs from one sender keeps the payload valid."""
+    calc = fork.transaction_intrinsic_cost_calculator()
+    simple_transfer_gas = calc()
+    second_tx_gas = calc(
+        calldata=b"\x00" * SECOND_TX_ZERO_BYTES,
+    )
+    block_gas_limit = (
+        simple_transfer_gas + second_tx_gas + SAME_SENDER_BLOCK_HEADROOM
+    )
+    built_block = build_block(
+        pre,
+        fork=fork,
+        block_gas_limit=block_gas_limit,
+        included_block_tx_specs=(
+            IncludedBlockTx(
+                actual_gas_used=simple_transfer_gas,
+                nonce=0,
+                is_inclusion_list_tx=True,
+                sender_label="alice",
+            ),
+            IncludedBlockTx(
+                actual_gas_used=second_tx_gas,
+                nonce=1,
+                is_inclusion_list_tx=True,
+                sender_label="alice",
+            ),
+        ),
+        pending_inclusion_list_tx_specs=(),
+    )
+    assert built_block.remaining_gas == SAME_SENDER_BLOCK_HEADROOM
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=block_gas_limit),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=built_block.block_txs,
+                inclusion_list_txs=(built_block.inclusion_list_txs),
+            )
+        ],
+    )
+
+
+def test_block_with_reverting_included_il_tx_is_valid(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Include an IL tx that calls a reverting contract.
+
+    The tx reverts during execution but is present in the block body,
+    so the inclusion list check is satisfied.
+    """
+    reverting_contract = pre.deploy_contract(
+        code=Op.REVERT(0, 0),
+    )
+    sender = pre.fund_eoa(amount=10**18)
+    revert_tx = Transaction(
+        sender=sender,
+        to=reverting_contract,
+        gas_limit=100_000,
+    )
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=200_000),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[revert_tx],
+                inclusion_list_txs=[revert_tx],
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("pending_specs_data", "expected_status"),
+    [
+        pytest.param(
+            (),
+            None,
+            id="valid_with_empty_pending_il",
+        ),
+        pytest.param(
+            ({"actual_gas_used": "remaining_gas_plus_zero_byte_gas"},),
+            None,
+            id="valid_with_pending_il_txs_that_do_not_fit",
+        ),
+        pytest.param(
+            (
+                {
+                    "actual_gas_used": "simple_transfer_gas",
+                    "nonce": 1,
+                    "sender_label": "bob",
+                },
+            ),
+            None,
+            id="valid_with_pending_il_txs_that_are_invalid",
+        ),
+        pytest.param(
+            (
+                {
+                    "actual_gas_used": "simple_transfer_gas",
+                    "sender_label": "poor",
+                    "sender_balance": 0,
+                },
+            ),
+            None,
+            id="valid_with_pending_il_txs_that_fit_but_sender_cannot_afford",
+        ),
+        pytest.param(
+            (
+                {
+                    "actual_gas_used": "one_nonzero_byte_gas",
+                    "sender_balance": "simple_transfer_gas_times_gas_price",
+                },
+            ),
+            None,
+            id="valid_with_pending_il_tx_unaffordable_due_to_calldata",
+        ),
+        pytest.param(
+            ({"actual_gas_used": "simple_transfer_gas"},),
+            Spec.INCLUSION_LIST_UNSATISFIED_STATUS,
+            id="unsatisfied_with_appendable_pending_il_tx",
+        ),
+    ],
+)
+def test_block_status_depends_on_pending_inclusion_list(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    pending_specs_data: tuple[PendingSpecData, ...],
+    expected_status: str | None,
+) -> None:
+    """
+    A block is valid unless a pending IL tx is still appendable.
+
+    All scenarios share the same block body (one non-IL tx and one
+    IL tx, both simple transfers). The pending IL set varies: empty,
+    too large, invalid nonce, unaffordable, calldata-unaffordable,
+    or appendable. Only the appendable scenario should produce
+    INCLUSION_LIST_UNSATISFIED.
+    """
+    calc = fork.transaction_intrinsic_cost_calculator()
+    simple_transfer_gas = calc()
+    one_nonzero_byte_gas = calc(calldata=b"\x01")
+    zero_byte_gas = calc(calldata=b"\x00") - simple_transfer_gas
+    gas_price = TransactionDefaults.gas_price
+
+    # Block fits 2 included simple transfers plus room for a
+    # calldata-bearing pending tx and a small buffer.
+    remaining_headroom = zero_byte_gas
+    block_gas_limit = (
+        2 * simple_transfer_gas + one_nonzero_byte_gas + remaining_headroom
+    )
+    remaining_gas = one_nonzero_byte_gas + remaining_headroom
+
+    included_block_tx_specs = (
+        IncludedBlockTx(
+            actual_gas_used=simple_transfer_gas,
+            is_inclusion_list_tx=False,
+        ),
+        IncludedBlockTx(
+            actual_gas_used=simple_transfer_gas,
+            is_inclusion_list_tx=True,
+        ),
+    )
+
+    resolved_values: dict[PendingSpecValueKey, int] = {
+        "simple_transfer_gas": simple_transfer_gas,
+        "one_nonzero_byte_gas": one_nonzero_byte_gas,
+        "remaining_gas_plus_zero_byte_gas": remaining_gas + zero_byte_gas,
+        "simple_transfer_gas_times_gas_price": (
+            simple_transfer_gas * gas_price
+        ),
+    }
+    pending_specs_list: list[PendingInclusionListTx] = []
+    for pending_spec_data in pending_specs_data:
+        actual_gas_used = pending_spec_data["actual_gas_used"]
+        sender_balance = pending_spec_data.get("sender_balance", 10**18)
+        pending_specs_list.append(
+            PendingInclusionListTx(
+                actual_gas_used=(
+                    resolved_values[actual_gas_used]
+                    if isinstance(actual_gas_used, str)
+                    else actual_gas_used
+                ),
+                nonce=pending_spec_data.get("nonce", 0),
+                sender_label=pending_spec_data.get("sender_label"),
+                sender_balance=(
+                    resolved_values[sender_balance]
+                    if isinstance(sender_balance, str)
+                    else sender_balance
+                ),
+            )
+        )
+    pending_specs = tuple(pending_specs_list)
+
+    built_block = build_block(
+        pre,
+        fork=fork,
+        block_gas_limit=block_gas_limit,
+        included_block_tx_specs=included_block_tx_specs,
+        pending_inclusion_list_tx_specs=pending_specs,
+    )
+    assert built_block.remaining_gas == remaining_gas
+    assert expected_status in (
+        None,
+        Spec.INCLUSION_LIST_UNSATISFIED_STATUS,
+    )
+    blockchain_test(
+        genesis_environment=Environment(
+            gas_limit=block_gas_limit,
+        ),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=built_block.block_txs,
+                inclusion_list_txs=(built_block.inclusion_list_txs),
+            )
+        ],
+    )
+
+
+def test_unsatisfied_when_block_tx_funds_pending_il_sender(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    A preceding block tx funds the pending IL tx's sender.
+
+    Verify that FOCIL validates pending IL txs against the
+    post-execution state. A value transfer in the block gives the
+    pending IL tx's sender enough balance to afford its tx, so the
+    block is unsatisfied.
+    """
+    calc = fork.transaction_intrinsic_cost_calculator()
+    simple_transfer_gas = calc()
+    gas_price = TransactionDefaults.gas_price
+
+    value_to_fund_bob = simple_transfer_gas * gas_price
+    alice = pre.fund_eoa(
+        amount=simple_transfer_gas * gas_price + value_to_fund_bob,
+    )
+    bob = pre.fund_eoa(amount=0)
+    recipient = pre.fund_eoa()
+
+    alice_tx = Transaction(
+        sender=alice,
+        to=bob,
+        gas_limit=simple_transfer_gas,
+        value=value_to_fund_bob,
+    )
+    bob_il_tx = Transaction(
+        sender=bob,
+        to=recipient,
+        gas_limit=simple_transfer_gas,
+    )
+
+    block_gas_limit = simple_transfer_gas * 5
+    blockchain_test(
+        genesis_environment=Environment(
+            gas_limit=block_gas_limit,
+        ),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[alice_tx],
+                inclusion_list_txs=[bob_il_tx],
+            )
+        ],
+    )

--- a/tests/amsterdam/eip7805_focil/test_focil.py
+++ b/tests/amsterdam/eip7805_focil/test_focil.py
@@ -5,16 +5,21 @@ from typing import Literal, TypedDict
 import pytest
 from execution_testing import (
     Alloc,
+    AuthorizationTuple,
     Block,
     BlockchainTestFiller,
     Environment,
     Fork,
+    Hash,
     Op,
     Transaction,
+    add_kzg_version,
 )
 from execution_testing.test_types.transaction_types import (
     TransactionDefaults,
 )
+
+from ethereum.forks.amsterdam.fork import VERSIONED_HASH_VERSION_KZG
 
 from .helpers import (
     IncludedBlockTx,
@@ -190,6 +195,21 @@ def test_block_with_reverting_included_il_tx_is_valid(
             Spec.INCLUSION_LIST_UNSATISFIED_STATUS,
             id="unsatisfied_with_appendable_pending_il_tx",
         ),
+        pytest.param(
+            (
+                {
+                    "actual_gas_used": "simple_transfer_gas",
+                    "nonce": 1,
+                    "sender_label": "invalid",
+                },
+                {
+                    "actual_gas_used": "simple_transfer_gas",
+                    "sender_label": "valid",
+                },
+            ),
+            Spec.INCLUSION_LIST_UNSATISFIED_STATUS,
+            id="unsatisfied_with_mixed_valid_and_invalid_pending_il_txs",
+        ),
     ],
 )
 def test_block_status_depends_on_pending_inclusion_list(
@@ -205,8 +225,13 @@ def test_block_status_depends_on_pending_inclusion_list(
     All scenarios share the same block body (one non-IL tx and one
     IL tx, both simple transfers). The pending IL set varies: empty,
     too large, invalid nonce, unaffordable, calldata-unaffordable,
-    or appendable. Only the appendable scenario should produce
+    appendable, or a mix of invalid and appendable transactions.
+    Only scenarios with an appendable pending IL tx should produce
     INCLUSION_LIST_UNSATISFIED.
+
+    The actual IL satisfaction check happens in the Amsterdam fork after
+    executing the block body: missing IL txs are re-validated against the
+    post-state and the remaining gas headroom.
     """
     calc = fork.transaction_intrinsic_cost_calculator()
     simple_transfer_gas = calc()
@@ -290,6 +315,121 @@ def test_block_status_depends_on_pending_inclusion_list(
     )
 
 
+def test_block_with_pending_blob_il_tx_is_valid(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    Blob transactions in the IL may be omitted from the block body.
+
+    FOCIL only re-checks appendability for transactions that the execution
+    layer can validate from the block's post-state and gas headroom. Blob txs
+    are therefore ignored by the EL-side IL satisfaction pass.
+    """
+    calc = fork.transaction_intrinsic_cost_calculator()
+    simple_transfer_gas = calc()
+
+    sender = pre.fund_eoa(amount=10**18)
+    recipient = pre.fund_eoa()
+    blob_tx = Transaction(
+        sender=sender,
+        to=recipient,
+        gas_limit=simple_transfer_gas,
+        max_priority_fee_per_gas=1,
+        max_fee_per_gas=TransactionDefaults.gas_price,
+        max_fee_per_blob_gas=fork.min_base_fee_per_blob_gas(),
+        blob_versioned_hashes=add_kzg_version(
+            [Hash(1)],
+            VERSIONED_HASH_VERSION_KZG[0],
+        ),
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[],
+                inclusion_list_txs=[blob_tx],
+            )
+        ],
+    )
+
+
+def test_block_with_invalid_signature_pending_il_tx_is_valid(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    A pending IL tx with an invalid signature may be omitted.
+
+    FOCIL reuses normal transaction validation for missing IL transactions.
+    If the signature is invalid, the tx is not appendable and omission is
+    allowed.
+    """
+    del fork
+
+    sender = pre.fund_eoa(amount=10**18)
+    recipient = pre.fund_eoa()
+    invalid_signature_tx = Transaction(
+        sender=sender,
+        to=recipient,
+        gas_limit=21_000,
+        v=0,
+        r=0,
+        s=0,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=21_000 * 4),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[],
+                inclusion_list_txs=[invalid_signature_tx],
+            )
+        ],
+    )
+
+
+def test_block_with_intrinsic_gas_too_low_pending_il_tx_is_valid(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+) -> None:
+    """
+    A pending IL tx with gas limit below intrinsic gas may be omitted.
+
+    Even with enough remaining block gas, a transaction whose declared gas
+    limit is below its intrinsic cost is invalid and therefore does not make
+    the payload IL-unsatisfied.
+    """
+    simple_transfer_gas = fork.transaction_intrinsic_cost_calculator()()
+    sender = pre.fund_eoa(amount=10**18)
+    recipient = pre.fund_eoa()
+    intrinsic_gas_too_low_tx = Transaction(
+        sender=sender,
+        to=recipient,
+        gas_limit=simple_transfer_gas - 1,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=simple_transfer_gas * 4),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[],
+                inclusion_list_txs=[intrinsic_gas_too_low_tx],
+            )
+        ],
+    )
+
+
 def test_unsatisfied_when_block_tx_funds_pending_il_sender(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,
@@ -336,6 +476,83 @@ def test_unsatisfied_when_block_tx_funds_pending_il_sender(
         blocks=[
             Block(
                 txs=[alice_tx],
+                inclusion_list_txs=[bob_il_tx],
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("authorization_nonce", "pending_il_nonce"),
+    [
+        pytest.param(0, 0, id="valid_authorization_omits_nonce_zero_il"),
+        pytest.param(
+            0,
+            1,
+            id="valid_authorization_requires_nonce_one_il",
+        ),
+        pytest.param(
+            1,
+            0,
+            id="invalid_authorization_keeps_nonce_zero_il_appendable",
+        ),
+        pytest.param(
+            1,
+            1,
+            id="invalid_authorization_omits_nonce_one_il",
+        ),
+    ],
+)
+def test_pending_il_depends_on_7702_authorization_nonce_effect(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    authorization_nonce: int,
+    pending_il_nonce: int,
+) -> None:
+    """
+    EIP-7702 authorization handling changes whether a pending IL tx is valid.
+
+    A valid authorization from Bob increments Bob's nonce during block
+    execution, so Bob's pending nonce-0 tx becomes invalid while a nonce-1 tx
+    becomes appendable. If the authorization is invalid, Bob's nonce stays at
+    0 and the opposite IL outcome applies.
+    """
+    calc = fork.transaction_intrinsic_cost_calculator()
+    simple_transfer_gas = calc()
+
+    alice = pre.fund_eoa(amount=10**18)
+    bob = pre.fund_eoa(amount=10**18)
+    delegated_contract = pre.deploy_contract(Op.STOP)
+    recipient = pre.fund_eoa()
+    bob_recipient = pre.fund_eoa()
+
+    set_code_tx = Transaction(
+        sender=alice,
+        to=recipient,
+        gas_limit=100_000,
+        authorization_list=[
+            AuthorizationTuple(
+                signer=bob,
+                address=delegated_contract,
+                nonce=authorization_nonce,
+            )
+        ],
+    )
+    bob_il_tx = Transaction(
+        sender=bob,
+        nonce=pending_il_nonce,
+        to=bob_recipient,
+        gas_limit=simple_transfer_gas,
+    )
+
+    blockchain_test(
+        genesis_environment=Environment(gas_limit=200_000),
+        pre=pre,
+        post={},
+        blocks=[
+            Block(
+                txs=[set_code_tx],
                 inclusion_list_txs=[bob_il_tx],
             )
         ],


### PR DESCRIPTION
## 🗒️ Description
Adds the necessary framework logic to support FOCIL, also adds a bunch of FOCIL tests.

## How to reproduce

Unit tests: `uv run pytest -v -s packages/testing/src/execution_testing/specs/tests/test_fixtures.py packages/testing/src/execution_testing/fixtures/tests/test_blockchain.py packages/testing/src/execution_testing/client_clis/tests/test_transition_tool.py packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_sync.py packages/testing/src/execution_testing/cli/pytest_commands/plugins/consume/simulators/simulator_logic/test_via_engine.py`

Fill focil tests: `uv run fill -v -s --no-html --clean ./tests/amsterdam/eip7805_focil --until=amsterdam`

## 🔗 Related Issues or PRs
#1900 

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

<img
  src="https://media.discordapp.net/attachments/1349696533922320478/1491808386348613772/PNG_image_57.png?ex=69d90a53&is=69d7b8d3&hm=748aadb875c36fe445377de6d6c26943df5c187e4d6a3d1427980036ecc78b9b&=&format=webp&quality=lossless&width=1088&height=1088"
  alt="Cute Animal Picture"
  width="320">

