### PR TITLE
fix(github): Fix just setup

### DIFF
--- a/.github/workflows/eip-rebase.yaml
+++ b/.github/workflows/eip-rebase.yaml
@@ -30,8 +30,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      - uses: ./.github/actions/setup-uv
 
       - name: Rebase EIP branches onto fork
         uses: ./.github/actions/rebase-eip-branch

--- a/.github/workflows/update-devnet-branch.yaml
+++ b/.github/workflows/update-devnet-branch.yaml
@@ -36,8 +36,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+      - uses: ./.github/actions/setup-uv
 
       - name: Merge EIP branches into devnet
         uses: ./.github/actions/merge-eip-branches


### PR DESCRIPTION
## 🗒️ Description

Small fix to use the correct action to setup uv and just in the rebase github actions.

Fixes these fails:
https://github.com/ethereum/execution-specs/actions/runs/24263817492/job/70853966267

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.adn.com/resizer/v2/LBSQCW6I7XGPUV63LZE2U5XQWA.jpg?auth=92a2f4fd693e4dc153f6213f72d33e0c5cbc417352af701732bae250664b773f&width=800&height=533)
