### PR TITLE
feat(tooling,test-cli): add just checklist and `allowed_exit_codes` to `PytestCommand`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,4 @@ env.yaml
 site/
 
 # Generated checklists
-docs/checklist/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,5 @@ env.yaml
 
 site/
 
-# Generated checklists
+# Temporary data; used for generated checklists
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ logs/
 env.yaml
 
 site/
+
+# Generated checklists
+docs/checklist/

--- a/Justfile
+++ b/Justfile
@@ -263,6 +263,17 @@ bench-opcode-config *args:
         "$@" \
         tests/benchmark/compute
 
+# --- Checklists ---
+
+# Generate EIP test checklists from eip_checklist markers
+[group('checklists')]
+checklist *args:
+    #!/usr/bin/env bash
+    uv run checklist --output docs/checklist "$@"
+    rc=$?
+    # exit code 5 = "no tests ran" which is expected (collect-only)
+    if [ $rc -eq 5 ] || [ $rc -eq 0 ]; then exit 0; else exit $rc; fi
+
 # --- Docs ---
 
 # Generate documentation for EELS using docc

--- a/Justfile
+++ b/Justfile
@@ -94,6 +94,8 @@ lint-actions:
 coverage:
     uv run coverage html -d "{{ output_dir }}/fill/coverage-html"
 
+# Generate EIP test checklists from eip_checklist markers                                                                         
+[group('consensus tests')] 
 checklist *args:
     uv run checklist --output tmp/checklist "$@"
 

--- a/Justfile
+++ b/Justfile
@@ -94,6 +94,9 @@ lint-actions:
 coverage:
     uv run coverage html -d "{{ output_dir }}/fill/coverage-html"
 
+checklist *args:
+    uv run checklist --output tmp/checklist "$@"
+
 # --- Fill Tests ---
 
 # Fill the consensus tests using EELS (with Python)
@@ -262,17 +265,6 @@ bench-opcode-config *args:
         --clean \
         "$@" \
         tests/benchmark/compute
-
-# --- Checklists ---
-
-# Generate EIP test checklists from eip_checklist markers
-[group('checklists')]
-checklist *args:
-    #!/usr/bin/env bash
-    uv run checklist --output docs/checklist "$@"
-    rc=$?
-    # exit code 5 = "no tests ran" which is expected (collect-only)
-    if [ $rc -eq 5 ] || [ $rc -eq 0 ]; then exit 0; else exit $rc; fi
 
 # --- Docs ---
 

--- a/Justfile
+++ b/Justfile
@@ -89,6 +89,8 @@ lock-check:
 lint-actions:
     uv run actionlint -pyflakes pyflakes -shellcheck "shellcheck -S warning"
 
+# --- Consensus Tests ---
+
 # Generate HTML coverage report from last just fill run
 [group('consensus tests')]
 coverage:
@@ -98,8 +100,6 @@ coverage:
 [group('consensus tests')] 
 checklist *args:
     uv run checklist --output tmp/checklist "$@"
-
-# --- Fill Tests ---
 
 # Fill the consensus tests using EELS (with Python)
 [group('consensus tests')]
@@ -124,6 +124,8 @@ fill *args:
         "$@" \
         tests
 
+# --- Integration Tests ---
+
 # Fill the base coverage consensus tests using EELS with PyPy
 [group('integration tests')]
 fill-pypy *args:
@@ -146,8 +148,6 @@ fill-pypy *args:
         --ignore=tests/ported_static \
         "$@" \
         tests
-
-# --- Integration Tests ---
 
 # Fill the base coverage consensus tests and run EELS against the fixtures
 [group('integration tests')]

--- a/packages/testing/src/execution_testing/cli/pytest_commands/base.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from os.path import realpath
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, ClassVar, List, Optional
 
 import click
 import pytest
@@ -137,6 +137,9 @@ class PytestCommand:
     pytest_ini_folder: Path = PYTEST_INI_FOLDER
     """Folder where the pytest configuration files are located."""
 
+    allowed_exit_codes: ClassVar[List[pytest.ExitCode]] = [pytest.ExitCode.OK]
+    """Exit codes treated as successful for executions of this command."""
+
     @property
     def config_path(self) -> Path:
         """Path to the pytest configuration file."""
@@ -173,6 +176,7 @@ class PytestCommand:
                 config_file=self.config_path,
                 command_logic_test_paths=self.test_args,
                 args=processed_args,
+                allowed_exit_codes=self.allowed_exit_codes,
             )
         ]
 

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -1,11 +1,29 @@
 """CLI entry point for the `checklist` pytest-based command."""
 
-from typing import Any
+import sys
+from typing import Any, List
 
 import click
 
 from ...forks import get_development_forks
 from .fill import FillCommand
+
+
+class ChecklistCommand(FillCommand):
+    """Fill command that treats 'no tests ran' as success."""
+
+    def execute(self, pytest_args: List[str]) -> None:
+        """
+        Execute the command, treating pytest exit code 5 as success.
+
+        The checklist command only collects tests to analyze markers
+        and does not run them, so exit code 5 ("no tests ran") is expected.
+        """
+        executions = self.create_executions(pytest_args)
+        result = self.runner.run_multiple(executions)
+        if result == 5:
+            result = 0
+        sys.exit(result)
 
 
 def _last_development_fork() -> str | None:
@@ -81,7 +99,7 @@ def checklist(
     if until:
         args.extend(["--until", until])
 
-    command = FillCommand(
+    command = ChecklistCommand(
         plugins=[
             "execution_testing.cli.pytest_commands.plugins.filler.eip_checklist"
         ],

--- a/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/checklist.py
@@ -1,29 +1,30 @@
 """CLI entry point for the `checklist` pytest-based command."""
 
-import sys
-from typing import Any, List
+from typing import Any, ClassVar, List
 
 import click
+import pytest
 
 from ...forks import get_development_forks
-from .fill import FillCommand
+from .base import PytestCommand
 
 
-class ChecklistCommand(FillCommand):
-    """Fill command that treats 'no tests ran' as success."""
+class ChecklistCommand(PytestCommand):
+    """
+    Pytest command to generate checklist documentation.
 
-    def execute(self, pytest_args: List[str]) -> None:
-        """
-        Execute the command, treating pytest exit code 5 as success.
+    The checklist command only collects tests to analyze markers and does
+    not run them, so ``NO_TESTS_COLLECTED`` is treated as success.
+    """
 
-        The checklist command only collects tests to analyze markers
-        and does not run them, so exit code 5 ("no tests ran") is expected.
-        """
-        executions = self.create_executions(pytest_args)
-        result = self.runner.run_multiple(executions)
-        if result == 5:
-            result = 0
-        sys.exit(result)
+    allowed_exit_codes: ClassVar[List[pytest.ExitCode]] = [
+        pytest.ExitCode.OK,
+        pytest.ExitCode.NO_TESTS_COLLECTED,
+    ]
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize checklist command."""
+        super().__init__(config_file="pytest-fill.ini", **kwargs)
 
 
 def _last_development_fork() -> str | None:

--- a/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
+++ b/packages/testing/src/execution_testing/cli/pytest_commands/fill.py
@@ -60,6 +60,7 @@ class FillCommand(PytestCommand):
                 PytestExecution(
                     config_file=self.config_path,
                     args=processed_args,
+                    allowed_exit_codes=self.allowed_exit_codes,
                 )
             ]
 
@@ -82,7 +83,7 @@ class FillCommand(PytestCommand):
                 args=phase1_args,
                 description="generating pre-allocation groups",
                 allowed_exit_codes=[
-                    pytest.ExitCode.OK,
+                    *self.allowed_exit_codes,
                     pytest.ExitCode.NO_TESTS_COLLECTED,
                 ],
             ),
@@ -282,6 +283,7 @@ class PhilCommand(FillCommand):
             PytestExecution(
                 config_file=self.config_path,
                 args=emoji_args,
+                allowed_exit_codes=self.allowed_exit_codes,
             )
         ]
 


### PR DESCRIPTION
## 🗒️ Description
- Adds a command for checklist generation: `just checklist`,
- Extracts exit-code tolerance into a `ClassVar[List[pytest.ExitCode]]` on `PytestCommand`.

## 🔗 Related Issues or PRs
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123). Default is N/A. -->
N/A.

## ✅ Checklist
<!-- Please check off all required items. For those that don't apply remove them accordingly. -->

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcROGBx2ysBUaZ2Q7USSTbLD8LPCm3F4hpFDag&s)
