### PR TITLE
chore(tooling): ignore `.mypy_cache` (symlink) and `.python-version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 # Cache
 cached_downloads/
 .cache
+.mypy_cache
 .mypy_cache/
 .ruff_cache/
 __pycache__/
@@ -47,6 +48,8 @@ MANIFEST
 # Python virtual environment
 .venv/
 venv/
+# User config; not imposed
+.python-version
 
 # pycharm
 .idea/


### PR DESCRIPTION
## 🗒️ Description

Add two entries to `.gitignore`:

- `.mypy_cache` (without trailing slash) so a symlink named `.mypy_cache` is also ignored. `mypy`'s cold runtime is slow, and ignoring the symlink lets git worktree managers link to a shared `.mypy_cache` in the directory where `execution-specs` was cloned.
- `.python-version`, which `uv` creates when a user runs `uv python pin 3.14`. This is user-local config and should not be imposed by the repo.

## 🔗 Related Issues or PRs

N/A.

## ✅ Checklist

- [x] All: Ran fast static checks to avoid unnecessary CI fails, see also [Code Standards](https://eest.ethereum.org/main/getting_started/code_standards/) and [Enabling Pre-commit Checks](https://eest.ethereum.org/main/dev/precommit/):
    ```console
    just static
    ```
- [x] All: PR title adheres to the [repo standard](https://eest.ethereum.org/main/getting_started/contributing/?h=contri#commit-messages-issue-and-pr-titles) - it will be used as the squash commit message and should start `type(scope):`.
- [x] All: Considered updating the online docs in the [./docs/](/ethereum/execution-specs/blob/HEAD/docs/) directory.
- [x] All: Set appropriate labels for the changes (only maintainers can apply labels).

#### Cute Animal Picture
<img width="514" height="353" alt="image" src="https://github.com/user-attachments/assets/023eaa3b-27eb-4eb5-ae1b-bc719b26fa98" />

