### PR TITLE
feat(tests): add test for worst-case prefetcher performance

### DIFF
--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -75,6 +75,22 @@ def _max_sloads_per_tx(tx_gas_limit: int, fork: Fork) -> int:
     return tx_gas_limit // cold_sload_cost
 
 
+def _sender_generator(
+    pre: Alloc, distinct_senders: bool
+) -> Generator[EOA, None, None]:
+    """
+    Yield one sender per tx.
+
+    In distinct mode, yields a fresh EOA per call. Otherwise, yields
+    the same shared sender for every call. Used by the bloated SLOAD
+    benchmarks so the BAL builder can group nonce changes by sender
+    uniformly regardless of mode.
+    """
+    sender = pre.fund_eoa()
+    while True:
+        yield sender if not distinct_senders else pre.fund_eoa()
+
+
 def delegate_with_calldata(
     pre: Alloc,
     authority: EOA,
@@ -204,7 +220,6 @@ def test_sload_bloated(
     )
 
 
-@pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("distinct_senders", [False, True])
 @pytest.mark.parametrize("existing_slots", [False, True])
@@ -278,18 +293,11 @@ def test_sload_bloated_prefetch_miss(
         calldata=b"\xff" * 32,
     )
 
-    # Yield one sender per tx via a generator. In distinct mode
-    # each call returns a fresh EOA; otherwise the same shared
-    # sender is reused. The senders list collects one entry per
-    # tx so the BAL builder below can group nonce changes by
-    # sender uniformly.
-    def sender_generator() -> Generator[EOA, None, None]:
-        """Yield senders, fresh if distinct, else reuse one shared."""
-        sender = pre.fund_eoa()
-        while True:
-            yield sender if not distinct_senders else pre.fund_eoa()
-
-    senders_iter = sender_generator()
+    # senders_iter yields one sender per tx (fresh per call in
+    # distinct mode, a single shared sender otherwise). The senders
+    # list collects one entry per tx so the BAL builder below can
+    # group nonce changes by sender uniformly.
+    senders_iter = _sender_generator(pre, distinct_senders)
     senders: list[EOA] = []
 
     gas_available = gas_benchmark_value
@@ -373,7 +381,6 @@ def test_sload_bloated_prefetch_miss(
     )
 
 
-@pytest.mark.repricing
 @pytest.mark.parametrize("distinct_senders", [False, True])
 @pytest.mark.parametrize("existing_slots", [False, True])
 def test_sload_bloated_multi_contract(
@@ -435,7 +442,7 @@ def test_sload_bloated_multi_contract(
     )
 
     base_offset = 1 if existing_slots else START_SLOT
-    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit)
+    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit, fork)
 
     # Pre-load slot 0 with the starting offset. For existing_slots,
     # also fill the slot range the loop will read so SLOADs land on
@@ -454,18 +461,11 @@ def test_sload_bloated_multi_contract(
     # + one iteration + final SSTORE, with buffer.
     min_tx_gas = intrinsic_gas + 130_000
 
-    # Yield one sender per tx via a generator. In distinct mode
-    # each call returns a fresh EOA; otherwise the same shared
-    # sender is reused. The senders list collects one entry per
-    # tx so the BAL builder below can group nonce changes by
-    # sender uniformly.
-    def sender_generator() -> Generator[EOA, None, None]:
-        """Yield senders, fresh if distinct, else reuse one shared."""
-        sender = pre.fund_eoa()
-        while True:
-            yield sender if not distinct_senders else pre.fund_eoa()
-
-    senders_iter = sender_generator()
+    # senders_iter yields one sender per tx (fresh per call in
+    # distinct mode, a single shared sender otherwise). The senders
+    # list collects one entry per tx so the BAL builder below can
+    # group nonce changes by sender uniformly.
+    senders_iter = _sender_generator(pre, distinct_senders)
     senders: list[EOA] = []
 
     gas_available = gas_benchmark_value

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -9,7 +9,7 @@ abstract: BloatNet single-opcode benchmark cases for state-related operations.
 
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, List
+from typing import Callable, Generator, List
 
 import pytest
 from execution_testing import (
@@ -60,6 +60,18 @@ START_SLOT = (
     0xA4896A3F93BF4BF58378E579F3CF193BB4AF1022AF7D2089F37D8BAE7157B85F
     % (2**160)
 )
+
+
+def _max_sloads_per_tx(tx_gas_limit: int) -> int:
+    """
+    Conservative upper bound on cold SLOADs that fit in a max-gas tx.
+
+    Derived from the cold SLOAD cost (EIP-2929: 2100 gas) and used by
+    the bloated SLOAD benchmarks both as the inter-tx offset stride
+    (to keep consecutive txs' SLOAD ranges disjoint) and as the
+    per-target storage pre-load count.
+    """
+    return tx_gas_limit // 2100
 
 
 def delegate_with_calldata(
@@ -216,7 +228,10 @@ def test_sload_bloated_prefetch_miss(
     SLOAD range depends on state written by its predecessor, a
     prefetcher that predicts SLOAD targets from pre-block state
     without simulating intra-block writes will pre-warm incorrect
-    storage slots.
+    storage slots. The minimal first tx is load-bearing: it lives
+    inside the benchmark block so every subsequent max-gas tx reads
+    a slot 0 value that differs from the prefetcher's pre-block
+    snapshot, achieving a 100% miss rate.
 
     When ``distinct_senders`` is True every transaction uses a fresh
     sender. This additionally defeats per-sender prewarm
@@ -238,7 +253,12 @@ def test_sload_bloated_prefetch_miss(
     authority = pre.stub_eoa(token_name)
     runtime_address = pre.deploy_contract(code=runtime_code)
 
-    # Setup: delegate authority to the runtime contract.
+    # Setup: delegate authority to the runtime contract. Slot 0 is
+    # left at 0 (the delegation tx's calldata) so the benchmark
+    # block's pre-state has slot 0 = 0; the first benchmark tx
+    # then plants base_offset in slot 0 inside the benchmark block,
+    # forcing the prefetcher's pre-block snapshot to disagree with
+    # the actual slot 0 value seen by every max-gas tx that follows.
     delegation_tx = delegate_with_calldata(
         pre, authority, runtime_address, Hash(0)
     )
@@ -247,39 +267,49 @@ def test_sload_bloated_prefetch_miss(
 
     # Offset spacing: upper bound on SLOADs per tx ensures each
     # transaction reads a completely disjoint slot range.
-    sload_spacing = tx_gas_limit // 2100
+    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit)
 
-    # The base offset must be at least sload_spacing away from the
-    # pre-block slot 0 value (0) so the prefetcher's predicted
+    # The base offset must be at least max_sloads_per_tx away from
+    # the pre-block slot 0 value (0) so the prefetcher's predicted
     # SLOAD range is completely disjoint from the actual range.
-    base_offset = sload_spacing if existing_slots else START_SLOT
+    base_offset = max_sloads_per_tx if existing_slots else START_SLOT
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
         calldata=b"\xff" * 32,
     )
 
-    # For distinct_senders, append a fresh EOA per tx. Otherwise
-    # pre-seed the list with a single shared sender reused by all.
-    senders: list[EOA] = [] if distinct_senders else [pre.fund_eoa()]
+    # Yield one sender per tx via a generator. In distinct mode
+    # each call returns a fresh EOA; otherwise the same shared
+    # sender is reused. The senders list collects one entry per
+    # tx so the BAL builder below can group nonce changes by
+    # sender uniformly.
+    def sender_generator() -> Generator[EOA, None, None]:
+        """Yield senders, fresh if distinct, else reuse one shared."""
+        sender = pre.fund_eoa()
+        while True:
+            yield sender if not distinct_senders else pre.fund_eoa()
 
-    def next_sender() -> EOA:
-        if distinct_senders:
-            senders.append(pre.fund_eoa())
-            return senders[-1]
-        return senders[0]
+    senders_iter = sender_generator()
+    senders: list[EOA] = []
 
     gas_available = gas_benchmark_value
     txs: list[Transaction] = []
 
     # First transaction: minimal gas, only writes the initial
     # offset. Gas limit ensures remaining gas after the SLOAD +
-    # SSTORE setup falls below the 0xFFFF loop threshold.
+    # SSTORE setup falls below the 0xFFFF loop threshold so the
+    # SLOAD loop does not run. This tx's job is to change slot 0
+    # inside the benchmark block so every subsequent max-gas tx
+    # reads an offset the prefetcher's pre-block snapshot does
+    # not see, achieving a 100% prefetch miss rate on max-gas txs.
     first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
+    sender = next(senders_iter)
+    senders.append(sender)
     txs.append(
         Transaction(
             gas_limit=first_tx_gas,
             to=authority,
             data=Hash(base_offset),
-            sender=next_sender(),
+            sender=sender,
         )
     )
     gas_available -= first_tx_gas
@@ -289,14 +319,14 @@ def test_sload_bloated_prefetch_miss(
     tx_index = 1
     while gas_available >= intrinsic_gas:
         tx_gas = min(gas_available, tx_gas_limit)
-        new_offset = base_offset + tx_index * sload_spacing
+        new_offset = base_offset + tx_index * max_sloads_per_tx
+        sender = next(senders_iter)
+        senders.append(sender)
         txs.append(
             Transaction(
                 gas_limit=tx_gas,
                 to=authority,
                 data=Hash(new_offset),
-                sender = next(sender_generator)
-                sender_list.append(sender)
                 sender=sender,
             )
         )
@@ -314,17 +344,17 @@ def test_sload_bloated_prefetch_miss(
             ],
         ),
     }
- sender_nonce: dict[Address, list[BalNonceChange]] = {}
-  for i, s in enumerate(senders):             
-      changes = sender_nonces.setdefault(s, [])
-      changes.append(
-          BalNonceChange(                                                                                      
-              block_access_index=i + 1,
-              post_nonce=len(changes) + 1,                                                                     
-          )                                             
-      )                                   
-  for s, nonces in sender_nonces.items():
-      expectations[s] = BalAccountExpectation(nonce_changes=nonces)
+    sender_nonces: dict[Address, list[BalNonceChange]] = {}
+    for i, s in enumerate(senders):
+        changes = sender_nonces.setdefault(s, [])
+        changes.append(
+            BalNonceChange(
+                block_access_index=i + 1,
+                post_nonce=len(changes) + 1,
+            )
+        )
+    for addr, nonces in sender_nonces.items():
+        expectations[addr] = BalAccountExpectation(nonce_changes=nonces)
     blocks.append(
         Block(
             txs=txs,
@@ -404,7 +434,7 @@ def test_sload_bloated_multi_contract(
     )
 
     base_offset = 1 if existing_slots else START_SLOT
-    sloads_per_tx = tx_gas_limit // 2100
+    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit)
 
     # Pre-load slot 0 with the starting offset. For existing_slots,
     # also fill the slot range the loop will read so SLOADs land on
@@ -413,7 +443,7 @@ def test_sload_bloated_multi_contract(
     # gets an independent root dict, not an alias of the same one.
     storage_data: Storage.StorageDictType = {0: base_offset}
     if existing_slots:
-        for i in range(base_offset, base_offset + sloads_per_tx):
+        for i in range(base_offset, base_offset + max_sloads_per_tx):
             storage_data[i] = i
 
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
@@ -423,15 +453,19 @@ def test_sload_bloated_multi_contract(
     # + one iteration + final SSTORE, with buffer.
     min_tx_gas = intrinsic_gas + 130_000
 
-    # For distinct_senders, append a fresh EOA per tx. Otherwise
-    # pre-seed the list with a single shared sender reused by all.
-    senders: list[EOA] = [] if distinct_senders else [pre.fund_eoa()]
+    # Yield one sender per tx via a generator. In distinct mode
+    # each call returns a fresh EOA; otherwise the same shared
+    # sender is reused. The senders list collects one entry per
+    # tx so the BAL builder below can group nonce changes by
+    # sender uniformly.
+    def sender_generator() -> Generator[EOA, None, None]:
+        """Yield senders, fresh if distinct, else reuse one shared."""
+        sender = pre.fund_eoa()
+        while True:
+            yield sender if not distinct_senders else pre.fund_eoa()
 
-    def next_sender() -> EOA:
-        if distinct_senders:
-            senders.append(pre.fund_eoa())
-            return senders[-1]
-        return senders[0]
+    senders_iter = sender_generator()
+    senders: list[EOA] = []
 
     gas_available = gas_benchmark_value
     targets: list[Address] = []
@@ -443,14 +477,16 @@ def test_sload_bloated_multi_contract(
         tx_gas = min(gas_available, tx_gas_limit)
         target = pre.deploy_contract(
             code=runtime_code,
-            storage=Storage(storage_data),  # type: ignore
+            storage=Storage(storage_data),
         )
         targets.append(target)
+        sender = next(senders_iter)
+        senders.append(sender)
         txs.append(
             Transaction(
                 gas_limit=tx_gas,
                 to=target,
-                sender=next_sender(),
+                sender=sender,
             )
         )
         gas_available -= tx_gas
@@ -475,26 +511,17 @@ def test_sload_bloated_multi_contract(
                 ),
             ],
         )
-    if distinct_senders:
-        for i, s in enumerate(senders):
-            expectations[s] = BalAccountExpectation(
-                nonce_changes=[
-                    BalNonceChange(
-                        block_access_index=i + 1,
-                        post_nonce=1,
-                    ),
-                ],
+    sender_nonces: dict[Address, list[BalNonceChange]] = {}
+    for i, s in enumerate(senders):
+        changes = sender_nonces.setdefault(s, [])
+        changes.append(
+            BalNonceChange(
+                block_access_index=i + 1,
+                post_nonce=len(changes) + 1,
             )
-    else:
-        expectations[senders[0]] = BalAccountExpectation(
-            nonce_changes=[
-                BalNonceChange(
-                    block_access_index=i + 1,
-                    post_nonce=i + 1,
-                )
-                for i in range(len(txs))
-            ],
         )
+    for addr, nonces in sender_nonces.items():
+        expectations[addr] = BalAccountExpectation(nonce_changes=nonces)
 
     blocks = [
         Block(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -193,6 +193,7 @@ def test_sload_bloated(
 
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
+@pytest.mark.parametrize("distinct_senders", [False, True])
 @pytest.mark.parametrize("existing_slots", [False, True])
 def test_sload_bloated_prefetch_miss(
     benchmark_test: BenchmarkTestFiller,
@@ -202,6 +203,7 @@ def test_sload_bloated_prefetch_miss(
     tx_gas_limit: int,
     token_name: str,
     existing_slots: bool,
+    distinct_senders: bool,
 ) -> None:
     """
     Benchmark SLOAD with calldata-driven offsets to defeat prefetching.
@@ -214,9 +216,13 @@ def test_sload_bloated_prefetch_miss(
     SLOAD range depends on state written by its predecessor, a
     prefetcher that predicts SLOAD targets from pre-block state
     without simulating intra-block writes will pre-warm incorrect
-    storage slots. Each transaction uses a distinct sender so that
-    per-sender prewarm serialization also restarts from pre-block
-    state.
+    storage slots.
+
+    When ``distinct_senders`` is True every transaction uses a fresh
+    sender. This additionally defeats per-sender prewarm
+    serialization (e.g. Nethermind) that groups txs by sender and
+    runs them sequentially to propagate state changes — forcing
+    every tx's prewarm scope to restart from pre-block state.
     """
     # Runtime: read old offset from slot 0, write new offset from
     # calldata to slot 0, then SLOAD sequentially from old offset.
@@ -253,40 +259,45 @@ def test_sload_bloated_prefetch_miss(
         calldata=b"\xff" * 32,
     )
 
+    # For distinct_senders, append a fresh EOA per tx. Otherwise
+    # pre-seed the list with a single shared sender reused by all.
+    senders: list[EOA] = [] if distinct_senders else [pre.fund_eoa()]
+
+    def next_sender() -> EOA:
+        if distinct_senders:
+            senders.append(pre.fund_eoa())
+            return senders[-1]
+        return senders[0]
+
     gas_available = gas_benchmark_value
-    senders: list[EOA] = []
     txs: list[Transaction] = []
 
     # First transaction: minimal gas, only writes the initial
     # offset. Gas limit ensures remaining gas after the SLOAD +
     # SSTORE setup falls below the 0xFFFF loop threshold.
     first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
-    senders.append(pre.fund_eoa())
     txs.append(
         Transaction(
             gas_limit=first_tx_gas,
             to=authority,
             data=Hash(base_offset),
-            sender=senders[-1],
+            sender=next_sender(),
         )
     )
     gas_available -= first_tx_gas
 
-    # Subsequent transactions: max gas, each shifts the offset so
-    # the next tx SLOADs from a different range. Distinct senders
-    # defeat per-sender prefetcher optimizations (e.g. Nethermind)
-    # that would otherwise propagate slot 0 updates within a sender.
+    # Subsequent transactions: max gas, each shifts the offset
+    # so the next transaction SLOADs from a different range.
     tx_index = 1
     while gas_available >= intrinsic_gas:
         tx_gas = min(gas_available, tx_gas_limit)
         new_offset = base_offset + tx_index * sload_spacing
-        senders.append(pre.fund_eoa())
         txs.append(
             Transaction(
                 gas_limit=tx_gas,
                 to=authority,
                 data=Hash(new_offset),
-                sender=senders[-1],
+                sender=next_sender(),
             )
         )
         gas_available -= tx_gas
@@ -303,13 +314,24 @@ def test_sload_bloated_prefetch_miss(
             ],
         ),
     }
-    for i, s in enumerate(senders):
-        expectations[s] = BalAccountExpectation(
+    if distinct_senders:
+        for i, s in enumerate(senders):
+            expectations[s] = BalAccountExpectation(
+                nonce_changes=[
+                    BalNonceChange(
+                        block_access_index=i + 1,
+                        post_nonce=1,
+                    ),
+                ],
+            )
+    else:
+        expectations[senders[0]] = BalAccountExpectation(
             nonce_changes=[
                 BalNonceChange(
                     block_access_index=i + 1,
-                    post_nonce=1,
-                ),
+                    post_nonce=i + 1,
+                )
+                for i in range(len(txs))
             ],
         )
     blocks.append(
@@ -320,6 +342,181 @@ def test_sload_bloated_prefetch_miss(
             ),
         )
     )
+
+    benchmark_test(
+        pre=pre,
+        blocks=blocks,
+        skip_gas_used_validation=True,
+        expected_receipt_status=True,
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.parametrize("distinct_senders", [False, True])
+@pytest.mark.parametrize("existing_slots", [False, True])
+def test_sload_bloated_multi_contract(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    existing_slots: bool,
+    distinct_senders: bool,
+) -> None:
+    """
+    Benchmark SLOAD across a distinct contract per transaction.
+
+    Each transaction calls a freshly-deployed contract whose slot 0
+    is pre-loaded with the starting offset; the contract then runs a
+    SLOAD loop over sequential slots until gas runs low. Unlike
+    test_sload_bloated_prefetch_miss which hammers one account's
+    storage trie via an EIP-7702 delegated EOA, every transaction
+    here opens a different storage trie, stressing cross-account
+    state access and state-trie breadth in a single block.
+
+    Every target contract first CALLs a shared offset_holder
+    contract whose slot 0 is read, incremented, and written back.
+    This mirrors the first test's "same-contract slot 0" dependency
+    pattern via cross-contract CALL: every transaction forms a
+    read-after-write edge on offset_holder's slot 0, preventing
+    parallel execution.
+
+    When ``distinct_senders`` is True every transaction uses a fresh
+    sender. This additionally exercises per-sender prewarm
+    serialization (e.g. Nethermind) differently than the shared-
+    sender case; we run both so clients can be measured in both
+    regimes.
+    """
+    # Shared offset_holder: reads, increments, and writes its own
+    # slot 0. Every target CALLs this to create an inter-tx RAW
+    # dependency chain on a single shared storage slot.
+    offset_holder = pre.deploy_contract(
+        code=Op.SSTORE(0, Op.ADD(Op.SLOAD(0), 1)),
+    )
+
+    # Target runtime: CALL offset_holder (for the dependency), then
+    # run the same SLOAD loop as test_sload_bloated in its own
+    # storage. Final counter is written back to slot 0.
+    runtime_code = (
+        Op.POP(
+            Op.CALL(
+                address=offset_holder,
+                value=0,
+                args_offset=0,
+                args_size=0,
+                ret_offset=0,
+                ret_size=0,
+            )
+        )
+        + Op.SLOAD(Op.PUSH0)
+        + While(
+            body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
+            condition=Op.GT(Op.GAS, 0xFFFF),
+        )
+        + Op.PUSH0
+        + Op.SSTORE
+    )
+
+    base_offset = 1 if existing_slots else START_SLOT
+    sloads_per_tx = tx_gas_limit // 2100
+
+    # Pre-load slot 0 with the starting offset. For existing_slots,
+    # also fill the slot range the loop will read so SLOADs land on
+    # populated entries rather than empty slots.
+    storage_data: dict[int, int] = {0: base_offset}
+    if existing_slots:
+        for i in range(base_offset, base_offset + sloads_per_tx):
+            storage_data[i] = i
+    contract_storage = Storage(storage_data)  # type: ignore
+
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
+    # Minimum per-tx gas ensuring the SLOAD loop runs at least one
+    # iteration so every target satisfies storage_reads=[base_offset]:
+    # intrinsic + CALL + offset_holder + setup + 0xFFFF loop threshold
+    # + one iteration + final SSTORE, with buffer.
+    min_tx_gas = intrinsic_gas + 130_000
+
+    # For distinct_senders, append a fresh EOA per tx. Otherwise
+    # pre-seed the list with a single shared sender reused by all.
+    senders: list[EOA] = [] if distinct_senders else [pre.fund_eoa()]
+
+    def next_sender() -> EOA:
+        if distinct_senders:
+            senders.append(pre.fund_eoa())
+            return senders[-1]
+        return senders[0]
+
+    gas_available = gas_benchmark_value
+    targets: list[Address] = []
+    txs: list[Transaction] = []
+
+    # Each tx targets a freshly-deployed contract with identical code
+    # and storage layout.
+    while gas_available >= min_tx_gas:
+        tx_gas = min(gas_available, tx_gas_limit)
+        target = pre.deploy_contract(
+            code=runtime_code,
+            storage=contract_storage,
+        )
+        targets.append(target)
+        txs.append(
+            Transaction(
+                gas_limit=tx_gas,
+                to=target,
+                sender=next_sender(),
+            )
+        )
+        gas_available -= tx_gas
+
+    expectations: dict[Address, BalAccountExpectation] = {
+        offset_holder: BalAccountExpectation(
+            storage_changes=[
+                BalStorageSlot(
+                    slot=0,
+                    validate_any_change=True,
+                ),
+            ],
+        ),
+    }
+    for t in targets:
+        expectations[t] = BalAccountExpectation(
+            storage_reads=[base_offset],
+            storage_changes=[
+                BalStorageSlot(
+                    slot=0,
+                    validate_any_change=True,
+                ),
+            ],
+        )
+    if distinct_senders:
+        for i, s in enumerate(senders):
+            expectations[s] = BalAccountExpectation(
+                nonce_changes=[
+                    BalNonceChange(
+                        block_access_index=i + 1,
+                        post_nonce=1,
+                    ),
+                ],
+            )
+    else:
+        expectations[senders[0]] = BalAccountExpectation(
+            nonce_changes=[
+                BalNonceChange(
+                    block_access_index=i + 1,
+                    post_nonce=i + 1,
+                )
+                for i in range(len(txs))
+            ],
+        )
+
+    blocks = [
+        Block(
+            txs=txs,
+            expected_block_access_list=BlockAccessListExpectation(
+                account_expectations=expectations,
+            ),
+        )
+    ]
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -62,7 +62,7 @@ START_SLOT = (
 )
 
 
-def _max_sloads_per_tx(tx_gas_limit: int) -> int:
+def _max_sloads_per_tx(tx_gas_limit: int, fork: Fork) -> int:
     """
     Conservative upper bound on cold SLOADs that fit in a max-gas tx.
 
@@ -71,7 +71,8 @@ def _max_sloads_per_tx(tx_gas_limit: int) -> int:
     (to keep consecutive txs' SLOAD ranges disjoint) and as the
     per-target storage pre-load count.
     """
-    return tx_gas_limit // 2100
+    cold_sload_cost = Op.SLOAD(key_warm=False).gas_cost(fork)
+    return tx_gas_limit // cold_sload_cost
 
 
 def delegate_with_calldata(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -312,26 +312,17 @@ def test_sload_bloated_prefetch_miss(
             ],
         ),
     }
-    if distinct_senders:
-        for i, s in enumerate(senders):
-            expectations[s] = BalAccountExpectation(
-                nonce_changes=[
-                    BalNonceChange(
-                        block_access_index=i + 1,
-                        post_nonce=1,
-                    ),
-                ],
-            )
-    else:
-        expectations[senders[0]] = BalAccountExpectation(
-            nonce_changes=[
-                BalNonceChange(
-                    block_access_index=i + 1,
-                    post_nonce=i + 1,
-                )
-                for i in range(len(txs))
-            ],
-        )
+ sender_nonce: dict[Address, list[BalNonceChange]] = {}
+  for i, s in enumerate(senders):             
+      changes = sender_nonces.setdefault(s, [])
+      changes.append(
+          BalNonceChange(                                                                                      
+              block_access_index=i + 1,
+              post_nonce=len(changes) + 1,                                                                     
+          )                                             
+      )                                   
+  for s, nonces in sender_nonces.items():
+      expectations[s] = BalAccountExpectation(nonce_changes=nonces)
     blocks.append(
         Block(
             txs=txs,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -288,6 +288,7 @@ def test_sload_bloated_prefetch_miss(
     bench_bal = BlockAccessListExpectation(
         account_expectations={
             authority: BalAccountExpectation(
+                storage_reads=[base_offset],
                 storage_changes=[
                     BalStorageSlot(
                         slot=0,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -189,6 +189,110 @@ def test_sload_bloated(
 
 @pytest.mark.repricing
 @pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
+@pytest.mark.parametrize("existing_slots", [False, True])
+def test_sload_bloated_prefetch_miss(
+    benchmark_test: BenchmarkTestFiller,
+    pre: Alloc,
+    fork: Fork,
+    gas_benchmark_value: int,
+    tx_gas_limit: int,
+    token_name: str,
+    existing_slots: bool,
+) -> None:
+    """
+    Benchmark SLOAD with calldata-driven offsets to defeat prefetching.
+
+    A small first transaction writes an initial offset into the
+    authority's slot 0 via calldata. Subsequent max-gas transactions
+    each read the previous offset from slot 0, SLOAD sequentially
+    from that offset, and overwrite slot 0 with a new offset from
+    their own calldata. Because each transaction's SLOAD range
+    depends on state written by its predecessor, a prefetcher that
+    analyzes transactions before execution will pre-warm incorrect
+    storage slots.
+    """
+    # Runtime: read old offset from slot 0, write new offset from
+    # calldata to slot 0, then SLOAD sequentially from old offset.
+    runtime_code = (
+        Op.SLOAD(Op.PUSH0)
+        + Op.CALLDATALOAD(0)
+        + Op.PUSH0
+        + Op.SSTORE
+        + While(
+            body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
+            condition=Op.GT(Op.GAS, 0xFFFF),
+        )
+    )
+
+    authority = pre.stub_eoa(token_name)
+    runtime_address = pre.deploy_contract(code=runtime_code)
+
+    # Setup: delegate authority to the runtime contract.
+    delegation_tx = delegate_and_set_slot0(
+        pre, authority, runtime_address, Hash(0)
+    )
+
+    blocks: list[Block] = [Block(txs=[delegation_tx])]
+
+    # Offset spacing: upper bound on SLOADs per tx ensures each
+    # transaction reads a completely disjoint slot range.
+    sload_spacing = tx_gas_limit // 2100
+
+    # The base offset must be at least sload_spacing away from the
+    # pre-block slot 0 value (0) so the prefetcher's predicted
+    # SLOAD range is completely disjoint from the actual range.
+    base_offset = sload_spacing if existing_slots else START_SLOT
+    intrinsic_gas = fork.transaction_intrinsic_cost_calculator()(
+        calldata=b"\xff" * 32,
+    )
+
+    gas_available = gas_benchmark_value
+    sender = pre.fund_eoa()
+    txs: list[Transaction] = []
+
+    # First transaction: minimal gas, only writes the initial
+    # offset. Gas limit ensures remaining gas after the SLOAD +
+    # SSTORE setup falls below the 0xFFFF loop threshold.
+    first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
+    txs.append(
+        Transaction(
+            gas_limit=first_tx_gas,
+            to=authority,
+            data=Hash(base_offset),
+            sender=sender,
+        )
+    )
+    gas_available -= first_tx_gas
+
+    # Subsequent transactions: max gas, each shifts the offset
+    # so the next transaction SLOADs from a different range.
+    tx_index = 1
+    while gas_available >= intrinsic_gas:
+        tx_gas = min(gas_available, tx_gas_limit)
+        new_offset = base_offset + tx_index * sload_spacing
+        txs.append(
+            Transaction(
+                gas_limit=tx_gas,
+                to=authority,
+                data=Hash(new_offset),
+                sender=sender,
+            )
+        )
+        gas_available -= tx_gas
+        tx_index += 1
+
+    blocks.append(Block(txs=txs))
+
+    benchmark_test(
+        pre=pre,
+        blocks=blocks,
+        skip_gas_used_validation=True,
+        expected_receipt_status=True,
+    )
+
+
+@pytest.mark.repricing
+@pytest.mark.stub_parametrize("token_name", "bloated_eoa_")
 @pytest.mark.parametrize("write_new_value", [False, True])
 @pytest.mark.parametrize("existing_slots", [True, False])
 def test_sstore_bloated(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -295,7 +295,9 @@ def test_sload_bloated_prefetch_miss(
                 gas_limit=tx_gas,
                 to=authority,
                 data=Hash(new_offset),
-                sender=next_sender(),
+                sender = next(sender_generator)
+                sender_list.append(sender)
+                sender=sender,
             )
         )
         gas_available -= tx_gas

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -399,11 +399,6 @@ def test_sload_bloated_multi_contract(
         Op.POP(
             Op.CALL(
                 address=offset_holder,
-                value=0,
-                args_offset=0,
-                args_size=0,
-                ret_offset=0,
-                ret_size=0,
             )
         )
         + Op.SLOAD(Op.PUSH0)

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -418,7 +418,7 @@ def test_sload_bloated_multi_contract(
     # populated entries rather than empty slots. A fresh Storage
     # instance is built per deployment (below) so that every target
     # gets an independent root dict, not an alias of the same one.
-    storage_data: dict[int, int] = {0: base_offset}
+    storage_data: Storage.StorageDictType = {0: base_offset}
     if existing_slots:
         for i in range(base_offset, base_offset + sloads_per_tx):
             storage_data[i] = i

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -208,11 +208,12 @@ def test_sload_bloated_prefetch_miss(
 
     A small first transaction writes an initial offset into the
     authority's slot 0 via calldata. Subsequent max-gas transactions
-    each read the previous offset from slot 0, SLOAD sequentially
-    from that offset, and overwrite slot 0 with a new offset from
-    their own calldata. Because each transaction's SLOAD range
-    depends on state written by its predecessor, a prefetcher that
-    analyzes transactions before execution will pre-warm incorrect
+    each read the previous offset from slot 0, immediately overwrite
+    slot 0 with a new offset from their own calldata, then SLOAD
+    sequentially from the previous offset. Because each transaction's
+    SLOAD range depends on state written by its predecessor, a
+    prefetcher that predicts SLOAD targets from pre-block state
+    without simulating intra-block writes will pre-warm incorrect
     storage slots.
     """
     # Runtime: read old offset from slot 0, write new offset from

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -214,7 +214,9 @@ def test_sload_bloated_prefetch_miss(
     SLOAD range depends on state written by its predecessor, a
     prefetcher that predicts SLOAD targets from pre-block state
     without simulating intra-block writes will pre-warm incorrect
-    storage slots.
+    storage slots. Each transaction uses a distinct sender so that
+    per-sender prewarm serialization also restarts from pre-block
+    state.
     """
     # Runtime: read old offset from slot 0, write new offset from
     # calldata to slot 0, then SLOAD sequentially from old offset.
@@ -252,66 +254,70 @@ def test_sload_bloated_prefetch_miss(
     )
 
     gas_available = gas_benchmark_value
-    sender = pre.fund_eoa()
+    senders: list[EOA] = []
     txs: list[Transaction] = []
 
     # First transaction: minimal gas, only writes the initial
     # offset. Gas limit ensures remaining gas after the SLOAD +
     # SSTORE setup falls below the 0xFFFF loop threshold.
     first_tx_gas = min(gas_available, intrinsic_gas + 30_000)
+    senders.append(pre.fund_eoa())
     txs.append(
         Transaction(
             gas_limit=first_tx_gas,
             to=authority,
             data=Hash(base_offset),
-            sender=sender,
+            sender=senders[-1],
         )
     )
     gas_available -= first_tx_gas
 
-    # Subsequent transactions: max gas, each shifts the offset
-    # so the next transaction SLOADs from a different range.
+    # Subsequent transactions: max gas, each shifts the offset so
+    # the next tx SLOADs from a different range. Distinct senders
+    # defeat per-sender prefetcher optimizations (e.g. Nethermind)
+    # that would otherwise propagate slot 0 updates within a sender.
     tx_index = 1
     while gas_available >= intrinsic_gas:
         tx_gas = min(gas_available, tx_gas_limit)
         new_offset = base_offset + tx_index * sload_spacing
+        senders.append(pre.fund_eoa())
         txs.append(
             Transaction(
                 gas_limit=tx_gas,
                 to=authority,
                 data=Hash(new_offset),
-                sender=sender,
+                sender=senders[-1],
             )
         )
         gas_available -= tx_gas
         tx_index += 1
 
-    bench_bal = BlockAccessListExpectation(
-        account_expectations={
-            authority: BalAccountExpectation(
-                storage_reads=[base_offset],
-                storage_changes=[
-                    BalStorageSlot(
-                        slot=0,
-                        validate_any_change=True,
-                    ),
-                ],
-            ),
-            sender: BalAccountExpectation(
-                nonce_changes=[
-                    BalNonceChange(
-                        block_access_index=i + 1,
-                        post_nonce=i + 1,
-                    )
-                    for i in range(len(txs))
-                ],
-            ),
-        }
-    )
+    expectations: dict[Address, BalAccountExpectation] = {
+        authority: BalAccountExpectation(
+            storage_reads=[base_offset],
+            storage_changes=[
+                BalStorageSlot(
+                    slot=0,
+                    validate_any_change=True,
+                ),
+            ],
+        ),
+    }
+    for i, s in enumerate(senders):
+        expectations[s] = BalAccountExpectation(
+            nonce_changes=[
+                BalNonceChange(
+                    block_access_index=i + 1,
+                    post_nonce=1,
+                ),
+            ],
+        )
     blocks.append(
         Block(
             txs=txs,
-            expected_block_access_list=bench_bal,
+            expected_block_access_list=BlockAccessListExpectation(
+                account_expectations=expectations,
+            ),
         )
     )
 

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -228,9 +228,7 @@ def test_sload_bloated_prefetch_miss(
     # calldata to slot 0, then SLOAD sequentially from old offset.
     runtime_code = (
         Op.SLOAD(Op.PUSH0)
-        + Op.CALLDATALOAD(0)
-        + Op.PUSH0
-        + Op.SSTORE
+        + Op.SSTORE(Op.PUSH0, Op.CALLDATALOAD(Op.PUSH0))
         + While(
             body=(Op.DUP1 + Op.SLOAD + Op.POP + Op.PUSH1(1) + Op.ADD),
             condition=Op.GT(Op.GAS, 0xFFFF),

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -18,8 +18,12 @@ from execution_testing import (
     Address,
     Alloc,
     AuthorizationTuple,
+    BalAccountExpectation,
+    BalNonceChange,
+    BalStorageSlot,
     BenchmarkTestFiller,
     Block,
+    BlockAccessListExpectation,
     Bytecode,
     CreatePreimageLayout,
     Fork,
@@ -58,28 +62,28 @@ START_SLOT = (
 )
 
 
-def delegate_and_set_slot0(
+def delegate_with_calldata(
     pre: Alloc,
     authority: EOA,
-    setter_address: Address,
-    slot_0_value: Hash,
+    address: Address,
+    calldata: Hash,
 ) -> Transaction:
     """
-    Create a tx that delegates the authority to the setter and calls
-    it with slot_0_value as calldata, writing it into slot 0.
+    Create a tx that delegates the authority and calls it with calldata.
 
+    The delegated code determines what happens with the calldata.
     The authority nonce is incremented in-place.
     """
     tx = Transaction(
         gas_limit=100_000,
         to=authority,
         value=0,
-        data=slot_0_value,
+        data=calldata,
         sender=pre.fund_eoa(),
         authorization_list=[
             AuthorizationTuple(
                 chain_id=0,
-                address=setter_address,
+                address=address,
                 nonce=authority.nonce,
                 signer=authority,
             ),
@@ -111,10 +115,10 @@ def run_bloated_eoa_benchmark(
     setter_address = pre.deploy_contract(code=Op.SSTORE(0, Op.CALLDATALOAD(0)))
     runtime_address = pre.deploy_contract(code=runtime_code)
 
-    init_tx = delegate_and_set_slot0(
+    init_tx = delegate_with_calldata(
         pre, authority, setter_address, slot_0_value
     )
-    runtime_tx = delegate_and_set_slot0(
+    runtime_tx = delegate_with_calldata(
         pre, authority, runtime_address, Hash(0)
     )
 
@@ -228,7 +232,7 @@ def test_sload_bloated_prefetch_miss(
     runtime_address = pre.deploy_contract(code=runtime_code)
 
     # Setup: delegate authority to the runtime contract.
-    delegation_tx = delegate_and_set_slot0(
+    delegation_tx = delegate_with_calldata(
         pre, authority, runtime_address, Hash(0)
     )
 
@@ -281,7 +285,33 @@ def test_sload_bloated_prefetch_miss(
         gas_available -= tx_gas
         tx_index += 1
 
-    blocks.append(Block(txs=txs))
+    bench_bal = BlockAccessListExpectation(
+        account_expectations={
+            authority: BalAccountExpectation(
+                storage_changes=[
+                    BalStorageSlot(
+                        slot=0,
+                        validate_any_change=True,
+                    ),
+                ],
+            ),
+            sender: BalAccountExpectation(
+                nonce_changes=[
+                    BalNonceChange(
+                        block_access_index=i + 1,
+                        post_nonce=i + 1,
+                    )
+                    for i in range(len(txs))
+                ],
+            ),
+        }
+    )
+    blocks.append(
+        Block(
+            txs=txs,
+            expected_block_access_list=bench_bal,
+        )
+    )
 
     benchmark_test(
         pre=pre,

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -422,12 +422,13 @@ def test_sload_bloated_multi_contract(
 
     # Pre-load slot 0 with the starting offset. For existing_slots,
     # also fill the slot range the loop will read so SLOADs land on
-    # populated entries rather than empty slots.
+    # populated entries rather than empty slots. A fresh Storage
+    # instance is built per deployment (below) so that every target
+    # gets an independent root dict, not an alias of the same one.
     storage_data: dict[int, int] = {0: base_offset}
     if existing_slots:
         for i in range(base_offset, base_offset + sloads_per_tx):
             storage_data[i] = i
-    contract_storage = Storage(storage_data)  # type: ignore
 
     intrinsic_gas = fork.transaction_intrinsic_cost_calculator()()
     # Minimum per-tx gas ensuring the SLOAD loop runs at least one
@@ -456,7 +457,7 @@ def test_sload_bloated_multi_contract(
         tx_gas = min(gas_available, tx_gas_limit)
         target = pre.deploy_contract(
             code=runtime_code,
-            storage=contract_storage,
+            storage=Storage(storage_data),  # type: ignore
         )
         targets.append(target)
         txs.append(

--- a/tests/benchmark/stateful/bloatnet/test_single_opcode.py
+++ b/tests/benchmark/stateful/bloatnet/test_single_opcode.py
@@ -268,7 +268,7 @@ def test_sload_bloated_prefetch_miss(
 
     # Offset spacing: upper bound on SLOADs per tx ensures each
     # transaction reads a completely disjoint slot range.
-    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit)
+    max_sloads_per_tx = _max_sloads_per_tx(tx_gas_limit, fork)
 
     # The base offset must be at least max_sloads_per_tx away from
     # the pre-block slot 0 value (0) so the prefetcher's predicted


### PR DESCRIPTION
## 🗒️ Description

Add `test_sload_bloated_prefetch_miss` benchmark that defeats client prefetchers by making each transaction's SLOAD range depend on state written by its predecessor. A minimal first tx writes an offset to slot 0 via calldata; subsequent max-gas txs read the previous offset, SLOAD from it, and write a new offset for the next tx.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
  ```console
  just static
#### Cute Animal Picture

<img width="320" alt="image" src="https://github.com/user-attachments/assets/39996198-384d-4526-99d6-19b3ea05cdc8" />

