### PR TITLE
feat(test-plugins-forks): Introduce `pytest.mark.valid_before`

### DIFF
--- a/docs/writing_tests/test_markers.md
+++ b/docs/writing_tests/test_markers.md
@@ -16,6 +16,10 @@ These markers are used to specify the forks for which a test is valid.
 
 :::execution_testing.cli.pytest_commands.plugins.forks.forks.ValidUntil
 
+### `@pytest.mark.valid_before("FORK_OR_EIP")`
+
+:::execution_testing.cli.pytest_commands.plugins.forks.forks.ValidBefore
+
 ### `@pytest.mark.valid_at("FORK_NAME_1", "FORK_NAME_2", ...)`
 
 :::execution_testing.cli.pytest_commands.plugins.forks.forks.ValidAt

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/forks.py
@@ -478,7 +478,17 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "valid_until(fork): specifies until which fork a test case is valid",
+        (
+            "valid_until(fork): specifies until which fork a test "
+            "case is valid (inclusive)"
+        ),
+    )
+    config.addinivalue_line(
+        "markers",
+        (
+            "valid_before(fork_or_eip): specifies the fork or EIP "
+            "before which a test case is valid (exclusive)"
+        ),
     )
     config.addinivalue_line(
         "markers",
@@ -967,6 +977,49 @@ class ValidUntil(ValidityMarker):
         return resulting_set
 
 
+class ValidBefore(ValidityMarker, mutually_exclusive=[ValidUntil]):
+    """
+    Marker to specify the fork or EIP before which the test is valid.
+
+    The test will be filled for all forks strictly before the specified
+    fork — the fork itself is **excluded**.
+
+    ``valid_before`` vs ``valid_until``:
+
+    - ``valid_until("Prague")`` — inclusive: runs *through* Prague.
+    - ``valid_before("EIP7825")`` — exclusive: runs up to but *not at*
+      the point where EIP-7825 activates.
+
+    ```python
+    import pytest
+
+    from execution_testing import  Alloc, StateTestFiller
+
+    @pytest.mark.valid_before("EIP7825")
+    def test_something_only_valid_before_eip7825(
+        state_test: StateTestFiller,
+        pre: Alloc
+    ):
+        pass
+    ```
+
+    In this example, the test will only be filled for forks where
+    EIP-7825 is not yet active.
+    """
+
+    def _process_with_marker_args(
+        self, *fork_args: str
+    ) -> Set[Fork | TransitionFork]:
+        """Process the fork arguments."""
+        forks: Set[Fork | TransitionFork] = self.process_fork_arguments(
+            *fork_args
+        )
+        resulting_set: Set[Fork | TransitionFork] = set()
+        for fork in forks:
+            resulting_set |= {f for f in ALL_FORKS if f < fork}
+        return resulting_set
+
+
 class ValidAt(ValidityMarker):
     """
     Marker to specify each fork individually for which the test is valid.
@@ -996,7 +1049,8 @@ class ValidAt(ValidityMarker):
 
 
 class ValidAtTransitionTo(
-    ValidityMarker, mutually_exclusive=[ValidAt, ValidFrom, ValidUntil]
+    ValidityMarker,
+    mutually_exclusive=[ValidAt, ValidFrom, ValidUntil, ValidBefore],
 ):
     """
     Marker to specify that a test is only meant to be filled at the transition
@@ -1476,8 +1530,9 @@ def pytest_collection_modifyitems(
 
     Two kinds of filtering are applied:
 
-    1. **Validity markers** — param-level ``valid_from`` / ``valid_until``
-       markers that the ``pytest_generate_tests`` hook cannot see.
+    1. **Validity markers** — param-level ``valid_from`` / ``valid_until`` /
+       ``valid_before`` markers that the ``pytest_generate_tests`` hook
+       cannot see.
     2. **Combination filters** — the ``filter_combinations`` marker lets
        test authors reject specific cross-parameter tuples at collection
        time instead of calling ``pytest.skip()`` at runtime.

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_covariant_markers.py
@@ -129,6 +129,20 @@ import pytest
         pytest.param(
             """
             import pytest
+            @pytest.mark.with_all_tx_types()
+            @pytest.mark.valid_from("Paris")
+            @pytest.mark.valid_before("Shanghai")
+            @pytest.mark.state_test_only
+            def test_case(state_test, tx_type):
+                pass
+            """,
+            {"passed": 3, "failed": 0, "skipped": 0, "errors": 0},
+            None,
+            id="with_all_tx_types_valid_before",
+        ),
+        pytest.param(
+            """
+            import pytest
             @pytest.mark.with_all_contract_creating_tx_types()
             @pytest.mark.valid_from("Paris")
             @pytest.mark.valid_until("Paris")

--- a/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/plugins/forks/tests/test_markers.py
@@ -159,6 +159,40 @@ def test_case(state_test):
         ),
         pytest.param(
             generate_test(
+                valid_before='"Cancun"',
+            ),
+            ["--from=Berlin", "--until=Prague"],
+            {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_before",
+        ),
+        pytest.param(
+            generate_test(
+                valid_from='"Paris"',
+                valid_before='"Cancun"',
+            ),
+            ["--until=Prague"],
+            {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_from_before",
+        ),
+        pytest.param(
+            generate_test(
+                valid_before='"EIP4844"',
+            ),
+            ["--from=Berlin", "--until=Prague"],
+            {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_before_eip",
+        ),
+        pytest.param(
+            generate_test(
+                valid_from='"EIP3675"',
+                valid_before='"EIP4844"',
+            ),
+            ["--until=Prague"],
+            {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
+            id="valid_from_eip_before_eip",
+        ),
+        pytest.param(
+            generate_test(
                 valid_from='"Osaka"',
                 valid_until='"BPO1"',
             ),
@@ -320,6 +354,32 @@ def test_param_level_valid_until(state_test, value):
 """
 
 
+def generate_param_level_valid_before_test() -> str:
+    """Generate a test with param-level valid_before markers."""
+    return """
+import pytest
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(
+            True,
+            id="before_cancun",
+            marks=pytest.mark.valid_before("Cancun"),
+        ),
+        pytest.param(
+            False,
+            id="before_paris",
+            marks=pytest.mark.valid_before("Paris"),
+        ),
+    ],
+)
+@pytest.mark.state_test_only
+def test_param_level_valid_before(state_test, value):
+    pass
+"""
+
+
 def generate_param_level_mixed_test() -> str:
     """Generate a test with both function-level and param-level markers."""
     return """
@@ -417,6 +477,24 @@ def test_mixed_function_and_param_markers(state_test, value):
             {"passed": 4, "failed": 0, "skipped": 0, "errors": 0},
             id="mixed_markers_paris_to_shanghai",
         ),
+        pytest.param(
+            generate_param_level_valid_before_test(),
+            ["--from=Paris", "--until=Prague"],
+            # before_cancun: Paris, Shanghai = 2 forks
+            # before_paris: none (Paris is not < Paris)
+            # Total: 2 tests
+            {"passed": 2, "failed": 0, "skipped": 0, "errors": 0},
+            id="param_level_valid_before_paris_to_prague",
+        ),
+        pytest.param(
+            generate_param_level_valid_before_test(),
+            ["--from=Berlin", "--until=Prague"],
+            # before_cancun: Berlin, London, Paris, Shanghai = 4
+            # before_paris: Berlin, London = 2
+            # Total: 6 tests
+            {"passed": 6, "failed": 0, "skipped": 0, "errors": 0},
+            id="param_level_valid_before_berlin_to_prague",
+        ),
     ],
 )
 def test_param_level_validity_markers(
@@ -426,7 +504,7 @@ def test_param_level_validity_markers(
     pytest_args: List[str],
 ) -> None:
     """
-    Test param-level validity markers (valid_from, valid_until).
+    Test param-level validity markers (valid_from, valid_until, valid_before).
 
     The pytest_collection_modifyitems hook filters tests based on param-level
     markers after parametrization, allowing different parameter values to have

--- a/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_6780.py
+++ b/packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_6780.py
@@ -1,0 +1,16 @@
+"""
+EIP-6780: SELFDESTRUCT only in same transaction.
+
+SELFDESTRUCT will recover all funds to the target but not delete the account,
+except when called in the same transaction as creation.
+
+https://eips.ethereum.org/EIPS/eip-6780
+"""
+
+from ....base_fork import BaseFork
+
+
+class EIP6780(BaseFork):
+    """EIP-6780 class."""
+
+    pass

--- a/packages/testing/src/execution_testing/forks/forks/forks.py
+++ b/packages/testing/src/execution_testing/forks/forks/forks.py
@@ -1389,6 +1389,7 @@ class Cancun(
     eips.EIP4788,
     eips.EIP4844,
     eips.EIP7516,
+    eips.EIP6780,
     Shanghai,
 ):
     """Cancun fork."""

--- a/tests/constantinople/eip1014_create2/test_recreate.py
+++ b/tests/constantinople/eip1014_create2/test_recreate.py
@@ -21,7 +21,7 @@ REFERENCE_SPEC_VERSION = ref_spec_1014.version
 
 @pytest.mark.parametrize("recreate_on_separate_block", [True, False])
 @pytest.mark.valid_from("Constantinople")
-@pytest.mark.valid_until("Shanghai")
+@pytest.mark.valid_before("EIP6780")
 def test_recreate(
     blockchain_test: BlockchainTestFiller,
     pre: Alloc,

--- a/tests/frontier/examples/test_block_intermediate_state.py
+++ b/tests/frontier/examples/test_block_intermediate_state.py
@@ -12,7 +12,7 @@ from execution_testing import (
 
 
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.valid_until("Homestead")
+@pytest.mark.valid_before("SpuriousDragon")
 def test_block_intermediate_state(
     blockchain_test: BlockchainTestFiller, pre: Alloc
 ) -> None:

--- a/tests/frontier/opcodes/test_selfdestruct.py
+++ b/tests/frontier/opcodes/test_selfdestruct.py
@@ -13,7 +13,7 @@ from execution_testing import (
 
 
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.valid_until("Homestead")
+@pytest.mark.valid_before("SpuriousDragon")
 def test_double_kill(
     blockchain_test: BlockchainTestFiller, pre: Alloc
 ) -> None:

--- a/tests/frontier/touch/test_touch.py
+++ b/tests/frontier/touch/test_touch.py
@@ -12,7 +12,7 @@ from execution_testing import (
 
 
 @pytest.mark.valid_from("Frontier")
-@pytest.mark.valid_until("Berlin")
+@pytest.mark.valid_before("EIP1559")
 @pytest.mark.eels_base_coverage
 def test_zero_gas_price_and_touching(
     state_test: StateTestFiller,

--- a/tests/frontier/validation/test_header.py
+++ b/tests/frontier/validation/test_header.py
@@ -19,11 +19,11 @@ from execution_testing.test_types.block_types import Environment
         pytest.param(0, marks=pytest.mark.exception_test),
         pytest.param(1, marks=pytest.mark.exception_test),
         pytest.param(4999, marks=pytest.mark.exception_test),
-        pytest.param(5000, marks=pytest.mark.valid_until("Osaka")),
+        pytest.param(5000, marks=pytest.mark.valid_before("EIP7928")),
         pytest.param(
             5000,
             marks=[
-                pytest.mark.valid_from("Amsterdam"),
+                pytest.mark.valid_from("EIP7928"),
                 pytest.mark.exception_test,
             ],
         ),


### PR DESCRIPTION
## 🗒️ Description

Add a new `@pytest.mark.valid_before("FORK_OR_EIP")` test validity marker with exclusive upper-bound semantics, complementing the existing inclusive `valid_until`.

The distinction:
- `valid_until("Prague")`: Inclusive, test runs through Prague.
- `valid_before("EIP7825")`: Exclusive, test runs up to but not at the point where EIP-7825 activates.

This is useful when a test becomes invalid due to a specific EIP rather than at a fork boundary.

Using `valid_before("EIP7825")` is more precise and self-documenting than `valid_until("Prague")` (it says why the test stops being valid, not just when).

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://photos.mongabay.com/j/lynx_DSC0134.568.jpg)
