### PR TITLE
feat(tests): EIP-8037 - CALL with value to selfdestructed account

### DIFF
--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -23,13 +23,17 @@ from execution_testing import (
     BlockchainTestFiller,
     Environment,
     Fork,
+    Header,
     Op,
     StateTestFiller,
     Storage,
     Transaction,
+    compute_create2_address,
+    compute_create_address,
 )
+from execution_testing.checklists import EIPChecklist
 
-from .spec import ref_spec_8037
+from .spec import init_code_at_high_bytes, ref_spec_8037
 
 REFERENCE_SPEC_GIT_PATH = ref_spec_8037.git_path
 REFERENCE_SPEC_VERSION = ref_spec_8037.version
@@ -914,3 +918,360 @@ def test_call_new_account_header_gas_used(
         ],
         post={contract: Account(storage=storage)},
     )
+
+
+@pytest.mark.parametrize(
+    "create_opcode",
+    [
+        pytest.param(Op.CREATE, id="create"),
+        pytest.param(Op.CREATE2, id="create2"),
+    ],
+)
+@EIPChecklist.GasCostChanges.Test.GasUpdatesMeasurement()
+@pytest.mark.valid_from("EIP8037")
+def test_call_value_to_self_destructed_same_tx_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+) -> None:
+    """
+    Verify CALL with value to a same transaction selfdestructed
+    account succeeds and charges no new account state gas.
+
+    The account still has its CREATE nonce when the CALL runs, so it
+    is neither empty nor nonexistent and the new account creation
+    gate does not fire. End of the transaction destruction removes
+    the account regardless, and the value transferred is burned.
+    """
+    env = Environment()
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+    sstore_state_gas = fork.sstore_state_gas()
+
+    inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    mstore_value, size = init_code_at_high_bytes(inner_code)
+
+    storage = Storage()
+    orchestrator = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, mstore_value)
+            + (
+                Op.CREATE2(1, 0, size, 0)
+                if create_opcode == Op.CREATE2
+                else Op.CREATE(1, 0, size)
+            )
+            + Op.MSTORE(0x20, Op.DUP1)
+            + Op.POP
+            + Op.SSTORE(
+                storage.store_next(1, "call_succeeds"),
+                Op.CALL(gas=Op.GAS, address=Op.MLOAD(0x20), value=1),
+            )
+        ),
+        balance=3,
+    )
+
+    tx = Transaction(
+        to=orchestrator,
+        gas_limit=gas_limit_cap + new_account_state_gas + sstore_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {orchestrator: Account(storage=storage)}
+    state_test(env=env, pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "selfdestruct_beneficiary",
+    [
+        pytest.param("self", id="self_beneficiary"),
+        pytest.param("external", id="external_beneficiary"),
+    ],
+)
+@pytest.mark.parametrize(
+    "create_opcode",
+    [
+        pytest.param(Op.CREATE, id="create"),
+        pytest.param(Op.CREATE2, id="create2"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_call_value_to_self_destructed_header_gas_used(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    selfdestruct_beneficiary: str,
+) -> None:
+    """
+    Verify block gas accounting for CALL with value to a same
+    transaction selfdestructed account.
+
+    Reservoir is sized for the CREATE's state charge only. Under
+    the spec no new account charge fires on the CALL, so block
+    state gas used equals exactly the single account creation
+    charge and the header reports that value. The created account
+    is queued for destruction regardless of whether SELFDESTRUCT
+    targeted itself or an external beneficiary, so the no charge
+    behavior holds across both cases.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+
+    if selfdestruct_beneficiary == "self":
+        inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    else:
+        # Alive EOA so the SELFDESTRUCT itself does not charge a
+        # new account state gas for the beneficiary.
+        alive_beneficiary = pre.fund_eoa(amount=1)
+        inner_code = Op.SELFDESTRUCT(alive_beneficiary)
+    mstore_value, size = init_code_at_high_bytes(inner_code)
+
+    orchestrator = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, mstore_value)
+            + (
+                Op.CREATE2(1, 0, size, 0)
+                if create_opcode == Op.CREATE2
+                else Op.CREATE(1, 0, size)
+            )
+            + Op.MSTORE(0x20, Op.DUP1)
+            + Op.POP
+            + Op.POP(Op.CALL(gas=Op.GAS, address=Op.MLOAD(0x20), value=1))
+        ),
+        balance=3,
+    )
+
+    tx = Transaction(
+        to=orchestrator,
+        gas_limit=gas_limit_cap + new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=new_account_state_gas),
+            ),
+        ],
+        post={},
+    )
+
+
+@pytest.mark.parametrize(
+    "call_value",
+    [
+        pytest.param(1, id="one_wei"),
+        pytest.param(10**18, id="one_ether"),
+    ],
+)
+@pytest.mark.parametrize(
+    "create_opcode",
+    [
+        pytest.param(Op.CREATE, id="create"),
+        pytest.param(Op.CREATE2, id="create2"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_call_value_to_self_destructed_burns_value(
+    blockchain_test: BlockchainTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+    call_value: int,
+) -> None:
+    """
+    Verify value transferred to a same transaction selfdestructed
+    account is burned when end of the transaction destruction runs.
+
+    The orchestrator funds the inner contract via CREATE, the
+    initcode immediately selfdestructs, and then the orchestrator
+    transfers more value into the now queued for destruction
+    address. At the end of the transaction the account is removed
+    and the accumulated balance is lost.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+
+    inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    mstore_value, size = init_code_at_high_bytes(inner_code)
+
+    initial_balance = 2 * call_value
+    orchestrator = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, mstore_value)
+            + (
+                Op.CREATE2(call_value, 0, size, 0)
+                if create_opcode == Op.CREATE2
+                else Op.CREATE(call_value, 0, size)
+            )
+            + Op.MSTORE(0x20, Op.DUP1)
+            + Op.POP
+            + Op.POP(
+                Op.CALL(
+                    gas=Op.GAS,
+                    address=Op.MLOAD(0x20),
+                    value=call_value,
+                )
+            )
+        ),
+        balance=initial_balance,
+    )
+    # CREATE/CREATE2 address depends on the opcode, but for both the
+    # orchestrator's nonce after the deploy is 1 at the time of the
+    # CREATE. Using compute_create_address for CREATE is correct; for
+    # CREATE2 the deterministic address depends on salt and initcode.
+    # Use a salt of 0 and the initcode built above for CREATE2.
+    if create_opcode == Op.CREATE2:
+        created_address = compute_create2_address(
+            address=orchestrator,
+            salt=0,
+            initcode=bytes(inner_code),
+        )
+    else:
+        created_address = compute_create_address(address=orchestrator, nonce=1)
+
+    tx = Transaction(
+        to=orchestrator,
+        gas_limit=gas_limit_cap + new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    blockchain_test(
+        pre=pre,
+        blocks=[Block(txs=[tx])],
+        post={
+            created_address: Account.NONEXISTENT,
+            orchestrator: Account(balance=0),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "create_opcode",
+    [
+        pytest.param(Op.CREATE, id="create"),
+        pytest.param(Op.CREATE2, id="create2"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_call_zero_value_to_self_destructed_same_tx_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    create_opcode: Op,
+) -> None:
+    """
+    Verify CALL with zero value to a same transaction selfdestructed
+    account charges no new account state gas.
+
+    Value transfer gates the new account creation charge, so a zero
+    value CALL never triggers it regardless of the target's state.
+    The reservoir covers only the CREATE's charge; any spurious
+    charge on the zero value CALL would spill and run the
+    orchestrator out of gas.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+    new_account_state_gas = fork.gas_costs().GAS_NEW_ACCOUNT
+
+    inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
+    mstore_value, size = init_code_at_high_bytes(inner_code)
+
+    storage = Storage()
+    orchestrator = pre.deploy_contract(
+        code=(
+            Op.MSTORE(0, mstore_value)
+            + (
+                Op.CREATE2(1, 0, size, 0)
+                if create_opcode == Op.CREATE2
+                else Op.CREATE(1, 0, size)
+            )
+            + Op.MSTORE(0x20, Op.DUP1)
+            + Op.POP
+            + Op.SSTORE(
+                storage.store_next(1, "call_succeeds"),
+                Op.CALL(gas=Op.GAS, address=Op.MLOAD(0x20), value=0),
+            )
+        ),
+        balance=3,
+    )
+
+    tx = Transaction(
+        to=orchestrator,
+        gas_limit=gas_limit_cap + new_account_state_gas,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {orchestrator: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)
+
+
+@pytest.mark.parametrize(
+    "beneficiary_type",
+    [
+        pytest.param("eoa", id="eoa_beneficiary"),
+        pytest.param("contract", id="contract_beneficiary"),
+    ],
+)
+@pytest.mark.valid_from("EIP8037")
+def test_call_value_to_pre_existing_selfdestructed_account(
+    state_test: StateTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    beneficiary_type: str,
+) -> None:
+    """
+    Verify CALL with value to a pre existing contract that ran
+    SELFDESTRUCT charges no new account state gas.
+
+    Per EIP-6780 a pre existing contract that executes SELFDESTRUCT
+    is not queued for end of the transaction destruction, so a
+    subsequent CALL sees an existing, code carrying account and the
+    new account creation gate does not fire. No reservoir is needed
+    for the value bearing CALL. Covered for both an EOA beneficiary
+    and a pre existing contract beneficiary.
+    """
+    gas_limit_cap = fork.transaction_gas_limit_cap()
+    assert gas_limit_cap is not None
+
+    # Beneficiary must be alive so the target's SELFDESTRUCT itself
+    # does not charge for creating a new beneficiary.
+    beneficiary: Address = (
+        pre.fund_eoa(amount=1)
+        if beneficiary_type == "eoa"
+        else pre.deploy_contract(code=Op.STOP)
+    )
+    target = pre.deploy_contract(
+        code=Op.SELFDESTRUCT(beneficiary),
+        balance=1,
+    )
+
+    storage = Storage()
+    orchestrator = pre.deploy_contract(
+        code=(
+            Op.SSTORE(
+                storage.store_next(1, "selfdestruct_call_succeeds"),
+                Op.CALL(gas=Op.GAS, address=target),
+            )
+            + Op.SSTORE(
+                storage.store_next(1, "value_call_succeeds"),
+                Op.CALL(gas=Op.GAS, address=target, value=1),
+            )
+        ),
+        balance=3,
+    )
+
+    tx = Transaction(
+        to=orchestrator,
+        gas_limit=gas_limit_cap,
+        sender=pre.fund_eoa(),
+    )
+
+    post = {orchestrator: Account(storage=storage)}
+    state_test(pre=pre, post=post, tx=tx)

--- a/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
+++ b/tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py
@@ -21,6 +21,7 @@ from execution_testing import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Environment,
     Fork,
     Header,
@@ -936,13 +937,16 @@ def test_call_value_to_self_destructed_same_tx_account(
     create_opcode: Op,
 ) -> None:
     """
-    Verify CALL with value to a same transaction selfdestructed
-    account succeeds and charges no new account state gas.
+    Smoke test for CALL with value to a same transaction
+    selfdestructed account.
 
-    The account still has its CREATE nonce when the CALL runs, so it
-    is neither empty nor nonexistent and the new account creation
-    gate does not fire. End of the transaction destruction removes
-    the account regardless, and the value transferred is burned.
+    Confirms the happy path runs to completion. The account still
+    has its CREATE nonce when the CALL runs, so it is neither empty
+    nor nonexistent and the new account creation gate does not fire;
+    end of the transaction destruction removes the account regardless
+    and the value transferred is burned. Strict discrimination of
+    the no charge behavior lives in
+    `test_call_value_to_self_destructed_header_gas_used`.
     """
     env = Environment()
     gas_limit_cap = fork.transaction_gas_limit_cap()
@@ -1142,9 +1146,17 @@ def test_call_value_to_self_destructed_burns_value(
         sender=pre.fund_eoa(),
     )
 
+    # Header reflects the CREATE's single new account state gas
+    # charge. A spurious charge on the value bearing CALL would
+    # double the state gas component.
     blockchain_test(
         pre=pre,
-        blocks=[Block(txs=[tx])],
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=new_account_state_gas),
+            ),
+        ],
         post={
             created_address: Account.NONEXISTENT,
             orchestrator: Account(balance=0),
@@ -1161,7 +1173,7 @@ def test_call_value_to_self_destructed_burns_value(
 )
 @pytest.mark.valid_from("EIP8037")
 def test_call_zero_value_to_self_destructed_same_tx_account(
-    state_test: StateTestFiller,
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     create_opcode: Op,
@@ -1170,11 +1182,11 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
     Verify CALL with zero value to a same transaction selfdestructed
     account charges no new account state gas.
 
-    Value transfer gates the new account creation charge, so a zero
-    value CALL never triggers it regardless of the target's state.
-    The reservoir covers only the CREATE's charge; any spurious
-    charge on the zero value CALL would spill and run the
-    orchestrator out of gas.
+    Value transfer gates the new account creation charge. Under the
+    correct spec the block header reflects only the CREATE's single
+    new account state gas charge. A spurious charge on the zero
+    value CALL (value gate broken) would double the state gas
+    component.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
@@ -1183,7 +1195,6 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
     inner_code = Op.SELFDESTRUCT(Op.ADDRESS)
     mstore_value, size = init_code_at_high_bytes(inner_code)
 
-    storage = Storage()
     orchestrator = pre.deploy_contract(
         code=(
             Op.MSTORE(0, mstore_value)
@@ -1194,10 +1205,7 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
             )
             + Op.MSTORE(0x20, Op.DUP1)
             + Op.POP
-            + Op.SSTORE(
-                storage.store_next(1, "call_succeeds"),
-                Op.CALL(gas=Op.GAS, address=Op.MLOAD(0x20), value=0),
-            )
+            + Op.POP(Op.CALL(gas=Op.GAS, address=Op.MLOAD(0x20), value=0))
         ),
         balance=3,
     )
@@ -1208,8 +1216,16 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
         sender=pre.fund_eoa(),
     )
 
-    post = {orchestrator: Account(storage=storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=new_account_state_gas),
+            ),
+        ],
+        post={},
+    )
 
 
 @pytest.mark.parametrize(
@@ -1221,7 +1237,7 @@ def test_call_zero_value_to_self_destructed_same_tx_account(
 )
 @pytest.mark.valid_from("EIP8037")
 def test_call_value_to_pre_existing_selfdestructed_account(
-    state_test: StateTestFiller,
+    blockchain_test: BlockchainTestFiller,
     pre: Alloc,
     fork: Fork,
     beneficiary_type: str,
@@ -1233,12 +1249,23 @@ def test_call_value_to_pre_existing_selfdestructed_account(
     Per EIP-6780 a pre existing contract that executes SELFDESTRUCT
     is not queued for end of the transaction destruction, so a
     subsequent CALL sees an existing, code carrying account and the
-    new account creation gate does not fire. No reservoir is needed
-    for the value bearing CALL. Covered for both an EOA beneficiary
-    and a pre existing contract beneficiary.
+    new account creation gate does not fire.
+
+    Several cold SSTOREs after the CALLs make block state gas
+    dominate the block regular gas component, so the block header
+    reflects exactly `num_probes * sstore_state_gas`. A spurious
+    new account charge on the value bearing CALL would push the
+    header up by that charge, breaking the assertion.
     """
     gas_limit_cap = fork.transaction_gas_limit_cap()
     assert gas_limit_cap is not None
+    sstore_state_gas = fork.sstore_state_gas()
+
+    # Enough probes that the combined probe state gas dominates the
+    # transaction's regular gas component and the header reflects
+    # block state gas alone.
+    num_probes = 6
+    probe_state_gas = num_probes * sstore_state_gas
 
     # Beneficiary must be alive so the target's SELFDESTRUCT itself
     # does not charge for creating a new beneficiary.
@@ -1252,26 +1279,31 @@ def test_call_value_to_pre_existing_selfdestructed_account(
         balance=1,
     )
 
-    storage = Storage()
+    probes = Bytecode()
+    for slot in range(num_probes):
+        probes += Op.SSTORE(slot, 1)
     orchestrator = pre.deploy_contract(
         code=(
-            Op.SSTORE(
-                storage.store_next(1, "selfdestruct_call_succeeds"),
-                Op.CALL(gas=Op.GAS, address=target),
-            )
-            + Op.SSTORE(
-                storage.store_next(1, "value_call_succeeds"),
-                Op.CALL(gas=Op.GAS, address=target, value=1),
-            )
+            Op.POP(Op.CALL(gas=Op.GAS, address=target))
+            + Op.POP(Op.CALL(gas=Op.GAS, address=target, value=1))
+            + probes
         ),
         balance=3,
     )
 
     tx = Transaction(
         to=orchestrator,
-        gas_limit=gas_limit_cap,
+        gas_limit=gas_limit_cap + probe_state_gas,
         sender=pre.fund_eoa(),
     )
 
-    post = {orchestrator: Account(storage=storage)}
-    state_test(pre=pre, post=post, tx=tx)
+    blockchain_test(
+        pre=pre,
+        blocks=[
+            Block(
+                txs=[tx],
+                header_verify=Header(gas_used=probe_state_gas),
+            ),
+        ],
+        post={},
+    )


### PR DESCRIPTION
## 🗒️ Description

Adds test coverage for CALL with value to an account that was selfdestructed (per EIP-6780), both the same transaction case and the pre existing case. No spec change: EIP-8037 and EIP-6780 together already produce the correct behavior, and this PR documents it with strict `header_verify` discriminators.

Related EIP spec clarification: ethereum/EIPs#11532 (point 5).

### Behavior under test

When an account is created and then selfdestructed in the same transaction, EIP-6780 defers deletion to the end of the transaction. During the transaction the account still has `nonce = 1` from the CREATE, so it is neither empty nor nonexistent and the new account creation gate does not fire on a subsequent CALL with value, no `GAS_NEW_ACCOUNT` state gas is charged. End of the transaction destruction still removes the account regardless of any value received after SELFDESTRUCT, so value transferred by the CALL is burned along with the destroyed account. Combined with the same transaction SELFDESTRUCT state gas refund (ethereum/execution-specs#2707), the net state gas across the `CREATE + SELFDESTRUCT + CALL(value)` lifecycle is zero.

For a pre existing contract that runs SELFDESTRUCT, EIP-6780 does not queue it for destruction, so a subsequent CALL sees an existing, code carrying account and the new account creation gate does not fire either.

### Tests

All in `tests/amsterdam/eip8037_state_creation_gas_cost_increase/test_state_gas_call.py`. The `init_code_at_high_bytes` helper is moved to `spec.py` for reuse with the related PR ethereum/execution-specs#2707.

- `test_call_value_to_self_destructed_same_tx_account`, smoke test parametrized `create_opcode=[CREATE, CREATE2]`. Confirms the happy path runs to completion. Strict discrimination lives in `test_call_value_to_self_destructed_header_gas_used`.
- `test_call_value_to_self_destructed_header_gas_used`, strict `header_verify` discriminator parametrized `create_opcode=[CREATE, CREATE2]` × `selfdestruct_beneficiary=[self, external]`. Block header `gas_used` equals exactly one `GAS_NEW_ACCOUNT` (only the CREATE's state charge), proving no second charge from the CALL.
- `test_call_value_to_self_destructed_burns_value`, strict `header_verify` parametrized `create_opcode=[CREATE, CREATE2]` × `call_value=[1 wei, 1 ether]`. Block header gas used equals one `GAS_NEW_ACCOUNT`. Post state asserts the created address is `NONEXISTENT` and the orchestrator balance is zero, proving the value is burned when end of the transaction destruction runs.
- `test_call_zero_value_to_self_destructed_same_tx_account`, strict `header_verify` parametrized `create_opcode=[CREATE, CREATE2]`. Value transfer gates the new account charge, so a zero value CALL never triggers it. Block header equals one `GAS_NEW_ACCOUNT`.
- `test_call_value_to_pre_existing_selfdestructed_account`, strict `header_verify` parametrized `beneficiary_type=[eoa, contract]`. Pre deployed contract runs SELFDESTRUCT, then the orchestrator does a value bearing CALL and a sequence of cold SSTORE probes that make block state gas dominate. Block header gas used equals `num_probes * sstore_state_gas` exactly. A spurious new account charge on the value bearing CALL would push the header up by that charge.

## 🔗 Related Issues or PRs

- EIPs PR: ethereum/EIPs#11532

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).