### PR TITLE
feat(tooling): add `shell-completions` recipe to print setup instructions

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -301,3 +301,37 @@ clean *args:
 [group('housekeeping')]
 clean-all *args:
     uv run eest clean --all "$@"
+
+# Print the command to install shell completions for just recipes
+[group('housekeeping')]
+shell-completions:
+    #!/usr/bin/env bash
+    case "$(basename "$SHELL")" in
+        bash)
+            echo "Run the following commands to install just completions for bash:"
+            echo ""
+            echo "  mkdir -p ~/.local/share/bash-completion/completions"
+            echo "  just --completions bash > ~/.local/share/bash-completion/completions/just"
+            ;;
+        zsh)
+            echo "Run the following commands to install just completions for zsh:"
+            echo ""
+            echo "  mkdir -p ~/.zsh/completions"
+            echo "  just --completions zsh > ~/.zsh/completions/_just"
+            echo ""
+            echo "Then add to your .zshrc:"
+            echo ""
+            echo "  fpath=(~/.zsh/completions \$fpath)"
+            echo "  autoload -U compinit"
+            echo "  compinit"
+            ;;
+        fish)
+            echo "Run the following commands to install just completions for fish:"
+            echo ""
+            echo "  mkdir -p ~/.config/fish/completions"
+            echo "  just --completions fish > ~/.config/fish/completions/just.fish"
+            ;;
+        *)
+            echo "See https://just.systems/man/en/shell-completion-scripts.html"
+            ;;
+    esac

--- a/Justfile
+++ b/Justfile
@@ -332,6 +332,8 @@ shell-completions:
             echo "  just --completions fish > ~/.config/fish/completions/just.fish"
             ;;
         *)
-            echo "See https://just.systems/man/en/shell-completion-scripts.html"
+            echo "See the link below for instructions for your shell."
             ;;
     esac
+    echo ""
+    echo "For more details, see https://just.systems/man/en/shell-completion-scripts.html"


### PR DESCRIPTION
## 🗒️ Description

Add a `shell-completions` housekeeping recipe to the `Justfile` that detects the user's shell and prints the commands needed to enable tab completion for `just` recipes. Supports `bash`, `zsh`, and `fish`; falls back to the upstream docs URL for other shells.

https://just.systems/man/en/shell-completion-scripts.html

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory. -> SEPARATE PR WIP
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture

<img width="642" height="331" alt="image" src="https://github.com/user-attachments/assets/8d42a5b8-896c-48ed-8e08-0686e76191b5" />
