### PR TITLE
feat(tooling): add docs-serve just recipes and tidy docs env handling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -281,6 +281,16 @@ docs:
 docs-fast:
     FAST_DOCS=True GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs build --strict -d "{{ output_dir }}/docs/site"
 
+# Serve site documentation locally with mkdocs (live reload)
+[group('docs')]
+docs-serve:
+    GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs serve
+
+# Serve site documentation locally with mkdocs (skip test case reference)
+[group('docs')]
+docs-serve-fast:
+    FAST_DOCS=True GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs serve
+
 # Validate docs/CHANGELOG.md entries
 [group('docs')]
 changelog:

--- a/Justfile
+++ b/Justfile
@@ -265,6 +265,9 @@ bench-opcode-config *args:
 
 # --- Docs ---
 
+export GEN_TEST_DOC_VERSION := "local"
+export DYLD_FALLBACK_LIBRARY_PATH := if os() == "macos" { "/opt/homebrew/lib" } else { "" }
+
 # Generate documentation for EELS using docc
 [group('docs')]
 docs-spec:
@@ -273,23 +276,23 @@ docs-spec:
 
 # Build HTML site documentation with mkdocs
 [group('docs')]
-docs:
-    GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs build --strict -d "{{ output_dir }}/docs/site"
+docs *args:
+    uv run mkdocs build --strict -d "{{ output_dir }}/docs/site" "$@"
 
 # Build HTML site documentation with mkdocs (skip test case reference)
 [group('docs')]
-docs-fast:
-    FAST_DOCS=True GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs build --strict -d "{{ output_dir }}/docs/site"
+docs-fast *args:
+    FAST_DOCS=True uv run mkdocs build --strict -d "{{ output_dir }}/docs/site" "$@"
 
 # Serve site documentation locally with mkdocs (live reload)
 [group('docs')]
-docs-serve:
-    GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs serve
+docs-serve *args:
+    uv run mkdocs serve "$@"
 
 # Serve site documentation locally with mkdocs (skip test case reference)
 [group('docs')]
-docs-serve-fast:
-    FAST_DOCS=True GEN_TEST_DOC_VERSION="local" DYLD_FALLBACK_LIBRARY_PATH="/opt/homebrew/lib" uv run mkdocs serve
+docs-serve-fast *args:
+    FAST_DOCS=True uv run mkdocs serve "$@"
 
 # Validate docs/CHANGELOG.md entries
 [group('docs')]


### PR DESCRIPTION
## 🗒️ Description

Add `docs-serve` and `docs-serve-fast` `just` recipes for local live-reload previewing of the mkdocs site, and tidy up the shared environment handling for all four `docs*` recipes.

- Added `docs-serve` and `docs-serve-fast` recipes that run `mkdocs serve` with the same env setup as the existing build recipes.
- Extracted `GEN_TEST_DOC_VERSION` and `DYLD_FALLBACK_LIBRARY_PATH` into top-level `export` directives so each recipe body is a single `uv run mkdocs ...` invocation.
- Gated `DYLD_FALLBACK_LIBRARY_PATH` to macOS only via `if os() == "macos"`, so Linux shells no longer see a spurious `/opt/homebrew/lib` value.
- Added `*args` passthrough to all four `docs*` recipes for ad-hoc flag forwarding to `mkdocs`.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).
- [x] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://eest.ethereum.org/main/tests/) are correctly formatted.