### PR TITLE
fix(tests-eip-8024): Fix cross-eip failures (EIP-8037)

### DIFF
--- a/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
+++ b/tests/amsterdam/eip8024_dupn_swapn_exchange/test_exchange.py
@@ -10,6 +10,7 @@ from execution_testing import (
     Account,
     Alloc,
     Bytecode,
+    Fork,
     Op,
     StateTestFiller,
     Transaction,
@@ -39,6 +40,7 @@ def test_exchange_basic(
     n: int,
     m: int,
     pre: Alloc,
+    fork: Fork,
     state_test: StateTestFiller,
 ) -> None:
     """Test EXCHANGE with various n and m values."""
@@ -72,7 +74,11 @@ def test_exchange_basic(
 
     contract_address = pre.deploy_contract(code=code)
 
-    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+    gas_limit = 1_000_000
+    if fork.is_eip_enabled(eip_number=8037):
+        gas_limit = 5_000_000
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=gas_limit)
 
     # Build expected storage
     expected_storage = {}
@@ -100,6 +106,7 @@ def test_exchange_basic(
 def test_exchange_valid_immediates(
     immediate: int,
     pre: Alloc,
+    fork: Fork,
     state_test: StateTestFiller,
 ) -> None:
     """Test EXCHANGE with valid immediate values (0-81 and 128-255)."""
@@ -134,7 +141,11 @@ def test_exchange_valid_immediates(
 
     contract_address = pre.deploy_contract(code=code)
 
-    tx = Transaction(to=contract_address, sender=sender, gas_limit=1_000_000)
+    gas_limit = 1_000_000
+    if fork.is_eip_enabled(eip_number=8037):
+        gas_limit = 5_000_000
+
+    tx = Transaction(to=contract_address, sender=sender, gas_limit=gas_limit)
 
     # Build expected storage
     expected_storage = {}


### PR DESCRIPTION
## 🗒️ Description

Fixes to the tests if EIP-8037 is included in the branch where the tests are being filled (for devnet merged branches), using the new `fork.is_eip_enabled` feature.

## 🔗 Related Issues or PRs
N/A.

## ✅ Checklist
- [ ] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [ ] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [ ] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.
- [ ] Tests: For PRs implementing a missed test case, update the [post-mortem document](/ethereum/execution-specs/blob/HEAD/docs/writing_tests/post_mortems.md) to add an entry the list.
- [ ] Ported Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) or [tests/static](/ethereum/execution-specs/blob/HEAD/tests/static) have been assigned `@ported_from` marker.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/9iR0aOpp88E/maxresdefault.jpg)
